### PR TITLE
Bump pypdf for Dependabot alert 61

### DIFF
--- a/pipeline/requirements-batch.txt
+++ b/pipeline/requirements-batch.txt
@@ -1,5 +1,5 @@
 spacy==3.7.4
-pypdf==6.9.2
+pypdf==6.10.0
 scikit-learn==1.5.0
 pytextrank==3.3.0
 camelot-py==0.11.0

--- a/tests/test_docker_build_contracts.py
+++ b/tests/test_docker_build_contracts.py
@@ -89,7 +89,7 @@ def test_worker_live_and_batch_requirements_split_table_stack_only():
         assert package not in core
         assert package in batch
 
-    for package in ("spacy==3.7.4", "pytextrank==3.3.0", "scikit-learn==1.5.0", "pypdf==6.9.2"):
+    for package in ("spacy==3.7.4", "pytextrank==3.3.0", "scikit-learn==1.5.0", "pypdf==6.10.0"):
         assert package not in core
         assert package in batch
 


### PR DESCRIPTION
Update the batch-worker pypdf pin from 6.9.2 to 6.10.0 to pick up the fix for GHSA-3crg-w4f6-42mx / CVE-2026-40260, where manipulated XMP metadata entity declarations can exhaust memory.

Keep the dependency split guardrail aligned by updating tests/test_docker_build_contracts.py to expect the patched batch-only pypdf version. No Ruff, repository guardrail, runtime policy, or allowlist settings were changed.

Verification run: ./.venv/bin/ruff check api pipeline scripts tests; ./.venv/bin/mypy; PYTHONPATH=. .venv/bin/pytest -q tests/test_repository_guardrails.py tests/test_docker_build_contracts.py tests/test_docs_links.py; git diff --check. All passed.

