### PR TITLE
Improve README contributor entrypoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ For complete troubleshooting (auth, stale/blocked/not-generated states, startup 
 ## Contributing
 - Use [`AGENTS.md`](AGENTS.md) for repo workflow, policy, verification, and collaboration constraints.
 - Use [`docs/CONTRIBUTING_CITIES.md`](docs/CONTRIBUTING_CITIES.md) when adding or updating city crawlers.
-- Use the PR checklist in [`.github/pull_request_template.md`](.github/pull_request_template.md) before opening a pull request.
+- Include changed behavior, risk, compatibility impact, and validation results in pull request summaries.
 - Keep contributor workflows local-first and avoid silent remote inference fallback.
 
 ## Support / Issues

--- a/README.md
+++ b/README.md
@@ -9,6 +9,19 @@ This project ingests agendas/minutes, extracts text, indexes search content, and
 - Topic tagging
 - Official profile browsing
 
+## Contents
+- [Quickstart](#quickstart)
+- [Access URLs](#access-urls)
+- [Search Behavior](#search-behavior-meetings-vs-agenda-items)
+- [Feature Flags](#feature-flags-quick-reference)
+- [Runtime Modes](#runtime-modes)
+- [GitHub Pages Demo](#github-pages-demo)
+- [Troubleshooting](#common-troubleshooting-quick)
+- [Documentation Map](#documentation-map)
+- [Contributing](#contributing)
+- [Support / Issues](#support--issues)
+- [License](#license)
+
 ## Quickstart
 
 ### 1) Prerequisites
@@ -301,6 +314,17 @@ For complete troubleshooting (auth, stale/blocked/not-generated states, startup 
 - Use reproducibility and performance notes: [`docs/PERFORMANCE.md`](docs/PERFORMANCE.md)
 - Use contributor guidance for new crawlers: [`docs/CONTRIBUTING_CITIES.md`](docs/CONTRIBUTING_CITIES.md)
 - Use repo policy and collaboration constraints: [`AGENTS.md`](AGENTS.md)
+
+## Contributing
+- Use [`AGENTS.md`](AGENTS.md) for repo workflow, policy, verification, and collaboration constraints.
+- Use [`docs/CONTRIBUTING_CITIES.md`](docs/CONTRIBUTING_CITIES.md) when adding or updating city crawlers.
+- Use the PR checklist in [`.github/pull_request_template.md`](.github/pull_request_template.md) before opening a pull request.
+- Keep contributor workflows local-first and avoid silent remote inference fallback.
+
+## Support / Issues
+- Open bugs, feature requests, and documentation issues in [GitHub Issues](https://github.com/manumissio/town-council/issues).
+- For operator troubleshooting, start with [`docs/OPERATIONS.md`](docs/OPERATIONS.md).
+- For architecture or roadmap questions, use [`ARCHITECTURE.md`](ARCHITECTURE.md) and [`ROADMAP.md`](ROADMAP.md).
 
 ## Documentation Maintenance Checklist
 Update docs when you change:


### PR DESCRIPTION
## What changed
- Added a README table of contents for faster navigation.
- Added contributor entrypoints for repo workflow, city crawler guidance, and PR checklist.
- Added support and issue guidance that points readers to GitHub Issues and existing operator docs.

## Why
GitHub README guidance recommends clear navigation, contribution paths, support links, and license visibility. The README already had strong setup and usage coverage; this fills the missing contributor/support entrypoints.

## Risk / compatibility
- Docs-only change.
- No command, config, API, Docker, runtime, or policy behavior changed.
- Existing local-first and fail-fast remote inference guidance preserved.

## Verification
- PASS `PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py`
- PASS `git diff --check`