### PR TITLE
docs: sync contributor and operator guidance with current runtime def…

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Town Council Architecture (2026)
 
-Last updated: 2026-03-14
+Last updated: 2026-03-16
 
 ## 1) System Overview
 
@@ -48,6 +48,7 @@ Operational tuning, rollout state, and troubleshooting are maintained in:
 - `crawler` (Scrapy ingestion)
 - `pipeline` (batch enrichment and indexing)
 - `api` (FastAPI read/write endpoints)
+- `frontend` server-side route handlers (same-origin proxy for protected write actions)
 - `worker` (Celery async task execution)
 - `inference` (HTTP LLM service when `LOCAL_AI_BACKEND=http`)
 - `postgres` (system of record, including semantic and lineage data)
@@ -149,9 +150,14 @@ flowchart LR
 
 #### Async user-triggered generation
 1. UI calls protected write endpoints.
-2. API enqueues Celery tasks in Redis.
-3. Worker executes task and persists updates.
-4. UI polls `/tasks/{id}` with bounded retry logic.
+2. Frontend server-side route handlers forward protected mutations with `API_AUTH_KEY`; the browser does not hold a public write key.
+3. API enqueues Celery tasks in Redis.
+4. Worker executes task and persists updates.
+5. UI polls `/tasks/{id}` with bounded retry logic.
+
+Trust note:
+- protected frontend mutations now rely on server-side Next route handlers configured with `INTERNAL_API_BASE_URL` and `API_AUTH_KEY`
+- `NEXT_PUBLIC_API_AUTH_KEY` is not part of the current stable contract
 
 ### Domain Design Summaries
 

--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ What it does *not* do:
 - process/index documents (no `run_pipeline.py`)
 
 Note on Full Text after restart:
-If `STARTUP_PURGE_DERIVED=true` (default in this repo’s `docker-compose.yml`), extracted text is cleared from the DB on startup.
-(`pipeline/config.py` defaults to `false` outside Compose unless env is explicitly set.)
+If `STARTUP_PURGE_DERIVED=true`, extracted text is cleared from the DB on startup.
+The checked-in base `docker-compose.yml` defaults this to `false`; `docker-compose.dev.yml` turns it on for dev convenience.
+(`pipeline/config.py` also defaults to `false` unless env is explicitly set.)
 The UI Full Text tab pulls canonical text from Postgres (`/catalog/{id}/content`), so it may show **Not extracted yet** until you click **Re-extract text** for that record.
 
 ### 2.5) Verify containers are using the latest image
@@ -133,6 +134,7 @@ docker compose --env-file env/profiles/desktop_balanced.env up -d --build infere
 
 Current compose default:
 - The checked-in `docker-compose.yml` defaults to the HTTP inference backend (`LOCAL_AI_BACKEND=http`) and starts the worker as `prefork` with concurrency `3`.
+- `LOCAL_AI_BACKEND=inprocess` remains supported, but it is an explicit alternative mode that should run with stricter worker settings (`WORKER_POOL=solo`, `WORKER_CONCURRENCY=1`).
 - That is a local-first default because the HTTP inference service is part of the local Compose stack, not a required remote dependency.
 
 For detailed rollout status, milestones, and policy:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,7 +25,8 @@ This roadmap turns feature ideas into an implementation sequence that fits the c
 It aligns with current architecture facts:
 - `AgendaItem.result`, `AgendaItem.votes`, and `raw_history` already exist.
 - Search is Meilisearch-first and meeting-only by default unless `include_agenda_items=true`.
-- Celery worker is currently single-process (`--concurrency=1 --pool=solo`) with guardrails for LocalAI process duplication.
+- The checked-in Compose default for the HTTP inference path is a prefork Celery worker (`--concurrency=3 --pool=prefork`).
+- In-process inference remains available as an explicit alternative mode with stricter single-process guardrails.
 
 Re-baseline note after recent pushes:
 - Summary trust/quality hardening is now complete (grounded decision-brief summaries + contextual AI disclaimers).

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -208,8 +208,12 @@ These routes require `X-API-Key`:
 Docker dev default key:
 - `API_AUTH_KEY=dev_secret_key_change_me`
 
-Frontend must set:
-- `NEXT_PUBLIC_API_AUTH_KEY` (for browser-triggered protected actions)
+Frontend server-side proxy must set:
+- `INTERNAL_API_BASE_URL` for backend-to-backend calls, default `http://api:8000`
+- `API_AUTH_KEY` for forwarding privileged requests
+
+Task polling note:
+- `GET /tasks/{task_id}` expects a valid UUID task ID; malformed IDs return `400`
 
 ## Local AI tuning (Gemma 3)
 Default local model: Gemma 3 270M (trained for up to 32K context).


### PR DESCRIPTION
…aults

What changed:
- corrected the README startup-purge note to distinguish base compose defaults from docker-compose.dev overrides
- clarified in README that the checked-in default stack is HTTP backend plus prefork worker, while in-process remains an explicit stricter alternative
- added the current frontend protected-write trust boundary to ARCHITECTURE.md, documenting the server-side Next proxy contract with API_AUTH_KEY and INTERNAL_API_BASE_URL
- removed stale NEXT_PUBLIC_API_AUTH_KEY guidance from docs/OPERATIONS.md and added a short note that /tasks/{task_id} expects a UUID
- updated ROADMAP.md so the current worker-process description matches the checked-in compose defaults instead of the old solo-worker baseline

Why:
- these docs had drifted from the live compose/runtime behavior and frontend auth path
- operators and contributors should not be told to use a browser-exposed API key that is no longer part of the supported contract
- the canonical docs should agree on current startup defaults and worker topology

Risk/compat impact:
- documentation only
- no runtime behavior changes
- clarifies current defaults and trust boundaries without restructuring the docs

Verification run:
- PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py (pass)
- PYTHONPATH=. .venv/bin/pytest -q tests/test_env_example_profile_alignment.py (pass)

## Summary

-

## Validation

- [ ] Tests added or updated for changed behavior
- [ ] Local validation commands and results included

## Security Checklist

- [ ] No secrets or partial secrets are logged
- [ ] New endpoints/mutations enforce existing auth requirements
