### PR TITLE
Refactor API task route helpers

### DIFF
--- a/api/task_route_generation.py
+++ b/api/task_route_generation.py
@@ -1,0 +1,105 @@
+from typing import Any, Callable
+
+from fastapi import HTTPException
+
+
+def extract_votes_request(
+    *,
+    task_facade: Any,
+    db: Any,
+    catalog_id: int,
+    force: bool,
+    catalog_model: type[Any],
+) -> dict[str, str]:
+    catalog = db.get(catalog_model, catalog_id)
+    if not catalog:
+        raise HTTPException(status_code=404, detail="Document not found")
+
+    task_id = task_facade._enqueue_task("extract_votes_task", task_facade.extract_votes_task, catalog_id, force=force)
+    return {
+        "status": "processing",
+        "task_id": task_id,
+        "poll_url": f"/tasks/{task_id}",
+    }
+
+
+def generate_topics_request(
+    *,
+    task_facade: Any,
+    db: Any,
+    catalog_id: int,
+    force: bool,
+    catalog_model: type[Any],
+    analyze_source_text: Callable[[str], Any],
+    build_low_signal_message: Callable[[Any], str],
+    compute_content_hash: Callable[[str], str],
+    is_source_topicable: Callable[[Any], bool],
+) -> dict[str, Any]:
+    catalog = db.get(catalog_model, catalog_id)
+    if not catalog:
+        raise HTTPException(status_code=404, detail="Document not found")
+    if not catalog.content:
+        raise HTTPException(status_code=400, detail="Document has no text to tag")
+
+    quality = analyze_source_text(catalog.content)
+    if not is_source_topicable(quality):
+        return {
+            "status": "blocked_low_signal",
+            "reason": build_low_signal_message(quality),
+            "topics": [],
+        }
+
+    content_hash = catalog.content_hash or (compute_content_hash(catalog.content) if catalog.content else None)
+    is_fresh = bool(
+        catalog.topics is not None
+        and content_hash
+        and catalog.topics_source_hash
+        and catalog.topics_source_hash == content_hash
+    )
+    if (not force) and is_fresh:
+        return {"status": "cached", "topics": catalog.topics or []}
+    if (not force) and catalog.topics is not None and not is_fresh:
+        return {"status": "stale", "topics": catalog.topics or []}
+
+    task_id = task_facade._enqueue_task(
+        "generate_topics_task",
+        task_facade.generate_topics_task,
+        catalog_id,
+        force=force,
+    )
+    return {
+        "status": "processing",
+        "task_id": task_id,
+        "poll_url": f"/tasks/{task_id}",
+    }
+
+
+def extract_catalog_text_request(
+    *,
+    task_facade: Any,
+    db: Any,
+    catalog_id: int,
+    force: bool,
+    ocr_fallback: bool,
+    catalog_model: type[Any],
+    cached_content_min_chars: int,
+) -> dict[str, Any]:
+    catalog = db.get(catalog_model, catalog_id)
+    if not catalog:
+        raise HTTPException(status_code=404, detail="Document not found")
+
+    if (not force) and catalog.content and len(catalog.content.strip()) >= cached_content_min_chars:
+        return {"status": "cached", "catalog_id": catalog_id, "chars": len(catalog.content)}
+
+    task_id = task_facade._enqueue_task(
+        "extract_text_task",
+        task_facade.extract_text_task,
+        catalog_id,
+        force=force,
+        ocr_fallback=ocr_fallback,
+    )
+    return {
+        "status": "processing",
+        "task_id": task_id,
+        "poll_url": f"/tasks/{task_id}",
+    }

--- a/api/task_route_segmentation.py
+++ b/api/task_route_segmentation.py
@@ -1,0 +1,44 @@
+import logging
+from typing import Any
+
+from fastapi import HTTPException
+
+
+def segment_agenda_request(
+    *,
+    task_facade: Any,
+    db: Any,
+    catalog_id: int,
+    force: bool,
+    catalog_model: type[Any],
+    agenda_item_model: type[Any],
+    logger: logging.Logger,
+) -> dict[str, Any]:
+    catalog = db.get(catalog_model, catalog_id)
+    if not catalog:
+        raise HTTPException(status_code=404, detail="Document not found")
+
+    existing_items = (
+        db.query(agenda_item_model).filter_by(catalog_id=catalog_id).order_by(agenda_item_model.order).all()
+    )
+    if (
+        not force
+        and existing_items
+        and task_facade.agenda_items_look_low_quality
+        and not task_facade.agenda_items_look_low_quality(existing_items)
+    ):
+        return {"status": "cached", "items": existing_items}
+    if not force and existing_items:
+        logger.info(
+            "Agenda cache for catalog_id=%s looks low quality; regenerating asynchronously.",
+            catalog_id,
+        )
+    if force:
+        logger.info("Force-regenerating agenda cache for catalog_id=%s.", catalog_id)
+
+    task_id = task_facade._enqueue_task("segment_agenda_task", task_facade.segment_agenda_task, catalog_id)
+    return {
+        "status": "processing",
+        "task_id": task_id,
+        "poll_url": f"/tasks/{task_id}",
+    }

--- a/api/task_route_summary.py
+++ b/api/task_route_summary.py
@@ -1,0 +1,55 @@
+from typing import Any, Callable
+
+from fastapi import HTTPException
+
+
+def summarize_document_request(
+    *,
+    task_facade: Any,
+    db: Any,
+    catalog_id: int,
+    force: bool,
+    catalog_model: type[Any],
+    analyze_source_text: Callable[[str], Any],
+    build_low_signal_message: Callable[[Any], str],
+    is_summary_fresh: Callable[..., bool],
+    is_source_summarizable: Callable[[Any], bool],
+) -> dict[str, Any]:
+    catalog = db.get(catalog_model, catalog_id)
+    if not catalog:
+        raise HTTPException(status_code=404, detail="Document not found")
+    if not catalog.content:
+        raise HTTPException(status_code=400, detail="Document has no text to summarize")
+
+    quality = analyze_source_text(catalog.content)
+    if not is_source_summarizable(quality):
+        return {
+            "status": "blocked_low_signal",
+            "reason": build_low_signal_message(quality),
+        }
+
+    doc_kind, content_hash, agenda_items_hash = task_facade._summary_doc_kind_and_hashes(db, catalog_id, catalog)
+    is_fresh = is_summary_fresh(
+        doc_kind,
+        summary=catalog.summary,
+        summary_source_hash=catalog.summary_source_hash,
+        content_hash=content_hash,
+        agenda_items_hash=agenda_items_hash,
+    )
+
+    if (not force) and is_fresh:
+        return {"summary": catalog.summary, "status": "cached"}
+    if (not force) and catalog.summary and not is_fresh:
+        return {"summary": catalog.summary, "status": "stale"}
+
+    task_id = task_facade._enqueue_task(
+        "generate_summary_task",
+        task_facade.generate_summary_task,
+        catalog_id,
+        force=force,
+    )
+    return {
+        "status": "processing",
+        "task_id": task_id,
+        "poll_url": f"/tasks/{task_id}",
+    }

--- a/api/task_routes.py
+++ b/api/task_routes.py
@@ -2,7 +2,7 @@ import logging
 from typing import Any, Callable
 
 from celery.result import AsyncResult as AsyncResult
-from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request
+from fastapi import APIRouter, Depends, Path, Query, Request
 from sqlalchemy.orm import Session as SQLAlchemySession
 
 from pipeline.celery_app import app as celery_app
@@ -32,6 +32,13 @@ from api.task_dispatch import (  # noqa: F401
     generate_topics_task,
     segment_agenda_task,
 )
+from api.task_route_generation import (
+    extract_catalog_text_request,
+    extract_votes_request,
+    generate_topics_request,
+)
+from api.task_route_segmentation import segment_agenda_request
+from api.task_route_summary import summarize_document_request
 from api.task_route_support import get_task_status_payload
 
 logger = logging.getLogger("town-council-api")
@@ -71,45 +78,17 @@ def build_task_router(
         Returns a 'Task ID' immediately. Use GET /tasks/{id} to check progress.
         """
         _ = request
-        catalog = db.get(Catalog, catalog_id)
-        if not catalog:
-            raise HTTPException(status_code=404, detail="Document not found")
-        if not catalog.content:
-            raise HTTPException(status_code=400, detail="Document has no text to summarize")
-
-        # Block generation when extracted text is too weak to support reliable output.
-        quality = analyze_source_text(catalog.content)
-        if not is_source_summarizable(quality):
-            return {
-                "status": "blocked_low_signal",
-                "reason": build_low_signal_message(quality),
-            }
-
-        doc_kind, content_hash, agenda_items_hash = task_facade._summary_doc_kind_and_hashes(db, catalog_id, catalog)
-        is_fresh = is_summary_fresh(
-            doc_kind,
-            summary=catalog.summary,
-            summary_source_hash=catalog.summary_source_hash,
-            content_hash=content_hash,
-            agenda_items_hash=agenda_items_hash,
-        )
-
-        if (not force) and is_fresh:
-            return {"summary": catalog.summary, "status": "cached"}
-        if (not force) and catalog.summary and not is_fresh:
-            return {"summary": catalog.summary, "status": "stale"}
-
-        task_id = task_facade._enqueue_task(
-            "generate_summary_task",
-            task_facade.generate_summary_task,
-            catalog_id,
+        return summarize_document_request(
+            task_facade=task_facade,
+            db=db,
+            catalog_id=catalog_id,
             force=force,
+            catalog_model=Catalog,
+            analyze_source_text=analyze_source_text,
+            build_low_signal_message=build_low_signal_message,
+            is_summary_fresh=is_summary_fresh,
+            is_source_summarizable=is_source_summarizable,
         )
-        return {
-            "status": "processing",
-            "task_id": task_id,
-            "poll_url": f"/tasks/{task_id}",
-        }
 
     @router.post("/segment/{catalog_id}", dependencies=[Depends(verify_api_key_dependency)])
     @limiter.limit(SEGMENT_RATE_LIMIT)
@@ -130,32 +109,15 @@ def build_task_router(
         Returns a 'Task ID' immediately.
         """
         _ = request
-        catalog = db.get(Catalog, catalog_id)
-        if not catalog:
-            raise HTTPException(status_code=404, detail="Document not found")
-
-        existing_items = db.query(AgendaItem).filter_by(catalog_id=catalog_id).order_by(AgendaItem.order).all()
-        if (
-            not force
-            and existing_items
-            and task_facade.agenda_items_look_low_quality
-            and not task_facade.agenda_items_look_low_quality(existing_items)
-        ):
-            return {"status": "cached", "items": existing_items}
-        if not force and existing_items:
-            logger.info(
-                "Agenda cache for catalog_id=%s looks low quality; regenerating asynchronously.",
-                catalog_id,
-            )
-        if force:
-            logger.info("Force-regenerating agenda cache for catalog_id=%s.", catalog_id)
-
-        task_id = task_facade._enqueue_task("segment_agenda_task", task_facade.segment_agenda_task, catalog_id)
-        return {
-            "status": "processing",
-            "task_id": task_id,
-            "poll_url": f"/tasks/{task_id}",
-        }
+        return segment_agenda_request(
+            task_facade=task_facade,
+            db=db,
+            catalog_id=catalog_id,
+            force=force,
+            catalog_model=Catalog,
+            agenda_item_model=AgendaItem,
+            logger=logger,
+        )
 
     @router.post("/votes/{catalog_id}", dependencies=[Depends(verify_api_key_dependency)])
     @limiter.limit(VOTES_RATE_LIMIT)
@@ -176,16 +138,13 @@ def build_task_router(
         Returns a Task ID immediately.
         """
         _ = request
-        catalog = db.get(Catalog, catalog_id)
-        if not catalog:
-            raise HTTPException(status_code=404, detail="Document not found")
-
-        task_id = task_facade._enqueue_task("extract_votes_task", task_facade.extract_votes_task, catalog_id, force=force)
-        return {
-            "status": "processing",
-            "task_id": task_id,
-            "poll_url": f"/tasks/{task_id}",
-        }
+        return extract_votes_request(
+            task_facade=task_facade,
+            db=db,
+            catalog_id=catalog_id,
+            force=force,
+            catalog_model=Catalog,
+        )
 
     @router.post("/topics/{catalog_id}", dependencies=[Depends(verify_api_key_dependency)])
     @limiter.limit(TOPICS_RATE_LIMIT)
@@ -208,43 +167,17 @@ def build_task_router(
         but we also avoid serving "cached" topics when they are stale.
         """
         _ = request
-        catalog = db.get(Catalog, catalog_id)
-        if not catalog:
-            raise HTTPException(status_code=404, detail="Document not found")
-        if not catalog.content:
-            raise HTTPException(status_code=400, detail="Document has no text to tag")
-
-        quality = analyze_source_text(catalog.content)
-        if not is_source_topicable(quality):
-            return {
-                "status": "blocked_low_signal",
-                "reason": build_low_signal_message(quality),
-                "topics": [],
-            }
-
-        content_hash = catalog.content_hash or (compute_content_hash(catalog.content) if catalog.content else None)
-        is_fresh = bool(
-            catalog.topics is not None
-            and content_hash
-            and catalog.topics_source_hash
-            and catalog.topics_source_hash == content_hash
-        )
-        if (not force) and is_fresh:
-            return {"status": "cached", "topics": catalog.topics or []}
-        if (not force) and catalog.topics is not None and not is_fresh:
-            return {"status": "stale", "topics": catalog.topics or []}
-
-        task_id = task_facade._enqueue_task(
-            "generate_topics_task",
-            task_facade.generate_topics_task,
-            catalog_id,
+        return generate_topics_request(
+            task_facade=task_facade,
+            db=db,
+            catalog_id=catalog_id,
             force=force,
+            catalog_model=Catalog,
+            analyze_source_text=analyze_source_text,
+            build_low_signal_message=build_low_signal_message,
+            compute_content_hash=compute_content_hash,
+            is_source_topicable=is_source_topicable,
         )
-        return {
-            "status": "processing",
-            "task_id": task_id,
-            "poll_url": f"/tasks/{task_id}",
-        }
 
     @router.post("/extract/{catalog_id}", dependencies=[Depends(verify_api_key_dependency)])
     @limiter.limit(EXTRACT_RATE_LIMIT)
@@ -267,25 +200,15 @@ def build_task_router(
         We do not download here. If the file isn't present on disk, the task fails fast.
         """
         _ = request
-        catalog = db.get(Catalog, catalog_id)
-        if not catalog:
-            raise HTTPException(status_code=404, detail="Document not found")
-
-        if (not force) and catalog.content and len(catalog.content.strip()) >= EXTRACT_CACHED_CONTENT_MIN_CHARS:
-            return {"status": "cached", "catalog_id": catalog_id, "chars": len(catalog.content)}
-
-        task_id = task_facade._enqueue_task(
-            "extract_text_task",
-            task_facade.extract_text_task,
-            catalog_id,
+        return extract_catalog_text_request(
+            task_facade=task_facade,
+            db=db,
+            catalog_id=catalog_id,
             force=force,
             ocr_fallback=ocr_fallback,
+            catalog_model=Catalog,
+            cached_content_min_chars=EXTRACT_CACHED_CONTENT_MIN_CHARS,
         )
-        return {
-            "status": "processing",
-            "task_id": task_id,
-            "poll_url": f"/tasks/{task_id}",
-        }
 
     @router.get("/tasks/{task_id}")
     def get_task_status(task_id: str) -> dict[str, Any]:

--- a/docs/ADR.md
+++ b/docs/ADR.md
@@ -8,6 +8,23 @@ Use each entry to record:
 - the affected boundary or contract
 - links to the canonical docs that carry the ongoing operational or architecture detail
 
+## 2026-05-10: Split API task route helpers behind the task route facade
+
+- Status: Accepted
+- Decision:
+  - `api/task_routes.py` remains the protected task-route facade and `build_task_router` entrypoint.
+  - Summary, segmentation, and generation/extraction endpoint decisions move behind focused `api/task_route_*` helpers.
+- Why:
+  - The task route facade had reached the cleanup size target while still mixing route wiring, cache checks, freshness checks, and enqueue decisions.
+  - Passing the task facade, DB session, route parameters, models, and helper dependencies explicitly keeps `api.main` monkeypatch seams intact without helper imports from `api.main`.
+- Affected boundaries:
+  - Routes, auth dependencies, rate limits, response payloads, task names, enqueue behavior, and task polling remain unchanged.
+  - Guardrails track the task API helper family under the 300-line cleanup target.
+- Canonical references:
+  - [ARCHITECTURE.md](../ARCHITECTURE.md)
+  - [docs/PIPELINE.md](PIPELINE.md)
+  - [docs/ENGINEERING_GUARDRAILS.md](ENGINEERING_GUARDRAILS.md)
+
 ## 2026-05-10: Split model and migration cleanup seams
 
 - Status: Accepted

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -311,6 +311,9 @@ TASK_API_FACADE_CLEANUP_MODULES = (
     "pipeline/task_summary_side_effects.py",
     "api/task_routes.py",
     "api/task_dispatch.py",
+    "api/task_route_generation.py",
+    "api/task_route_segmentation.py",
+    "api/task_route_summary.py",
     "api/task_route_support.py",
 )
 SEARCH_SUPPORT_CLEANUP_MODULES = (

--- a/tests/test_task_facade_cleanup.py
+++ b/tests/test_task_facade_cleanup.py
@@ -1,4 +1,5 @@
 import sys
+from pathlib import Path
 from unittest.mock import MagicMock
 
 sys.modules["llama_cpp"] = MagicMock()
@@ -18,6 +19,55 @@ def test_api_task_routes_reexports_dispatch_facade():
     assert task_routes._enqueue_task is task_dispatch._enqueue_task
     assert task_routes.generate_summary_task is task_dispatch.generate_summary_task
     assert task_routes.extract_text_task is task_dispatch.extract_text_task
+
+
+def test_api_task_route_helpers_do_not_import_main():
+    helper_modules = (
+        "api.task_route_summary",
+        "api.task_route_segmentation",
+        "api.task_route_generation",
+        "api.task_route_support",
+    )
+
+    for module_name in helper_modules:
+        module = __import__(module_name, fromlist=["__name__"])
+        module_path = Path(module.__file__)
+        assert "api.main" not in module_path.read_text(encoding="utf-8")
+
+
+def test_summary_helper_uses_injected_task_facade_patch_seam():
+    from api.task_route_summary import summarize_document_request
+
+    db = MagicMock()
+    catalog = MagicMock(
+        content="City council meeting discussed budget updates and adopted multiple motions after public comment.",
+        summary=None,
+        summary_source_hash=None,
+    )
+    db.get.return_value = catalog
+    facade = MagicMock()
+    facade._summary_doc_kind_and_hashes.return_value = ("minutes", "content-hash", None)
+    facade._enqueue_task.return_value = "summary-task"
+
+    payload = summarize_document_request(
+        task_facade=facade,
+        db=db,
+        catalog_id=123,
+        force=False,
+        catalog_model=MagicMock,
+        analyze_source_text=lambda text: {"text": text},
+        build_low_signal_message=lambda _quality: "low signal",
+        is_summary_fresh=lambda *_args, **_kwargs: False,
+        is_source_summarizable=lambda _quality: True,
+    )
+
+    assert payload == {"status": "processing", "task_id": "summary-task", "poll_url": "/tasks/summary-task"}
+    facade._enqueue_task.assert_called_once_with(
+        "generate_summary_task",
+        facade.generate_summary_task,
+        123,
+        force=False,
+    )
 
 
 def test_pipeline_tasks_summary_services_use_pipeline_tasks_patch_seams(monkeypatch):


### PR DESCRIPTION
## What changed
- Kept api.task_routes as the route facade and build_task_router entrypoint.
- Moved summary, segmentation, extraction, votes, and topics request logic into focused helper modules.
- Added guardrails and tests for helper imports and dispatch patch seams.

## Why
api/task_routes.py was near the file-size cap and still route-heavy. This narrows helper ownership while preserving route decorators, auth, rate limits, response payloads, and task dispatch behavior.

## Risk / compatibility
- Public routes and task names remain unchanged.
- Helpers receive dependencies explicitly and do not import api.main.
- No API route, response shape, auth, DB, queue, or config change.

## Verification
- PASS ./.venv/bin/ruff check api pipeline scripts tests
- PASS PYTHONPATH=. .venv/bin/pytest -q tests/test_api.py
- PASS PYTHONPATH=. .venv/bin/pytest -q tests/test_async_flow.py
- PASS PYTHONPATH=. .venv/bin/pytest -q tests/test_extract_endpoint.py
- PASS PYTHONPATH=. .venv/bin/pytest -q tests/test_summary_staleness.py
- PASS PYTHONPATH=. .venv/bin/pytest -q tests/test_topics_staleness.py
- PASS PYTHONPATH=. .venv/bin/pytest -q tests/test_task_facade_cleanup.py tests/test_task_provider_retry_semantics.py tests/test_repository_guardrails.py tests/test_docs_links.py
- PASS git diff --check

## Remaining deficits
- Combined endpoint test invocation can hit shared rate-limit state; plan-listed separate invocations passed.