### PR TITLE
Split Wave 1 legacy cleanup facades

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -301,8 +301,8 @@ Primary owners:
 
 - Add or modify async generation endpoint:
   - `api/main.py` (app facade and compatibility surface)
-  - `api/task_routes.py` (route + task dispatch)
-  - `pipeline/tasks.py` (Celery task logic)
+  - `api/task_routes.py` facade plus focused `api/task_*` helpers
+  - `pipeline/tasks.py` facade plus focused `pipeline/task_*` helpers
   - `frontend/components/ResultCard.js` (polling/status UI)
 - Adjust lineage recompute behavior:
   - `pipeline/lineage_service.py`
@@ -319,13 +319,13 @@ Primary owners:
 
 - Ingestion and promotion: `council_crawler/`, `crawler/promote_stage.py`
 - Canonical extraction/content hashing: `pipeline/extraction_service.py`, `pipeline/content_hash.py`
-- Async orchestration and writes: `pipeline/tasks.py`
+- Async orchestration and writes: `pipeline/tasks.py` facade plus focused `pipeline/task_*` helpers
 - Inference abstraction and provider telemetry: `pipeline/llm.py`, `pipeline/agenda_extraction.py`, `pipeline/llm_provider.py`, `pipeline/http_inference_provider.py` facade plus focused `pipeline/http_inference_*` helpers, `pipeline/inprocess_inference_provider.py`, `pipeline/provider_telemetry.py`, `pipeline/metrics.py`, `pipeline/metrics_provider_recorders.py`
-- API surface and auth: `api/main.py`, `api/app_setup.py`, `api/search_routes.py`, `api/task_routes.py`, `api/search/query_builder.py`, `api/metrics.py`
+- API surface and auth: `api/main.py`, `api/app_setup.py`, `api/search_routes.py`, `api/task_routes.py` facade plus focused `api/task_*` helpers, `api/search_support.py` facade plus focused `api/search/*_support.py` helpers, `api/search/query_builder.py`, `api/metrics.py`
 - Semantic retrieval and embeddings: `pipeline/semantic_index.py`, `pipeline/semantic_faiss_backend.py`, `pipeline/semantic_pgvector_backend.py`, focused semantic backend helpers, `pipeline/models.py`
 - Frontend query/task UX: `frontend/app/page.js`, `frontend/state/search-state.js`, `frontend/components/ResultCard.js`
 - Data model and persistence: `pipeline/models.py`, `pipeline/db_migrate.py`, `pipeline/migrate_v8.py`, `pipeline/migrate_v9.py`
-- Onboarding orchestration and evaluation: `scripts/onboard_city_wave.sh`, `scripts/check_city_crawl_evidence.py`, `scripts/evaluate_city_onboarding.py`
+- Onboarding orchestration and evaluation: `scripts/onboard_city_wave.sh`, `scripts/check_city_crawl_evidence.py`, `scripts/evaluate_city_onboarding.py` facade plus focused `pipeline/city_onboarding_*` helpers
 
 ### Runtime Lifecycles
 

--- a/api/search/filter_support.py
+++ b/api/search/filter_support.py
@@ -1,0 +1,88 @@
+import re
+from typing import Any, Optional
+
+from fastapi import HTTPException
+
+from api.search.query_builder import build_meili_filter_clauses, normalize_city_filter, normalize_filters
+from api.search.support_core import INVALID_DATE_FORMAT_DETAIL
+
+
+def validate_date_format(date_str: str) -> None:
+    """Ensures date is YYYY-MM-DD before forwarding it downstream."""
+    if not re.match(r"^\d{4}-\d{2}-\d{2}$", date_str):
+        raise HTTPException(status_code=400, detail=INVALID_DATE_FORMAT_DETAIL)
+
+
+def _normalize_filters_or_400(
+    city: Optional[str],
+    meeting_type: Optional[str],
+    org: Optional[str],
+    date_from: Optional[str],
+    date_to: Optional[str],
+    include_agenda_items: bool,
+) -> Any:
+    try:
+        return normalize_filters(
+            city=city,
+            meeting_type=meeting_type,
+            org=org,
+            date_from=date_from,
+            date_to=date_to,
+            include_agenda_items=include_agenda_items,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+def _normalize_city_or_400(city: str) -> str:
+    try:
+        return normalize_city_filter(city)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+def _build_filter_values(
+    city: Optional[str],
+    meeting_type: Optional[str],
+    org: Optional[str],
+    date_from: Optional[str],
+    date_to: Optional[str],
+    include_agenda_items: bool,
+) -> dict[str, Any]:
+    filters = _normalize_filters_or_400(
+        city=city,
+        meeting_type=meeting_type,
+        org=org,
+        date_from=date_from,
+        date_to=date_to,
+        include_agenda_items=include_agenda_items,
+    )
+    return {
+        "city": filters.city,
+        "meeting_type": filters.meeting_type,
+        "org": filters.org,
+        "date_from": filters.date_from,
+        "date_to": filters.date_to,
+        "include_agenda_items": filters.include_agenda_items,
+    }
+
+
+def _build_meilisearch_filter_clauses(
+    city: Optional[str],
+    meeting_type: Optional[str],
+    org: Optional[str],
+    date_from: Optional[str],
+    date_to: Optional[str],
+    include_agenda_items: bool,
+) -> list[str]:
+    # One shared QueryBuilder contract keeps /search and /trends in sync.
+    return build_meili_filter_clauses(
+        _normalize_filters_or_400(
+            city=city,
+            meeting_type=meeting_type,
+            org=org,
+            date_from=date_from,
+            date_to=date_to,
+            include_agenda_items=include_agenda_items,
+        )
+    )

--- a/api/search/semantic_support.py
+++ b/api/search/semantic_support.py
@@ -1,0 +1,36 @@
+from typing import Any
+
+import httpx
+from fastapi import HTTPException
+
+from api.app_setup import SEMANTIC_SERVICE_URL
+from api.search.support_core import (
+    SEMANTIC_HEALTHCHECK_TIMEOUT_SECONDS,
+    SEMANTIC_SEARCH_TIMEOUT_SECONDS,
+    SEMANTIC_SERVICE_ERROR_DETAIL,
+)
+
+
+def _semantic_service_healthcheck() -> dict[str, Any]:
+    try:
+        response = httpx.get(f"{SEMANTIC_SERVICE_URL}/health", timeout=SEMANTIC_HEALTHCHECK_TIMEOUT_SECONDS)
+        response.raise_for_status()
+        return response.json()
+    except (httpx.HTTPError, ValueError) as exc:
+        raise RuntimeError(f"Semantic service unavailable: {exc}") from exc
+
+
+def _semantic_service_get_json(path: str, params: dict[str, Any]) -> dict[str, Any]:
+    try:
+        response = httpx.get(f"{SEMANTIC_SERVICE_URL}{path}", params=params, timeout=SEMANTIC_SEARCH_TIMEOUT_SECONDS)
+    except httpx.RequestError as exc:
+        raise HTTPException(status_code=503, detail=f"Semantic service unavailable: {exc}") from exc
+
+    if response.status_code >= 400:
+        try:
+            payload = response.json()
+            detail = payload.get("detail", payload) if isinstance(payload, dict) else payload
+        except ValueError:
+            detail = response.text or SEMANTIC_SERVICE_ERROR_DETAIL
+        raise HTTPException(status_code=response.status_code, detail=detail)
+    return response.json()

--- a/api/search/support_core.py
+++ b/api/search/support_core.py
@@ -1,0 +1,83 @@
+import logging
+import os
+from typing import Any
+
+import meilisearch
+
+from pipeline import config as pipeline_config
+
+MEILI_HOST = os.getenv("MEILI_HOST", "http://meilisearch:7700")
+MEILI_MASTER_KEY = os.getenv("MEILI_MASTER_KEY", "masterKey")
+
+DOCUMENT_INDEX_NAME = "documents"
+TOPICS_FACET_NAME = "topics"
+
+SEARCH_ENGINE_TIMEOUT_DETAIL = "Search engine timed out"
+SEARCH_ENGINE_UNAVAILABLE_DETAIL = "Search engine unavailable"
+INTERNAL_SEARCH_ENGINE_ERROR_DETAIL = "Internal search engine error"
+SEMANTIC_DISABLED_DETAIL = "Semantic search is disabled. Set SEMANTIC_ENABLED=true and build artifacts."
+TRENDS_DASHBOARD_DISABLED_DETAIL = "Trends dashboard is disabled"
+INVALID_DATE_FORMAT_DETAIL = "Invalid date format. Use YYYY-MM-DD."
+SEMANTIC_SERVICE_ERROR_DETAIL = "Semantic service error"
+
+SEMANTIC_HEALTHCHECK_TIMEOUT_SECONDS = 5.0
+SEMANTIC_SEARCH_TIMEOUT_SECONDS = 60.0
+MEETING_DOC_SCAN_LIMIT = 2000
+MEETING_DOC_PAGE_SIZE = 200
+
+SEARCH_RESULT_ATTRIBUTES_TO_RETRIEVE = [
+    "id",
+    "title",
+    "event_name",
+    "city",
+    "date",
+    "filename",
+    "url",
+    "result_type",
+    "event_id",
+    "catalog_id",
+    "classification",
+    "result",
+    "summary",
+    "summary_extractive",
+    "entities",
+    "topics",
+    "related_ids",
+    "summary_is_stale",
+    "topics_is_stale",
+    "people_metadata",
+]
+SEARCH_RESULT_ATTRIBUTES_TO_CROP = ["content", "description"]
+SEARCH_RESULT_ATTRIBUTES_TO_HIGHLIGHT = ["content", "title", "description"]
+SEARCH_RESULT_CROP_LENGTH = 50
+SEARCH_HIGHLIGHT_PRE_TAG = '<em class="bg-yellow-200 not-italic font-semibold px-0.5 rounded">'
+SEARCH_HIGHLIGHT_POST_TAG = "</em>"
+METADATA_FACETS = ["city", "organization", "meeting_category"]
+TOPICS_CSV_HEADER = ["topic", "count", "city", "date_from", "date_to"]
+
+FEATURE_TRENDS_DASHBOARD = pipeline_config.FEATURE_TRENDS_DASHBOARD
+SEMANTIC_ENABLED = pipeline_config.SEMANTIC_ENABLED
+
+logger = logging.getLogger("town-council-api")
+
+# Search helpers read this through api.main at runtime so existing tests can patch
+# the facade without knowing about the extracted modules.
+client = meilisearch.Client(MEILI_HOST, MEILI_MASTER_KEY, timeout=5)
+
+
+def _api_main() -> Any:
+    from api import main as api_main
+
+    return api_main
+
+
+def facade_value(name: str, fallback: Any) -> Any:
+    return getattr(_api_main(), name, fallback)
+
+
+def facade_callable(name: str, fallback: Any) -> Any:
+    return getattr(_api_main(), name, fallback)
+
+
+def search_client() -> Any:
+    return facade_value("client", client)

--- a/api/search/trends_support.py
+++ b/api/search/trends_support.py
@@ -1,0 +1,137 @@
+from datetime import date, datetime, timedelta
+from typing import Any, Optional
+
+from fastapi import HTTPException
+
+from api.search.filter_support import _build_meilisearch_filter_clauses
+from api.search.support_core import (
+    DOCUMENT_INDEX_NAME,
+    FEATURE_TRENDS_DASHBOARD,
+    MEETING_DOC_PAGE_SIZE,
+    MEETING_DOC_SCAN_LIMIT,
+    TOPICS_FACET_NAME,
+    TRENDS_DASHBOARD_DISABLED_DETAIL,
+    facade_callable,
+    facade_value,
+    search_client,
+)
+from pipeline.lexicon import is_trend_noise_topic
+
+
+def _require_trends_feature() -> None:
+    if not facade_value("FEATURE_TRENDS_DASHBOARD", FEATURE_TRENDS_DASHBOARD):
+        raise HTTPException(status_code=503, detail=TRENDS_DASHBOARD_DISABLED_DETAIL)
+
+
+def _bucket_start(value: date, granularity: str) -> date:
+    if granularity == "quarter":
+        q_month = ((value.month - 1) // 3) * 3 + 1
+        return date(value.year, q_month, 1)
+    return date(value.year, value.month, 1)
+
+
+def _next_bucket_start(value: date, granularity: str) -> date:
+    if granularity == "quarter":
+        month = value.month + 3
+    else:
+        month = value.month + 1
+    year = value.year
+    while month > 12:
+        month -= 12
+        year += 1
+    return date(year, month, 1)
+
+
+def _iter_time_buckets(start: date, end: date, granularity: str) -> list[tuple[date, date]]:
+    cursor = _bucket_start(start, granularity)
+    buckets: list[tuple[date, date]] = []
+    while cursor <= end:
+        next_bucket = _next_bucket_start(cursor, granularity)
+        bucket_end = min(end, next_bucket - timedelta(days=1))
+        buckets.append((cursor, bucket_end))
+        cursor = next_bucket
+    return buckets
+
+
+def _facet_topics(city: Optional[str], date_from: Optional[str], date_to: Optional[str]) -> dict[str, int]:
+    index = search_client().index(DOCUMENT_INDEX_NAME)
+    filter_builder = facade_callable("_build_meilisearch_filter_clauses", _build_meilisearch_filter_clauses)
+    filters = filter_builder(
+        city=city,
+        meeting_type=None,
+        org=None,
+        date_from=date_from,
+        date_to=date_to,
+        include_agenda_items=False,
+    )
+    params: dict[str, Any] = {"limit": 0, "facets": [TOPICS_FACET_NAME]}
+    if filters:
+        params["filter"] = filters
+    result = index.search("", params)
+    return result.get("facetDistribution", {}).get(TOPICS_FACET_NAME, {}) or {}
+
+
+def _parse_iso_date(value: Optional[str]) -> Optional[date]:
+    if not value:
+        return None
+    try:
+        return datetime.strptime(value[:10], "%Y-%m-%d").date()
+    except (TypeError, ValueError):
+        return None
+
+
+def _collect_meeting_docs(city: Optional[str], scan_limit: int = MEETING_DOC_SCAN_LIMIT) -> list[dict[str, Any]]:
+    index = search_client().index(DOCUMENT_INDEX_NAME)
+    filter_builder = facade_callable("_build_meilisearch_filter_clauses", _build_meilisearch_filter_clauses)
+    filters = filter_builder(
+        city=city,
+        meeting_type=None,
+        org=None,
+        date_from=None,
+        date_to=None,
+        include_agenda_items=False,
+    )
+    meeting_docs: list[dict[str, Any]] = []
+    offset = 0
+    while offset < scan_limit:
+        params: dict[str, Any] = {
+            "limit": min(MEETING_DOC_PAGE_SIZE, scan_limit - offset),
+            "offset": offset,
+            "attributesToRetrieve": [TOPICS_FACET_NAME, "date", "city"],
+            "filter": filters,
+        }
+        if not filters:
+            del params["filter"]
+        page = index.search("", params)
+        hits = page.get("hits", []) or []
+        meeting_docs.extend(hits)
+        if len(hits) < MEETING_DOC_PAGE_SIZE:
+            break
+        offset += len(hits)
+    return meeting_docs
+
+
+def _count_topics_from_docs(
+    docs: list[dict[str, Any]],
+    date_from: Optional[str],
+    date_to: Optional[str],
+) -> dict[str, int]:
+    start = _parse_iso_date(date_from)
+    end = _parse_iso_date(date_to)
+    counts: dict[str, int] = {}
+    for row in docs:
+        row_date = _parse_iso_date(row.get("date"))
+        if start and (row_date is None or row_date < start):
+            continue
+        if end and (row_date is None or row_date > end):
+            continue
+        topics = row.get(TOPICS_FACET_NAME) or []
+        if isinstance(topics, list):
+            for topic in topics:
+                topic_name = str(topic).strip()
+                if not topic_name:
+                    continue
+                if is_trend_noise_topic(topic_name):
+                    continue
+                counts[topic_name] = counts.get(topic_name, 0) + 1
+    return counts

--- a/api/search_support.py
+++ b/api/search_support.py
@@ -1,314 +1,99 @@
-import logging
-import os
-import re
-from datetime import date, datetime, timedelta
-from typing import Any, Optional
+from api.search.filter_support import (
+    _build_filter_values as _build_filter_values,
+    _build_meilisearch_filter_clauses as _build_meilisearch_filter_clauses,
+    _normalize_city_or_400 as _normalize_city_or_400,
+    _normalize_filters_or_400 as _normalize_filters_or_400,
+    validate_date_format as validate_date_format,
+)
+from api.search.semantic_support import (
+    _semantic_service_get_json as _semantic_service_get_json,
+    _semantic_service_healthcheck as _semantic_service_healthcheck,
+    httpx as httpx,
+)
+from api.search.support_core import (
+    DOCUMENT_INDEX_NAME as DOCUMENT_INDEX_NAME,
+    FEATURE_TRENDS_DASHBOARD as FEATURE_TRENDS_DASHBOARD,
+    INTERNAL_SEARCH_ENGINE_ERROR_DETAIL as INTERNAL_SEARCH_ENGINE_ERROR_DETAIL,
+    INVALID_DATE_FORMAT_DETAIL as INVALID_DATE_FORMAT_DETAIL,
+    MEETING_DOC_PAGE_SIZE as MEETING_DOC_PAGE_SIZE,
+    MEETING_DOC_SCAN_LIMIT as MEETING_DOC_SCAN_LIMIT,
+    MEILI_HOST as MEILI_HOST,
+    MEILI_MASTER_KEY as MEILI_MASTER_KEY,
+    METADATA_FACETS as METADATA_FACETS,
+    SEARCH_ENGINE_TIMEOUT_DETAIL as SEARCH_ENGINE_TIMEOUT_DETAIL,
+    SEARCH_ENGINE_UNAVAILABLE_DETAIL as SEARCH_ENGINE_UNAVAILABLE_DETAIL,
+    SEARCH_HIGHLIGHT_POST_TAG as SEARCH_HIGHLIGHT_POST_TAG,
+    SEARCH_HIGHLIGHT_PRE_TAG as SEARCH_HIGHLIGHT_PRE_TAG,
+    SEARCH_RESULT_ATTRIBUTES_TO_CROP as SEARCH_RESULT_ATTRIBUTES_TO_CROP,
+    SEARCH_RESULT_ATTRIBUTES_TO_HIGHLIGHT as SEARCH_RESULT_ATTRIBUTES_TO_HIGHLIGHT,
+    SEARCH_RESULT_ATTRIBUTES_TO_RETRIEVE as SEARCH_RESULT_ATTRIBUTES_TO_RETRIEVE,
+    SEARCH_RESULT_CROP_LENGTH as SEARCH_RESULT_CROP_LENGTH,
+    SEMANTIC_DISABLED_DETAIL as SEMANTIC_DISABLED_DETAIL,
+    SEMANTIC_ENABLED as SEMANTIC_ENABLED,
+    SEMANTIC_HEALTHCHECK_TIMEOUT_SECONDS as SEMANTIC_HEALTHCHECK_TIMEOUT_SECONDS,
+    SEMANTIC_SEARCH_TIMEOUT_SECONDS as SEMANTIC_SEARCH_TIMEOUT_SECONDS,
+    SEMANTIC_SERVICE_ERROR_DETAIL as SEMANTIC_SERVICE_ERROR_DETAIL,
+    TOPICS_CSV_HEADER as TOPICS_CSV_HEADER,
+    TOPICS_FACET_NAME as TOPICS_FACET_NAME,
+    TRENDS_DASHBOARD_DISABLED_DETAIL as TRENDS_DASHBOARD_DISABLED_DETAIL,
+    client as client,
+    facade_callable as facade_callable,
+    facade_value as facade_value,
+    logger as logger,
+    search_client as search_client,
+)
+from api.search.trends_support import (
+    _collect_meeting_docs as _collect_meeting_docs,
+    _count_topics_from_docs as _count_topics_from_docs,
+    _facet_topics as _facet_topics,
+    _iter_time_buckets as _iter_time_buckets,
+    _parse_iso_date as _parse_iso_date,
+    _require_trends_feature as _require_trends_feature,
+)
 
-import httpx
-import meilisearch
-from fastapi import HTTPException
-
-from api.app_setup import SEMANTIC_SERVICE_URL
-from api.search.query_builder import build_meili_filter_clauses, normalize_city_filter, normalize_filters
-from pipeline import config as pipeline_config
-from pipeline.lexicon import is_trend_noise_topic
-
-MEILI_HOST = os.getenv("MEILI_HOST", "http://meilisearch:7700")
-MEILI_MASTER_KEY = os.getenv("MEILI_MASTER_KEY", "masterKey")
-
-DOCUMENT_INDEX_NAME = "documents"
-TOPICS_FACET_NAME = "topics"
-
-SEARCH_ENGINE_TIMEOUT_DETAIL = "Search engine timed out"
-SEARCH_ENGINE_UNAVAILABLE_DETAIL = "Search engine unavailable"
-INTERNAL_SEARCH_ENGINE_ERROR_DETAIL = "Internal search engine error"
-SEMANTIC_DISABLED_DETAIL = "Semantic search is disabled. Set SEMANTIC_ENABLED=true and build artifacts."
-TRENDS_DASHBOARD_DISABLED_DETAIL = "Trends dashboard is disabled"
-INVALID_DATE_FORMAT_DETAIL = "Invalid date format. Use YYYY-MM-DD."
-SEMANTIC_SERVICE_ERROR_DETAIL = "Semantic service error"
-
-SEMANTIC_HEALTHCHECK_TIMEOUT_SECONDS = 5.0
-SEMANTIC_SEARCH_TIMEOUT_SECONDS = 60.0
-MEETING_DOC_SCAN_LIMIT = 2000
-MEETING_DOC_PAGE_SIZE = 200
-
-SEARCH_RESULT_ATTRIBUTES_TO_RETRIEVE = [
-    "id",
-    "title",
-    "event_name",
-    "city",
-    "date",
-    "filename",
-    "url",
-    "result_type",
-    "event_id",
-    "catalog_id",
-    "classification",
-    "result",
-    "summary",
-    "summary_extractive",
-    "entities",
-    "topics",
-    "related_ids",
-    "summary_is_stale",
-    "topics_is_stale",
-    "people_metadata",
+__all__ = [
+    "DOCUMENT_INDEX_NAME",
+    "FEATURE_TRENDS_DASHBOARD",
+    "INTERNAL_SEARCH_ENGINE_ERROR_DETAIL",
+    "INVALID_DATE_FORMAT_DETAIL",
+    "MEETING_DOC_PAGE_SIZE",
+    "MEETING_DOC_SCAN_LIMIT",
+    "MEILI_HOST",
+    "MEILI_MASTER_KEY",
+    "METADATA_FACETS",
+    "SEARCH_ENGINE_TIMEOUT_DETAIL",
+    "SEARCH_ENGINE_UNAVAILABLE_DETAIL",
+    "SEARCH_HIGHLIGHT_POST_TAG",
+    "SEARCH_HIGHLIGHT_PRE_TAG",
+    "SEARCH_RESULT_ATTRIBUTES_TO_CROP",
+    "SEARCH_RESULT_ATTRIBUTES_TO_HIGHLIGHT",
+    "SEARCH_RESULT_ATTRIBUTES_TO_RETRIEVE",
+    "SEARCH_RESULT_CROP_LENGTH",
+    "SEMANTIC_DISABLED_DETAIL",
+    "SEMANTIC_ENABLED",
+    "SEMANTIC_HEALTHCHECK_TIMEOUT_SECONDS",
+    "SEMANTIC_SEARCH_TIMEOUT_SECONDS",
+    "SEMANTIC_SERVICE_ERROR_DETAIL",
+    "TOPICS_CSV_HEADER",
+    "TOPICS_FACET_NAME",
+    "TRENDS_DASHBOARD_DISABLED_DETAIL",
+    "client",
+    "facade_callable",
+    "facade_value",
+    "httpx",
+    "logger",
+    "search_client",
+    "validate_date_format",
+    "_build_filter_values",
+    "_build_meilisearch_filter_clauses",
+    "_collect_meeting_docs",
+    "_count_topics_from_docs",
+    "_facet_topics",
+    "_iter_time_buckets",
+    "_normalize_city_or_400",
+    "_normalize_filters_or_400",
+    "_parse_iso_date",
+    "_require_trends_feature",
+    "_semantic_service_get_json",
+    "_semantic_service_healthcheck",
 ]
-SEARCH_RESULT_ATTRIBUTES_TO_CROP = ["content", "description"]
-SEARCH_RESULT_ATTRIBUTES_TO_HIGHLIGHT = ["content", "title", "description"]
-SEARCH_RESULT_CROP_LENGTH = 50
-SEARCH_HIGHLIGHT_PRE_TAG = '<em class="bg-yellow-200 not-italic font-semibold px-0.5 rounded">'
-SEARCH_HIGHLIGHT_POST_TAG = "</em>"
-METADATA_FACETS = ["city", "organization", "meeting_category"]
-TOPICS_CSV_HEADER = ["topic", "count", "city", "date_from", "date_to"]
-
-logger = logging.getLogger("town-council-api")
-
-# Search helpers read this through api.main at runtime so existing tests can patch
-# the facade without knowing about the extracted modules.
-client = meilisearch.Client(MEILI_HOST, MEILI_MASTER_KEY, timeout=5)
-
-
-def _api_main() -> Any:
-    from api import main as api_main
-
-    return api_main
-
-
-def facade_value(name: str, fallback: Any) -> Any:
-    return getattr(_api_main(), name, fallback)
-
-
-def facade_callable(name: str, fallback: Any) -> Any:
-    return getattr(_api_main(), name, fallback)
-
-
-def search_client() -> Any:
-    return facade_value("client", client)
-
-
-def validate_date_format(date_str: str) -> None:
-    """Ensures date is YYYY-MM-DD before forwarding it downstream."""
-    if not re.match(r"^\d{4}-\d{2}-\d{2}$", date_str):
-        raise HTTPException(status_code=400, detail=INVALID_DATE_FORMAT_DETAIL)
-
-
-def _normalize_filters_or_400(
-    city: Optional[str],
-    meeting_type: Optional[str],
-    org: Optional[str],
-    date_from: Optional[str],
-    date_to: Optional[str],
-    include_agenda_items: bool,
-) -> Any:
-    try:
-        return normalize_filters(
-            city=city,
-            meeting_type=meeting_type,
-            org=org,
-            date_from=date_from,
-            date_to=date_to,
-            include_agenda_items=include_agenda_items,
-        )
-    except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
-
-
-def _normalize_city_or_400(city: str) -> str:
-    try:
-        return normalize_city_filter(city)
-    except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
-
-
-def _build_filter_values(
-    city: Optional[str],
-    meeting_type: Optional[str],
-    org: Optional[str],
-    date_from: Optional[str],
-    date_to: Optional[str],
-    include_agenda_items: bool,
-) -> dict[str, Any]:
-    filters = _normalize_filters_or_400(
-        city=city,
-        meeting_type=meeting_type,
-        org=org,
-        date_from=date_from,
-        date_to=date_to,
-        include_agenda_items=include_agenda_items,
-    )
-    return {
-        "city": filters.city,
-        "meeting_type": filters.meeting_type,
-        "org": filters.org,
-        "date_from": filters.date_from,
-        "date_to": filters.date_to,
-        "include_agenda_items": filters.include_agenda_items,
-    }
-
-
-def _build_meilisearch_filter_clauses(
-    city: Optional[str],
-    meeting_type: Optional[str],
-    org: Optional[str],
-    date_from: Optional[str],
-    date_to: Optional[str],
-    include_agenda_items: bool,
-) -> list[str]:
-    # One shared QueryBuilder contract keeps /search and /trends in sync.
-    return build_meili_filter_clauses(
-        _normalize_filters_or_400(
-            city=city,
-            meeting_type=meeting_type,
-            org=org,
-            date_from=date_from,
-            date_to=date_to,
-            include_agenda_items=include_agenda_items,
-        )
-    )
-
-
-def _require_trends_feature() -> None:
-    if not facade_value("FEATURE_TRENDS_DASHBOARD", FEATURE_TRENDS_DASHBOARD):
-        raise HTTPException(status_code=503, detail=TRENDS_DASHBOARD_DISABLED_DETAIL)
-
-
-def _bucket_start(value: date, granularity: str) -> date:
-    if granularity == "quarter":
-        q_month = ((value.month - 1) // 3) * 3 + 1
-        return date(value.year, q_month, 1)
-    return date(value.year, value.month, 1)
-
-
-def _next_bucket_start(value: date, granularity: str) -> date:
-    if granularity == "quarter":
-        month = value.month + 3
-    else:
-        month = value.month + 1
-    year = value.year
-    while month > 12:
-        month -= 12
-        year += 1
-    return date(year, month, 1)
-
-
-def _iter_time_buckets(start: date, end: date, granularity: str) -> list[tuple[date, date]]:
-    cursor = _bucket_start(start, granularity)
-    buckets: list[tuple[date, date]] = []
-    while cursor <= end:
-        next_bucket = _next_bucket_start(cursor, granularity)
-        bucket_end = min(end, next_bucket - timedelta(days=1))
-        buckets.append((cursor, bucket_end))
-        cursor = next_bucket
-    return buckets
-
-
-def _facet_topics(city: Optional[str], date_from: Optional[str], date_to: Optional[str]) -> dict[str, int]:
-    index = search_client().index(DOCUMENT_INDEX_NAME)
-    filter_builder = facade_callable("_build_meilisearch_filter_clauses", _build_meilisearch_filter_clauses)
-    filters = filter_builder(
-        city=city,
-        meeting_type=None,
-        org=None,
-        date_from=date_from,
-        date_to=date_to,
-        include_agenda_items=False,
-    )
-    params: dict[str, Any] = {"limit": 0, "facets": [TOPICS_FACET_NAME]}
-    if filters:
-        params["filter"] = filters
-    result = index.search("", params)
-    return result.get("facetDistribution", {}).get(TOPICS_FACET_NAME, {}) or {}
-
-
-def _parse_iso_date(value: Optional[str]) -> Optional[date]:
-    if not value:
-        return None
-    try:
-        return datetime.strptime(value[:10], "%Y-%m-%d").date()
-    except (TypeError, ValueError):
-        return None
-
-
-def _collect_meeting_docs(city: Optional[str], scan_limit: int = MEETING_DOC_SCAN_LIMIT) -> list[dict[str, Any]]:
-    index = search_client().index(DOCUMENT_INDEX_NAME)
-    filter_builder = facade_callable("_build_meilisearch_filter_clauses", _build_meilisearch_filter_clauses)
-    filters = filter_builder(
-        city=city,
-        meeting_type=None,
-        org=None,
-        date_from=None,
-        date_to=None,
-        include_agenda_items=False,
-    )
-    meeting_docs: list[dict[str, Any]] = []
-    offset = 0
-    while offset < scan_limit:
-        params: dict[str, Any] = {
-            "limit": min(MEETING_DOC_PAGE_SIZE, scan_limit - offset),
-            "offset": offset,
-            "attributesToRetrieve": [TOPICS_FACET_NAME, "date", "city"],
-            "filter": filters,
-        }
-        if not filters:
-            del params["filter"]
-        page = index.search("", params)
-        hits = page.get("hits", []) or []
-        meeting_docs.extend(hits)
-        if len(hits) < MEETING_DOC_PAGE_SIZE:
-            break
-        offset += len(hits)
-    return meeting_docs
-
-
-def _count_topics_from_docs(
-    docs: list[dict[str, Any]],
-    date_from: Optional[str],
-    date_to: Optional[str],
-) -> dict[str, int]:
-    start = _parse_iso_date(date_from)
-    end = _parse_iso_date(date_to)
-    counts: dict[str, int] = {}
-    for row in docs:
-        row_date = _parse_iso_date(row.get("date"))
-        if start and (row_date is None or row_date < start):
-            continue
-        if end and (row_date is None or row_date > end):
-            continue
-        topics = row.get(TOPICS_FACET_NAME) or []
-        if isinstance(topics, list):
-            for topic in topics:
-                topic_name = str(topic).strip()
-                if not topic_name:
-                    continue
-                if is_trend_noise_topic(topic_name):
-                    continue
-                counts[topic_name] = counts.get(topic_name, 0) + 1
-    return counts
-
-
-def _semantic_service_healthcheck() -> dict[str, Any]:
-    try:
-        response = httpx.get(f"{SEMANTIC_SERVICE_URL}/health", timeout=SEMANTIC_HEALTHCHECK_TIMEOUT_SECONDS)
-        response.raise_for_status()
-        return response.json()
-    except (httpx.HTTPError, ValueError) as exc:
-        raise RuntimeError(f"Semantic service unavailable: {exc}") from exc
-
-
-def _semantic_service_get_json(path: str, params: dict[str, Any]) -> dict[str, Any]:
-    try:
-        response = httpx.get(f"{SEMANTIC_SERVICE_URL}{path}", params=params, timeout=SEMANTIC_SEARCH_TIMEOUT_SECONDS)
-    except httpx.RequestError as exc:
-        raise HTTPException(status_code=503, detail=f"Semantic service unavailable: {exc}") from exc
-
-    if response.status_code >= 400:
-        try:
-            payload = response.json()
-            detail = payload.get("detail", payload) if isinstance(payload, dict) else payload
-        except ValueError:
-            detail = response.text or SEMANTIC_SERVICE_ERROR_DETAIL
-        raise HTTPException(status_code=response.status_code, detail=detail)
-    return response.json()
-FEATURE_TRENDS_DASHBOARD = pipeline_config.FEATURE_TRENDS_DASHBOARD
-SEMANTIC_ENABLED = pipeline_config.SEMANTIC_ENABLED

--- a/api/task_dispatch.py
+++ b/api/task_dispatch.py
@@ -1,0 +1,61 @@
+import logging
+from typing import Any
+
+from fastapi import HTTPException
+from kombu.exceptions import KombuError
+
+from pipeline.celery_app import app as celery_app
+
+logger = logging.getLogger("town-council-api")
+
+TASK_QUEUE_UNAVAILABLE_DETAIL = "Task queue unavailable"
+INVALID_TASK_ID_DETAIL = "Invalid task_id format"
+GENERATE_SUMMARY_TASK_NAME = "pipeline.tasks.generate_summary_task"
+GENERATE_TOPICS_TASK_NAME = "pipeline.enrichment_tasks.generate_topics_task"
+SEGMENT_AGENDA_TASK_NAME = "pipeline.tasks.segment_agenda_task"
+EXTRACT_VOTES_TASK_NAME = "pipeline.tasks.extract_votes_task"
+EXTRACT_TEXT_TASK_NAME = "pipeline.tasks.extract_text_task"
+TASK_DISPATCH_ERRORS = (KombuError, OSError, ConnectionError, TimeoutError)
+
+
+class _CeleryTaskProxy:
+    """
+    Keep the API enqueue surface lightweight while preserving test patch points.
+    """
+
+    def __init__(self, task_name: str):
+        self.name = task_name
+
+    def delay(self, *args: Any, **kwargs: Any) -> Any:
+        return celery_app.send_task(self.name, args=args, kwargs=kwargs)
+
+
+generate_summary_task = _CeleryTaskProxy(GENERATE_SUMMARY_TASK_NAME)
+generate_topics_task = _CeleryTaskProxy(GENERATE_TOPICS_TASK_NAME)
+segment_agenda_task = _CeleryTaskProxy(SEGMENT_AGENDA_TASK_NAME)
+extract_votes_task = _CeleryTaskProxy(EXTRACT_VOTES_TASK_NAME)
+extract_text_task = _CeleryTaskProxy(EXTRACT_TEXT_TASK_NAME)
+
+
+def _enqueue_task(task_name: str, task_callable: Any, *task_args: Any, **task_kwargs: Any) -> str:
+    """
+    Normalize broker/enqueue failures at the API boundary.
+    """
+    try:
+        task = task_callable.delay(*task_args, **task_kwargs)
+    except TASK_DISPATCH_ERRORS as exc:
+        logger.error(
+            "Task enqueue failed",
+            extra={"task_name": task_name, "failure_class": exc.__class__.__name__},
+            exc_info=True,
+        )
+        raise HTTPException(status_code=503, detail=TASK_QUEUE_UNAVAILABLE_DETAIL) from exc
+
+    task_id = str(getattr(task, "id", "") or "").strip()
+    if not task_id:
+        logger.error(
+            "Task enqueue returned missing task id",
+            extra={"task_name": task_name, "failure_class": "missing_task_id"},
+        )
+        raise HTTPException(status_code=503, detail=TASK_QUEUE_UNAVAILABLE_DETAIL)
+    return task_id

--- a/api/task_route_support.py
+++ b/api/task_route_support.py
@@ -1,0 +1,36 @@
+import logging
+import uuid
+from typing import Any
+
+from fastapi import HTTPException
+
+from api.task_dispatch import INVALID_TASK_ID_DETAIL
+
+
+def get_task_status_payload(
+    task_facade: Any,
+    task_id: str,
+    *,
+    celery_app: Any,
+    logger: logging.Logger,
+) -> dict[str, Any]:
+    try:
+        uuid.UUID(task_id)
+    except (ValueError, TypeError):
+        logger.warning("Invalid task status request", extra={"task_id": task_id})
+        raise HTTPException(status_code=400, detail=INVALID_TASK_ID_DETAIL)
+
+    task = task_facade.AsyncResult(task_id, app=celery_app)
+    if not task.ready():
+        return {"status": "processing"}
+
+    task_payload = task.result
+    if isinstance(task_payload, Exception):
+        return {"status": "failed", "error": str(task_payload)}
+    if isinstance(task_payload, dict) and "error" in task_payload:
+        return {"status": "failed", "error": task_payload["error"]}
+
+    return {
+        "status": "complete",
+        "result": task_payload,
+    }

--- a/api/task_routes.py
+++ b/api/task_routes.py
@@ -1,10 +1,8 @@
 import logging
-import uuid
 from typing import Any, Callable
 
 from celery.result import AsyncResult as AsyncResult
 from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request
-from kombu.exceptions import KombuError
 from sqlalchemy.orm import Session as SQLAlchemySession
 
 from pipeline.celery_app import app as celery_app
@@ -17,71 +15,33 @@ from pipeline.summary_quality import (
     is_source_summarizable,
     is_source_topicable,
 )
+from api.task_dispatch import (  # noqa: F401
+    EXTRACT_TEXT_TASK_NAME,
+    EXTRACT_VOTES_TASK_NAME,
+    GENERATE_SUMMARY_TASK_NAME,
+    GENERATE_TOPICS_TASK_NAME,
+    INVALID_TASK_ID_DETAIL,
+    SEGMENT_AGENDA_TASK_NAME,
+    TASK_DISPATCH_ERRORS,
+    TASK_QUEUE_UNAVAILABLE_DETAIL,
+    _CeleryTaskProxy,
+    _enqueue_task,
+    extract_text_task,
+    extract_votes_task,
+    generate_summary_task,
+    generate_topics_task,
+    segment_agenda_task,
+)
+from api.task_route_support import get_task_status_payload
 
 logger = logging.getLogger("town-council-api")
 
-TASK_QUEUE_UNAVAILABLE_DETAIL = "Task queue unavailable"
-INVALID_TASK_ID_DETAIL = "Invalid task_id format"
-GENERATE_SUMMARY_TASK_NAME = "pipeline.tasks.generate_summary_task"
-GENERATE_TOPICS_TASK_NAME = "pipeline.enrichment_tasks.generate_topics_task"
-SEGMENT_AGENDA_TASK_NAME = "pipeline.tasks.segment_agenda_task"
-EXTRACT_VOTES_TASK_NAME = "pipeline.tasks.extract_votes_task"
-EXTRACT_TEXT_TASK_NAME = "pipeline.tasks.extract_text_task"
 SUMMARIZE_RATE_LIMIT = "20/minute"
 SEGMENT_RATE_LIMIT = "20/minute"
 VOTES_RATE_LIMIT = "20/minute"
 TOPICS_RATE_LIMIT = "10/minute"
 EXTRACT_RATE_LIMIT = "5/minute"
 EXTRACT_CACHED_CONTENT_MIN_CHARS = 800
-TASK_DISPATCH_ERRORS = (KombuError, OSError, ConnectionError, TimeoutError)
-
-
-class _CeleryTaskProxy:
-    """
-    Keep the API enqueue surface lightweight while preserving test patch points.
-    """
-
-    def __init__(self, task_name: str):
-        self.name = task_name
-
-    def delay(self, *args: Any, **kwargs: Any) -> Any:
-        return celery_app.send_task(self.name, args=args, kwargs=kwargs)
-
-
-generate_summary_task = _CeleryTaskProxy(GENERATE_SUMMARY_TASK_NAME)
-generate_topics_task = _CeleryTaskProxy(GENERATE_TOPICS_TASK_NAME)
-segment_agenda_task = _CeleryTaskProxy(SEGMENT_AGENDA_TASK_NAME)
-extract_votes_task = _CeleryTaskProxy(EXTRACT_VOTES_TASK_NAME)
-extract_text_task = _CeleryTaskProxy(EXTRACT_TEXT_TASK_NAME)
-
-
-def _enqueue_task(task_name: str, task_callable: Any, *task_args: Any, **task_kwargs: Any) -> str:
-    """
-    Normalize broker/enqueue failures at the API boundary.
-
-    Why this exists:
-    The API can be healthy enough to answer /health while the Celery broker is
-    degraded. In that case we want an explicit 503 instead of a generic 500 or
-    a response body without task_id.
-    """
-    try:
-        task = task_callable.delay(*task_args, **task_kwargs)
-    except TASK_DISPATCH_ERRORS as exc:
-        logger.error(
-            "Task enqueue failed",
-            extra={"task_name": task_name, "failure_class": exc.__class__.__name__},
-            exc_info=True,
-        )
-        raise HTTPException(status_code=503, detail=TASK_QUEUE_UNAVAILABLE_DETAIL) from exc
-
-    task_id = str(getattr(task, "id", "") or "").strip()
-    if not task_id:
-        logger.error(
-            "Task enqueue returned missing task id",
-            extra={"task_name": task_name, "failure_class": "missing_task_id"},
-        )
-        raise HTTPException(status_code=503, detail=TASK_QUEUE_UNAVAILABLE_DETAIL)
-    return task_id
 
 
 def build_task_router(
@@ -332,25 +292,6 @@ def build_task_router(
         """
         Check the status of a background AI task.
         """
-        try:
-            uuid.UUID(task_id)
-        except (ValueError, TypeError):
-            logger.warning("Invalid task status request", extra={"task_id": task_id})
-            raise HTTPException(status_code=400, detail=INVALID_TASK_ID_DETAIL)
-
-        task = task_facade.AsyncResult(task_id, app=celery_app)
-        if not task.ready():
-            return {"status": "processing"}
-
-        task_payload = task.result
-        if isinstance(task_payload, Exception):
-            return {"status": "failed", "error": str(task_payload)}
-        if isinstance(task_payload, dict) and "error" in task_payload:
-            return {"status": "failed", "error": task_payload["error"]}
-
-        return {
-            "status": "complete",
-            "result": task_payload,
-        }
+        return get_task_status_payload(task_facade, task_id, celery_app=celery_app, logger=logger)
 
     return router

--- a/docs/ADR.md
+++ b/docs/ADR.md
@@ -8,6 +8,25 @@ Use each entry to record:
 - the affected boundary or contract
 - links to the canonical docs that carry the ongoing operational or architecture detail
 
+## 2026-05-09: Split Wave 2 task, search, onboarding, and repair cleanup seams
+
+- Status: Accepted
+- Decision:
+  - `pipeline/tasks.py`, `api/task_routes.py`, and `pipeline/task_summary_generation.py` remain task/API facades while dispatch, route-status, task-helper, and summary-side-effect logic move behind focused support modules.
+  - `api/search_support.py` remains the compatibility surface while shared filter, trends, semantic, and client helper logic moves behind focused `api/search/*_support.py` modules.
+  - `scripts/evaluate_city_onboarding.py` remains the CLI facade while city metric collection and gate/report rendering move behind focused `pipeline/city_onboarding_*` modules.
+  - `scripts/repair_san_mateo_laserfiche_backlog.py` remains the CLI facade while Laserfiche parsing/contracts, PDF I/O, download/classification, and backlog mutation move behind focused `scripts/laserfiche_repair_*` modules.
+- Why:
+  - These files were the lowest-conflict cleanup targets left after the provider/person/reporting split.
+  - Existing task names, API routes, operator commands, JSON/stdout contracts, and patch seams must remain stable.
+- Affected boundaries:
+  - Celery retry/session ownership, API task dispatch, search response helpers, onboarding artifacts, Laserfiche repair mutation/reindex behavior, and operator exit codes stay unchanged.
+  - Guardrails track the new module families under the 300-line cleanup target.
+- Canonical references:
+  - [ARCHITECTURE.md](../ARCHITECTURE.md)
+  - [docs/PIPELINE.md](PIPELINE.md)
+  - [docs/ENGINEERING_GUARDRAILS.md](ENGINEERING_GUARDRAILS.md)
+
 ## 2026-05-09: Split parallel Wave 1 legacy cleanup seams behind stable entrypoints
 
 - Status: Accepted

--- a/docs/ENGINEERING_GUARDRAILS.md
+++ b/docs/ENGINEERING_GUARDRAILS.md
@@ -29,7 +29,7 @@ The first pass is intentionally moderate. It is meant to block lazy hygiene regr
 - no raw `print(...)` in non-CLI pipeline modules
 - no silent broad exception handlers or broad exception allowlist drift
 - existing Town Council policy tests for fail-fast runtime behavior, freshness contracts, and profile comparability
-- cleanup module families for indexing, semantic backends, summary text, provider/person utilities, reporting scripts, and prior facade splits stay under the 300-line target
+- cleanup module families for indexing, semantic backends, summary text, provider/person utilities, reporting scripts, task/API/search helpers, onboarding/repair scripts, and prior facade splits stay under the 300-line target
 
 ## How to request an exception
 

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -317,7 +317,8 @@ Most regressions come from partial stage additions (route without durable write 
 
 Use these files as primary references:
 - Batch orchestration: `pipeline/run_pipeline.py` facade plus `pipeline/run_pipeline_steps.py`, `pipeline/run_pipeline_onboarding.py`, `pipeline/run_pipeline_selectors.py`, `pipeline/run_pipeline_extraction.py`, and `pipeline/run_pipeline_parallel.py`
-- Async orchestration: `pipeline/tasks.py`
+- Async orchestration: `pipeline/tasks.py` facade plus focused `pipeline/task_*` helpers
+- API task dispatch: `api/task_routes.py` facade plus focused `api/task_*` helpers
 - API task entrypoints: `api/main.py`
 - Inference policy: `pipeline/llm.py`
 - Agenda extraction: `pipeline/agenda_extraction.py` facade plus `pipeline/agenda_extraction_*` implementation modules

--- a/pipeline/city_onboarding_gate.py
+++ b/pipeline/city_onboarding_gate.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Protocol
+
+from pipeline.city_onboarding_metrics import CityMetrics
+from pipeline.rollout_registry import RolloutEntry, load_rollout_entry
+
+
+class RolloutLoader(Protocol):
+    def __call__(self, city_slug: str) -> RolloutEntry: ...
+
+
+def safe_rate(numerator: int, denominator: int) -> float | None:
+    if denominator <= 0:
+        return None
+    return float(numerator) / float(denominator)
+
+
+def evaluate_city(
+    city: str,
+    metrics: CityMetrics,
+    *,
+    rollout_loader: RolloutLoader = load_rollout_entry,
+) -> dict[str, Any]:
+    rollout_entry = rollout_loader(city)
+    crawl_success_rate = safe_rate(metrics.crawl_success_count, metrics.run_count)
+    extraction_non_empty_rate = safe_rate(
+        metrics.run_window_extraction_non_empty_count,
+        metrics.run_window_catalog_total,
+    )
+    segmentation_complete_empty_rate = safe_rate(
+        metrics.run_window_segmentation_complete_empty_count,
+        metrics.run_window_agenda_catalog_total,
+    )
+    segmentation_failed_rate = safe_rate(
+        metrics.run_window_segmentation_failed_count,
+        metrics.run_window_agenda_catalog_total,
+    )
+
+    insufficient_data = (
+        metrics.run_count <= 0
+        or metrics.run_window_catalog_total <= 0
+        or metrics.run_window_agenda_catalog_total <= 0
+    )
+
+    stable_noop_confirmation = (
+        rollout_entry.stable_noop_eligible == "yes"
+        and rollout_entry.last_fresh_pass_run_id != ""
+        and metrics.run_count > 0
+        and metrics.stable_noop_run_count == metrics.run_count
+        and metrics.run_window_catalog_total == 0
+        and metrics.run_window_agenda_catalog_total == 0
+    )
+
+    gates = {
+        "crawl_success_rate_gte_95pct": bool(crawl_success_rate is not None and crawl_success_rate >= 0.95),
+        "non_empty_extraction_rate_gte_90pct": bool(
+            extraction_non_empty_rate is not None and extraction_non_empty_rate >= 0.90
+        ),
+        "segmentation_complete_empty_rate_gte_95pct": bool(
+            segmentation_complete_empty_rate is not None and segmentation_complete_empty_rate >= 0.95
+        ),
+        "segmentation_failed_rate_lt_5pct": bool(
+            segmentation_failed_rate is not None and segmentation_failed_rate < 0.05
+        ),
+        "searchability_smoke_pass": bool(metrics.search_success_count == metrics.run_count and metrics.run_count > 0),
+    }
+
+    failed_gates = [name for name, passed in gates.items() if not passed]
+    if stable_noop_confirmation:
+        failed_gates = []
+        quality_gate = "pass"
+        quality_gate_reason = f"stable_delta_noop:{rollout_entry.last_fresh_pass_run_id}"
+    else:
+        quality_gate = (
+            "pass" if (not insufficient_data and not failed_gates) else "insufficient_data" if insufficient_data else "fail"
+        )
+        quality_gate_reason = (
+            "fresh_evidence" if quality_gate == "pass" else "insufficient_data" if insufficient_data else "failed_gates"
+        )
+
+    return {
+        "city": city,
+        "run_count": metrics.run_count,
+        "crawl_success_count": metrics.crawl_success_count,
+        "search_success_count": metrics.search_success_count,
+        "catalog_total": metrics.catalog_total,
+        "agenda_catalog_total": metrics.agenda_catalog_total,
+        "extraction_non_empty_count": metrics.extraction_non_empty_count,
+        "segmentation_complete_empty_count": metrics.segmentation_complete_empty_count,
+        "segmentation_failed_count": metrics.segmentation_failed_count,
+        "run_window_catalog_total": metrics.run_window_catalog_total,
+        "run_window_agenda_catalog_total": metrics.run_window_agenda_catalog_total,
+        "run_window_extraction_non_empty_count": metrics.run_window_extraction_non_empty_count,
+        "run_window_segmentation_complete_empty_count": metrics.run_window_segmentation_complete_empty_count,
+        "run_window_segmentation_failed_count": metrics.run_window_segmentation_failed_count,
+        "crawl_success_rate": crawl_success_rate,
+        "extraction_non_empty_rate": extraction_non_empty_rate,
+        "segmentation_complete_empty_rate": segmentation_complete_empty_rate,
+        "segmentation_failed_rate": segmentation_failed_rate,
+        "gates": gates,
+        "failed_gates": failed_gates,
+        "quality_gate": quality_gate,
+        "quality_gate_reason": quality_gate_reason,
+        "stable_noop_run_count": metrics.stable_noop_run_count,
+    }
+
+
+def write_markdown(path: Path, run_id: str, results: list[dict[str, Any]]) -> None:
+    lines = [
+        "# City Onboarding Gate Evaluation",
+        "",
+        f"run_id: `{run_id}`",
+        "",
+        "| city | quality_gate | reason | run_window_catalog_total | historical_catalog_total | crawl_success_rate | extraction_non_empty_rate | segmentation_complete_empty_rate | segmentation_failed_rate | failed_gates |",
+        "|---|---|---|---:|---:|---:|---:|---:|---:|---|",
+    ]
+    for row in results:
+        lines.append(
+            "| {city} | {quality_gate} | {quality_gate_reason} | {run_window_catalog_total} | {catalog_total} | {crawl_success_rate} | {extraction_non_empty_rate} | {segmentation_complete_empty_rate} | {segmentation_failed_rate} | {failed_gates} |".format(
+                city=row["city"],
+                quality_gate=row["quality_gate"],
+                quality_gate_reason=row["quality_gate_reason"],
+                run_window_catalog_total=row["run_window_catalog_total"],
+                catalog_total=row["catalog_total"],
+                crawl_success_rate="-" if row["crawl_success_rate"] is None else f"{row['crawl_success_rate']:.3f}",
+                extraction_non_empty_rate=(
+                    "-" if row["extraction_non_empty_rate"] is None else f"{row['extraction_non_empty_rate']:.3f}"
+                ),
+                segmentation_complete_empty_rate=(
+                    "-"
+                    if row["segmentation_complete_empty_rate"] is None
+                    else f"{row['segmentation_complete_empty_rate']:.3f}"
+                ),
+                segmentation_failed_rate=(
+                    "-" if row["segmentation_failed_rate"] is None else f"{row['segmentation_failed_rate']:.3f}"
+                ),
+                failed_gates=", ".join(row["failed_gates"]) if row["failed_gates"] else "-",
+            )
+        )
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")

--- a/pipeline/city_onboarding_metrics.py
+++ b/pipeline/city_onboarding_metrics.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+import csv
+import json
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy import and_, or_, union_all
+
+from pipeline.models import Catalog, Document, Event, UrlStage, UrlStageHist
+
+
+ISO_FMT = "%Y-%m-%dT%H:%M:%SZ"
+logger = logging.getLogger("city_onboarding_eval")
+
+
+@dataclass
+class CityMetrics:
+    run_count: int
+    crawl_success_count: int
+    search_success_count: int
+    stable_noop_run_count: int
+    catalog_total: int
+    agenda_catalog_total: int
+    extraction_non_empty_count: int
+    segmentation_complete_empty_count: int
+    segmentation_failed_count: int
+    run_window_catalog_total: int
+    run_window_agenda_catalog_total: int
+    run_window_extraction_non_empty_count: int
+    run_window_segmentation_complete_empty_count: int
+    run_window_segmentation_failed_count: int
+
+
+def parse_iso_utc(value: str) -> datetime:
+    dt = datetime.strptime(value, ISO_FMT)
+    return dt.replace(tzinfo=timezone.utc)
+
+
+def load_city_metadata_slugs(path: Path = Path("city_metadata/list_of_cities.csv")) -> set[str]:
+    slugs: set[str] = set()
+    with path.open("r", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            division = (row.get("ocd_division_id") or "").strip()
+            if "/place:" not in division:
+                continue
+            slugs.add(division.split("/place:", 1)[1])
+    return slugs
+
+
+def source_aliases_for_city(city: str) -> set[str]:
+    aliases = {city}
+    legacy_aliases = {
+        "san_mateo": {"san mateo"},
+        "san_leandro": {"san leandro"},
+        "mtn_view": {"mountain view"},
+    }
+    aliases.update(legacy_aliases.get(city, set()))
+    return aliases
+
+
+def ocd_division_id_for_city(city: str) -> str:
+    return f"ocd-division/country:us/state:ca/place:{city}"
+
+
+def load_runs(path: Path) -> list[dict[str, Any]]:
+    runs: list[dict[str, Any]] = []
+    if not path.exists():
+        return runs
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        row = json.loads(line)
+        row["started_dt"] = parse_iso_utc(row["started_at_utc"])
+        row["finished_dt"] = parse_iso_utc(row["finished_at_utc"])
+        runs.append(row)
+    return runs
+
+
+def collect_historical_city_catalog_rows(
+    db_session, city: str, city_runs: list[dict[str, Any]]
+) -> list[tuple[int, str, str | None, str | None]]:
+    windows = [
+        (run["started_dt"].replace(tzinfo=None), run["finished_dt"].replace(tzinfo=None))
+        for run in city_runs
+    ]
+    if not windows:
+        return []
+
+    source_aliases = sorted(source_aliases_for_city(city))
+    window_filters = [
+        and_(Event.scraped_datetime >= start_dt, Event.scraped_datetime <= end_dt)
+        for start_dt, end_dt in windows
+    ]
+
+    event_ids = [
+        row[0]
+        for row in db_session.query(Event.id)
+        .filter(Event.source.in_(source_aliases))
+        .filter(or_(*window_filters))
+        .all()
+    ]
+
+    # Delta crawls can succeed without inserting new events in a run window.
+    # Fall back to existing city corpus so historical diagnostics remain useful.
+    if not event_ids:
+        event_ids = [row[0] for row in db_session.query(Event.id).filter(Event.source.in_(source_aliases)).all()]
+
+    if not event_ids:
+        return []
+
+    return (
+        db_session.query(Catalog.id, Document.category, Catalog.content, Catalog.agenda_segmentation_status)
+        .join(Document, Document.catalog_id == Catalog.id)
+        .filter(Document.event_id.in_(event_ids))
+        .all()
+    )
+
+
+def collect_run_window_catalog_rows(
+    db_session, city: str, city_runs: list[dict[str, Any]]
+) -> tuple[list[tuple[int, str, str | None, str | None]], int]:
+    ocd_division_id = ocd_division_id_for_city(city)
+
+    touched_queries = []
+    for run in city_runs:
+        started_dt = run["started_dt"].replace(tzinfo=None)
+        finished_dt = run["finished_dt"].replace(tzinfo=None)
+        touched_queries.append(
+            db_session.query(
+                UrlStageHist.url_hash.label("url_hash"),
+                UrlStageHist.category.label("category"),
+            ).filter(
+                UrlStageHist.ocd_division_id == ocd_division_id,
+                UrlStageHist.created_at >= started_dt,
+                UrlStageHist.created_at <= finished_dt,
+            )
+        )
+        touched_queries.append(
+            db_session.query(
+                UrlStage.url_hash.label("url_hash"),
+                UrlStage.category.label("category"),
+            ).filter(
+                UrlStage.ocd_division_id == ocd_division_id,
+                UrlStage.created_at >= started_dt,
+                UrlStage.created_at <= finished_dt,
+            )
+        )
+
+    if not touched_queries:
+        return [], 0
+
+    # Keep an explicit subquery shape so Postgres and SQLite expose the same columns.
+    touched_hashes = union_all(*(query.statement for query in touched_queries)).subquery("touched_hashes")
+    touched_hash_count = db_session.query(touched_hashes.c.url_hash).distinct().count()
+    catalog_rows = (
+        db_session.query(
+            Catalog.id,
+            touched_hashes.c.category,
+            Catalog.content,
+            Catalog.agenda_segmentation_status,
+        )
+        .join(Catalog, Catalog.url_hash == touched_hashes.c.url_hash)
+        .distinct()
+        .all()
+    )
+    logger.info(
+        "run_window_scope city=%s ocd_division_id=%s touched_hashes=%s resolved_catalogs=%s "
+        "source=url_stage_hist+url_stage",
+        city,
+        ocd_division_id,
+        touched_hash_count,
+        len(catalog_rows),
+    )
+    return catalog_rows, touched_hash_count
+
+
+def build_counts(catalog_rows: list[tuple[int, str, str | None, str | None]]) -> dict[str, int]:
+    return {
+        "catalog_total": len(catalog_rows),
+        "agenda_catalog_total": sum(1 for _id, category, _content, _status in catalog_rows if category == "agenda"),
+        "extraction_non_empty_count": sum(
+            1
+            for _id, _category, content, _status in catalog_rows
+            if content is not None and str(content).strip() != ""
+        ),
+        "segmentation_complete_empty_count": sum(
+            1
+            for _id, category, _content, status in catalog_rows
+            if category == "agenda" and status in {"complete", "empty"}
+        ),
+        "segmentation_failed_count": sum(
+            1 for _id, category, _content, status in catalog_rows if category == "agenda" and status == "failed"
+        ),
+    }
+
+
+def collect_city_metrics(db_session, city: str, city_runs: list[dict[str, Any]]) -> CityMetrics:
+    crawl_success_count = sum(
+        1 for run in city_runs if run.get("crawler_status") in {"success", "crawler_stable_noop"}
+    )
+    search_success_count = sum(1 for run in city_runs if run.get("search_status") == "success")
+    stable_noop_run_count = sum(1 for run in city_runs if run.get("crawler_status") == "crawler_stable_noop")
+
+    historical_counts = build_counts(collect_historical_city_catalog_rows(db_session, city, city_runs))
+    run_window_rows, touched_hash_count = collect_run_window_catalog_rows(db_session, city, city_runs)
+    run_window_counts = build_counts(run_window_rows)
+
+    logger.info(
+        "run_window_scope city=%s run_window_catalog_total=%s run_window_agenda_catalog_total=%s "
+        "historical_catalog_total=%s historical_agenda_catalog_total=%s touched_hashes=%s",
+        city,
+        run_window_counts["catalog_total"],
+        run_window_counts["agenda_catalog_total"],
+        historical_counts["catalog_total"],
+        historical_counts["agenda_catalog_total"],
+        touched_hash_count,
+    )
+
+    return CityMetrics(
+        run_count=len(city_runs),
+        crawl_success_count=crawl_success_count,
+        search_success_count=search_success_count,
+        stable_noop_run_count=stable_noop_run_count,
+        catalog_total=historical_counts["catalog_total"],
+        agenda_catalog_total=historical_counts["agenda_catalog_total"],
+        extraction_non_empty_count=historical_counts["extraction_non_empty_count"],
+        segmentation_complete_empty_count=historical_counts["segmentation_complete_empty_count"],
+        segmentation_failed_count=historical_counts["segmentation_failed_count"],
+        run_window_catalog_total=run_window_counts["catalog_total"],
+        run_window_agenda_catalog_total=run_window_counts["agenda_catalog_total"],
+        run_window_extraction_non_empty_count=run_window_counts["extraction_non_empty_count"],
+        run_window_segmentation_complete_empty_count=run_window_counts["segmentation_complete_empty_count"],
+        run_window_segmentation_failed_count=run_window_counts["segmentation_failed_count"],
+    )

--- a/pipeline/task_facade_helpers.py
+++ b/pipeline/task_facade_helpers.py
@@ -1,0 +1,213 @@
+from collections.abc import Mapping
+from typing import Any, Callable
+
+from pipeline.summary_backfill import (
+    _enqueue_embed_catalogs as _enqueue_embed_catalogs_impl,
+    _summary_doc_kind_map as _summary_doc_kind_map_impl,
+    _summary_doc_kind_subquery as _summary_doc_kind_subquery_impl,
+    run_summary_hydration_backfill as run_summary_hydration_backfill_impl,
+    select_catalog_ids_for_summary_hydration as select_catalog_ids_for_summary_hydration_impl,
+)
+from pipeline.task_agenda_segmentation import (
+    AgendaSegmentationTaskServices,
+    persist_agenda_segmentation_failure_status as persist_agenda_segmentation_failure_status_impl,
+    record_agenda_segmentation_status as record_agenda_segmentation_status_impl,
+    run_post_segmentation_vote_extraction as run_post_segmentation_vote_extraction_impl,
+    run_segment_agenda_task_family as run_segment_agenda_task_family_impl,
+)
+from pipeline.task_summary_generation import (
+    SummaryGenerationTaskServices,
+    run_generate_summary_task_family as run_generate_summary_task_family_impl,
+    run_summary_generation_side_effects as run_summary_generation_side_effects_impl,
+)
+from pipeline.task_text_extraction import run_extract_text_task_family as run_extract_text_task_family_impl
+from pipeline.task_vote_extraction import run_extract_votes_task_family as run_extract_votes_task_family_impl
+
+
+def _summary_doc_kind_subquery(db: Any) -> Any:
+    return _summary_doc_kind_subquery_impl(db)
+
+
+def select_catalog_ids_for_summary_hydration(db: Any, limit: int | None = None, city: str | None = None) -> list[int]:
+    return select_catalog_ids_for_summary_hydration_impl(db, limit=limit, city=city)
+
+
+def _summary_doc_kind_map(db: Any, catalog_ids: list[int]) -> dict[int, str]:
+    return _summary_doc_kind_map_impl(db, catalog_ids)
+
+
+def _enqueue_embed_catalogs(catalog_ids: list[int]) -> dict[str, object]:
+    return _enqueue_embed_catalogs_impl(catalog_ids)
+
+
+def run_summary_hydration_backfill(
+    facade: Mapping[str, Any],
+    *,
+    force: bool,
+    limit: int | None,
+    city: str | None,
+    summary_timeout_seconds: int | None,
+    summary_fallback_mode: str,
+    progress_callback: Callable[[dict[str, Any]], None] | None,
+    progress_every: int,
+) -> dict[str, int]:
+    return run_summary_hydration_backfill_impl(
+        force=force,
+        limit=limit,
+        city=city,
+        summary_timeout_seconds=summary_timeout_seconds,
+        summary_fallback_mode=summary_fallback_mode,
+        progress_callback=progress_callback,
+        progress_every=progress_every,
+        generate_summary_callable=lambda catalog_id: facade["generate_summary_task"].run(catalog_id, force=force),
+        session_factory=facade["SessionLocal"],
+        select_catalog_ids_callable=facade["select_catalog_ids_for_summary_hydration"],
+        summary_doc_kind_map_callable=facade["_summary_doc_kind_map"],
+        agenda_summary_batch_builder=facade["build_deterministic_agenda_summary_payloads"],
+        summarize_catalog_callable=facade["summarize_catalog_with_maintenance_mode"],
+    )
+
+
+def run_extract_text_task_family(
+    facade: Mapping[str, Any],
+    db: Any,
+    catalog_id: int,
+    *,
+    force: bool,
+    ocr_fallback: bool,
+) -> dict[str, Any]:
+    return run_extract_text_task_family_impl(
+        db,
+        catalog_id,
+        force=force,
+        ocr_fallback=ocr_fallback,
+        min_chars=facade["TIKA_MIN_EXTRACTED_CHARS_FOR_NO_OCR"],
+        reextract_catalog_content_callable=facade["reextract_catalog_content"],
+        reindex_catalog_callable=facade["reindex_catalog"],
+    )
+
+
+def run_extract_votes_task_family(
+    facade: Mapping[str, Any],
+    db: Any,
+    catalog_id: int,
+    *,
+    force: bool,
+    local_ai: Any,
+) -> dict[str, Any]:
+    return run_extract_votes_task_family_impl(
+        db,
+        catalog_id,
+        force=force,
+        local_ai=local_ai,
+        vote_extraction_enabled=facade["ENABLE_VOTE_EXTRACTION"],
+        run_vote_extraction_for_catalog_callable=facade["run_vote_extraction_for_catalog"],
+        reindex_catalog_callable=facade["reindex_catalog"],
+    )
+
+
+def agenda_segmentation_task_services(facade: Mapping[str, Any]) -> AgendaSegmentationTaskServices:
+    return AgendaSegmentationTaskServices(
+        classify_catalog_bad_content=facade["classify_catalog_bad_content"],
+        has_viable_structured_agenda_source=facade["has_viable_structured_agenda_source"],
+        resolve_agenda_items=facade["resolve_agenda_items"],
+        persist_agenda_items=facade["persist_agenda_items"],
+        run_vote_extraction_for_catalog=facade["run_vote_extraction_for_catalog"],
+        reindex_catalog=facade["reindex_catalog"],
+        vote_extraction_enabled=facade["ENABLE_VOTE_EXTRACTION"],
+    )
+
+
+def summary_generation_task_services(facade: Mapping[str, Any]) -> SummaryGenerationTaskServices:
+    return SummaryGenerationTaskServices(
+        local_ai_factory=facade["LocalAI"],
+        classify_catalog_bad_content=facade["classify_catalog_bad_content"],
+        compute_content_hash=facade["compute_content_hash"],
+        normalize_summary_doc_kind=facade["normalize_summary_doc_kind"],
+        analyze_source_text=facade["analyze_source_text"],
+        is_source_summarizable=facade["is_source_summarizable"],
+        build_low_signal_message=facade["build_low_signal_message"],
+        build_agenda_summary_input_bundle=facade["build_agenda_summary_input_bundle"],
+        is_summary_fresh=facade["is_summary_fresh"],
+        compute_summary_source_hash=facade["compute_summary_source_hash"],
+        postprocess_extracted_text=facade["postprocess_extracted_text"],
+        is_summary_grounded=facade["is_summary_grounded"],
+        persist_agenda_summary=facade["persist_agenda_summary"],
+        reindex_catalog=facade["reindex_catalog"],
+        embed_catalog=facade["embed_catalog_task"].delay,
+    )
+
+
+def run_summary_generation_side_effects(facade: Mapping[str, Any], catalog_id: int) -> dict[str, int]:
+    return run_summary_generation_side_effects_impl(
+        catalog_id,
+        services=summary_generation_task_services(facade),
+    )
+
+
+def record_agenda_segmentation_status(
+    catalog: Any,
+    *,
+    status: str,
+    item_count: int,
+    error_message: str | None,
+) -> None:
+    record_agenda_segmentation_status_impl(
+        catalog,
+        status=status,
+        item_count=item_count,
+        error_message=error_message,
+    )
+
+
+def run_post_segmentation_vote_extraction(
+    facade: Mapping[str, Any],
+    db: Any,
+    *,
+    local_ai: Any,
+    catalog: Any,
+    doc: Any,
+    created_items: list[Any],
+) -> dict[str, Any]:
+    return run_post_segmentation_vote_extraction_impl(
+        db,
+        local_ai=local_ai,
+        catalog=catalog,
+        doc=doc,
+        created_items=created_items,
+        services=agenda_segmentation_task_services(facade),
+    )
+
+
+def persist_agenda_segmentation_failure_status(db: Any, catalog_id: int, error_message: str) -> None:
+    persist_agenda_segmentation_failure_status_impl(db, catalog_id, error_message)
+
+
+def run_segment_agenda_task_family(
+    facade: Mapping[str, Any],
+    db: Any,
+    catalog_id: int,
+    *,
+    local_ai: Any,
+) -> dict[str, Any]:
+    return run_segment_agenda_task_family_impl(
+        db,
+        catalog_id,
+        local_ai=local_ai,
+        services=agenda_segmentation_task_services(facade),
+    )
+
+
+def run_generate_summary_task_family(
+    facade: Mapping[str, Any],
+    db: Any,
+    catalog_id: int,
+    *,
+    force: bool,
+) -> dict[str, Any]:
+    return run_generate_summary_task_family_impl(
+        db,
+        catalog_id,
+        force=force,
+        services=summary_generation_task_services(facade),
+    )

--- a/pipeline/task_summary_generation.py
+++ b/pipeline/task_summary_generation.py
@@ -2,11 +2,9 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
-from pipeline.agenda_summary_maintenance import AGENDA_SUMMARY_EMBED_DISPATCH_ERRORS
 from pipeline.llm import LocalAI
 from pipeline.models import AgendaItem, Catalog, Document
-from pipeline.task_runtime import logger
-from pipeline.task_side_effects import REINDEX_FAILURE_EXCEPTIONS
+from pipeline.task_summary_side_effects import run_summary_generation_side_effects
 
 
 AGENDA_DOC_KIND = "agenda"
@@ -36,41 +34,6 @@ class SummaryGenerationTaskServices:
     persist_agenda_summary: Callable[..., dict[str, Any]]
     reindex_catalog: Callable[[int], object]
     embed_catalog: Callable[[int], object]
-
-
-def run_summary_generation_side_effects(
-    catalog_id: int,
-    *,
-    services: SummaryGenerationTaskServices,
-) -> dict[str, int]:
-    """
-    Summary persistence is the source of truth; search and embedding side effects stay best-effort.
-    """
-    reindexed = 0
-    reindex_failed = 0
-    try:
-        services.reindex_catalog(catalog_id)
-        reindexed = 1
-    except REINDEX_FAILURE_EXCEPTIONS as reindex_error:
-        reindex_failed = 1
-        logger.warning("summary_generation.reindex_failed catalog_id=%s error=%s", catalog_id, reindex_error)
-
-    embed_enqueued = 0
-    embed_dispatch_failed = 0
-    try:
-        services.embed_catalog(catalog_id)
-        embed_enqueued = 1
-    except AGENDA_SUMMARY_EMBED_DISPATCH_ERRORS as dispatch_error:
-        logger.warning("embed_catalog_task.dispatch_failed catalog_id=%s error=%s", catalog_id, dispatch_error)
-        embed_dispatch_failed = 1
-
-    return {
-        "reindexed": reindexed,
-        "reindex_failed": reindex_failed,
-        "embed_enqueued": embed_enqueued,
-        "embed_dispatch_failed": embed_dispatch_failed,
-    }
-
 
 def _source_text_quality_payload(catalog: Catalog, services: SummaryGenerationTaskServices) -> dict[str, Any] | None:
     if not catalog.content:

--- a/pipeline/task_summary_side_effects.py
+++ b/pipeline/task_summary_side_effects.py
@@ -1,0 +1,45 @@
+from typing import Protocol
+
+from pipeline.agenda_summary_maintenance import AGENDA_SUMMARY_EMBED_DISPATCH_ERRORS
+from pipeline.task_runtime import logger
+from pipeline.task_side_effects import REINDEX_FAILURE_EXCEPTIONS
+
+
+class SummarySideEffectServices(Protocol):
+    def reindex_catalog(self, catalog_id: int) -> object: ...
+
+    def embed_catalog(self, catalog_id: int) -> object: ...
+
+
+def run_summary_generation_side_effects(
+    catalog_id: int,
+    *,
+    services: SummarySideEffectServices,
+) -> dict[str, int]:
+    """
+    Summary persistence is authoritative; search and embedding updates are best-effort.
+    """
+    reindexed = 0
+    reindex_failed = 0
+    try:
+        services.reindex_catalog(catalog_id)
+        reindexed = 1
+    except REINDEX_FAILURE_EXCEPTIONS as reindex_error:
+        reindex_failed = 1
+        logger.warning("summary_generation.reindex_failed catalog_id=%s error=%s", catalog_id, reindex_error)
+
+    embed_enqueued = 0
+    embed_dispatch_failed = 0
+    try:
+        services.embed_catalog(catalog_id)
+        embed_enqueued = 1
+    except AGENDA_SUMMARY_EMBED_DISPATCH_ERRORS as dispatch_error:
+        logger.warning("embed_catalog_task.dispatch_failed catalog_id=%s error=%s", catalog_id, dispatch_error)
+        embed_dispatch_failed = 1
+
+    return {
+        "reindexed": reindexed,
+        "reindex_failed": reindex_failed,
+        "embed_enqueued": embed_enqueued,
+        "embed_dispatch_failed": embed_dispatch_failed,
+    }

--- a/pipeline/tasks.py
+++ b/pipeline/tasks.py
@@ -1,78 +1,57 @@
-from celery.signals import worker_ready
-from sqlalchemy.exc import SQLAlchemyError
 from typing import Any, Callable
 
+from celery.signals import worker_ready
+from sqlalchemy.exc import SQLAlchemyError
+
+from pipeline import metrics as _worker_metrics  # noqa: F401
+from pipeline import task_facade_helpers
+from pipeline.agenda_service import persist_agenda_items
+from pipeline.agenda_resolver import has_viable_structured_agenda_source, resolve_agenda_items
 from pipeline.backlog_maintenance import (
     build_agenda_summary_input_bundle,
     build_deterministic_agenda_summary_payloads,
     persist_agenda_summary,
     summarize_catalog_with_maintenance_mode,
 )
-from pipeline.laserfiche_error_pages import classify_catalog_bad_content
-from pipeline.models import Catalog, Document
-from pipeline.llm import LocalAI, LocalAIConfigError
-from pipeline.agenda_service import persist_agenda_items
-from pipeline.agenda_resolver import has_viable_structured_agenda_source, resolve_agenda_items
-from pipeline.models import AgendaItem
+from pipeline.celery_app import app
 from pipeline.config import (
-    TIKA_MIN_EXTRACTED_CHARS_FOR_NO_OCR,
     LOCAL_AI_ALLOW_MULTIPROCESS,
-    LOCAL_AI_REQUIRE_SOLO_POOL,
     LOCAL_AI_BACKEND,
     ENABLE_VOTE_EXTRACTION,
+    LOCAL_AI_REQUIRE_SOLO_POOL,
+    TIKA_MIN_EXTRACTED_CHARS_FOR_NO_OCR,
 )
-from pipeline.extraction_service import reextract_catalog_content
-from pipeline.indexer import reindex_catalog
 from pipeline.content_hash import compute_content_hash
 from pipeline.document_kinds import normalize_summary_doc_kind
-from pipeline.summary_freshness import (
-    compute_summary_source_hash,
-    is_summary_fresh,
-)
-from pipeline.summary_quality import (
-    analyze_source_text,
-    build_low_signal_message,
-    is_source_summarizable,
-    is_summary_grounded,
-)
-from pipeline.text_cleaning import postprocess_extracted_text
+from pipeline.extraction_service import reextract_catalog_content
+from pipeline.indexer import reindex_catalog
+from pipeline.laserfiche_error_pages import classify_catalog_bad_content
 from pipeline.runtime_guardrails import local_ai_runtime_guardrail_message
-from pipeline.startup_purge import run_startup_purge_if_enabled
-from pipeline.summary_backfill import (
-    _summary_doc_kind_map as _summary_doc_kind_map_impl,
-    _summary_doc_kind_subquery as _summary_doc_kind_subquery_impl,
-    _enqueue_embed_catalogs as _enqueue_embed_catalogs_impl,
-    run_summary_hydration_backfill as run_summary_hydration_backfill_impl,
-    select_catalog_ids_for_summary_hydration as select_catalog_ids_for_summary_hydration_impl,
-)
+from pipeline.llm import LocalAI, LocalAIConfigError
 from pipeline.lineage_task_support import run_lineage_recompute
+from pipeline.models import Document
+from pipeline.semantic_tasks import embed_catalog_task
+from pipeline.startup_purge import run_startup_purge_if_enabled
+from pipeline.summary_freshness import compute_summary_source_hash, is_summary_fresh
+from pipeline.summary_quality import analyze_source_text, build_low_signal_message, is_source_summarizable, is_summary_grounded
 from pipeline.task_agenda_titles import _extract_agenda_titles_from_text as _extract_agenda_titles_from_text
-from pipeline.task_agenda_segmentation import (
-    AgendaSegmentationTaskServices,
-    persist_agenda_segmentation_failure_status as persist_agenda_segmentation_failure_status_impl,
-    record_agenda_segmentation_status as record_agenda_segmentation_status_impl,
-    run_post_segmentation_vote_extraction as run_post_segmentation_vote_extraction_impl,
-    run_segment_agenda_task_family as run_segment_agenda_task_family_impl,
-)
+from pipeline.task_runtime import logger, task_session
 from pipeline.task_startup import (
     get_celery_pool_from_argv as get_celery_pool_from_argv_impl,
     run_startup_purge_on_worker_ready as run_startup_purge_on_worker_ready_impl,
 )
-from pipeline.task_summary_generation import (
-    SummaryGenerationTaskServices,
-    run_generate_summary_task_family as run_generate_summary_task_family_impl,
-    run_summary_generation_side_effects as run_summary_generation_side_effects_impl,
-)
-from pipeline.task_text_extraction import run_extract_text_task_family as run_extract_text_task_family_impl
-from pipeline.task_runtime import logger, task_session
-from pipeline.task_vote_extraction import run_extract_votes_task_family as run_extract_votes_task_family_impl
+from pipeline.text_cleaning import postprocess_extracted_text
 from pipeline.vote_extractor import run_vote_extraction_for_catalog
-from pipeline.celery_app import app
-from pipeline.semantic_tasks import embed_catalog_task
 
-# Register worker metrics (safe in non-worker contexts; the HTTP server only starts
-# when TC_WORKER_METRICS_PORT is set and the Celery worker is ready).
-from pipeline import metrics as _worker_metrics  # noqa: F401
+_TASK_FACADE_DEPENDENCIES = (
+    build_agenda_summary_input_bundle, build_deterministic_agenda_summary_payloads, persist_agenda_summary,
+    summarize_catalog_with_maintenance_mode, classify_catalog_bad_content, persist_agenda_items,
+    has_viable_structured_agenda_source, resolve_agenda_items, TIKA_MIN_EXTRACTED_CHARS_FOR_NO_OCR,
+    ENABLE_VOTE_EXTRACTION, reextract_catalog_content, reindex_catalog, compute_content_hash,
+    normalize_summary_doc_kind, compute_summary_source_hash, is_summary_fresh, analyze_source_text,
+    build_low_signal_message, is_source_summarizable, is_summary_grounded, postprocess_extracted_text,
+    run_vote_extraction_for_catalog, embed_catalog_task, Document,
+)
 
 
 def SessionLocal():
@@ -80,19 +59,19 @@ def SessionLocal():
 
 
 def _summary_doc_kind_subquery(db):
-    return _summary_doc_kind_subquery_impl(db)
+    return task_facade_helpers._summary_doc_kind_subquery(db)
 
 
 def select_catalog_ids_for_summary_hydration(db, limit: int | None = None, city: str | None = None) -> list[int]:
-    return select_catalog_ids_for_summary_hydration_impl(db, limit=limit, city=city)
+    return task_facade_helpers.select_catalog_ids_for_summary_hydration(db, limit=limit, city=city)
 
 
 def _summary_doc_kind_map(db, catalog_ids: list[int]) -> dict[int, str]:
-    return _summary_doc_kind_map_impl(db, catalog_ids)
+    return task_facade_helpers._summary_doc_kind_map(db, catalog_ids)
 
 
 def _enqueue_embed_catalogs(catalog_ids: list[int]) -> dict[str, object]:
-    return _enqueue_embed_catalogs_impl(catalog_ids)
+    return task_facade_helpers._enqueue_embed_catalogs(catalog_ids)
 
 
 def run_summary_hydration_backfill(
@@ -105,7 +84,8 @@ def run_summary_hydration_backfill(
     progress_callback: Callable[[dict[str, Any]], None] | None = None,
     progress_every: int = 25,
 ) -> dict[str, int]:
-    return run_summary_hydration_backfill_impl(
+    return task_facade_helpers.run_summary_hydration_backfill(
+        globals(),
         force=force,
         limit=limit,
         city=city,
@@ -113,12 +93,6 @@ def run_summary_hydration_backfill(
         summary_fallback_mode=summary_fallback_mode,
         progress_callback=progress_callback,
         progress_every=progress_every,
-        generate_summary_callable=lambda catalog_id: generate_summary_task.run(catalog_id, force=force),
-        session_factory=SessionLocal,
-        select_catalog_ids_callable=select_catalog_ids_for_summary_hydration,
-        summary_doc_kind_map_callable=_summary_doc_kind_map,
-        agenda_summary_batch_builder=build_deterministic_agenda_summary_payloads,
-        summarize_catalog_callable=summarize_catalog_with_maintenance_mode,
     )
 
 
@@ -139,194 +113,60 @@ def _run_startup_purge_on_worker_ready(sender=None, **kwargs):
     )
 
 
-def _run_extract_text_task_family(
-    db,
-    catalog_id: int,
-    *,
-    force: bool,
-    ocr_fallback: bool,
-) -> dict[str, Any]:
-    """
-    Keep the historical pipeline.tasks patch seam around the extracted text helper.
-    """
-    return run_extract_text_task_family_impl(
-        db,
-        catalog_id,
-        force=force,
-        ocr_fallback=ocr_fallback,
-        min_chars=TIKA_MIN_EXTRACTED_CHARS_FOR_NO_OCR,
-        reextract_catalog_content_callable=reextract_catalog_content,
-        reindex_catalog_callable=reindex_catalog,
-    )
+def _run_extract_text_task_family(db, catalog_id: int, *, force: bool, ocr_fallback: bool) -> dict[str, Any]:
+    return task_facade_helpers.run_extract_text_task_family(globals(), db, catalog_id, force=force, ocr_fallback=ocr_fallback)
 
 
-def _run_extract_votes_task_family(
-    db,
-    catalog_id: int,
-    *,
-    force: bool,
-    local_ai: LocalAI,
-) -> dict[str, Any]:
-    """
-    Keep the historical pipeline.tasks patch seam around the extracted vote helper.
-    """
-    return run_extract_votes_task_family_impl(
-        db,
-        catalog_id,
-        force=force,
-        local_ai=local_ai,
-        vote_extraction_enabled=ENABLE_VOTE_EXTRACTION,
-        run_vote_extraction_for_catalog_callable=run_vote_extraction_for_catalog,
-        reindex_catalog_callable=reindex_catalog,
-    )
+def _run_extract_votes_task_family(db, catalog_id: int, *, force: bool, local_ai: LocalAI) -> dict[str, Any]:
+    return task_facade_helpers.run_extract_votes_task_family(globals(), db, catalog_id, force=force, local_ai=local_ai)
 
 
-def _agenda_segmentation_task_services() -> AgendaSegmentationTaskServices:
-    return AgendaSegmentationTaskServices(
-        classify_catalog_bad_content=classify_catalog_bad_content,
-        has_viable_structured_agenda_source=has_viable_structured_agenda_source,
-        resolve_agenda_items=resolve_agenda_items,
-        persist_agenda_items=persist_agenda_items,
-        run_vote_extraction_for_catalog=run_vote_extraction_for_catalog,
-        reindex_catalog=reindex_catalog,
-        vote_extraction_enabled=ENABLE_VOTE_EXTRACTION,
-    )
+def _agenda_segmentation_task_services():
+    return task_facade_helpers.agenda_segmentation_task_services(globals())
 
 
-def _summary_generation_task_services() -> SummaryGenerationTaskServices:
-    return SummaryGenerationTaskServices(
-        local_ai_factory=LocalAI,
-        classify_catalog_bad_content=classify_catalog_bad_content,
-        compute_content_hash=compute_content_hash,
-        normalize_summary_doc_kind=normalize_summary_doc_kind,
-        analyze_source_text=analyze_source_text,
-        is_source_summarizable=is_source_summarizable,
-        build_low_signal_message=build_low_signal_message,
-        build_agenda_summary_input_bundle=build_agenda_summary_input_bundle,
-        is_summary_fresh=is_summary_fresh,
-        compute_summary_source_hash=compute_summary_source_hash,
-        postprocess_extracted_text=postprocess_extracted_text,
-        is_summary_grounded=is_summary_grounded,
-        persist_agenda_summary=persist_agenda_summary,
-        reindex_catalog=reindex_catalog,
-        embed_catalog=embed_catalog_task.delay,
-    )
+def _summary_generation_task_services():
+    return task_facade_helpers.summary_generation_task_services(globals())
 
 
 def _run_summary_generation_side_effects(catalog_id: int) -> dict[str, int]:
-    """
-    Keep the historical pipeline.tasks patch seam around summary side effects.
-    """
-    return run_summary_generation_side_effects_impl(
-        catalog_id,
-        services=_summary_generation_task_services(),
+    return task_facade_helpers.run_summary_generation_side_effects(globals(), catalog_id)
+
+
+def _record_agenda_segmentation_status(catalog, *, status: str, item_count: int, error_message: str | None) -> None:
+    task_facade_helpers.record_agenda_segmentation_status(
+        catalog, status=status, item_count=item_count, error_message=error_message
     )
 
 
-def _record_agenda_segmentation_status(
-    catalog: Catalog,
-    *,
-    status: str,
-    item_count: int,
-    error_message: str | None,
-) -> None:
-    """
-    Keep the historical pipeline.tasks patch seam around segmentation status writes.
-    """
-    record_agenda_segmentation_status_impl(
-        catalog,
-        status=status,
-        item_count=item_count,
-        error_message=error_message,
+def _run_post_segmentation_vote_extraction(db, *, local_ai: LocalAI, catalog, doc, created_items: list[Any]) -> dict[str, Any]:
+    return task_facade_helpers.run_post_segmentation_vote_extraction(
+        globals(), db, local_ai=local_ai, catalog=catalog, doc=doc, created_items=created_items
     )
 
 
-def _run_post_segmentation_vote_extraction(
-    db,
-    *,
-    local_ai: LocalAI,
-    catalog: Catalog,
-    doc: Document,
-    created_items: list[AgendaItem],
-) -> dict[str, Any]:
-    """
-    Keep the historical pipeline.tasks patch seam around post-segmentation votes.
-    """
-    return run_post_segmentation_vote_extraction_impl(
-        db,
-        local_ai=local_ai,
-        catalog=catalog,
-        doc=doc,
-        created_items=created_items,
-        services=_agenda_segmentation_task_services(),
-    )
+def _persist_agenda_segmentation_failure_status(db, catalog_id: int, error_message: str) -> None:
+    task_facade_helpers.persist_agenda_segmentation_failure_status(db, catalog_id, error_message)
 
 
-def _persist_agenda_segmentation_failure_status(
-    db,
-    catalog_id: int,
-    error_message: str,
-) -> None:
-    """
-    Keep the historical pipeline.tasks patch seam around failure persistence.
-    """
-    persist_agenda_segmentation_failure_status_impl(db, catalog_id, error_message)
+def _run_segment_agenda_task_family(db, catalog_id: int, *, local_ai: LocalAI) -> dict[str, Any]:
+    return task_facade_helpers.run_segment_agenda_task_family(globals(), db, catalog_id, local_ai=local_ai)
 
 
-def _run_segment_agenda_task_family(
-    db,
-    catalog_id: int,
-    *,
-    local_ai: LocalAI,
-) -> dict[str, Any]:
-    """
-    Keep the historical pipeline.tasks patch seam around the extracted segmentation helper.
-    """
-    return run_segment_agenda_task_family_impl(
-        db,
-        catalog_id,
-        local_ai=local_ai,
-        services=_agenda_segmentation_task_services(),
-    )
-
-
-def _run_generate_summary_task_family(
-    db,
-    catalog_id: int,
-    *,
-    force: bool,
-) -> dict[str, Any]:
-    """
-    Keep the historical pipeline.tasks patch seam around the extracted summary helper.
-    """
-    return run_generate_summary_task_family_impl(
-        db,
-        catalog_id,
-        force=force,
-        services=_summary_generation_task_services(),
-    )
+def _run_generate_summary_task_family(db, catalog_id: int, *, force: bool) -> dict[str, Any]:
+    return task_facade_helpers.run_generate_summary_task_family(globals(), db, catalog_id, force=force)
 
 
 @app.task(bind=True, max_retries=3)
 def generate_summary_task(self, catalog_id: int, force: bool = False):
-    """
-    Background task: generate and store a catalog summary.
-    """
     db = SessionLocal()
-    
     try:
         logger.info(f"Starting summarization for Catalog ID {catalog_id}")
-        result = _run_generate_summary_task_family(
-            db,
-            catalog_id,
-            force=force,
-        )
+        result = _run_generate_summary_task_family(db, catalog_id, force=force)
         if result.get("status") == "complete":
             logger.info(f"Summarization complete for Catalog ID {catalog_id}")
         return result
-
     except LocalAIConfigError as e:
-        # Configuration errors are not transient; do not retry.
         logger.critical(f"LocalAI misconfiguration: {e}")
         db.rollback()
         return {"status": "error", "error": str(e)}
@@ -340,20 +180,11 @@ def generate_summary_task(self, catalog_id: int, force: bool = False):
 
 @app.task(bind=True, max_retries=3)
 def segment_agenda_task(self, catalog_id: int):
-    """
-    Background task: segment catalog text into agenda items.
-    """
     db = SessionLocal()
-    
     try:
         logger.info(f"Starting segmentation for Catalog ID {catalog_id}")
         local_ai = LocalAI()
-        return _run_segment_agenda_task_family(
-            db,
-            catalog_id,
-            local_ai=local_ai,
-        )
-
+        return _run_segment_agenda_task_family(db, catalog_id, local_ai=local_ai)
     except LocalAIConfigError as e:
         logger.critical(f"LocalAI misconfiguration: {e}")
         db.rollback()
@@ -365,7 +196,6 @@ def segment_agenda_task(self, catalog_id: int):
     except (SQLAlchemyError, RuntimeError, KeyError, ValueError) as e:
         logger.error(f"Task failed: {e}")
         db.rollback()
-        # Best-effort: persist failure status so batch workers don't spin forever.
         try:
             _persist_agenda_segmentation_failure_status(db, catalog_id, str(e))
         except Exception:
@@ -377,19 +207,10 @@ def segment_agenda_task(self, catalog_id: int):
 
 @app.task(bind=True, max_retries=3)
 def extract_votes_task(self, catalog_id: int, force: bool = False):
-    """
-    Background task: extract agenda-item outcomes/vote tallies from catalog text.
-    """
     db = SessionLocal()
     local_ai = LocalAI()
-
     try:
-        return _run_extract_votes_task_family(
-            db,
-            catalog_id,
-            force=force,
-            local_ai=local_ai,
-        )
+        return _run_extract_votes_task_family(db, catalog_id, force=force, local_ai=local_ai)
     except LocalAIConfigError as e:
         logger.critical(f"LocalAI misconfiguration: {e}")
         db.rollback()
@@ -404,22 +225,9 @@ def extract_votes_task(self, catalog_id: int, force: bool = False):
 
 @app.task(bind=True, max_retries=3)
 def extract_text_task(self, catalog_id: int, force: bool = False, ocr_fallback: bool = False):
-    """
-    Background task: re-extract a catalog's text from the already-downloaded file.
-
-    This is intentionally "no download" and single-catalog scoped:
-    - It only reads Catalog.location on disk.
-    - It updates Catalog.content in the DB.
-    - It reindexes just this catalog into Meilisearch.
-    """
     db = SessionLocal()
     try:
-        return _run_extract_text_task_family(
-            db,
-            catalog_id,
-            force=force,
-            ocr_fallback=ocr_fallback,
-        )
+        return _run_extract_text_task_family(db, catalog_id, force=force, ocr_fallback=ocr_fallback)
     except (SQLAlchemyError, RuntimeError, ValueError) as e:
         db.rollback()
         raise self.retry(exc=e, countdown=60)
@@ -429,9 +237,6 @@ def extract_text_task(self, catalog_id: int, force: bool = False, ocr_fallback: 
 
 @app.task(bind=True, max_retries=3)
 def compute_lineage_task(self):
-    """
-    Recompute meeting-level lineage assignments from related_ids.
-    """
     db = SessionLocal()
     try:
         return run_lineage_recompute(db)
@@ -445,8 +250,5 @@ def compute_lineage_task(self):
 
 @app.task(bind=True, max_retries=1)
 def compute_lineage_for_catalog_task(self, catalog_id: int):
-    """
-    Catalog-triggered lineage update wrapper.
-    """
     _ = catalog_id
     return compute_lineage_task.run(self)

--- a/scripts/evaluate_city_onboarding.py
+++ b/scripts/evaluate_city_onboarding.py
@@ -2,393 +2,77 @@
 from __future__ import annotations
 
 import argparse
-import csv
 import json
 import logging
 from collections import defaultdict
-from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from sqlalchemy import and_, or_, union_all
 from sqlalchemy.orm import sessionmaker
 
+from pipeline.city_onboarding_gate import evaluate_city, safe_rate, write_markdown
+from pipeline.city_onboarding_metrics import (
+    CityMetrics,
+    ISO_FMT,
+    build_counts,
+    collect_city_metrics,
+    collect_historical_city_catalog_rows,
+    collect_run_window_catalog_rows,
+    load_city_metadata_slugs,
+    load_runs,
+    ocd_division_id_for_city,
+    parse_iso_utc,
+    source_aliases_for_city,
+)
 from pipeline.models import Catalog, Document, Event, UrlStage, UrlStageHist, db_connect
 from pipeline.rollout_registry import load_rollout_entry
 
 
-ISO_FMT = "%Y-%m-%dT%H:%M:%SZ"
 logger = logging.getLogger("city_onboarding_eval")
 
 
-@dataclass
-class CityMetrics:
-    run_count: int
-    crawl_success_count: int
-    search_success_count: int
-    stable_noop_run_count: int
-    catalog_total: int
-    agenda_catalog_total: int
-    extraction_non_empty_count: int
-    segmentation_complete_empty_count: int
-    segmentation_failed_count: int
-    run_window_catalog_total: int
-    run_window_agenda_catalog_total: int
-    run_window_extraction_non_empty_count: int
-    run_window_segmentation_complete_empty_count: int
-    run_window_segmentation_failed_count: int
-
-
-def _parse_iso_utc(value: str) -> datetime:
-    dt = datetime.strptime(value, ISO_FMT)
-    return dt.replace(tzinfo=timezone.utc)
-
-
-def _safe_rate(numerator: int, denominator: int) -> float | None:
-    if denominator <= 0:
-        return None
-    return float(numerator) / float(denominator)
-
-
-def _load_city_metadata_slugs() -> set[str]:
-    path = Path("city_metadata/list_of_cities.csv")
-    slugs: set[str] = set()
-    with path.open("r", encoding="utf-8") as f:
-        reader = csv.DictReader(f)
-        for row in reader:
-            division = (row.get("ocd_division_id") or "").strip()
-            if "/place:" not in division:
-                continue
-            slugs.add(division.split("/place:", 1)[1])
-    return slugs
-
-
-def _source_aliases_for_city(city: str) -> set[str]:
-    aliases = {city}
-    legacy_aliases = {
-        "san_mateo": {"san mateo"},
-        "san_leandro": {"san leandro"},
-        "mtn_view": {"mountain view"},
-    }
-    aliases.update(legacy_aliases.get(city, set()))
-    return aliases
-
-
-def _ocd_division_id_for_city(city: str) -> str:
-    return f"ocd-division/country:us/state:ca/place:{city}"
-
-
-def _load_runs(path: Path) -> list[dict[str, Any]]:
-    runs: list[dict[str, Any]] = []
-    if not path.exists():
-        return runs
-    for raw_line in path.read_text(encoding="utf-8").splitlines():
-        line = raw_line.strip()
-        if not line:
-            continue
-        row = json.loads(line)
-        row["started_dt"] = _parse_iso_utc(row["started_at_utc"])
-        row["finished_dt"] = _parse_iso_utc(row["finished_at_utc"])
-        runs.append(row)
-    return runs
-
-
-def _collect_historical_city_catalog_rows(
-    db_session, city: str, city_runs: list[dict[str, Any]]
-) -> list[tuple[int, str, str | None, str | None]]:
-    windows = []
-    for run in city_runs:
-        windows.append((run["started_dt"].replace(tzinfo=None), run["finished_dt"].replace(tzinfo=None)))
-    source_aliases = sorted(_source_aliases_for_city(city))
-    if not windows:
-        return []
-
-    window_filters = [
-        and_(Event.scraped_datetime >= start_dt, Event.scraped_datetime <= end_dt)
-        for start_dt, end_dt in windows
-    ]
-
-    event_ids = [
-        row[0]
-        for row in db_session.query(Event.id)
-        .filter(Event.source.in_(source_aliases))
-        .filter(or_(*window_filters))
-        .all()
-    ]
-
-    # Delta crawls can succeed without inserting new events in a given run window.
-    # Fall back to existing city corpus so extraction/segmentation gates remain evaluable.
-    if not event_ids:
-        event_ids = [
-            row[0]
-            for row in db_session.query(Event.id)
-            .filter(Event.source.in_(source_aliases))
-            .all()
-        ]
-
-    if not event_ids:
-        return []
-
-    return (
-        db_session.query(Catalog.id, Document.category, Catalog.content, Catalog.agenda_segmentation_status)
-        .join(Document, Document.catalog_id == Catalog.id)
-        .filter(Document.event_id.in_(event_ids))
-        .all()
-    )
-
-
-def _collect_run_window_catalog_rows(
-    db_session, city: str, city_runs: list[dict[str, Any]]
-) -> tuple[list[tuple[int, str, str | None, str | None]], int]:
-    ocd_division_id = _ocd_division_id_for_city(city)
-
-    touched_queries = []
-    for run in city_runs:
-        started_dt = run["started_dt"].replace(tzinfo=None)
-        finished_dt = run["finished_dt"].replace(tzinfo=None)
-        touched_queries.append(
-            db_session.query(
-                UrlStageHist.url_hash.label("url_hash"),
-                UrlStageHist.category.label("category"),
-            ).filter(
-                UrlStageHist.ocd_division_id == ocd_division_id,
-                UrlStageHist.created_at >= started_dt,
-                UrlStageHist.created_at <= finished_dt,
-            )
-        )
-        touched_queries.append(
-            db_session.query(
-                UrlStage.url_hash.label("url_hash"),
-                UrlStage.category.label("category"),
-            ).filter(
-                UrlStage.ocd_division_id == ocd_division_id,
-                UrlStage.created_at >= started_dt,
-                UrlStage.created_at <= finished_dt,
-            )
-        )
-
-    if not touched_queries:
-        return [], 0
-
-    # Build the touched-hash scope with an explicit subquery shape so Postgres
-    # and SQLite expose the same column names during live evaluation.
-    touched_hashes = union_all(*(query.statement for query in touched_queries)).subquery("touched_hashes")
-    touched_hash_count = db_session.query(touched_hashes.c.url_hash).distinct().count()
-    catalog_rows = (
-        db_session.query(
-            Catalog.id,
-            touched_hashes.c.category,
-            Catalog.content,
-            Catalog.agenda_segmentation_status,
-        )
-        .join(Catalog, Catalog.url_hash == touched_hashes.c.url_hash)
-        .distinct()
-        .all()
-    )
-    logger.info(
-        "run_window_scope city=%s ocd_division_id=%s touched_hashes=%s resolved_catalogs=%s source=url_stage_hist+url_stage",
-        city,
-        ocd_division_id,
-        touched_hash_count,
-        len(catalog_rows),
-    )
-    return catalog_rows, touched_hash_count
-
-
-def _build_counts(catalog_rows: list[tuple[int, str, str | None, str | None]]) -> dict[str, int]:
-    return {
-        "catalog_total": len(catalog_rows),
-        "agenda_catalog_total": sum(1 for _id, category, _content, _status in catalog_rows if category == "agenda"),
-        "extraction_non_empty_count": sum(
-            1
-            for _id, _category, content, _status in catalog_rows
-            if content is not None and str(content).strip() != ""
-        ),
-        "segmentation_complete_empty_count": sum(
-            1
-            for _id, category, _content, status in catalog_rows
-            if category == "agenda" and status in {"complete", "empty"}
-        ),
-        "segmentation_failed_count": sum(
-            1 for _id, category, _content, status in catalog_rows if category == "agenda" and status == "failed"
-        ),
-    }
-
-
-def _collect_city_metrics(db_session, city: str, city_runs: list[dict[str, Any]]) -> CityMetrics:
-    crawl_success_count = sum(
-        1 for run in city_runs if run.get("crawler_status") in {"success", "crawler_stable_noop"}
-    )
-    search_success_count = sum(1 for run in city_runs if run.get("search_status") == "success")
-    stable_noop_run_count = sum(1 for run in city_runs if run.get("crawler_status") == "crawler_stable_noop")
-
-    historical_counts = _build_counts(_collect_historical_city_catalog_rows(db_session, city, city_runs))
-    run_window_rows, touched_hash_count = _collect_run_window_catalog_rows(db_session, city, city_runs)
-    run_window_counts = _build_counts(run_window_rows)
-
-    logger.info(
-        "run_window_scope city=%s run_window_catalog_total=%s run_window_agenda_catalog_total=%s "
-        "historical_catalog_total=%s historical_agenda_catalog_total=%s touched_hashes=%s",
-        city,
-        run_window_counts["catalog_total"],
-        run_window_counts["agenda_catalog_total"],
-        historical_counts["catalog_total"],
-        historical_counts["agenda_catalog_total"],
-        touched_hash_count,
-    )
-
-    return CityMetrics(
-        run_count=len(city_runs),
-        crawl_success_count=crawl_success_count,
-        search_success_count=search_success_count,
-        stable_noop_run_count=stable_noop_run_count,
-        catalog_total=historical_counts["catalog_total"],
-        agenda_catalog_total=historical_counts["agenda_catalog_total"],
-        extraction_non_empty_count=historical_counts["extraction_non_empty_count"],
-        segmentation_complete_empty_count=historical_counts["segmentation_complete_empty_count"],
-        segmentation_failed_count=historical_counts["segmentation_failed_count"],
-        run_window_catalog_total=run_window_counts["catalog_total"],
-        run_window_agenda_catalog_total=run_window_counts["agenda_catalog_total"],
-        run_window_extraction_non_empty_count=run_window_counts["extraction_non_empty_count"],
-        run_window_segmentation_complete_empty_count=run_window_counts["segmentation_complete_empty_count"],
-        run_window_segmentation_failed_count=run_window_counts["segmentation_failed_count"],
-    )
+_parse_iso_utc = parse_iso_utc
+_safe_rate = safe_rate
+_ocd_division_id_for_city = ocd_division_id_for_city
+_build_counts = build_counts
+_load_city_metadata_slugs = load_city_metadata_slugs
+_source_aliases_for_city = source_aliases_for_city
+_load_runs = load_runs
+_collect_historical_city_catalog_rows = collect_historical_city_catalog_rows
+_collect_run_window_catalog_rows = collect_run_window_catalog_rows
+_collect_city_metrics = collect_city_metrics
+_write_markdown = write_markdown
 
 
 def _evaluate_city(city: str, metrics: CityMetrics) -> dict[str, Any]:
-    rollout_entry = load_rollout_entry(city)
-    crawl_success_rate = _safe_rate(metrics.crawl_success_count, metrics.run_count)
-    extraction_non_empty_rate = _safe_rate(
-        metrics.run_window_extraction_non_empty_count,
-        metrics.run_window_catalog_total,
-    )
-    segmentation_complete_empty_rate = _safe_rate(
-        metrics.run_window_segmentation_complete_empty_count,
-        metrics.run_window_agenda_catalog_total,
-    )
-    segmentation_failed_rate = _safe_rate(
-        metrics.run_window_segmentation_failed_count,
-        metrics.run_window_agenda_catalog_total,
-    )
-
-    insufficient_data = (
-        metrics.run_count <= 0
-        or metrics.run_window_catalog_total <= 0
-        or metrics.run_window_agenda_catalog_total <= 0
-    )
-
-    stable_noop_confirmation = (
-        rollout_entry.stable_noop_eligible == "yes"
-        and rollout_entry.last_fresh_pass_run_id != ""
-        and metrics.run_count > 0
-        and metrics.stable_noop_run_count == metrics.run_count
-        and metrics.run_window_catalog_total == 0
-        and metrics.run_window_agenda_catalog_total == 0
-    )
-
-    gates = {
-        "crawl_success_rate_gte_95pct": bool(crawl_success_rate is not None and crawl_success_rate >= 0.95),
-        "non_empty_extraction_rate_gte_90pct": bool(
-            extraction_non_empty_rate is not None and extraction_non_empty_rate >= 0.90
-        ),
-        "segmentation_complete_empty_rate_gte_95pct": bool(
-            segmentation_complete_empty_rate is not None and segmentation_complete_empty_rate >= 0.95
-        ),
-        "segmentation_failed_rate_lt_5pct": bool(
-            segmentation_failed_rate is not None and segmentation_failed_rate < 0.05
-        ),
-        "searchability_smoke_pass": bool(metrics.search_success_count == metrics.run_count and metrics.run_count > 0),
-    }
-
-    failed_gates = [name for name, passed in gates.items() if not passed]
-    if stable_noop_confirmation:
-        failed_gates = []
-        quality_gate = "pass"
-        quality_gate_reason = f"stable_delta_noop:{rollout_entry.last_fresh_pass_run_id}"
-    else:
-        quality_gate = "pass" if (not insufficient_data and not failed_gates) else ("insufficient_data" if insufficient_data else "fail")
-        quality_gate_reason = "fresh_evidence" if quality_gate == "pass" else ("insufficient_data" if insufficient_data else "failed_gates")
-
-    return {
-        "city": city,
-        "run_count": metrics.run_count,
-        "crawl_success_count": metrics.crawl_success_count,
-        "search_success_count": metrics.search_success_count,
-        "catalog_total": metrics.catalog_total,
-        "agenda_catalog_total": metrics.agenda_catalog_total,
-        "extraction_non_empty_count": metrics.extraction_non_empty_count,
-        "segmentation_complete_empty_count": metrics.segmentation_complete_empty_count,
-        "segmentation_failed_count": metrics.segmentation_failed_count,
-        "run_window_catalog_total": metrics.run_window_catalog_total,
-        "run_window_agenda_catalog_total": metrics.run_window_agenda_catalog_total,
-        "run_window_extraction_non_empty_count": metrics.run_window_extraction_non_empty_count,
-        "run_window_segmentation_complete_empty_count": metrics.run_window_segmentation_complete_empty_count,
-        "run_window_segmentation_failed_count": metrics.run_window_segmentation_failed_count,
-        "crawl_success_rate": crawl_success_rate,
-        "extraction_non_empty_rate": extraction_non_empty_rate,
-        "segmentation_complete_empty_rate": segmentation_complete_empty_rate,
-        "segmentation_failed_rate": segmentation_failed_rate,
-        "gates": gates,
-        "failed_gates": failed_gates,
-        "quality_gate": quality_gate,
-        "quality_gate_reason": quality_gate_reason,
-        "stable_noop_run_count": metrics.stable_noop_run_count,
-    }
+    return evaluate_city(city, metrics, rollout_loader=load_rollout_entry)
 
 
-def _write_markdown(path: Path, run_id: str, results: list[dict[str, Any]]) -> None:
-    lines = [
-        "# City Onboarding Gate Evaluation",
-        "",
-        f"run_id: `{run_id}`",
-        "",
-        "| city | quality_gate | reason | run_window_catalog_total | historical_catalog_total | crawl_success_rate | extraction_non_empty_rate | segmentation_complete_empty_rate | segmentation_failed_rate | failed_gates |",
-        "|---|---|---|---:|---:|---:|---:|---:|---:|---|",
-    ]
-    for row in results:
-        lines.append(
-            "| {city} | {quality_gate} | {quality_gate_reason} | {run_window_catalog_total} | {catalog_total} | {crawl_success_rate} | {extraction_non_empty_rate} | {segmentation_complete_empty_rate} | {segmentation_failed_rate} | {failed_gates} |".format(
-                city=row["city"],
-                quality_gate=row["quality_gate"],
-                quality_gate_reason=row["quality_gate_reason"],
-                run_window_catalog_total=row["run_window_catalog_total"],
-                catalog_total=row["catalog_total"],
-                crawl_success_rate="-" if row["crawl_success_rate"] is None else f"{row['crawl_success_rate']:.3f}",
-                extraction_non_empty_rate="-" if row["extraction_non_empty_rate"] is None else f"{row['extraction_non_empty_rate']:.3f}",
-                segmentation_complete_empty_rate="-" if row["segmentation_complete_empty_rate"] is None else f"{row['segmentation_complete_empty_rate']:.3f}",
-                segmentation_failed_rate="-" if row["segmentation_failed_rate"] is None else f"{row['segmentation_failed_rate']:.3f}",
-                failed_gates=", ".join(row["failed_gates"]) if row["failed_gates"] else "-",
-            )
-        )
-    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
-
-
-def main() -> int:
-    logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(name)s:%(message)s")
+def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Evaluate city onboarding quality gates")
     parser.add_argument("--run-id", required=True)
     parser.add_argument("--cities", default="")
     parser.add_argument("--output-dir", default="experiments/results/city_onboarding")
-    args = parser.parse_args()
+    return parser.parse_args()
 
-    run_dir = Path(args.output_dir) / args.run_id
-    runs_path = run_dir / "runs.jsonl"
 
-    rows = _load_runs(runs_path)
-    if not rows:
-        raise SystemExit(f"No run rows found: {runs_path}")
-
+def _select_cities(rows: list[dict[str, Any]], requested_csv: str) -> list[str]:
     valid_city_slugs = _load_city_metadata_slugs()
-    requested = [c.strip() for c in args.cities.split(",") if c.strip()]
-    if requested:
-        unknown = [c for c in requested if c not in valid_city_slugs]
-        if unknown:
-            raise SystemExit(f"Unknown city slug(s): {', '.join(unknown)}")
-        selected_cities = requested
-    else:
-        selected_cities = sorted({row["city"] for row in rows})
+    requested = [city.strip() for city in requested_csv.split(",") if city.strip()]
+    if not requested:
+        return sorted({row["city"] for row in rows})
 
+    unknown = [city for city in requested if city not in valid_city_slugs]
+    if unknown:
+        raise SystemExit(f"Unknown city slug(s): {', '.join(unknown)}")
+    return requested
+
+
+def _evaluate_selected_cities(
+    rows: list[dict[str, Any]],
+    selected_cities: list[str],
+) -> list[dict[str, Any]]:
     by_city: dict[str, list[dict[str, Any]]] = defaultdict(list)
     for row in rows:
         if row["city"] in selected_cities:
@@ -398,12 +82,27 @@ def main() -> int:
     Session = sessionmaker(bind=engine)
     session = Session()
     try:
-        results = []
-        for city in selected_cities:
-            metrics = _collect_city_metrics(session, city, by_city.get(city, []))
-            results.append(_evaluate_city(city, metrics))
+        return [
+            _evaluate_city(city, _collect_city_metrics(session, city, by_city.get(city, [])))
+            for city in selected_cities
+        ]
     finally:
         session.close()
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(name)s:%(message)s")
+    args = _parse_args()
+
+    run_dir = Path(args.output_dir) / args.run_id
+    runs_path = run_dir / "runs.jsonl"
+
+    rows = _load_runs(runs_path)
+    if not rows:
+        raise SystemExit(f"No run rows found: {runs_path}")
+
+    selected_cities = _select_cities(rows, args.cities)
+    results = _evaluate_selected_cities(rows, selected_cities)
 
     output_json = run_dir / "city_gate_eval.json"
     output_md = run_dir / "city_gate_eval.md"

--- a/scripts/laserfiche_repair_backlog.py
+++ b/scripts/laserfiche_repair_backlog.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from sqlalchemy import and_
+
+from pipeline.city_scope import source_aliases_for_city
+from pipeline.db_session import db_session
+from pipeline.indexer import reindex_catalog
+from pipeline.models import AgendaItem, Catalog, Document, Event, SemanticEmbedding
+from scripts.laserfiche_repair_contracts import RepairTarget
+from scripts.laserfiche_repair_pdf_io import is_valid_pdf_artifact
+
+
+def select_targets(
+    city: str,
+    *,
+    limit: int | None,
+    resume_after_id: int | None,
+    salvage_bad_electronicfile: bool = False,
+) -> list[RepairTarget]:
+    with db_session() as session:
+        query = (
+            session.query(Catalog.id, Catalog.url, Catalog.location)
+            .join(Document, Document.catalog_id == Catalog.id)
+            .join(Event, Event.id == Document.event_id)
+            .outerjoin(AgendaItem, AgendaItem.catalog_id == Catalog.id)
+            .filter(
+                Event.source.in_(sorted(source_aliases_for_city(city))),
+                Document.category == "agenda",
+                Catalog.summary.is_(None),
+                AgendaItem.id.is_(None),
+            )
+            .distinct()
+            .order_by(Catalog.id)
+        )
+        if salvage_bad_electronicfile:
+            query = query.filter(
+                Catalog.url.ilike("%/ElectronicFile.aspx%"),
+                Catalog.content.is_(None),
+            )
+        else:
+            query = query.filter(Catalog.url.ilike("%/DocView.aspx%"))
+        if resume_after_id is not None:
+            query = query.filter(Catalog.id > resume_after_id)
+        if limit is not None:
+            query = query.limit(limit)
+        rows = query.all()
+    targets = [
+        RepairTarget(
+            catalog_id=row[0],
+            old_url=row[1],
+            location=row[2],
+            mode="salvage" if salvage_bad_electronicfile else "docview",
+        )
+        for row in rows
+    ]
+    if salvage_bad_electronicfile:
+        return [target for target in targets if not is_valid_pdf_artifact(target.location)]
+    return targets
+
+
+def apply_repairs(repairs: list[dict[str, object]], *, reindex: bool) -> dict[str, int]:
+    counts = {"updated": 0, "skipped_duplicate_hash": 0}
+    reindex_ids: list[int] = []
+
+    with db_session() as session:
+        for repair in repairs:
+            catalog_id = int(repair["catalog_id"])
+            new_hash = str(repair["new_hash"])
+            existing = (
+                session.query(Catalog.id)
+                .filter(Catalog.url_hash == new_hash, Catalog.id != catalog_id)
+                .first()
+            )
+            if existing:
+                counts["skipped_duplicate_hash"] += 1
+                continue
+
+            catalog = session.get(Catalog, catalog_id)
+            if not catalog:
+                continue
+
+            _mutate_catalog(catalog, repair, new_hash)
+            session.query(SemanticEmbedding).filter(SemanticEmbedding.catalog_id == catalog_id).delete(
+                synchronize_session=False
+            )
+            session.query(Document).filter(
+                and_(Document.catalog_id == catalog_id, Document.category == "agenda")
+            ).update(
+                {
+                    Document.url: str(repair["new_url"]),
+                    Document.url_hash: new_hash,
+                },
+                synchronize_session=False,
+            )
+
+            counts["updated"] += 1
+            if reindex:
+                reindex_ids.append(catalog_id)
+
+        session.commit()
+
+    for catalog_id in reindex_ids:
+        reindex_catalog(catalog_id)
+
+    return counts
+
+
+def _mutate_catalog(catalog: Catalog, repair: dict[str, object], new_hash: str) -> None:
+    catalog.url = str(repair["new_url"])
+    catalog.url_hash = new_hash
+    catalog.location = str(repair["path"])
+    catalog.filename = str(repair["filename"])
+
+    catalog.content = None
+    catalog.content_hash = None
+    catalog.extraction_status = "pending"
+    catalog.extraction_attempted_at = None
+    catalog.extraction_attempt_count = 0
+    catalog.extraction_error = None
+
+    catalog.summary = None
+    catalog.summary_source_hash = None
+    catalog.summary_extractive = None
+    catalog.entities = None
+    catalog.topics = None
+    catalog.topics_source_hash = None
+
+    catalog.agenda_segmentation_status = None
+    catalog.agenda_segmentation_attempted_at = None
+    catalog.agenda_segmentation_item_count = None
+    catalog.agenda_segmentation_error = None

--- a/scripts/laserfiche_repair_contracts.py
+++ b/scripts/laserfiche_repair_contracts.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import threading
+from dataclasses import dataclass
+
+
+DOCVIEW_RE = re.compile(r"/DocView\.aspx\?id=(?P<entry_id>\d+)&repo=(?P<repo>[^&]+)", re.IGNORECASE)
+ELECTRONIC_FILE_RE = re.compile(
+    r"/ElectronicFile\.aspx\?docid=(?P<entry_id>\d+)&repo=(?P<repo>[^&]+)",
+    re.IGNORECASE,
+)
+PDF_TRANSITION_TIMEOUT_SECONDS = 30
+PDF_TRANSITION_POLL_INTERVAL_SECONDS = 1
+GENERATED_PDF_FETCH_RETRIES = 3
+GENERATED_PDF_FETCH_RETRY_DELAY_SECONDS = 1
+RETRYABLE_FAILURE_REASONS = {
+    "timed_out",
+    "token_missing",
+    "remote_disconnected",
+    "incomplete_read",
+    "connection_error",
+    "read_timeout",
+    "generated_pdf_html_retryable",
+    "invalid_partial_pdf",
+}
+THREAD_STATE = threading.local()
+
+
+@dataclass(frozen=True)
+class RepairTarget:
+    catalog_id: int
+    old_url: str
+    location: str | None
+    mode: str = "docview"
+    entry_id: int | None = None
+    repo: str | None = None
+    new_url: str | None = None
+    preferred_method: str = "electronic_file"
+    page_count: int | None = None
+
+
+class RepairRetryableError(RuntimeError):
+    def __init__(self, reason: str, message: str):
+        super().__init__(message)
+        self.reason = reason
+
+
+class RepairNonRetryableError(RuntimeError):
+    def __init__(self, reason: str, message: str):
+        super().__init__(message)
+        self.reason = reason
+
+
+def url_to_md5(value: str) -> str:
+    return hashlib.md5((value or "").encode("utf-8")).hexdigest()
+
+
+def parse_docview_url(url: str) -> tuple[int, str]:
+    match = DOCVIEW_RE.search(url or "")
+    if not match:
+        raise ValueError(f"Unsupported Laserfiche DocView URL: {url!r}")
+    return int(match.group("entry_id")), match.group("repo")
+
+
+def parse_electronic_file_url(url: str) -> tuple[int, str]:
+    match = ELECTRONIC_FILE_RE.search(url or "")
+    if not match:
+        raise ValueError(f"Unsupported Laserfiche ElectronicFile URL: {url!r}")
+    return int(match.group("entry_id")), match.group("repo")
+
+
+def electronic_file_url(entry_id: int, repo: str) -> str:
+    return f"https://portal.laserfiche.com/Portal/ElectronicFile.aspx?docid={entry_id}&repo={repo}"
+
+
+def target_path(existing_location: str | None, url_hash: str) -> tuple[str, str]:
+    base_dir = os.path.dirname(existing_location) if existing_location else ""
+    if not base_dir:
+        raise ValueError("Catalog has no existing directory to store repaired PDF")
+    filename = f"{url_hash}.pdf"
+    return os.path.join(base_dir, filename), filename
+
+
+def coerce_bool(value: object) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "yes", "y"}:
+            return True
+        if lowered in {"0", "false", "no", "n"}:
+            return False
+    return None
+
+
+def failure_reason(exc: Exception) -> str:
+    explicit_reason = getattr(exc, "reason", None)
+    if isinstance(explicit_reason, str) and explicit_reason:
+        return explicit_reason
+    lowered = str(exc).strip().lower()
+    if "timed out" in lowered:
+        return "timed_out"
+    if "token missing" in lowered:
+        return "token_missing"
+    if "unexpected content type" in lowered:
+        return "unexpected_content_type"
+    if "zero-byte" in lowered:
+        return "zero_byte"
+    if "invalid pdf" in lowered:
+        return "invalid_pdf"
+    return re.sub(r"[^a-z0-9]+", "_", lowered).strip("_") or type(exc).__name__.lower()

--- a/scripts/laserfiche_repair_downloads.py
+++ b/scripts/laserfiche_repair_downloads.py
@@ -1,0 +1,296 @@
+from __future__ import annotations
+
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+import requests
+
+from pipeline.config import DOWNLOAD_TIMEOUT_SECONDS
+from scripts.laserfiche_repair_contracts import (
+    GENERATED_PDF_FETCH_RETRIES,
+    GENERATED_PDF_FETCH_RETRY_DELAY_SECONDS,
+    PDF_TRANSITION_POLL_INTERVAL_SECONDS,
+    PDF_TRANSITION_TIMEOUT_SECONDS,
+    THREAD_STATE,
+    RepairNonRetryableError,
+    RepairRetryableError,
+    RepairTarget,
+    coerce_bool,
+    electronic_file_url,
+    parse_docview_url,
+    parse_electronic_file_url,
+    target_path,
+    url_to_md5,
+)
+from scripts.laserfiche_repair_pdf_io import laserfiche_headers, worker_session, write_validated_pdf_response
+
+
+def fetch_basic_document_info(session: requests.Session, *, entry_id: int, repo: str) -> dict[str, object]:
+    response = session.post(
+        "https://portal.laserfiche.com/Portal/DocumentService.aspx/GetBasicDocumentInfo",
+        headers=laserfiche_headers(),
+        json={"repoName": repo, "entryId": entry_id},
+        timeout=DOWNLOAD_TIMEOUT_SECONDS,
+    )
+    response.raise_for_status()
+    payload = response.json()
+    data = payload.get("data")
+    if not isinstance(data, dict):
+        raise ValueError(f"Laserfiche basic document info missing for entry {entry_id}")
+    return data
+
+
+def build_page_range(page_count: int) -> str:
+    if page_count <= 0:
+        raise ValueError("Laserfiche document has no pages to export")
+    return f"1 - {page_count}"
+
+
+def document_supports_electronic_file(info: dict[str, object]) -> bool:
+    for key in (
+        "hasEdoc",
+        "hasEDoc",
+        "isEdoc",
+        "isEDoc",
+        "isElectronicDoc",
+        "hasElectronicFile",
+        "electronicDocument",
+        "electronicFile",
+    ):
+        if key in info:
+            coerced = coerce_bool(info.get(key))
+            if coerced is not None:
+                return coerced
+
+    for key in ("edocUrl", "electronicFileUrl", "electronicUrl"):
+        value = str(info.get(key) or "").strip()
+        if value:
+            return True
+
+    return False
+
+
+def classify_target(target: RepairTarget) -> RepairTarget:
+    if target.mode == "salvage":
+        entry_id, repo = parse_electronic_file_url(target.old_url)
+        new_url = target.old_url
+    else:
+        entry_id, repo = parse_docview_url(target.old_url)
+        new_url = electronic_file_url(entry_id, repo)
+
+    info: dict[str, object] = {}
+    try:
+        info = fetch_basic_document_info(worker_session(), entry_id=entry_id, repo=repo)
+    except (requests.RequestException, ValueError, TypeError, KeyError):
+        info = {}
+
+    page_count = int(info.get("pageCount") or 0) if info else 0
+    preferred_method = "electronic_file"
+    if target.mode != "salvage" and not document_supports_electronic_file(info):
+        preferred_method = "generated_pdf"
+
+    return RepairTarget(
+        catalog_id=target.catalog_id,
+        old_url=target.old_url,
+        location=target.location,
+        mode=target.mode,
+        entry_id=entry_id,
+        repo=repo,
+        new_url=new_url,
+        preferred_method=preferred_method,
+        page_count=page_count if page_count > 0 else None,
+    )
+
+
+def classify_targets(targets: list[RepairTarget], *, workers: int) -> list[RepairTarget]:
+    if not targets:
+        return []
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        futures = [executor.submit(classify_target, target) for target in targets]
+        return [future.result() for future in as_completed(futures)]
+
+
+def download_generated_pdf(
+    session: requests.Session,
+    *,
+    entry_id: int,
+    repo: str,
+    page_count: int,
+    temp_path: str,
+    final_path: str,
+    catalog_id: int,
+    pdf_transition_timeout_seconds: int = PDF_TRANSITION_TIMEOUT_SECONDS,
+) -> int:
+    page_range = build_page_range(page_count).replace(" ", "+")
+    generate = session.post(
+        f"https://portal.laserfiche.com/Portal/GeneratePDF10.aspx?key={entry_id}&PageRange={page_range}&Watermark=0&repo={repo}",
+        headers=laserfiche_headers(),
+        data="{}",
+        timeout=DOWNLOAD_TIMEOUT_SECONDS,
+    )
+    generate.raise_for_status()
+    token = (generate.text.split("\n", 1)[0] or "").strip().replace("\r", "")
+    if not token:
+        raise ValueError(f"Laserfiche PDF generation token missing for catalog {catalog_id}")
+
+    _wait_for_generated_pdf(session, token=token, catalog_id=catalog_id, timeout_seconds=pdf_transition_timeout_seconds)
+    return _fetch_generated_pdf(
+        session,
+        token=token,
+        entry_id=entry_id,
+        temp_path=temp_path,
+        final_path=final_path,
+        catalog_id=catalog_id,
+    )
+
+
+def _wait_for_generated_pdf(
+    session: requests.Session,
+    *,
+    token: str,
+    catalog_id: int,
+    timeout_seconds: int,
+) -> None:
+    deadline = time.time() + timeout_seconds
+    while True:
+        progress = session.post(
+            "https://portal.laserfiche.com/Portal/DocumentService.aspx/PDFTransition",
+            headers=laserfiche_headers(),
+            json={"Key": token},
+            timeout=DOWNLOAD_TIMEOUT_SECONDS,
+        )
+        progress.raise_for_status()
+        progress_payload = progress.json().get("data") or {}
+        if progress_payload.get("finished"):
+            if not progress_payload.get("success"):
+                message = progress_payload.get("errMsg") or "unknown error"
+                raise ValueError(f"Laserfiche PDF generation failed for catalog {catalog_id}: {message}")
+            return
+        if time.time() >= deadline:
+            raise ValueError(f"Laserfiche PDF generation timed out for catalog {catalog_id}")
+        time.sleep(PDF_TRANSITION_POLL_INTERVAL_SECONDS)
+
+
+def _fetch_generated_pdf(
+    session: requests.Session,
+    *,
+    token: str,
+    entry_id: int,
+    temp_path: str,
+    final_path: str,
+    catalog_id: int,
+) -> int:
+    last_error: Exception | None = None
+    for attempt in range(1, GENERATED_PDF_FETCH_RETRIES + 1):
+        try:
+            download = session.get(
+                f"https://portal.laserfiche.com/Portal/PDF10/{token}/{entry_id}",
+                stream=True,
+                timeout=DOWNLOAD_TIMEOUT_SECONDS,
+            )
+            download.raise_for_status()
+            size = write_validated_pdf_response(
+                download,
+                temp_path=temp_path,
+                final_path=final_path,
+                catalog_id=catalog_id,
+            )
+            setattr(THREAD_STATE, "last_generated_pdf_fetch_retries", attempt - 1)
+            return size
+        except requests.exceptions.ReadTimeout as exc:
+            last_error = RepairRetryableError("read_timeout", f"Read timeout while fetching generated PDF: {exc}")
+        except requests.exceptions.ConnectionError as exc:
+            last_error = _classify_fetch_connection_error(exc)
+        except RepairRetryableError as exc:
+            last_error = exc
+        if attempt < GENERATED_PDF_FETCH_RETRIES:
+            time.sleep(GENERATED_PDF_FETCH_RETRY_DELAY_SECONDS * attempt)
+    assert last_error is not None
+    raise last_error
+
+
+def _classify_fetch_connection_error(exc: requests.exceptions.ConnectionError) -> RepairRetryableError:
+    message = str(exc).lower()
+    if "remotedisconnected" in message:
+        return RepairRetryableError("remote_disconnected", f"Remote disconnected while fetching generated PDF: {exc}")
+    if "incompleteread" in message:
+        return RepairRetryableError("incomplete_read", f"Incomplete generated PDF response: {exc}")
+    return RepairRetryableError("connection_error", f"Connection error while fetching generated PDF: {exc}")
+
+
+def download_repaired_pdf(
+    target: RepairTarget,
+    *,
+    pdf_transition_timeout_seconds: int = PDF_TRANSITION_TIMEOUT_SECONDS,
+    force_generated_pdf: bool = False,
+) -> dict[str, object]:
+    if target.entry_id is None or target.repo is None or target.new_url is None:
+        target = classify_target(target)
+
+    assert target.entry_id is not None
+    assert target.repo is not None
+    assert target.new_url is not None
+    new_hash = url_to_md5(target.new_url)
+    path, filename = target_path(target.location, new_hash)
+    temp_path = f"{path}.tmp.{target.catalog_id}"
+    setattr(THREAD_STATE, "last_generated_pdf_fetch_retries", 0)
+
+    session = worker_session()
+    direct_error: Exception | None = None
+    preferred_method = "generated_pdf" if force_generated_pdf else target.preferred_method
+    if preferred_method == "electronic_file":
+        try:
+            response = session.get(target.new_url, stream=True, timeout=DOWNLOAD_TIMEOUT_SECONDS)
+            response.raise_for_status()
+            size = write_validated_pdf_response(
+                response,
+                temp_path=temp_path,
+                final_path=path,
+                catalog_id=target.catalog_id,
+            )
+            return _repair_payload(target, new_hash, path, filename, size, "electronic_file", "electronic_file")
+        except (RepairRetryableError, RepairNonRetryableError, requests.RequestException, ValueError) as exc:
+            direct_error = exc
+
+    viewer_url = f"https://portal.laserfiche.com/Portal/DocView.aspx?id={target.entry_id}&repo={target.repo}"
+    viewer = session.get(viewer_url, timeout=DOWNLOAD_TIMEOUT_SECONDS)
+    viewer.raise_for_status()
+    page_count = int(target.page_count or 0)
+    if page_count <= 0:
+        info = fetch_basic_document_info(session, entry_id=target.entry_id, repo=target.repo)
+        page_count = int(info.get("pageCount") or 0)
+    size = download_generated_pdf(
+        session,
+        entry_id=target.entry_id,
+        repo=target.repo,
+        page_count=page_count,
+        temp_path=temp_path,
+        final_path=path,
+        catalog_id=target.catalog_id,
+        pdf_transition_timeout_seconds=pdf_transition_timeout_seconds,
+    )
+    method = f"generated_pdf_after_{type(direct_error).__name__}" if direct_error else "generated_pdf"
+    payload = _repair_payload(target, new_hash, path, filename, size, method, "generated_pdf")
+    payload["fetch_retries"] = int(getattr(THREAD_STATE, "last_generated_pdf_fetch_retries", 0))
+    return payload
+
+
+def _repair_payload(
+    target: RepairTarget,
+    new_hash: str,
+    path: str,
+    filename: str,
+    size: int,
+    method: str,
+    retrieval_type: str,
+) -> dict[str, object]:
+    return {
+        "catalog_id": target.catalog_id,
+        "new_url": target.new_url,
+        "new_hash": new_hash,
+        "path": path,
+        "filename": filename,
+        "size": size,
+        "method": method,
+        "retrieval_type": retrieval_type,
+    }

--- a/scripts/laserfiche_repair_pdf_io.py
+++ b/scripts/laserfiche_repair_pdf_io.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import os
+from http.client import IncompleteRead, RemoteDisconnected
+from typing import Iterator
+
+import requests
+
+from pipeline.config import DOWNLOAD_TIMEOUT_SECONDS
+from scripts.laserfiche_repair_contracts import RepairNonRetryableError, RepairRetryableError, THREAD_STATE
+
+
+def file_has_pdf_signature(path: str) -> bool:
+    try:
+        with open(path, "rb") as fh:
+            return fh.read(5) == b"%PDF-"
+    except OSError:
+        return False
+
+
+def file_has_pdf_eof_marker(path: str) -> bool:
+    try:
+        with open(path, "rb") as fh:
+            fh.seek(0, os.SEEK_END)
+            size = fh.tell()
+            fh.seek(max(0, size - 2048))
+            tail = fh.read()
+        return b"%%EOF" in tail
+    except OSError:
+        return False
+
+
+def is_valid_pdf_artifact(path: str | None) -> bool:
+    if not path or not os.path.exists(path):
+        return False
+    try:
+        if os.path.getsize(path) <= 0:
+            return False
+    except OSError:
+        return False
+    return file_has_pdf_signature(path)
+
+
+def laserfiche_headers() -> dict[str, str]:
+    return {
+        "Content-Type": "application/json",
+        "X-Lf-Suppress-Login-Redirect": "1",
+    }
+
+
+def worker_session() -> requests.Session:
+    session = getattr(THREAD_STATE, "session", None)
+    if session is None:
+        session = requests.Session()
+        session.trust_env = False
+        THREAD_STATE.session = session
+    return session
+
+
+def raise_for_invalid_pdf_response(response: requests.Response, *, catalog_id: int) -> None:
+    content_type = (response.headers.get("Content-Type") or "").split(";")[0].strip().lower()
+    if content_type and content_type != "application/pdf":
+        body = (response.text or "")[:2000]
+        lowered = body.lower()
+        if "laserfiche" in lowered or "docview" in lowered or "electronicfile" in lowered or "portal" in lowered:
+            raise RepairRetryableError(
+                "generated_pdf_html_retryable",
+                f"Retryable HTML interstitial returned for catalog {catalog_id}",
+            )
+        raise RepairNonRetryableError(
+            "unexpected_content_type",
+            f"Unexpected content type {content_type!r} for catalog {catalog_id}",
+        )
+
+
+def iter_pdf_chunks(response: requests.Response) -> Iterator[bytes]:
+    try:
+        yield from response.iter_content(chunk_size=1024 * 256)
+    except requests.exceptions.ReadTimeout as exc:
+        raise RepairRetryableError("read_timeout", f"Read timeout while downloading generated PDF: {exc}") from exc
+    except requests.exceptions.ChunkedEncodingError as exc:
+        message = str(exc).lower()
+        if "incompleteread" in message:
+            raise RepairRetryableError("incomplete_read", f"Incomplete generated PDF response: {exc}") from exc
+        raise RepairRetryableError("connection_error", f"Chunked response failed for generated PDF: {exc}") from exc
+    except requests.exceptions.ConnectionError as exc:
+        message = str(exc).lower()
+        cause = getattr(exc, "__cause__", None)
+        if "remotedisconnected" in message or isinstance(cause, RemoteDisconnected):
+            raise RepairRetryableError("remote_disconnected", f"Remote disconnected during generated PDF fetch: {exc}") from exc
+        if "incompleteread" in message or isinstance(cause, IncompleteRead):
+            raise RepairRetryableError("incomplete_read", f"Incomplete generated PDF response: {exc}") from exc
+        raise RepairRetryableError("connection_error", f"Connection failed during generated PDF fetch: {exc}") from exc
+
+
+def write_validated_pdf_response(
+    response: requests.Response,
+    *,
+    temp_path: str,
+    final_path: str,
+    catalog_id: int,
+) -> int:
+    raise_for_invalid_pdf_response(response, catalog_id=catalog_id)
+    try:
+        with open(temp_path, "wb") as fh:
+            for chunk in iter_pdf_chunks(response):
+                if chunk:
+                    fh.write(chunk)
+
+        size = os.path.getsize(temp_path)
+        if size <= 0:
+            raise RepairRetryableError("invalid_partial_pdf", f"Downloaded zero-byte PDF for catalog {catalog_id}")
+        if not file_has_pdf_signature(temp_path):
+            raise RepairRetryableError("invalid_partial_pdf", f"Downloaded invalid PDF bytes for catalog {catalog_id}")
+        if not file_has_pdf_eof_marker(temp_path):
+            raise RepairRetryableError("invalid_partial_pdf", f"Downloaded truncated PDF for catalog {catalog_id}")
+
+        os.replace(temp_path, final_path)
+        return size
+    finally:
+        if os.path.exists(temp_path):
+            os.remove(temp_path)

--- a/scripts/laserfiche_repair_reporting.py
+++ b/scripts/laserfiche_repair_reporting.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+
+from scripts.laserfiche_repair_contracts import RepairTarget
+
+
+def _print_start(args: argparse.Namespace, selected: int) -> None:
+    print(
+        f"[{args.city}] repair_targets selected={selected} resume_after_id={args.resume_after_id} "
+        f"workers={args.workers} generated_pdf_workers={args.generated_pdf_workers} retry_only={args.retry_only} "
+        f"dry_run={args.dry_run} salvage_bad_electronicfile={args.salvage_bad_electronicfile}",
+        flush=True,
+    )
+
+
+def _print_lane_selection(city: str, targets: list[RepairTarget]) -> None:
+    preferred_counts = Counter(target.preferred_method for target in targets)
+    print(
+        f"[{city}] repair_lane_selection electronic_file={preferred_counts.get('electronic_file', 0)} "
+        f"generated_pdf={preferred_counts.get('generated_pdf', 0)}",
+        flush=True,
+    )
+
+
+def _print_dry_run(city: str, targets: list[RepairTarget]) -> None:
+    for target in targets[:5]:
+        print(
+            f"[{city}] dry_run catalog_id={target.catalog_id} old_url={target.old_url} "
+            f"new_url={target.new_url} preferred_method={target.preferred_method}",
+            flush=True,
+        )
+
+
+def _print_finish(
+    args: argparse.Namespace,
+    state: dict[str, object],
+    targets: list[RepairTarget],
+    classified_targets: list[RepairTarget],
+) -> None:
+    last_catalog_id = max((target.catalog_id for target in classified_targets), default=args.resume_after_id)
+    print(
+        f"[{args.city}] repair_finish downloaded={len(targets) - int(state['failed'])} failed={state['failed']} "
+        f"updated={state['total_updated']} skipped_duplicate_hash={state['total_skipped_duplicate_hash']} "
+        f"retrieval_counts={dict(sorted(state['retrieval_counts'].items()))} "
+        f"failure_counts={dict(sorted(state['failure_counts'].items()))} "
+        f"retry_stats={dict(sorted(state['retry_stats'].items()))} resume_after_id={last_catalog_id}",
+        flush=True,
+    )

--- a/scripts/repair_san_mateo_laserfiche_backlog.py
+++ b/scripts/repair_san_mateo_laserfiche_backlog.py
@@ -2,613 +2,85 @@
 from __future__ import annotations
 
 import argparse
-import hashlib
-import os
-import re
-import threading
-import time
+import requests
 from collections import Counter
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from dataclasses import dataclass
-from http.client import IncompleteRead, RemoteDisconnected
-from typing import Iterator
+from typing import Sequence
 
-import requests
-from sqlalchemy import and_
-from pipeline.city_scope import source_aliases_for_city
 from pipeline.config import DOWNLOAD_TIMEOUT_SECONDS
-from pipeline.db_session import db_session
-from pipeline.indexer import reindex_catalog
-from pipeline.models import AgendaItem, Catalog, Document, Event, SemanticEmbedding
-from scripts.operator_cli import nonnegative_int as _nonnegative_int
-from scripts.operator_cli import positive_int as _positive_int
+from scripts import laserfiche_repair_downloads as _download_impl
+from scripts.laserfiche_repair_backlog import apply_repairs as _apply_repairs
+from scripts.laserfiche_repair_backlog import select_targets as _select_targets
+from scripts.laserfiche_repair_contracts import GENERATED_PDF_FETCH_RETRIES
+from scripts.laserfiche_repair_contracts import GENERATED_PDF_FETCH_RETRY_DELAY_SECONDS
+from scripts.laserfiche_repair_contracts import PDF_TRANSITION_POLL_INTERVAL_SECONDS
+from scripts.laserfiche_repair_contracts import PDF_TRANSITION_TIMEOUT_SECONDS
+from scripts.laserfiche_repair_contracts import RETRYABLE_FAILURE_REASONS
+from scripts.laserfiche_repair_contracts import THREAD_STATE as _THREAD_STATE
+from scripts.laserfiche_repair_contracts import RepairNonRetryableError
+from scripts.laserfiche_repair_contracts import RepairRetryableError
+from scripts.laserfiche_repair_contracts import RepairTarget
+from scripts.laserfiche_repair_contracts import coerce_bool as _coerce_bool
+from scripts.laserfiche_repair_contracts import electronic_file_url as _electronic_file_url
+from scripts.laserfiche_repair_contracts import failure_reason as _failure_reason
+from scripts.laserfiche_repair_contracts import parse_docview_url as _parse_docview_url
+from scripts.laserfiche_repair_contracts import parse_electronic_file_url as _parse_electronic_file_url
+from scripts.laserfiche_repair_contracts import target_path as _target_path
+from scripts.laserfiche_repair_contracts import url_to_md5 as _url_to_md5
+from scripts.laserfiche_repair_downloads import build_page_range as _build_page_range
+from scripts.laserfiche_repair_downloads import document_supports_electronic_file as _document_supports_electronic_file
+from scripts.laserfiche_repair_downloads import fetch_basic_document_info as _fetch_basic_document_info
+from scripts import laserfiche_repair_pdf_io as _pdf_io
+from scripts.laserfiche_repair_reporting import _print_dry_run
+from scripts.laserfiche_repair_reporting import _print_finish
+from scripts.laserfiche_repair_reporting import _print_lane_selection
+from scripts.laserfiche_repair_reporting import _print_start
+from scripts.operator_cli import nonnegative_int as _nonnegative_int, positive_int as _positive_int
+
+_file_has_pdf_eof_marker = _pdf_io.file_has_pdf_eof_marker
+_file_has_pdf_signature = _pdf_io.file_has_pdf_signature
+_is_valid_pdf_artifact = _pdf_io.is_valid_pdf_artifact
+_iter_pdf_chunks = _pdf_io.iter_pdf_chunks
+_laserfiche_headers = _pdf_io.laserfiche_headers
+_raise_for_invalid_pdf_response = _pdf_io.raise_for_invalid_pdf_response
+_worker_session = _pdf_io.worker_session
+_write_validated_pdf_response = _pdf_io.write_validated_pdf_response
 
 
-DOCVIEW_RE = re.compile(r"/DocView\.aspx\?id=(?P<entry_id>\d+)&repo=(?P<repo>[^&]+)", re.IGNORECASE)
-ELECTRONIC_FILE_RE = re.compile(
-    r"/ElectronicFile\.aspx\?docid=(?P<entry_id>\d+)&repo=(?P<repo>[^&]+)",
-    re.IGNORECASE,
-)
-PDF_TRANSITION_TIMEOUT_SECONDS = 30
-PDF_TRANSITION_POLL_INTERVAL_SECONDS = 1
-GENERATED_PDF_FETCH_RETRIES = 3
-GENERATED_PDF_FETCH_RETRY_DELAY_SECONDS = 1
-RETRYABLE_FAILURE_REASONS = {
-    "timed_out",
-    "token_missing",
-    "remote_disconnected",
-    "incomplete_read",
-    "connection_error",
-    "read_timeout",
-    "generated_pdf_html_retryable",
-    "invalid_partial_pdf",
-}
-_THREAD_STATE = threading.local()
-
-
-def _url_to_md5(value: str) -> str:
-    return hashlib.md5((value or "").encode("utf-8")).hexdigest()
-
-
-@dataclass(frozen=True)
-class RepairTarget:
-    catalog_id: int
-    old_url: str
-    location: str | None
-    mode: str = "docview"
-    entry_id: int | None = None
-    repo: str | None = None
-    new_url: str | None = None
-    preferred_method: str = "electronic_file"
-    page_count: int | None = None
-
-
-class RepairRetryableError(RuntimeError):
-    def __init__(self, reason: str, message: str):
-        super().__init__(message)
-        self.reason = reason
-
-
-class RepairNonRetryableError(RuntimeError):
-    def __init__(self, reason: str, message: str):
-        super().__init__(message)
-        self.reason = reason
-
-
-def _parse_docview_url(url: str) -> tuple[int, str]:
-    match = DOCVIEW_RE.search(url or "")
-    if not match:
-        raise ValueError(f"Unsupported Laserfiche DocView URL: {url!r}")
-    return int(match.group("entry_id")), match.group("repo")
-
-
-def _parse_electronic_file_url(url: str) -> tuple[int, str]:
-    match = ELECTRONIC_FILE_RE.search(url or "")
-    if not match:
-        raise ValueError(f"Unsupported Laserfiche ElectronicFile URL: {url!r}")
-    return int(match.group("entry_id")), match.group("repo")
-
-
-def _electronic_file_url(entry_id: int, repo: str) -> str:
-    return f"https://portal.laserfiche.com/Portal/ElectronicFile.aspx?docid={entry_id}&repo={repo}"
-
-
-def _target_path(existing_location: str | None, url_hash: str) -> tuple[str, str]:
-    base_dir = os.path.dirname(existing_location) if existing_location else ""
-    if not base_dir:
-        raise ValueError("Catalog has no existing directory to store repaired PDF")
-    filename = f"{url_hash}.pdf"
-    return os.path.join(base_dir, filename), filename
-
-
-def _file_has_pdf_signature(path: str) -> bool:
-    try:
-        with open(path, "rb") as fh:
-            return fh.read(5) == b"%PDF-"
-    except OSError:
-        return False
-
-
-def _file_has_pdf_eof_marker(path: str) -> bool:
-    try:
-        with open(path, "rb") as fh:
-            fh.seek(0, os.SEEK_END)
-            size = fh.tell()
-            fh.seek(max(0, size - 2048))
-            tail = fh.read()
-        return b"%%EOF" in tail
-    except OSError:
-        return False
-
-
-def _is_valid_pdf_artifact(path: str | None) -> bool:
-    if not path or not os.path.exists(path):
-        return False
-    try:
-        if os.path.getsize(path) <= 0:
-            return False
-    except OSError:
-        return False
-    return _file_has_pdf_signature(path)
-
-
-def _laserfiche_headers() -> dict[str, str]:
-    return {
-        "Content-Type": "application/json",
-        "X-Lf-Suppress-Login-Redirect": "1",
-    }
-
-
-def _worker_session() -> requests.Session:
-    session = getattr(_THREAD_STATE, "session", None)
-    if session is None:
-        session = requests.Session()
-        session.trust_env = False
-        _THREAD_STATE.session = session
-    return session
-
-
-def _raise_for_invalid_pdf_response(response: requests.Response, *, catalog_id: int) -> None:
-    content_type = (response.headers.get("Content-Type") or "").split(";")[0].strip().lower()
-    if content_type and content_type != "application/pdf":
-        body = (response.text or "")[:2000]
-        lowered = body.lower()
-        if "laserfiche" in lowered or "docview" in lowered or "electronicfile" in lowered or "portal" in lowered:
-            raise RepairRetryableError(
-                "generated_pdf_html_retryable",
-                f"Retryable HTML interstitial returned for catalog {catalog_id}",
-            )
-        raise RepairNonRetryableError(
-            "unexpected_content_type",
-            f"Unexpected content type {content_type!r} for catalog {catalog_id}",
-        )
-
-
-def _iter_pdf_chunks(response: requests.Response) -> Iterator[bytes]:
-    try:
-        yield from response.iter_content(chunk_size=1024 * 256)
-    except requests.exceptions.ReadTimeout as exc:
-        raise RepairRetryableError("read_timeout", f"Read timeout while downloading generated PDF: {exc}") from exc
-    except requests.exceptions.ChunkedEncodingError as exc:
-        message = str(exc).lower()
-        if "incompleteread" in message:
-            raise RepairRetryableError("incomplete_read", f"Incomplete generated PDF response: {exc}") from exc
-        raise RepairRetryableError("connection_error", f"Chunked response failed for generated PDF: {exc}") from exc
-    except requests.exceptions.ConnectionError as exc:
-        message = str(exc).lower()
-        if "remotedisconnected" in message or isinstance(getattr(exc, "__cause__", None), RemoteDisconnected):
-            raise RepairRetryableError("remote_disconnected", f"Remote disconnected during generated PDF fetch: {exc}") from exc
-        if "incompleteread" in message or isinstance(getattr(exc, "__cause__", None), IncompleteRead):
-            raise RepairRetryableError("incomplete_read", f"Incomplete generated PDF response: {exc}") from exc
-        raise RepairRetryableError("connection_error", f"Connection failed during generated PDF fetch: {exc}") from exc
-
-
-def _write_validated_pdf_response(
-    response: requests.Response,
-    *,
-    temp_path: str,
-    final_path: str,
-    catalog_id: int,
-) -> int:
-    _raise_for_invalid_pdf_response(response, catalog_id=catalog_id)
-    try:
-        with open(temp_path, "wb") as fh:
-            for chunk in _iter_pdf_chunks(response):
-                if chunk:
-                    fh.write(chunk)
-
-        size = os.path.getsize(temp_path)
-        if size <= 0:
-            raise RepairRetryableError("invalid_partial_pdf", f"Downloaded zero-byte PDF for catalog {catalog_id}")
-        if not _file_has_pdf_signature(temp_path):
-            raise RepairRetryableError("invalid_partial_pdf", f"Downloaded invalid PDF bytes for catalog {catalog_id}")
-        if not _file_has_pdf_eof_marker(temp_path):
-            raise RepairRetryableError("invalid_partial_pdf", f"Downloaded truncated PDF for catalog {catalog_id}")
-
-        os.replace(temp_path, final_path)
-        return size
-    finally:
-        if os.path.exists(temp_path):
-            os.remove(temp_path)
-
-
-def _fetch_basic_document_info(
-    session: requests.Session,
-    *,
-    entry_id: int,
-    repo: str,
-) -> dict[str, object]:
-    response = session.post(
-        "https://portal.laserfiche.com/Portal/DocumentService.aspx/GetBasicDocumentInfo",
-        headers=_laserfiche_headers(),
-        json={"repoName": repo, "entryId": entry_id},
-        timeout=DOWNLOAD_TIMEOUT_SECONDS,
-    )
-    response.raise_for_status()
-    payload = response.json()
-    data = payload.get("data")
-    if not isinstance(data, dict):
-        raise ValueError(f"Laserfiche basic document info missing for entry {entry_id}")
-    return data
-
-
-def _build_page_range(page_count: int) -> str:
-    if page_count <= 0:
-        raise ValueError("Laserfiche document has no pages to export")
-    return f"1 - {page_count}"
-
-
-def _coerce_bool(value: object) -> bool | None:
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, (int, float)):
-        return bool(value)
-    if isinstance(value, str):
-        lowered = value.strip().lower()
-        if lowered in {"1", "true", "yes", "y"}:
-            return True
-        if lowered in {"0", "false", "no", "n"}:
-            return False
-    return None
-
-
-def _document_supports_electronic_file(info: dict[str, object]) -> bool:
-    for key in (
-        "hasEdoc",
-        "hasEDoc",
-        "isEdoc",
-        "isEDoc",
-        "isElectronicDoc",
-        "hasElectronicFile",
-        "electronicDocument",
-        "electronicFile",
-    ):
-        if key in info:
-            coerced = _coerce_bool(info.get(key))
-            if coerced is not None:
-                return coerced
-
-    for key in ("edocUrl", "electronicFileUrl", "electronicUrl"):
-        value = str(info.get(key) or "").strip()
-        if value:
-            return True
-
-    return False
+def _sync_helper_test_hooks() -> None:
+    _download_impl.worker_session = _worker_session
+    _download_impl.fetch_basic_document_info = _fetch_basic_document_info
+    _download_impl.DOWNLOAD_TIMEOUT_SECONDS = DOWNLOAD_TIMEOUT_SECONDS
+    _download_impl.GENERATED_PDF_FETCH_RETRIES = GENERATED_PDF_FETCH_RETRIES
+    _download_impl.GENERATED_PDF_FETCH_RETRY_DELAY_SECONDS = GENERATED_PDF_FETCH_RETRY_DELAY_SECONDS
+    _download_impl.PDF_TRANSITION_POLL_INTERVAL_SECONDS = PDF_TRANSITION_POLL_INTERVAL_SECONDS
 
 
 def _classify_target(target: RepairTarget) -> RepairTarget:
-    if target.mode == "salvage":
-        entry_id, repo = _parse_electronic_file_url(target.old_url)
-        new_url = target.old_url
-    else:
-        entry_id, repo = _parse_docview_url(target.old_url)
-        new_url = _electronic_file_url(entry_id, repo)
-
-    info: dict[str, object] = {}
-    try:
-        info = _fetch_basic_document_info(_worker_session(), entry_id=entry_id, repo=repo)
-    except Exception:
-        info = {}
-
-    page_count = int(info.get("pageCount") or 0) if info else 0
-    preferred_method = "electronic_file"
-    if target.mode != "salvage" and not _document_supports_electronic_file(info):
-        preferred_method = "generated_pdf"
-
-    return RepairTarget(
-        catalog_id=target.catalog_id,
-        old_url=target.old_url,
-        location=target.location,
-        mode=target.mode,
-        entry_id=entry_id,
-        repo=repo,
-        new_url=new_url,
-        preferred_method=preferred_method,
-        page_count=page_count if page_count > 0 else None,
-    )
-
-
-def _download_generated_pdf(
-    session: requests.Session,
-    *,
-    entry_id: int,
-    repo: str,
-    page_count: int,
-    temp_path: str,
-    final_path: str,
-    catalog_id: int,
-    pdf_transition_timeout_seconds: int = PDF_TRANSITION_TIMEOUT_SECONDS,
-) -> int:
-    page_range = _build_page_range(page_count).replace(" ", "+")
-    generate = session.post(
-        f"https://portal.laserfiche.com/Portal/GeneratePDF10.aspx?key={entry_id}&PageRange={page_range}&Watermark=0&repo={repo}",
-        headers=_laserfiche_headers(),
-        data="{}",
-        timeout=DOWNLOAD_TIMEOUT_SECONDS,
-    )
-    generate.raise_for_status()
-    token = (generate.text.split("\n", 1)[0] or "").strip().replace("\r", "")
-    if not token:
-        raise ValueError(f"Laserfiche PDF generation token missing for catalog {catalog_id}")
-
-    deadline = time.time() + pdf_transition_timeout_seconds
-    while True:
-        progress = session.post(
-            "https://portal.laserfiche.com/Portal/DocumentService.aspx/PDFTransition",
-            headers=_laserfiche_headers(),
-            json={"Key": token},
-            timeout=DOWNLOAD_TIMEOUT_SECONDS,
-        )
-        progress.raise_for_status()
-        progress_payload = progress.json().get("data") or {}
-        if progress_payload.get("finished"):
-            if not progress_payload.get("success"):
-                raise ValueError(
-                    f"Laserfiche PDF generation failed for catalog {catalog_id}: {progress_payload.get('errMsg') or 'unknown error'}"
-                )
-            break
-        if time.time() >= deadline:
-            raise ValueError(f"Laserfiche PDF generation timed out for catalog {catalog_id}")
-        time.sleep(PDF_TRANSITION_POLL_INTERVAL_SECONDS)
-
-    last_error: Exception | None = None
-    for attempt in range(1, GENERATED_PDF_FETCH_RETRIES + 1):
-        try:
-            download = session.get(
-                f"https://portal.laserfiche.com/Portal/PDF10/{token}/{entry_id}",
-                stream=True,
-                timeout=DOWNLOAD_TIMEOUT_SECONDS,
-            )
-            download.raise_for_status()
-            size = _write_validated_pdf_response(
-                download,
-                temp_path=temp_path,
-                final_path=final_path,
-                catalog_id=catalog_id,
-            )
-            setattr(_THREAD_STATE, "last_generated_pdf_fetch_retries", attempt - 1)
-            return size
-        except requests.exceptions.ReadTimeout as exc:
-            last_error = RepairRetryableError("read_timeout", f"Read timeout while fetching generated PDF: {exc}")
-        except requests.exceptions.ConnectionError as exc:
-            message = str(exc).lower()
-            if "remotedisconnected" in message:
-                last_error = RepairRetryableError("remote_disconnected", f"Remote disconnected while fetching generated PDF: {exc}")
-            elif "incompleteread" in message:
-                last_error = RepairRetryableError("incomplete_read", f"Incomplete generated PDF response: {exc}")
-            else:
-                last_error = RepairRetryableError("connection_error", f"Connection error while fetching generated PDF: {exc}")
-        except RepairRetryableError as exc:
-            last_error = exc
-        if attempt < GENERATED_PDF_FETCH_RETRIES:
-            time.sleep(GENERATED_PDF_FETCH_RETRY_DELAY_SECONDS * attempt)
-    assert last_error is not None
-    raise last_error
-
-
-def _select_targets(
-    city: str,
-    *,
-    limit: int | None,
-    resume_after_id: int | None,
-    salvage_bad_electronicfile: bool = False,
-) -> list[RepairTarget]:
-    with db_session() as session:
-        query = (
-            session.query(Catalog.id, Catalog.url, Catalog.location)
-            .join(Document, Document.catalog_id == Catalog.id)
-            .join(Event, Event.id == Document.event_id)
-            .outerjoin(AgendaItem, AgendaItem.catalog_id == Catalog.id)
-            .filter(
-                Event.source.in_(sorted(source_aliases_for_city(city))),
-                Document.category == "agenda",
-                Catalog.summary.is_(None),
-                AgendaItem.id.is_(None),
-            )
-            .distinct()
-            .order_by(Catalog.id)
-        )
-        if salvage_bad_electronicfile:
-            query = query.filter(
-                Catalog.url.ilike("%/ElectronicFile.aspx%"),
-                Catalog.content.is_(None),
-            )
-        else:
-            query = query.filter(Catalog.url.ilike("%/DocView.aspx%"))
-        if resume_after_id is not None:
-            query = query.filter(Catalog.id > resume_after_id)
-        if limit is not None:
-            query = query.limit(limit)
-        rows = query.all()
-    targets = [
-        RepairTarget(
-            catalog_id=row[0],
-            old_url=row[1],
-            location=row[2],
-            mode="salvage" if salvage_bad_electronicfile else "docview",
-        )
-        for row in rows
-    ]
-    if salvage_bad_electronicfile:
-        return [target for target in targets if not _is_valid_pdf_artifact(target.location)]
-    return targets
+    _sync_helper_test_hooks()
+    return _download_impl.classify_target(target)
 
 
 def _classify_targets(targets: list[RepairTarget], *, workers: int) -> list[RepairTarget]:
-    if not targets:
-        return []
-    with ThreadPoolExecutor(max_workers=workers) as executor:
-        return [future.result() for future in as_completed([executor.submit(_classify_target, target) for target in targets])]
+    _sync_helper_test_hooks()
+    return _download_impl.classify_targets(targets, workers=workers)
 
 
-def _failure_reason(exc: Exception) -> str:
-    explicit_reason = getattr(exc, "reason", None)
-    if isinstance(explicit_reason, str) and explicit_reason:
-        return explicit_reason
-    lowered = str(exc).strip().lower()
-    if "timed out" in lowered:
-        return "timed_out"
-    if "token missing" in lowered:
-        return "token_missing"
-    if "unexpected content type" in lowered:
-        return "unexpected_content_type"
-    if "zero-byte" in lowered:
-        return "zero_byte"
-    if "invalid pdf" in lowered:
-        return "invalid_pdf"
-    return re.sub(r"[^a-z0-9]+", "_", lowered).strip("_") or type(exc).__name__.lower()
+def _download_generated_pdf(*args: object, **kwargs: object) -> int:
+    _sync_helper_test_hooks()
+    if "pdf_transition_timeout_seconds" not in kwargs:
+        kwargs["pdf_transition_timeout_seconds"] = PDF_TRANSITION_TIMEOUT_SECONDS
+    return _download_impl.download_generated_pdf(*args, **kwargs)
 
 
-def _download_repaired_pdf(
-    target: RepairTarget,
-    *,
-    pdf_transition_timeout_seconds: int = PDF_TRANSITION_TIMEOUT_SECONDS,
-    force_generated_pdf: bool = False,
-) -> dict[str, object]:
-    entry_id = target.entry_id
-    repo = target.repo
-    new_url = target.new_url
-    if entry_id is None or repo is None or new_url is None:
-        target = _classify_target(target)
-        entry_id = target.entry_id
-        repo = target.repo
-        new_url = target.new_url
-
-    assert entry_id is not None
-    assert repo is not None
-    assert new_url is not None
-    new_hash = _url_to_md5(new_url)
-    path, filename = _target_path(target.location, new_hash)
-    temp_path = f"{path}.tmp.{target.catalog_id}"
-    setattr(_THREAD_STATE, "last_generated_pdf_fetch_retries", 0)
-
-    session = _worker_session()
-    direct_error: Exception | None = None
-    preferred_method = "generated_pdf" if force_generated_pdf else target.preferred_method
-    if preferred_method == "electronic_file":
-        try:
-            response = session.get(new_url, stream=True, timeout=DOWNLOAD_TIMEOUT_SECONDS)
-            response.raise_for_status()
-            size = _write_validated_pdf_response(
-                response,
-                temp_path=temp_path,
-                final_path=path,
-                catalog_id=target.catalog_id,
-            )
-            return {
-                "catalog_id": target.catalog_id,
-                "new_url": new_url,
-                "new_hash": new_hash,
-                "path": path,
-                "filename": filename,
-                "size": size,
-                "method": "electronic_file",
-                "retrieval_type": "electronic_file",
-            }
-        except (RepairRetryableError, RepairNonRetryableError, requests.RequestException, ValueError) as exc:
-            direct_error = exc
-
-    viewer_url = f"https://portal.laserfiche.com/Portal/DocView.aspx?id={entry_id}&repo={repo}"
-    viewer = session.get(viewer_url, timeout=DOWNLOAD_TIMEOUT_SECONDS)
-    viewer.raise_for_status()
-    page_count = int(target.page_count or 0)
-    if page_count <= 0:
-        info = _fetch_basic_document_info(session, entry_id=entry_id, repo=repo)
-        page_count = int(info.get("pageCount") or 0)
-    size = _download_generated_pdf(
-        session,
-        entry_id=entry_id,
-        repo=repo,
-        page_count=page_count,
-        temp_path=temp_path,
-        final_path=path,
-        catalog_id=target.catalog_id,
-        pdf_transition_timeout_seconds=pdf_transition_timeout_seconds,
-    )
-    return {
-        "catalog_id": target.catalog_id,
-        "new_url": new_url,
-        "new_hash": new_hash,
-        "path": path,
-        "filename": filename,
-        "size": size,
-        "method": f"generated_pdf_after_{type(direct_error).__name__}" if direct_error else "generated_pdf",
-        "retrieval_type": "generated_pdf",
-        "fetch_retries": int(getattr(_THREAD_STATE, "last_generated_pdf_fetch_retries", 0)),
-    }
+def _download_repaired_pdf(*args: object, **kwargs: object) -> dict[str, object]:
+    _sync_helper_test_hooks()
+    if "pdf_transition_timeout_seconds" not in kwargs:
+        kwargs["pdf_transition_timeout_seconds"] = PDF_TRANSITION_TIMEOUT_SECONDS
+    return _download_impl.download_repaired_pdf(*args, **kwargs)
 
 
-def _apply_repairs(repairs: list[dict[str, object]], *, reindex: bool) -> dict[str, int]:
-    counts = {"updated": 0, "skipped_duplicate_hash": 0}
-    reindex_ids: list[int] = []
-
-    with db_session() as session:
-        for repair in repairs:
-            catalog_id = int(repair["catalog_id"])
-            new_hash = str(repair["new_hash"])
-            existing = (
-                session.query(Catalog.id)
-                .filter(Catalog.url_hash == new_hash, Catalog.id != catalog_id)
-                .first()
-            )
-            if existing:
-                counts["skipped_duplicate_hash"] += 1
-                continue
-
-            catalog = session.get(Catalog, catalog_id)
-            if not catalog:
-                continue
-
-            catalog.url = str(repair["new_url"])
-            catalog.url_hash = new_hash
-            catalog.location = str(repair["path"])
-            catalog.filename = str(repair["filename"])
-
-            catalog.content = None
-            catalog.content_hash = None
-            catalog.extraction_status = "pending"
-            catalog.extraction_attempted_at = None
-            catalog.extraction_attempt_count = 0
-            catalog.extraction_error = None
-
-            catalog.summary = None
-            catalog.summary_source_hash = None
-            catalog.summary_extractive = None
-            catalog.entities = None
-            catalog.topics = None
-            catalog.topics_source_hash = None
-
-            catalog.agenda_segmentation_status = None
-            catalog.agenda_segmentation_attempted_at = None
-            catalog.agenda_segmentation_item_count = None
-            catalog.agenda_segmentation_error = None
-
-            session.query(SemanticEmbedding).filter(SemanticEmbedding.catalog_id == catalog_id).delete(
-                synchronize_session=False
-            )
-            session.query(Document).filter(
-                and_(Document.catalog_id == catalog_id, Document.category == "agenda")
-            ).update(
-                {
-                    Document.url: str(repair["new_url"]),
-                    Document.url_hash: new_hash,
-                },
-                synchronize_session=False,
-            )
-
-            counts["updated"] += 1
-            if reindex:
-                reindex_ids.append(catalog_id)
-
-        session.commit()
-
-    for catalog_id in reindex_ids:
-        reindex_catalog(catalog_id)
-
-    return counts
-
-
-def main() -> int:
+def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Repair poisoned San Mateo Laserfiche agenda rows in place")
     parser.add_argument("--city", default="san_mateo")
     parser.add_argument("--limit", type=_positive_int, default=None)
@@ -621,173 +93,172 @@ def main() -> int:
     parser.add_argument("--reindex", action="store_true")
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument("--salvage-bad-electronicfile", action="store_true")
-    args = parser.parse_args()
+    return parser
 
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
     targets = _select_targets(
         args.city,
         limit=args.limit,
         resume_after_id=args.resume_after_id,
         salvage_bad_electronicfile=args.salvage_bad_electronicfile,
     )
-    print(
-        f"[{args.city}] repair_targets selected={len(targets)} "
-        f"resume_after_id={args.resume_after_id} workers={args.workers} "
-        f"generated_pdf_workers={args.generated_pdf_workers} retry_only={args.retry_only} "
-        f"dry_run={args.dry_run} salvage_bad_electronicfile={args.salvage_bad_electronicfile}",
-        flush=True,
-    )
+    _print_start(args, len(targets))
     if not targets:
         return 0
 
     classified_targets = _classify_targets(targets, workers=max(args.workers, args.generated_pdf_workers))
     classified_targets.sort(key=lambda target: target.catalog_id)
-    preferred_counts = Counter(target.preferred_method for target in classified_targets)
-    print(
-        f"[{args.city}] repair_lane_selection electronic_file={preferred_counts.get('electronic_file', 0)} "
-        f"generated_pdf={preferred_counts.get('generated_pdf', 0)}",
-        flush=True,
-    )
+    _print_lane_selection(args.city, classified_targets)
 
     if args.dry_run:
-        for target in classified_targets[:5]:
-            print(
-                f"[{args.city}] dry_run catalog_id={target.catalog_id} "
-                f"old_url={target.old_url} new_url={target.new_url} preferred_method={target.preferred_method}",
-                flush=True,
-            )
+        _print_dry_run(args.city, classified_targets)
         return 0
 
-    repairs: list[dict[str, object]] = []
-    failed = 0
-    total_updated = 0
-    total_skipped_duplicate_hash = 0
-    retrieval_counts: Counter[str] = Counter()
-    failure_counts: Counter[str] = Counter()
-    generated_pdf_retry_stats: Counter[str] = Counter()
-    retry_targets: list[RepairTarget] = []
+    return _download_apply_and_report(args, targets, classified_targets)
 
-    def _flush_repairs() -> None:
-        nonlocal repairs, total_updated, total_skipped_duplicate_hash
-        if not repairs:
-            return
-        counts = _apply_repairs(repairs, reindex=args.reindex)
-        total_updated += counts["updated"]
-        total_skipped_duplicate_hash += counts["skipped_duplicate_hash"]
-        print(
-            f"[{args.city}] repair_batch_applied updated={counts['updated']} "
-            f"skipped_duplicate_hash={counts['skipped_duplicate_hash']}",
-            flush=True,
-        )
-        repairs = []
 
-    def _run_lane(
-        lane_name: str,
-        lane_targets: list[RepairTarget],
-        *,
-        workers: int,
-        force_generated_pdf: bool,
-        collect_retryables: bool,
-        pdf_transition_timeout_seconds: int,
-    ) -> None:
-        nonlocal failed, repairs
-        if not lane_targets:
-            return
-        print(
-            f"[{args.city}] repair_lane_start lane={lane_name} selected={len(lane_targets)} "
-            f"workers={workers} force_generated_pdf={force_generated_pdf} "
-            f"pdf_transition_timeout={pdf_transition_timeout_seconds}",
-            flush=True,
-        )
-        with ThreadPoolExecutor(max_workers=workers) as executor:
-            futures = {
-                executor.submit(
-                    _download_repaired_pdf,
-                    target,
-                    pdf_transition_timeout_seconds=pdf_transition_timeout_seconds,
-                    force_generated_pdf=force_generated_pdf,
-                ): target
-                for target in lane_targets
-            }
-            for future in as_completed(futures):
-                target = futures[future]
-                try:
-                    repair = future.result()
-                    retrieval_counts[str(repair.get("retrieval_type") or "unknown")] += 1
-                    fetch_retries = int(repair.get("fetch_retries") or 0)
-                    if fetch_retries > 0:
-                        generated_pdf_retry_stats["generated_pdf_fetch_retries"] += fetch_retries
-                    repairs.append(repair)
-                    print(
-                        f"[{args.city}] repair_downloaded catalog_id={target.catalog_id} "
-                        f"path={repair['path']} size={repair['size']} method={repair['method']} "
-                        f"fetch_retries={fetch_retries}",
-                        flush=True,
-                    )
-                    if len(repairs) >= args.apply_batch_size:
-                        _flush_repairs()
-                except Exception as exc:
-                    reason = _failure_reason(exc)
-                    failure_counts[reason] += 1
-                    if reason == "generated_pdf_html_retryable":
-                        generated_pdf_retry_stats["generated_pdf_html_retryable"] += 1
-                    if reason in {"remote_disconnected", "incomplete_read", "connection_error", "read_timeout"}:
-                        generated_pdf_retry_stats["generated_pdf_transport_retryable"] += 1
-                    if reason == "invalid_partial_pdf":
-                        generated_pdf_retry_stats["generated_pdf_invalid_partial_pdf"] += 1
-                    if collect_retryables and reason in RETRYABLE_FAILURE_REASONS:
-                        retry_targets.append(target)
-                    else:
-                        failed += 1
-                    print(
-                        f"[{args.city}] repair_failed catalog_id={target.catalog_id} reason={reason} error={exc}",
-                        flush=True,
-                    )
-
-    fast_targets = [target for target in classified_targets if target.preferred_method == "electronic_file"]
-    generated_targets = [target for target in classified_targets if target.preferred_method == "generated_pdf"]
+def _download_apply_and_report(
+    args: argparse.Namespace,
+    targets: list[RepairTarget],
+    classified_targets: list[RepairTarget],
+) -> int:
+    state: dict[str, object] = {
+        "repairs": [],
+        "failed": 0,
+        "total_updated": 0,
+        "total_skipped_duplicate_hash": 0,
+        "retrieval_counts": Counter(),
+        "failure_counts": Counter(),
+        "retry_stats": Counter(),
+        "retry_targets": [],
+    }
 
     if args.retry_only:
-        retry_targets = classified_targets
+        state["retry_targets"] = classified_targets
     else:
+        fast_targets = [target for target in classified_targets if target.preferred_method == "electronic_file"]
+        generated_targets = [target for target in classified_targets if target.preferred_method == "generated_pdf"]
+        _run_lane(args, state, "fast", fast_targets, workers=args.workers, force_generated_pdf=False, collect_retryables=True)
         _run_lane(
-            "fast",
-            fast_targets,
-            workers=args.workers,
-            force_generated_pdf=False,
-            collect_retryables=True,
-            pdf_transition_timeout_seconds=args.pdf_transition_timeout,
-        )
-        _run_lane(
+            args,
+            state,
             "generated_pdf",
             generated_targets,
             workers=args.generated_pdf_workers,
             force_generated_pdf=True,
             collect_retryables=True,
-            pdf_transition_timeout_seconds=args.pdf_transition_timeout,
         )
     _run_lane(
+        args,
+        state,
         "retry",
-        retry_targets,
+        state["retry_targets"],
         workers=args.generated_pdf_workers,
         force_generated_pdf=True,
         collect_retryables=False,
         pdf_transition_timeout_seconds=max(args.pdf_transition_timeout, PDF_TRANSITION_TIMEOUT_SECONDS * 2),
     )
 
-    _flush_repairs()
-    failure_summary = dict(sorted(failure_counts.items()))
-    retrieval_summary = dict(sorted(retrieval_counts.items()))
-    retry_summary = dict(sorted(generated_pdf_retry_stats.items()))
-    last_catalog_id = max((target.catalog_id for target in classified_targets), default=args.resume_after_id)
+    _flush_repairs(args, state)
+    _print_finish(args, state, targets, classified_targets)
+    return 0 if int(state["failed"]) == 0 else 1
+
+
+def _run_lane(
+    args: argparse.Namespace,
+    state: dict[str, object],
+    lane_name: str,
+    lane_targets: list[RepairTarget],
+    *,
+    workers: int,
+    force_generated_pdf: bool,
+    collect_retryables: bool,
+    pdf_transition_timeout_seconds: int | None = None,
+) -> None:
+    if not lane_targets:
+        return
+    timeout = pdf_transition_timeout_seconds or args.pdf_transition_timeout
     print(
-        f"[{args.city}] repair_finish downloaded={len(targets) - failed} failed={failed} "
-        f"updated={total_updated} skipped_duplicate_hash={total_skipped_duplicate_hash} "
-        f"retrieval_counts={retrieval_summary} failure_counts={failure_summary} "
-        f"retry_stats={retry_summary} "
-        f"resume_after_id={last_catalog_id}",
+        f"[{args.city}] repair_lane_start lane={lane_name} selected={len(lane_targets)} "
+        f"workers={workers} force_generated_pdf={force_generated_pdf} pdf_transition_timeout={timeout}",
         flush=True,
     )
-    return 0 if failed == 0 else 1
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        futures = {
+            executor.submit(_download_repaired_pdf, target, pdf_transition_timeout_seconds=timeout, force_generated_pdf=force_generated_pdf): target
+            for target in lane_targets
+        }
+        for future in as_completed(futures):
+            target = futures[future]
+            try:
+                _record_repair(args, state, target, future.result())
+            except Exception as exc:
+                _record_failure(args, state, target, exc, collect_retryables)
+
+
+def _record_repair(
+    args: argparse.Namespace,
+    state: dict[str, object],
+    target: RepairTarget,
+    repair: dict[str, object],
+) -> None:
+    retrieval_counts: Counter[str] = state["retrieval_counts"]
+    retry_stats: Counter[str] = state["retry_stats"]
+    repairs: list[dict[str, object]] = state["repairs"]
+    retrieval_counts[str(repair.get("retrieval_type") or "unknown")] += 1
+    fetch_retries = int(repair.get("fetch_retries") or 0)
+    if fetch_retries > 0:
+        retry_stats["generated_pdf_fetch_retries"] += fetch_retries
+    repairs.append(repair)
+    print(
+        f"[{args.city}] repair_downloaded catalog_id={target.catalog_id} path={repair['path']} "
+        f"size={repair['size']} method={repair['method']} fetch_retries={fetch_retries}",
+        flush=True,
+    )
+    if len(repairs) >= args.apply_batch_size:
+        _flush_repairs(args, state)
+
+
+def _record_failure(
+    args: argparse.Namespace,
+    state: dict[str, object],
+    target: RepairTarget,
+    exc: Exception,
+    collect_retryables: bool,
+) -> None:
+    reason = _failure_reason(exc)
+    failure_counts: Counter[str] = state["failure_counts"]
+    retry_stats: Counter[str] = state["retry_stats"]
+    failure_counts[reason] += 1
+    if reason == "generated_pdf_html_retryable":
+        retry_stats["generated_pdf_html_retryable"] += 1
+    if reason in {"remote_disconnected", "incomplete_read", "connection_error", "read_timeout"}:
+        retry_stats["generated_pdf_transport_retryable"] += 1
+    if reason == "invalid_partial_pdf":
+        retry_stats["generated_pdf_invalid_partial_pdf"] += 1
+    if collect_retryables and reason in RETRYABLE_FAILURE_REASONS:
+        retry_targets: list[RepairTarget] = state["retry_targets"]
+        retry_targets.append(target)
+    else:
+        state["failed"] = int(state["failed"]) + 1
+    print(f"[{args.city}] repair_failed catalog_id={target.catalog_id} reason={reason} error={exc}", flush=True)
+
+
+def _flush_repairs(args: argparse.Namespace, state: dict[str, object]) -> None:
+    repairs: list[dict[str, object]] = state["repairs"]
+    if not repairs:
+        return
+    counts = _apply_repairs(repairs, reindex=args.reindex)
+    state["total_updated"] = int(state["total_updated"]) + counts["updated"]
+    state["total_skipped_duplicate_hash"] = int(state["total_skipped_duplicate_hash"]) + counts["skipped_duplicate_hash"]
+    print(
+        f"[{args.city}] repair_batch_applied updated={counts['updated']} "
+        f"skipped_duplicate_hash={counts['skipped_duplicate_hash']}",
+        flush=True,
+    )
+    state["repairs"] = []
 
 
 if __name__ == "__main__":

--- a/tests/test_city_onboarding_evaluator_facade.py
+++ b/tests/test_city_onboarding_evaluator_facade.py
@@ -1,0 +1,82 @@
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+spec = importlib.util.spec_from_file_location(
+    "evaluate_city_onboarding_facade", Path("scripts/evaluate_city_onboarding.py")
+)
+mod = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = mod
+spec.loader.exec_module(mod)
+
+
+def test_evaluator_facade_reexports_legacy_helpers_and_models():
+    from pipeline import city_onboarding_metrics
+    from pipeline import models
+
+    assert mod.ISO_FMT == city_onboarding_metrics.ISO_FMT
+    assert mod._ocd_division_id_for_city is city_onboarding_metrics.ocd_division_id_for_city
+    assert mod._build_counts is city_onboarding_metrics.build_counts
+    assert mod.Catalog is models.Catalog
+    assert mod.Document is models.Document
+    assert mod.Event is models.Event
+    assert mod.UrlStage is models.UrlStage
+    assert mod.UrlStageHist is models.UrlStageHist
+
+
+def test_evaluator_facade_writes_artifacts_and_stdout(tmp_path, monkeypatch, capsys):
+    run_id = "facade_contract"
+    run_dir = tmp_path / run_id
+    run_dir.mkdir()
+    (run_dir / "runs.jsonl").write_text(
+        json.dumps(
+            {
+                "city": "hayward",
+                "started_at_utc": "2026-03-14T00:00:00Z",
+                "finished_at_utc": "2026-03-14T01:00:00Z",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    expected_result = {
+        "city": "hayward",
+        "quality_gate": "pass",
+        "quality_gate_reason": "fresh_evidence",
+        "run_window_catalog_total": 1,
+        "catalog_total": 1,
+        "crawl_success_rate": 1.0,
+        "extraction_non_empty_rate": 1.0,
+        "segmentation_complete_empty_rate": 1.0,
+        "segmentation_failed_rate": 0.0,
+        "failed_gates": [],
+    }
+
+    monkeypatch.setattr(mod, "_load_city_metadata_slugs", lambda: {"hayward"})
+    monkeypatch.setattr(mod, "_evaluate_selected_cities", lambda rows, cities: [expected_result])
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "evaluate_city_onboarding.py",
+            "--run-id",
+            run_id,
+            "--cities",
+            "hayward",
+            "--output-dir",
+            str(tmp_path),
+        ],
+    )
+
+    assert mod.main() == 0
+
+    output_json = run_dir / "city_gate_eval.json"
+    output_md = run_dir / "city_gate_eval.md"
+    assert json.loads(output_json.read_text(encoding="utf-8")) == {
+        "run_id": run_id,
+        "results": [expected_result],
+    }
+    assert "hayward | pass | fresh_evidence" in output_md.read_text(encoding="utf-8")
+    assert capsys.readouterr().out == f"wrote: {output_json}\nwrote: {output_md}\n"

--- a/tests/test_city_onboarding_runner.py
+++ b/tests/test_city_onboarding_runner.py
@@ -336,11 +336,11 @@ def test_onboarding_runner_resets_anchor_aware_first_time_city_between_attempts(
 
     with Session() as session:
         place = Place(
-            name="San Leandro",
+            name="Mountain View",
             state="CA",
             country="us",
-            display_name="San Leandro, CA",
-            ocd_division_id="ocd-division/country:us/state:ca/place:san_leandro",
+            display_name="Mountain View, CA",
+            ocd_division_id="ocd-division/country:us/state:ca/place:mtn_view",
         )
         session.add(place)
         session.flush()
@@ -351,7 +351,7 @@ def test_onboarding_runner_resets_anchor_aware_first_time_city_between_attempts(
                 place_id=place.id,
                 scraped_datetime=datetime(2026, 3, 1, 12, 0, 0),
                 record_date=date(2026, 3, 1),
-                source="san_leandro",
+                source="mtn_view",
                 source_url="https://example.com/baseline",
                 name="Baseline meeting",
             )
@@ -376,34 +376,34 @@ if [[ "$1" == "image" && "$2" == "inspect" && "$3" == "town-council-crawler" ]];
   exit 0
 fi
 if [[ "$*" == *"scripts/reset_city_verification_state.py"* && "$*" == *"--print-baseline"* ]]; then
-  printf '%s\\n' '{"city": "san_leandro", "baseline_event_count": 1, "baseline_max_record_date": "2026-03-01", "baseline_max_scraped_datetime": "2026-03-01T12:00:00Z"}'
+  printf '%s\\n' '{"city": "mtn_view", "baseline_event_count": 1, "baseline_max_record_date": "2026-03-01", "baseline_max_scraped_datetime": "2026-03-01T12:00:00Z"}'
   exit 0
 fi
 if [[ "$*" == *"scripts/flush_city_pipeline_state.py"* ]]; then
-  printf '%s\\n' '{"city": "san_leandro", "dry_run": false, "deleted_event_stage_count": 0, "deleted_url_stage_count": 0, "deleted_url_stage_hist_count": 0, "deleted_event_count": 0, "deleted_document_count": 0, "deleted_catalog_count": 0, "catalog_reference_count": 0, "deleted_data_issue_count": 0, "remaining_event_stage_count": 0, "remaining_url_stage_count": 0, "remaining_url_stage_hist_count": 0, "remaining_event_count": 1, "remaining_document_count": 0, "remaining_catalog_count": 0}'
+  printf '%s\\n' '{"city": "mtn_view", "dry_run": false, "deleted_event_stage_count": 0, "deleted_url_stage_count": 0, "deleted_url_stage_hist_count": 0, "deleted_event_count": 0, "deleted_document_count": 0, "deleted_catalog_count": 0, "catalog_reference_count": 0, "deleted_data_issue_count": 0, "remaining_event_stage_count": 0, "remaining_url_stage_count": 0, "remaining_url_stage_hist_count": 0, "remaining_event_count": 1, "remaining_document_count": 0, "remaining_catalog_count": 0}'
   exit 0
 fi
 if [[ "$*" == *"scripts/reset_city_verification_state.py"* ]]; then
-  printf '%s\\n' '{"city": "san_leandro", "deleted_document_count": 1, "deleted_event_count": 1, "deleted_catalog_count": 1, "catalog_reference_count": 1, "deleted_data_issue_count": 0, "remaining_event_count": 1, "remaining_max_record_date": "2026-03-01", "remaining_max_scraped_datetime": "2026-03-01T12:00:00Z"}'
+  printf '%s\\n' '{"city": "mtn_view", "deleted_document_count": 1, "deleted_event_count": 1, "deleted_catalog_count": 1, "catalog_reference_count": 1, "deleted_data_issue_count": 0, "remaining_event_count": 1, "remaining_max_record_date": "2026-03-01", "remaining_max_scraped_datetime": "2026-03-01T12:00:00Z"}'
   exit 0
 fi
-if [[ "$*" == *"scrapy crawl san_leandro"* ]]; then
+if [[ "$*" == *"scrapy crawl mtn_view"* ]]; then
   printf '%s\\n' "crawl" >> "$CRAWL_LOG"
   touch "$CRAWL_STATE"
   exit 0
 fi
 if [[ "$*" == *"scripts/check_city_crawl_evidence.py"* ]]; then
   if [[ -f "$CRAWL_STATE" ]]; then
-    printf '%s\\n' '{"city": "san_leandro", "event_stage_count": 3, "has_evidence": true, "url_stage_count": 2}'
+    printf '%s\\n' '{"city": "mtn_view", "event_stage_count": 3, "has_evidence": true, "url_stage_count": 2}'
   else
-    printf '%s\\n' '{"city": "san_leandro", "event_stage_count": 0, "has_evidence": false, "url_stage_count": 0}'
+    printf '%s\\n' '{"city": "mtn_view", "event_stage_count": 0, "has_evidence": false, "url_stage_count": 0}'
   fi
   exit 0
 fi
 if [[ "$*" == *"run_pipeline.py"* ]]; then
   exit 0
 fi
-if [[ "$*" == *"scripts/segment_city_corpus.py --city san_leandro"* ]]; then
+if [[ "$*" == *"scripts/segment_city_corpus.py --city mtn_view"* ]]; then
   exit 0
 fi
 echo "unexpected docker invocation: $*" >&2
@@ -436,7 +436,7 @@ exit 0
         "scripts/onboard_city_wave.sh",
         "wave1",
         "--cities",
-        "san_leandro",
+        "mtn_view",
         "--runs",
         "3",
         "--run-id",
@@ -458,9 +458,9 @@ exit 0
     assert docker_commands.count("scripts/flush_city_pipeline_state.py") == 1
     assert docker_commands.count("--print-baseline") == 1
     assert docker_commands.count("--baseline-record-date 2026-03-01") == 2
-    assert "restoring first-time verification state for san_leandro before run 2" in result.stdout
-    assert "restoring first-time verification state for san_leandro before run 3" in result.stdout
-    preflight_payload = json.loads((output_dir / run_id / "preflight" / "san_leandro_flush.json").read_text(encoding="utf-8"))
+    assert "restoring first-time verification state for mtn_view before run 2" in result.stdout
+    assert "restoring first-time verification state for mtn_view before run 3" in result.stdout
+    preflight_payload = json.loads((output_dir / run_id / "preflight" / "mtn_view_flush.json").read_text(encoding="utf-8"))
     assert preflight_payload["mode"] == "clean_noop"
     assert preflight_payload["auto_flush_applied"] is False
 

--- a/tests/test_repair_san_mateo_laserfiche_backlog.py
+++ b/tests/test_repair_san_mateo_laserfiche_backlog.py
@@ -29,6 +29,15 @@ def test_parse_docview_url_extracts_entry_id_and_repo():
     assert repo == "r-98a383e2"
 
 
+def test_repair_facade_reexports_legacy_constants_and_dependencies():
+    assert mod.requests is not None
+    assert isinstance(mod.DOWNLOAD_TIMEOUT_SECONDS, int)
+    assert mod.GENERATED_PDF_FETCH_RETRIES == 3
+    assert mod.GENERATED_PDF_FETCH_RETRY_DELAY_SECONDS == 1
+    assert mod._THREAD_STATE is not None
+    assert mod._coerce_bool("yes") is True
+
+
 def test_electronic_file_url_uses_docid_query_parameter():
     assert mod._electronic_file_url(2040856, "r-98a383e2") == (
         "https://portal.laserfiche.com/Portal/ElectronicFile.aspx?docid=2040856&repo=r-98a383e2"

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -291,6 +291,35 @@ REPORTING_SCRIPTS_CLEANUP_MODULES = (
     "scripts/profile_pipeline_selection.py",
     "scripts/score_ab_results.py",
 )
+TASK_API_FACADE_CLEANUP_MODULES = (
+    "pipeline/tasks.py",
+    "pipeline/task_facade_helpers.py",
+    "pipeline/task_summary_generation.py",
+    "pipeline/task_summary_side_effects.py",
+    "api/task_routes.py",
+    "api/task_dispatch.py",
+    "api/task_route_support.py",
+)
+SEARCH_SUPPORT_CLEANUP_MODULES = (
+    "api/search_support.py",
+    "api/search/support_core.py",
+    "api/search/filter_support.py",
+    "api/search/trends_support.py",
+    "api/search/semantic_support.py",
+)
+CITY_ONBOARDING_EVALUATOR_CLEANUP_MODULES = (
+    "scripts/evaluate_city_onboarding.py",
+    "pipeline/city_onboarding_metrics.py",
+    "pipeline/city_onboarding_gate.py",
+)
+LASERFICHE_REPAIR_CLEANUP_MODULES = (
+    "scripts/repair_san_mateo_laserfiche_backlog.py",
+    "scripts/laserfiche_repair_contracts.py",
+    "scripts/laserfiche_repair_pdf_io.py",
+    "scripts/laserfiche_repair_downloads.py",
+    "scripts/laserfiche_repair_backlog.py",
+    "scripts/laserfiche_repair_reporting.py",
+)
 INDEXER_CLEANUP_MODULES = (
     "pipeline/indexer.py",
     "pipeline/indexer_documents.py",
@@ -352,6 +381,10 @@ def _broad_exception_scan_files() -> list[Path]:
         *HTTP_PROVIDER_CLEANUP_MODULES,
         *PERSON_UTILS_CLEANUP_MODULES,
         *REPORTING_SCRIPTS_CLEANUP_MODULES,
+        *TASK_API_FACADE_CLEANUP_MODULES,
+        *SEARCH_SUPPORT_CLEANUP_MODULES,
+        *CITY_ONBOARDING_EVALUATOR_CLEANUP_MODULES,
+        *LASERFICHE_REPAIR_CLEANUP_MODULES,
     ):
         tracked_files.add((ROOT / module_path).resolve())
     return sorted(tracked_files)
@@ -671,6 +704,46 @@ def test_reporting_scripts_cleanup_modules_stay_under_size_target():
     oversized_modules = [
         module_path
         for module_path in REPORTING_SCRIPTS_CLEANUP_MODULES
+        if len((ROOT / module_path).read_text(encoding="utf-8").splitlines()) > 300
+    ]
+
+    assert oversized_modules == []
+
+
+def test_task_api_facade_cleanup_modules_stay_under_size_target():
+    oversized_modules = [
+        module_path
+        for module_path in TASK_API_FACADE_CLEANUP_MODULES
+        if len((ROOT / module_path).read_text(encoding="utf-8").splitlines()) > 300
+    ]
+
+    assert oversized_modules == []
+
+
+def test_search_support_cleanup_modules_stay_under_size_target():
+    oversized_modules = [
+        module_path
+        for module_path in SEARCH_SUPPORT_CLEANUP_MODULES
+        if len((ROOT / module_path).read_text(encoding="utf-8").splitlines()) > 300
+    ]
+
+    assert oversized_modules == []
+
+
+def test_city_onboarding_evaluator_cleanup_modules_stay_under_size_target():
+    oversized_modules = [
+        module_path
+        for module_path in CITY_ONBOARDING_EVALUATOR_CLEANUP_MODULES
+        if len((ROOT / module_path).read_text(encoding="utf-8").splitlines()) > 300
+    ]
+
+    assert oversized_modules == []
+
+
+def test_laserfiche_repair_cleanup_modules_stay_under_size_target():
+    oversized_modules = [
+        module_path
+        for module_path in LASERFICHE_REPAIR_CLEANUP_MODULES
         if len((ROOT / module_path).read_text(encoding="utf-8").splitlines()) > 300
     ]
 

--- a/tests/test_search_support_facade.py
+++ b/tests/test_search_support_facade.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+import api.search_support as search_support
+
+
+def test_search_support_facade_preserves_route_patch_points():
+    expected_names = {
+        "client",
+        "httpx",
+        "search_client",
+        "facade_callable",
+        "facade_value",
+        "validate_date_format",
+        "_build_filter_values",
+        "_build_meilisearch_filter_clauses",
+        "_collect_meeting_docs",
+        "_count_topics_from_docs",
+        "_facet_topics",
+        "_iter_time_buckets",
+        "_normalize_city_or_400",
+        "_normalize_filters_or_400",
+        "_parse_iso_date",
+        "_require_trends_feature",
+        "_semantic_service_get_json",
+        "_semantic_service_healthcheck",
+    }
+
+    for name in expected_names:
+        assert hasattr(search_support, name), name
+
+
+def test_search_support_modules_stay_under_size_budget():
+    paths = [
+        Path("api/search_support.py"),
+        Path("api/search/filter_support.py"),
+        Path("api/search/semantic_support.py"),
+        Path("api/search/support_core.py"),
+        Path("api/search/trends_support.py"),
+    ]
+
+    for path in paths:
+        assert len(path.read_text(encoding="utf-8").splitlines()) < 300, path

--- a/tests/test_task_facade_cleanup.py
+++ b/tests/test_task_facade_cleanup.py
@@ -1,0 +1,38 @@
+import sys
+from unittest.mock import MagicMock
+
+sys.modules["llama_cpp"] = MagicMock()
+
+
+def test_api_task_routes_reexports_dispatch_facade():
+    from api import task_dispatch, task_routes
+
+    assert task_routes.INVALID_TASK_ID_DETAIL == task_dispatch.INVALID_TASK_ID_DETAIL
+    assert task_routes.GENERATE_SUMMARY_TASK_NAME == task_dispatch.GENERATE_SUMMARY_TASK_NAME
+    assert task_routes.GENERATE_TOPICS_TASK_NAME == task_dispatch.GENERATE_TOPICS_TASK_NAME
+    assert task_routes.SEGMENT_AGENDA_TASK_NAME == task_dispatch.SEGMENT_AGENDA_TASK_NAME
+    assert task_routes.EXTRACT_VOTES_TASK_NAME == task_dispatch.EXTRACT_VOTES_TASK_NAME
+    assert task_routes.EXTRACT_TEXT_TASK_NAME == task_dispatch.EXTRACT_TEXT_TASK_NAME
+    assert task_routes.TASK_DISPATCH_ERRORS == task_dispatch.TASK_DISPATCH_ERRORS
+    assert task_routes._CeleryTaskProxy is task_dispatch._CeleryTaskProxy
+    assert task_routes._enqueue_task is task_dispatch._enqueue_task
+    assert task_routes.generate_summary_task is task_dispatch.generate_summary_task
+    assert task_routes.extract_text_task is task_dispatch.extract_text_task
+
+
+def test_pipeline_tasks_summary_services_use_pipeline_tasks_patch_seams(monkeypatch):
+    import pipeline.tasks as tasks
+
+    fake_local_ai = MagicMock(name="fake_local_ai")
+    fake_reindex = MagicMock(name="fake_reindex")
+    fake_embed_task = MagicMock()
+
+    monkeypatch.setattr(tasks, "LocalAI", fake_local_ai)
+    monkeypatch.setattr(tasks, "reindex_catalog", fake_reindex)
+    monkeypatch.setattr(tasks, "embed_catalog_task", fake_embed_task)
+
+    services = tasks._summary_generation_task_services()
+
+    assert services.local_ai_factory is fake_local_ai
+    assert services.reindex_catalog is fake_reindex
+    assert services.embed_catalog is fake_embed_task.delay


### PR DESCRIPTION
## What changed
- Split task/API/search runtime facades into focused helper modules while keeping public imports and patch seams stable.
- Split city onboarding evaluator and San Mateo Laserfiche repair script into focused modules under the existing CLI entrypoints.
- Added facade compatibility tests and cleanup-family size guardrails.
- Updated ADR, architecture, pipeline, and guardrail docs for the new ownership seams.

## Why
Large facades and operator scripts were carrying unrelated responsibilities. This keeps behavior stable while reducing review and maintenance risk for the next cleanup waves.

## Risk / compatibility
- No CLI flags, API routes, Celery task names, DB schema, runtime defaults, or JSON output shapes changed.
- Existing facade imports and private test patch seams are preserved with explicit tests.
- Main risk is missed local patch surface; review found three gaps, and this PR adds coverage for them.

## Verification
- PASS `./.venv/bin/ruff check api pipeline scripts tests`
- PASS `./.venv/bin/mypy`
- PASS `PYTHONPATH=. .venv/bin/pytest -q tests/test_repository_guardrails.py tests/test_docs_links.py`
- PASS `PYTHONPATH=. .venv/bin/pytest -q tests/test_task_facade_cleanup.py tests/test_summary_staleness.py tests/test_api.py tests/test_async_flow.py tests/test_run_pipeline_orchestration.py tests/test_pipeline_batching.py tests/test_task_metrics.py tests/test_task_provider_retry_semantics.py tests/test_extract_task.py tests/test_summary_blocking.py`
- PASS `PYTHONPATH=. .venv/bin/pytest -q tests/test_city_onboarding_gate_evaluator.py tests/test_city_onboarding_evaluator_facade.py tests/test_city_onboarding_runner.py tests/test_city_onboarding_wave_script_contract.py`
- PASS `PYTHONPATH=. .venv/bin/pytest -q tests/test_search_support_facade.py tests/test_api.py tests/test_query_builder_filters.py tests/test_query_builder_parity_search_vs_trends.py`
- PASS `PYTHONPATH=. .venv/bin/pytest -q tests/test_repair_san_mateo_laserfiche_backlog.py tests/test_task_facade_cleanup.py tests/test_city_onboarding_evaluator_facade.py`
- PASS `git diff --check`

## Remaining deficits
- Wave 2/3 cleanup targets remain intentionally untouched: staged hydration, repaired hydration, runtime helpers, downloader, models, and db migrations.
