### PR TITLE
Align docs with metrics cleanup ownership

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -382,6 +382,12 @@ Owners:
 
 Owners:
 - `pipeline/metrics.py`
+- `pipeline/metrics_provider_collector.py`
+- `pipeline/metrics_provider_recorders.py`
+- `pipeline/metrics_provider_keys.py`
+- `pipeline/metrics_task_recorders.py`
+- `pipeline/metrics_celery_signals.py`
+- `pipeline/metrics_profile_events.py`
 - `pipeline/llm_provider.py`
 - `pipeline/provider_telemetry.py`
 
@@ -415,9 +421,9 @@ Owners:
 | Contract | Metric/endpoint | Primary owners |
 |---|---|---|
 | API service metrics | `GET /metrics` on API | `api/metrics.py`, `api/main.py` |
-| Worker service metrics | `GET /metrics` on worker exporter | `pipeline/metrics.py`, `pipeline/metrics_celery_signals.py` |
-| Provider transport telemetry | `tc_provider_*` (requests, duration, retries, timeouts, TTFT/TPS, token counters) | `pipeline/provider_telemetry.py`, `pipeline/llm_provider.py`, `pipeline/metrics.py`, `pipeline/metrics_provider_recorders.py` |
-| Prefork-safe provider visibility | Redis-backed provider metric aggregates | `pipeline/metrics.py`, `pipeline/metrics_provider_collector.py` |
+| Worker service metrics | `GET /metrics` on worker exporter | `pipeline/metrics.py`, `pipeline/metrics_definitions.py`, `pipeline/metrics_task_recorders.py`, `pipeline/metrics_celery_signals.py`, `pipeline/metrics_profile_events.py` |
+| Provider transport telemetry | `tc_provider_*` (requests, duration, retries, timeouts, TTFT/TPS, token counters) | `pipeline/provider_telemetry.py`, `pipeline/llm_provider.py`, `pipeline/metrics.py`, `pipeline/metrics_provider_keys.py`, `pipeline/metrics_provider_recorders.py` |
+| Prefork-safe provider visibility | Redis-backed provider metric aggregates | `pipeline/metrics.py`, `pipeline/metrics_provider_keys.py`, `pipeline/metrics_provider_collector.py` |
 
 ### Security and Reliability Controls
 

--- a/docs/ADR.md
+++ b/docs/ADR.md
@@ -15,6 +15,7 @@ Use each entry to record:
   - `pipeline/metrics.py` remains the public compatibility facade for worker metrics imports, Celery signal registration, and existing test patch seams.
   - Metric schema definitions move behind `pipeline/metrics_definitions.py`.
   - Provider Redis key handling, recorders, and collector behavior move behind focused `pipeline/metrics_provider_*` modules.
+  - Task metric recorders move behind `pipeline/metrics_task_recorders.py`.
   - Celery signal handling and profile-event construction move behind `pipeline/metrics_celery_signals.py` and `pipeline/metrics_profile_events.py`.
 - Why:
   - `pipeline/metrics.py` combined metric definitions, provider Redis mirroring, Prometheus collection, Celery signals, profile events, and Redis failure handling in one large module.
@@ -22,9 +23,12 @@ Use each entry to record:
 - Affected boundaries:
   - `pipeline/metrics.py` remains the import and patch boundary.
   - `pipeline/metrics_definitions.py` owns Prometheus metric object definitions.
+  - `pipeline/metrics_provider_keys.py` owns Redis-safe provider label encoding and decoding.
   - `pipeline/metrics_provider_collector.py` owns Redis-backed provider metric exposition.
   - `pipeline/metrics_provider_recorders.py` owns provider telemetry writes.
+  - `pipeline/metrics_task_recorders.py` owns Celery task, queue-wait, phase-duration, and lineage metric writes.
   - `pipeline/metrics_celery_signals.py` owns Celery task metrics hooks.
+  - `pipeline/metrics_profile_events.py` owns task profile-event construction.
 - Canonical references:
   - [ARCHITECTURE.md](../ARCHITECTURE.md)
   - [docs/PIPELINE.md](PIPELINE.md)

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -303,7 +303,7 @@ Why:
 
 Current queue signal:
 - `queue_wait_p95` is approximated by `phase_duration_p95_s_capped` when available, otherwise `phase_duration_p95_s`.
-- This is an operational proxy until explicit queue wait metrics are exported.
+- `tc_task_queue_wait_seconds` is exported by workers, but weekly soak promotion still uses the phase-duration proxy until queue-wait histogram aggregation is promoted into evaluator inputs.
 
 Soak confidence signals:
 - `worker_metrics_error` is recorded when worker metrics cannot be scraped.

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -321,7 +321,7 @@ Use these files as primary references:
 - Provider facade: `pipeline/llm_provider.py`
 - Provider transport + typed errors: `pipeline/http_inference_provider.py`, `pipeline/inprocess_inference_provider.py`, `pipeline/inference_provider_contract.py`
 - Extraction freshness/hash: `pipeline/extraction_service.py`, `pipeline/content_hash.py`
-- Metrics: `pipeline/metrics.py` (facade), `pipeline/metrics_definitions.py`, `pipeline/metrics_provider_recorders.py`, `pipeline/metrics_provider_collector.py`, `pipeline/metrics_celery_signals.py`
+- Metrics: `pipeline/metrics.py` (facade), `pipeline/metrics_definitions.py`, `pipeline/metrics_provider_keys.py`, `pipeline/metrics_provider_recorders.py`, `pipeline/metrics_provider_collector.py`, `pipeline/metrics_task_recorders.py`, `pipeline/metrics_celery_signals.py`, `pipeline/metrics_profile_events.py`
 - Runbook and troubleshooting: `docs/OPERATIONS.md`
 
 ## 12) Related Docs


### PR DESCRIPTION
Update the ADR, pipeline source map, performance queue-wait guidance, and architecture observability ownership so they match the metrics facade split.

This is documentation-only: public metric names, environment variables, and runtime behavior remain unchanged.