### PR TITLE
Connect people data in architecture diagram

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -107,12 +107,14 @@ flowchart LR
     Spider --> Stage --> Promote --> Core
 
     Core -->|"run_pipeline.py"| Meili
+    Core -->|"NLP/entity enrichment"| People
     Core --> Sem
     Agenda --> Meili
 
     UI -->|"search/read"| API
     API --> Meili
     API --> Semantic
+    People -->|"people reads"| API
     UI -->|"POST summarize/segment/topics/extract/votes"| API
     API <--> Queue --> Worker --> LocalAI
     LocalAI --> InProc


### PR DESCRIPTION
Show that core catalog records feed person and membership data through NLP/entity enrichment.

Connect the people store back to the FastAPI read path so the Mermaid topology no longer shows the people block as isolated.

Verification: PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py passed.


