### PR TITLE
Fix semantic service code scanning alerts

### DIFF
--- a/.github/workflows/python-guardrails.yml
+++ b/.github/workflows/python-guardrails.yml
@@ -29,6 +29,9 @@ on:
       - "mypy.ini"
       - "ruff.toml"
 
+permissions:
+  contents: read
+
 jobs:
   python-guardrails:
     runs-on: ubuntu-latest

--- a/semantic_service/main.py
+++ b/semantic_service/main.py
@@ -38,6 +38,24 @@ SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
 
 app = FastAPI(title="Town Council Semantic Service")
 
+SEMANTIC_BACKEND_UNHEALTHY_DETAIL = "Semantic backend unhealthy"
+SEMANTIC_SERVICE_MISCONFIGURED_DETAIL = "Semantic service is misconfigured"
+SEMANTIC_HEALTH_SAFE_BACKEND_KEYS = (
+    "status",
+    "row_count",
+    "model_name",
+    "built_at",
+    "engine",
+    "artifacts",
+)
+SEMANTIC_HEALTH_DIAGNOSTIC_ERRORS = (
+    FileNotFoundError,
+    OSError,
+    RuntimeError,
+    SemanticConfigError,
+    ValueError,
+)
+
 
 def get_db():
     db = SessionLocal()
@@ -45,6 +63,23 @@ def get_db():
         yield db
     finally:
         db.close()
+
+
+def _safe_semantic_backend_health(backend_health: dict[str, Any]) -> dict[str, Any]:
+    return {key: backend_health[key] for key in SEMANTIC_HEALTH_SAFE_BACKEND_KEYS if key in backend_health}
+
+
+def _semantic_backend_engine_for_diagnostics(backend: Any) -> str | None:
+    try:
+        backend_health = backend.health()
+    except SEMANTIC_HEALTH_DIAGNOSTIC_ERRORS as exc:
+        logger.warning("semantic backend health diagnostic failed: %s", exc)
+        return None
+    if backend_health.get("status") != "ok":
+        logger.warning("semantic backend health diagnostic returned unhealthy status: %s", backend_health)
+        return None
+    engine_name = backend_health.get("engine")
+    return str(engine_name) if engine_name else None
 
 
 def validate_date_format(date_str: str):
@@ -168,7 +203,7 @@ def _lexical_hit_to_candidate(hit: dict, order_idx: int):
             if raw_id.startswith("doc_"):
                 try:
                     db_id = int(raw_id.split("_", 1)[1])
-                except Exception:
+                except (IndexError, ValueError):
                     db_id = None
         catalog_id = hit.get("catalog_id")
         if db_id is None or catalog_id is None:
@@ -191,7 +226,7 @@ def _lexical_hit_to_candidate(hit: dict, order_idx: int):
             if raw_id.startswith("item_"):
                 try:
                     db_id = int(raw_id.split("_", 1)[1])
-                except Exception:
+                except (IndexError, ValueError):
                     db_id = None
         if db_id is None:
             return None
@@ -342,8 +377,14 @@ def health_check(db: SQLAlchemySession = Depends(get_db)):
             return {"status": "healthy", "database": "connected", "semantic_enabled": False}
         backend_health = get_semantic_backend().health()
         if backend_health.get("status") != "ok":
-            raise HTTPException(status_code=503, detail=backend_health)
-        return {"status": "healthy", "database": "connected", "semantic_enabled": True, "backend": backend_health}
+            logger.warning("semantic backend health returned unhealthy status: %s", backend_health)
+            raise HTTPException(status_code=503, detail=SEMANTIC_BACKEND_UNHEALTHY_DETAIL)
+        return {
+            "status": "healthy",
+            "database": "connected",
+            "semantic_enabled": True,
+            "backend": _safe_semantic_backend_health(backend_health),
+        }
     except HTTPException:
         raise
     except Exception as exc:
@@ -481,7 +522,8 @@ def search_documents_semantic(
             ),
         ) from exc
     except SemanticConfigError as exc:
-        raise HTTPException(status_code=503, detail=str(exc)) from exc
+        logger.error("semantic search configuration failed: %s", exc)
+        raise HTTPException(status_code=503, detail=SEMANTIC_SERVICE_MISCONFIGURED_DETAIL) from exc
     except Exception as exc:
         logger.error("semantic search failed: %s", exc)
         raise HTTPException(status_code=500, detail="Internal semantic search error") from exc
@@ -501,8 +543,7 @@ def search_documents_semantic(
         if hit:
             hits.append(hit)
     elapsed_ms = round((time.perf_counter() - t0) * 1000.0, 2)
-    backend_health = backend.health()
-    engine = backend_health.get("engine")
+    engine = _semantic_backend_engine_for_diagnostics(backend)
     return {
         "hits": hits,
         "estimatedTotalHits": len(deduped),

--- a/semantic_service/main.py
+++ b/semantic_service/main.py
@@ -59,17 +59,16 @@ def get_db():
         db.close()
 
 
-def _semantic_backend_health_engine(backend_health: dict[str, Any]) -> str | None:
-    engine_name = backend_health.get("engine")
-    if not isinstance(engine_name, str):
+def _public_semantic_backend_engine(engine_name: str | None) -> str | None:
+    if engine_name is None:
         return None
     normalized_engine = engine_name.lower()
     return normalized_engine if normalized_engine in SEMANTIC_BACKEND_HEALTH_ENGINES else None
 
 
-def _public_semantic_backend_health(backend_health: dict[str, Any]) -> dict[str, Any]:
+def _public_semantic_backend_health() -> dict[str, Any]:
     # The backend payload may contain exception details; build a fresh public shape instead of echoing it.
-    return {"status": SEMANTIC_BACKEND_HEALTH_OK_STATUS, "engine": _semantic_backend_health_engine(backend_health)}
+    return {"status": SEMANTIC_BACKEND_HEALTH_OK_STATUS, "engine": _public_semantic_backend_engine(SEMANTIC_BACKEND)}
 
 
 def _semantic_backend_engine_for_diagnostics(backend: Any) -> str | None:
@@ -81,7 +80,7 @@ def _semantic_backend_engine_for_diagnostics(backend: Any) -> str | None:
     if backend_health.get("status") != "ok":
         logger.warning("semantic backend health diagnostic returned unhealthy status: %s", backend_health)
         return None
-    return _semantic_backend_health_engine(backend_health)
+    return _public_semantic_backend_engine(SEMANTIC_BACKEND)
 
 
 def validate_date_format(date_str: str):
@@ -385,7 +384,7 @@ def health_check(db: SQLAlchemySession = Depends(get_db)):
             "status": "healthy",
             "database": "connected",
             "semantic_enabled": True,
-            "backend": _public_semantic_backend_health(backend_health),
+            "backend": _public_semantic_backend_health(),
         }
     except HTTPException:
         raise

--- a/semantic_service/main.py
+++ b/semantic_service/main.py
@@ -40,14 +40,8 @@ app = FastAPI(title="Town Council Semantic Service")
 
 SEMANTIC_BACKEND_UNHEALTHY_DETAIL = "Semantic backend unhealthy"
 SEMANTIC_SERVICE_MISCONFIGURED_DETAIL = "Semantic service is misconfigured"
-SEMANTIC_HEALTH_SAFE_BACKEND_KEYS = (
-    "status",
-    "row_count",
-    "model_name",
-    "built_at",
-    "engine",
-    "artifacts",
-)
+SEMANTIC_BACKEND_HEALTH_OK_STATUS = "ok"
+SEMANTIC_BACKEND_HEALTH_ENGINES = {"faiss", "numpy", "pgvector"}
 SEMANTIC_HEALTH_DIAGNOSTIC_ERRORS = (
     FileNotFoundError,
     OSError,
@@ -65,8 +59,17 @@ def get_db():
         db.close()
 
 
-def _safe_semantic_backend_health(backend_health: dict[str, Any]) -> dict[str, Any]:
-    return {key: backend_health[key] for key in SEMANTIC_HEALTH_SAFE_BACKEND_KEYS if key in backend_health}
+def _semantic_backend_health_engine(backend_health: dict[str, Any]) -> str | None:
+    engine_name = backend_health.get("engine")
+    if not isinstance(engine_name, str):
+        return None
+    normalized_engine = engine_name.lower()
+    return normalized_engine if normalized_engine in SEMANTIC_BACKEND_HEALTH_ENGINES else None
+
+
+def _public_semantic_backend_health(backend_health: dict[str, Any]) -> dict[str, Any]:
+    # The backend payload may contain exception details; build a fresh public shape instead of echoing it.
+    return {"status": SEMANTIC_BACKEND_HEALTH_OK_STATUS, "engine": _semantic_backend_health_engine(backend_health)}
 
 
 def _semantic_backend_engine_for_diagnostics(backend: Any) -> str | None:
@@ -78,8 +81,7 @@ def _semantic_backend_engine_for_diagnostics(backend: Any) -> str | None:
     if backend_health.get("status") != "ok":
         logger.warning("semantic backend health diagnostic returned unhealthy status: %s", backend_health)
         return None
-    engine_name = backend_health.get("engine")
-    return str(engine_name) if engine_name else None
+    return _semantic_backend_health_engine(backend_health)
 
 
 def validate_date_format(date_str: str):
@@ -383,7 +385,7 @@ def health_check(db: SQLAlchemySession = Depends(get_db)):
             "status": "healthy",
             "database": "connected",
             "semantic_enabled": True,
-            "backend": _safe_semantic_backend_health(backend_health),
+            "backend": _public_semantic_backend_health(backend_health),
         }
     except HTTPException:
         raise

--- a/tests/test_semantic_service_api.py
+++ b/tests/test_semantic_service_api.py
@@ -1,6 +1,11 @@
+import os
 from unittest.mock import MagicMock
 
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+
 from fastapi.testclient import TestClient
+
+from pipeline.semantic_index import SemanticCandidate, SemanticConfigError
 
 from semantic_service.main import app, get_db
 
@@ -13,6 +18,7 @@ def test_semantic_service_health_returns_backend_health_when_enabled(mocker):
     mocker.patch("semantic_service.main.get_semantic_backend").return_value.health.return_value = {
         "status": "ok",
         "engine": "faiss",
+        "detail": "/secret/path/index.faiss",
     }
     client = TestClient(app)
     try:
@@ -21,5 +27,82 @@ def test_semantic_service_health_returns_backend_health_when_enabled(mocker):
         payload = resp.json()
         assert payload["status"] == "healthy"
         assert payload["backend"]["engine"] == "faiss"
+        assert "detail" not in payload["backend"]
+    finally:
+        del app.dependency_overrides[get_db]
+
+
+def test_semantic_service_health_hides_backend_error_detail(mocker):
+    db = MagicMock()
+    app.dependency_overrides[get_db] = lambda: db
+    db.execute.return_value = 1
+    mocker.patch("semantic_service.main.SEMANTIC_ENABLED", True)
+    mocker.patch("semantic_service.main.get_semantic_backend").return_value.health.return_value = {
+        "status": "error",
+        "error": "FileNotFoundError",
+        "detail": "/secret/path/index.faiss",
+    }
+    client = TestClient(app)
+    try:
+        resp = client.get("/health")
+        assert resp.status_code == 503
+        response_text = resp.text
+        assert resp.json()["detail"] == "Semantic backend unhealthy"
+        assert "/secret/path" not in response_text
+    finally:
+        del app.dependency_overrides[get_db]
+
+
+def test_semantic_search_config_error_hides_exception_detail(mocker):
+    db = MagicMock()
+    app.dependency_overrides[get_db] = lambda: db
+    mocker.patch("semantic_service.main.SEMANTIC_ENABLED", True)
+    backend = MagicMock()
+    backend.query.side_effect = SemanticConfigError("secret /path/model.bin")
+    mocker.patch("semantic_service.main.get_semantic_backend", return_value=backend)
+    client = TestClient(app)
+    try:
+        resp = client.get("/search/semantic?q=zoning")
+        assert resp.status_code == 503
+        response_text = resp.text
+        assert "Semantic service is misconfigured" in response_text
+        assert "secret" not in response_text
+        assert "/path/model.bin" not in response_text
+    finally:
+        del app.dependency_overrides[get_db]
+
+
+def test_semantic_search_hides_backend_health_detail_from_diagnostics(mocker):
+    db = MagicMock()
+    app.dependency_overrides[get_db] = lambda: db
+    mocker.patch("semantic_service.main.SEMANTIC_ENABLED", True)
+    backend = MagicMock()
+    backend.query.return_value = [
+        SemanticCandidate(
+            row_id=1,
+            score=0.9,
+            metadata={"result_type": "meeting", "db_id": 10, "catalog_id": 101},
+        )
+    ]
+    backend.health.return_value = {
+        "status": "error",
+        "error": "RuntimeError",
+        "detail": "/secret/path/metadata.json",
+    }
+    mocker.patch("semantic_service.main.get_semantic_backend", return_value=backend)
+    mocker.patch(
+        "semantic_service.main._hydrate_meeting_hits",
+        return_value=[{"id": "doc_10", "db_id": 10, "result_type": "meeting", "event_name": "Meeting"}],
+    )
+    mocker.patch("semantic_service.main._hydrate_agenda_hits", return_value=[])
+    client = TestClient(app)
+    try:
+        resp = client.get("/search/semantic?q=zoning")
+        assert resp.status_code == 200
+        response_text = resp.text
+        payload = resp.json()
+        assert payload["semantic_diagnostics"]["engine"] is None
+        assert "/secret/path" not in response_text
+        assert "detail" not in response_text
     finally:
         del app.dependency_overrides[get_db]

--- a/tests/test_semantic_service_api.py
+++ b/tests/test_semantic_service_api.py
@@ -53,11 +53,12 @@ def test_semantic_service_health_hides_backend_error_detail(mocker):
         del app.dependency_overrides[get_db]
 
 
-def test_semantic_service_health_does_not_echo_unknown_backend_engine(mocker):
+def test_semantic_service_health_does_not_echo_backend_health_engine(mocker):
     db = MagicMock()
     app.dependency_overrides[get_db] = lambda: db
     db.execute.return_value = 1
     mocker.patch("semantic_service.main.SEMANTIC_ENABLED", True)
+    mocker.patch("semantic_service.main.SEMANTIC_BACKEND", "faiss")
     mocker.patch("semantic_service.main.get_semantic_backend").return_value.health.return_value = {
         "status": "ok",
         "engine": "secret-engine",
@@ -68,7 +69,7 @@ def test_semantic_service_health_does_not_echo_unknown_backend_engine(mocker):
         assert resp.status_code == 200
         response_text = resp.text
         payload = resp.json()
-        assert payload["backend"] == {"status": "ok", "engine": None}
+        assert payload["backend"] == {"status": "ok", "engine": "faiss"}
         assert "secret-engine" not in response_text
     finally:
         del app.dependency_overrides[get_db]

--- a/tests/test_semantic_service_api.py
+++ b/tests/test_semantic_service_api.py
@@ -53,6 +53,27 @@ def test_semantic_service_health_hides_backend_error_detail(mocker):
         del app.dependency_overrides[get_db]
 
 
+def test_semantic_service_health_does_not_echo_unknown_backend_engine(mocker):
+    db = MagicMock()
+    app.dependency_overrides[get_db] = lambda: db
+    db.execute.return_value = 1
+    mocker.patch("semantic_service.main.SEMANTIC_ENABLED", True)
+    mocker.patch("semantic_service.main.get_semantic_backend").return_value.health.return_value = {
+        "status": "ok",
+        "engine": "secret-engine",
+    }
+    client = TestClient(app)
+    try:
+        resp = client.get("/health")
+        assert resp.status_code == 200
+        response_text = resp.text
+        payload = resp.json()
+        assert payload["backend"] == {"status": "ok", "engine": None}
+        assert "secret-engine" not in response_text
+    finally:
+        del app.dependency_overrides[get_db]
+
+
 def test_semantic_search_config_error_hides_exception_detail(mocker):
     db = MagicMock()
     app.dependency_overrides[get_db] = lambda: db


### PR DESCRIPTION
Add explicit read-only permissions to the Python guardrails workflow so the GitHub token only has the access this job needs.

Sanitize semantic backend health responses before returning them from the service, so exception-derived details and local paths stay in server logs instead of HTTP responses.

Cover healthy and unhealthy backend health payloads, semantic configuration failures, and diagnostic-only health failures with semantic service tests.

