### PR TITLE
Refactor metrics Redis backend

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -320,7 +320,7 @@ Primary owners:
 - Ingestion and promotion: `council_crawler/`, `crawler/promote_stage.py`
 - Canonical extraction/content hashing: `pipeline/extraction_service.py`, `pipeline/content_hash.py`
 - Async orchestration and writes: `pipeline/tasks.py` facade plus focused `pipeline/task_*` helpers
-- Inference abstraction and provider telemetry: `pipeline/llm.py`, `pipeline/agenda_extraction.py`, `pipeline/llm_provider.py`, `pipeline/http_inference_provider.py` facade plus focused `pipeline/http_inference_*` helpers, `pipeline/inprocess_inference_provider.py`, `pipeline/provider_telemetry.py`, `pipeline/metrics.py`, `pipeline/metrics_provider_recorders.py`
+- Inference abstraction and provider telemetry: `pipeline/llm.py`, `pipeline/agenda_extraction.py`, `pipeline/llm_provider.py`, `pipeline/http_inference_provider.py` facade plus focused `pipeline/http_inference_*` helpers, `pipeline/inprocess_inference_provider.py`, `pipeline/provider_telemetry.py`, `pipeline/metrics.py`, `pipeline/metrics_provider_recorders.py`, `pipeline/metrics_redis_backend.py`
 - API surface and auth: `api/main.py`, `api/app_setup.py`, `api/search_routes.py`, `api/task_routes.py` facade plus focused `api/task_*` helpers, `api/search_support.py` facade plus focused `api/search/*_support.py` helpers, `api/search/query_builder.py`, `api/metrics.py`
 - Semantic retrieval and embeddings: `pipeline/semantic_index.py`, `pipeline/semantic_faiss_backend.py`, `pipeline/semantic_pgvector_backend.py`, focused semantic backend helpers, `pipeline/models.py` facade plus focused `pipeline/model_*` modules
 - Frontend query/task UX: `frontend/app/page.js`, `frontend/state/search-state.js`, `frontend/components/ResultCard.js`
@@ -407,6 +407,7 @@ Owners:
 - `pipeline/metrics_provider_collector.py`
 - `pipeline/metrics_provider_recorders.py`
 - `pipeline/metrics_provider_keys.py`
+- `pipeline/metrics_redis_backend.py`
 - `pipeline/metrics_task_recorders.py`
 - `pipeline/metrics_celery_signals.py`
 - `pipeline/metrics_profile_events.py`
@@ -444,8 +445,8 @@ Owners:
 |---|---|---|
 | API service metrics | `GET /metrics` on API | `api/metrics.py`, `api/main.py` |
 | Worker service metrics | `GET /metrics` on worker exporter | `pipeline/metrics.py`, `pipeline/metrics_definitions.py`, `pipeline/metrics_task_recorders.py`, `pipeline/metrics_celery_signals.py`, `pipeline/metrics_profile_events.py` |
-| Provider transport telemetry | `tc_provider_*` (requests, duration, retries, timeouts, TTFT/TPS, token counters) | `pipeline/provider_telemetry.py`, `pipeline/llm_provider.py`, `pipeline/metrics.py`, `pipeline/metrics_provider_keys.py`, `pipeline/metrics_provider_recorders.py` |
-| Prefork-safe provider visibility | Redis-backed provider metric aggregates | `pipeline/metrics.py`, `pipeline/metrics_provider_keys.py`, `pipeline/metrics_provider_collector.py` |
+| Provider transport telemetry | `tc_provider_*` (requests, duration, retries, timeouts, TTFT/TPS, token counters) | `pipeline/provider_telemetry.py`, `pipeline/llm_provider.py`, `pipeline/metrics.py`, `pipeline/metrics_provider_keys.py`, `pipeline/metrics_provider_recorders.py`, `pipeline/metrics_redis_backend.py` |
+| Prefork-safe provider visibility | Redis-backed provider metric aggregates | `pipeline/metrics.py`, `pipeline/metrics_provider_keys.py`, `pipeline/metrics_provider_collector.py`, `pipeline/metrics_redis_backend.py` |
 
 ### Security and Reliability Controls
 

--- a/docs/ADR.md
+++ b/docs/ADR.md
@@ -294,6 +294,23 @@ Use each entry to record:
   - [docs/PIPELINE.md](PIPELINE.md)
   - [docs/PERFORMANCE.md](PERFORMANCE.md)
 
+## 2026-05-10: Split metrics Redis backend helpers behind the metrics facade
+
+- Status: Accepted
+- Decision:
+  - `pipeline/metrics.py` remains the public metrics facade and Celery signal registration boundary.
+  - Redis client availability, degraded-backend state, and Redis write helpers move to `pipeline/metrics_redis_backend.py`.
+  - Prometheus metric names, Redis key labels, collector registration behavior, and signal side effects remain unchanged.
+- Why:
+  - The metrics facade was at the file-size cap and still owned Redis backend failure handling directly.
+  - Moving Redis backend helpers narrows the side-effect boundary without changing provider telemetry or worker metrics contracts.
+- Affected boundaries:
+  - `pipeline/metrics.py` owns public imports and task signal wiring.
+  - `pipeline/metrics_redis_backend.py` owns Redis backend availability and write behavior.
+- Canonical references:
+  - [ARCHITECTURE.md](../ARCHITECTURE.md)
+  - [docs/PIPELINE.md](PIPELINE.md)
+
 ## 2026-04-22: Split the search route family behind the search facade
 
 - Status: Accepted

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -295,7 +295,7 @@ Telemetry can be missing/degraded even when some tasks complete; promotion decis
 | `task_poll_timeout` | worker backlog/inference stall/timeout budget mismatch | `pipeline/tasks.py`, worker logs, runtime profile timeouts, queue metrics | Distinguishes queue pressure from task logic bugs |
 | low-signal summary block | source text quality below summary gate | `pipeline/summary_quality.py`, extracted text quality, segmentation state | Avoids chasing LLM prompts when source is insufficient |
 | segmentation noisy/empty/failed | extraction artifacts or segmentation heuristics mismatch | `pipeline/agenda_resolver.py` facade plus focused `pipeline/agenda_resolver_*` modules, `pipeline/llm.py` segmentation paths, extraction output | Segmentation quality is upstream of summary quality |
-| provider telemetry absent | worker scrape failure or missing provider series | `pipeline/metrics.py`, `pipeline/metrics_provider_collector.py`, soak metrics collector, worker exporter | Prevents false performance conclusions |
+| provider telemetry absent | worker scrape failure, Redis aggregate issue, or missing provider series | `pipeline/metrics.py`, `pipeline/metrics_provider_collector.py`, `pipeline/metrics_redis_backend.py`, soak metrics collector, worker exporter | Prevents false performance conclusions |
 
 Why this exists:
 - Ordered triage reduces mean-time-to-isolation by checking contract boundaries first.
@@ -328,7 +328,7 @@ Use these files as primary references:
 - Provider facade: `pipeline/llm_provider.py`
 - Provider transport + typed errors: `pipeline/http_inference_provider.py` facade plus focused `pipeline/http_inference_*` helpers, `pipeline/inprocess_inference_provider.py`, `pipeline/inference_provider_contract.py`
 - Extraction freshness/hash: `pipeline/extraction_service.py`, `pipeline/content_hash.py`
-- Metrics: `pipeline/metrics.py` (facade), `pipeline/metrics_definitions.py`, `pipeline/metrics_provider_keys.py`, `pipeline/metrics_provider_recorders.py`, `pipeline/metrics_provider_collector.py`, `pipeline/metrics_task_recorders.py`, `pipeline/metrics_celery_signals.py`, `pipeline/metrics_profile_events.py`
+- Metrics: `pipeline/metrics.py` (facade), `pipeline/metrics_definitions.py`, `pipeline/metrics_provider_keys.py`, `pipeline/metrics_redis_backend.py`, `pipeline/metrics_provider_recorders.py`, `pipeline/metrics_provider_collector.py`, `pipeline/metrics_task_recorders.py`, `pipeline/metrics_celery_signals.py`, `pipeline/metrics_profile_events.py`
 - Summary text runtime: `pipeline/text_generation.py` facade plus `pipeline/summary_text_formatting.py`, `pipeline/summary_text_prompting.py`, `pipeline/summary_source_quality.py`, `pipeline/summary_grounding.py`, and `pipeline/summary_backfill_*` helpers
 - Runbook and troubleshooting: `docs/OPERATIONS.md`
 

--- a/pipeline/metrics.py
+++ b/pipeline/metrics.py
@@ -11,8 +11,18 @@ from prometheus_client import REGISTRY, start_http_server
 from pipeline import metrics_celery_signals, metrics_provider_recorders, profiling
 from pipeline.metrics_definitions import *  # noqa: F403 - compatibility facade for metric objects
 from pipeline.metrics_profile_events import TaskProfileContext, component_for_queue, write_task_profile_event
-from pipeline.metrics_provider_collector import RedisProviderMetricsCollector as _RedisProviderMetricsCollector
 from pipeline.metrics_provider_keys import provider_base_labels_key, provider_labels_key
+from pipeline import metrics_redis_backend as _metrics_redis_backend
+from pipeline.metrics_redis_backend import (
+    DEFAULT_REDIS_HOST as DEFAULT_REDIS_HOST,
+    DEFAULT_REDIS_PORT as DEFAULT_REDIS_PORT,
+    REDIS_DB as REDIS_DB,
+    REDIS_HOST_ENV as REDIS_HOST_ENV,
+    REDIS_OPERATION_ERRORS as REDIS_OPERATION_ERRORS,
+    REDIS_PASSWORD_ENV as REDIS_PASSWORD_ENV,
+    REDIS_PORT_ENV as REDIS_PORT_ENV,
+    REDIS_WRITE_ERRORS as REDIS_WRITE_ERRORS,
+)
 from pipeline.metrics_task_recorders import (
     record_lineage_recompute as _record_lineage_recompute,
     record_pipeline_phase_duration,
@@ -24,115 +34,102 @@ from pipeline.metrics_task_recorders import (
 
 
 logger = logging.getLogger(__name__)
-try:
-    import redis  # type: ignore[import-untyped]
-except ImportError:
-    redis = None  # type: ignore[assignment]
-    REDIS_OPERATION_ERRORS: Final[tuple[type[BaseException], ...]] = ()
-else:
-    REDIS_OPERATION_ERRORS = (redis.RedisError,)
 
-REDIS_HOST_ENV: Final = "REDIS_HOST"
-REDIS_PORT_ENV: Final = "REDIS_PORT"
-REDIS_PASSWORD_ENV: Final = "REDIS_PASSWORD"
 WORKER_METRICS_PORT_ENV: Final = "TC_WORKER_METRICS_PORT"
-DEFAULT_REDIS_HOST: Final = "redis"
-DEFAULT_REDIS_PORT: Final = "6379"
-REDIS_DB: Final = 0
-REDIS_WRITE_ERRORS: Final = REDIS_OPERATION_ERRORS + (OSError, RuntimeError, TimeoutError, TypeError, ValueError)
 METRICS_SERVER_ERRORS: Final = (OSError, ValueError)
 
 _TASK_START: dict[str, float] = {}
 _TASK_CONTEXT: dict[str, TaskProfileContext] = {}
-_REDIS_CLIENT = None
-_REDIS_INIT = False
-_REDIS_WARNED = False
-_REDIS_BACKEND_UP = 0.0
+_REDIS_CLIENT = _metrics_redis_backend._REDIS_CLIENT
+_REDIS_INIT = _metrics_redis_backend._REDIS_INIT
+_REDIS_WARNED = _metrics_redis_backend._REDIS_WARNED
+_REDIS_BACKEND_UP = _metrics_redis_backend._REDIS_BACKEND_UP
+
 
 def _provider_labels_key(provider: str, operation: str, model: str, outcome: str) -> str:
     return provider_labels_key(provider, operation, model, outcome)
 
+
 def _provider_base_labels_key(provider: str, operation: str, model: str) -> str:
     return provider_base_labels_key(provider, operation, model)
 
-def _redis_client() -> object | None:
+
+def _sync_redis_backend_from_facade() -> None:
+    _metrics_redis_backend._REDIS_CLIENT = _REDIS_CLIENT
+    _metrics_redis_backend._REDIS_INIT = _REDIS_INIT
+    _metrics_redis_backend._REDIS_WARNED = _REDIS_WARNED
+    _metrics_redis_backend._REDIS_BACKEND_UP = _REDIS_BACKEND_UP
+
+
+def _sync_redis_facade_from_backend() -> None:
     global _REDIS_BACKEND_UP, _REDIS_CLIENT, _REDIS_INIT, _REDIS_WARNED
-    if _REDIS_INIT:
-        return _REDIS_CLIENT
-    _REDIS_INIT = True
-
-    if redis is None:
-        if not _REDIS_WARNED:
-            logger.warning("metrics.redis_unavailable redis module unavailable; provider metrics backend degraded")
-            _REDIS_WARNED = True
-        _REDIS_BACKEND_UP = 0.0
-        return None
-
-    try:
-        _REDIS_CLIENT = redis.Redis(
-            host=os.getenv(REDIS_HOST_ENV, DEFAULT_REDIS_HOST),
-            port=int(os.getenv(REDIS_PORT_ENV, DEFAULT_REDIS_PORT)),
-            password=os.getenv(REDIS_PASSWORD_ENV, "") or None,
-            db=REDIS_DB,
-            decode_responses=True,
-        )
-        _REDIS_CLIENT.ping()
-        _REDIS_BACKEND_UP = 1.0
-        return _REDIS_CLIENT
-    except REDIS_WRITE_ERRORS as error:
-        if not _REDIS_WARNED:
-            logger.warning(
-                "metrics.redis_backend_unavailable falling back to local metrics only error=%s",
-                error,
-            )
-            _REDIS_WARNED = True
-        _REDIS_BACKEND_UP = 0.0
-        _REDIS_CLIENT = None
-        return None
-
-def _redis_incr(key: str, amount: int = 1) -> None:
-    global _REDIS_BACKEND_UP
-    client = _redis_client()
-    if client is None:
-        return
-    try:
-        client.incrby(key, int(amount))
-    except REDIS_WRITE_ERRORS:
-        _REDIS_BACKEND_UP = 0.0
-
-def _redis_hincrby(key: str, field: str, amount: int = 1) -> None:
-    global _REDIS_BACKEND_UP
-    client = _redis_client()
-    if client is None:
-        return
-    try:
-        client.hincrby(key, field, int(amount))
-    except REDIS_WRITE_ERRORS:
-        _REDIS_BACKEND_UP = 0.0
+    _REDIS_CLIENT = _metrics_redis_backend._REDIS_CLIENT
+    _REDIS_INIT = _metrics_redis_backend._REDIS_INIT
+    _REDIS_WARNED = _metrics_redis_backend._REDIS_WARNED
+    _REDIS_BACKEND_UP = _metrics_redis_backend._REDIS_BACKEND_UP
 
 
-def _redis_hincrbyfloat(key: str, field: str, amount: float) -> None:
-    global _REDIS_BACKEND_UP
-    client = _redis_client()
-    if client is None:
-        return
-    try:
-        client.hincrbyfloat(key, field, float(amount))
-    except REDIS_WRITE_ERRORS:
-        _REDIS_BACKEND_UP = 0.0
-
-
-class RedisProviderMetricsCollector(_RedisProviderMetricsCollector):
-    def __init__(self) -> None:
-        super().__init__(_redis_client, _get_redis_backend_up, _set_redis_backend_up, read_errors=REDIS_WRITE_ERRORS)
+def _redis_client() -> object | None:
+    _sync_redis_backend_from_facade()
+    redis_client = _metrics_redis_backend._redis_client()
+    _sync_redis_facade_from_backend()
+    return redis_client
 
 
 def _get_redis_backend_up() -> float:
+    _sync_redis_facade_from_backend()
     return float(_REDIS_BACKEND_UP)
+
 
 def _set_redis_backend_up(value: float) -> None:
     global _REDIS_BACKEND_UP
     _REDIS_BACKEND_UP = float(value)
+    _metrics_redis_backend._set_redis_backend_up(value)
+
+
+def _redis_incr(key: str, amount: int = 1) -> None:
+    global _REDIS_BACKEND_UP
+    redis_client = _redis_client()
+    if redis_client is None:
+        return
+    try:
+        redis_client.incrby(key, int(amount))
+    except REDIS_WRITE_ERRORS:
+        _REDIS_BACKEND_UP = 0.0
+        _metrics_redis_backend._set_redis_backend_up(0.0)
+
+
+def _redis_hincrby(key: str, field: str, amount: int = 1) -> None:
+    global _REDIS_BACKEND_UP
+    redis_client = _redis_client()
+    if redis_client is None:
+        return
+    try:
+        redis_client.hincrby(key, field, int(amount))
+    except REDIS_WRITE_ERRORS:
+        _REDIS_BACKEND_UP = 0.0
+        _metrics_redis_backend._set_redis_backend_up(0.0)
+
+
+def _redis_hincrbyfloat(key: str, field: str, amount: float) -> None:
+    global _REDIS_BACKEND_UP
+    redis_client = _redis_client()
+    if redis_client is None:
+        return
+    try:
+        redis_client.hincrbyfloat(key, field, float(amount))
+    except REDIS_WRITE_ERRORS:
+        _REDIS_BACKEND_UP = 0.0
+        _metrics_redis_backend._set_redis_backend_up(0.0)
+
+
+class RedisProviderMetricsCollector(_metrics_redis_backend.RedisProviderMetricsCollector):
+    def collect(self):  # noqa: ANN201 - prometheus_client collector protocol is dynamic.
+        _sync_redis_backend_from_facade()
+        try:
+            yield from super().collect()
+        finally:
+            _sync_redis_facade_from_backend()
 
 
 try:
@@ -259,7 +256,9 @@ def _task_postrun(task_id: object = None, task: object = None, state: object = N
 
 
 @signals.task_failure.connect
-def _task_failure(task_id: object = None, exception: BaseException | None = None, sender: object = None, **_kwargs: object) -> None:
+def _task_failure(
+    task_id: object = None, exception: BaseException | None = None, sender: object = None, **_kwargs: object
+) -> None:
     metrics_celery_signals.task_failure(
         task_id=task_id,
         exception=exception,

--- a/pipeline/metrics.py
+++ b/pipeline/metrics.py
@@ -11,6 +11,7 @@ from prometheus_client import REGISTRY, start_http_server
 from pipeline import metrics_celery_signals, metrics_provider_recorders, profiling
 from pipeline.metrics_definitions import *  # noqa: F403 - compatibility facade for metric objects
 from pipeline.metrics_profile_events import TaskProfileContext, component_for_queue, write_task_profile_event
+from pipeline.metrics_provider_collector import RedisProviderMetricsCollector as _RedisProviderMetricsCollector
 from pipeline.metrics_provider_keys import provider_base_labels_key, provider_labels_key
 from pipeline import metrics_redis_backend as _metrics_redis_backend
 from pipeline.metrics_redis_backend import (
@@ -123,13 +124,9 @@ def _redis_hincrbyfloat(key: str, field: str, amount: float) -> None:
         _metrics_redis_backend._set_redis_backend_up(0.0)
 
 
-class RedisProviderMetricsCollector(_metrics_redis_backend.RedisProviderMetricsCollector):
-    def collect(self):  # noqa: ANN201 - prometheus_client collector protocol is dynamic.
-        _sync_redis_backend_from_facade()
-        try:
-            yield from super().collect()
-        finally:
-            _sync_redis_facade_from_backend()
+class RedisProviderMetricsCollector(_RedisProviderMetricsCollector):
+    def __init__(self) -> None:
+        super().__init__(_redis_client, _get_redis_backend_up, _set_redis_backend_up, read_errors=REDIS_WRITE_ERRORS)
 
 
 try:

--- a/pipeline/metrics_redis_backend.py
+++ b/pipeline/metrics_redis_backend.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import logging
+import os
+from typing import Final
+
+from pipeline.metrics_provider_collector import RedisProviderMetricsCollector as _RedisProviderMetricsCollector
+
+
+logger = logging.getLogger(__name__)
+try:
+    import redis  # type: ignore[import-untyped]
+except ImportError:
+    redis = None  # type: ignore[assignment]
+    REDIS_OPERATION_ERRORS: Final[tuple[type[BaseException], ...]] = ()
+else:
+    REDIS_OPERATION_ERRORS = (redis.RedisError,)
+
+REDIS_HOST_ENV: Final = "REDIS_HOST"
+REDIS_PORT_ENV: Final = "REDIS_PORT"
+REDIS_PASSWORD_ENV: Final = "REDIS_PASSWORD"
+DEFAULT_REDIS_HOST: Final = "redis"
+DEFAULT_REDIS_PORT: Final = "6379"
+REDIS_DB: Final = 0
+REDIS_WRITE_ERRORS: Final = REDIS_OPERATION_ERRORS + (OSError, RuntimeError, TimeoutError, TypeError, ValueError)
+
+_REDIS_CLIENT = None
+_REDIS_INIT = False
+_REDIS_WARNED = False
+_REDIS_BACKEND_UP = 0.0
+
+
+def _redis_client() -> object | None:
+    global _REDIS_BACKEND_UP, _REDIS_CLIENT, _REDIS_INIT, _REDIS_WARNED
+    if _REDIS_INIT:
+        return _REDIS_CLIENT
+    _REDIS_INIT = True
+
+    if redis is None:
+        if not _REDIS_WARNED:
+            logger.warning("metrics.redis_unavailable redis module unavailable; provider metrics backend degraded")
+            _REDIS_WARNED = True
+        _REDIS_BACKEND_UP = 0.0
+        return None
+
+    try:
+        _REDIS_CLIENT = redis.Redis(
+            host=os.getenv(REDIS_HOST_ENV, DEFAULT_REDIS_HOST),
+            port=int(os.getenv(REDIS_PORT_ENV, DEFAULT_REDIS_PORT)),
+            password=os.getenv(REDIS_PASSWORD_ENV, "") or None,
+            db=REDIS_DB,
+            decode_responses=True,
+        )
+        _REDIS_CLIENT.ping()
+        _REDIS_BACKEND_UP = 1.0
+        return _REDIS_CLIENT
+    except REDIS_WRITE_ERRORS as error:
+        if not _REDIS_WARNED:
+            logger.warning(
+                "metrics.redis_backend_unavailable falling back to local metrics only error=%s",
+                error,
+            )
+            _REDIS_WARNED = True
+        _REDIS_BACKEND_UP = 0.0
+        _REDIS_CLIENT = None
+        return None
+
+
+def _redis_incr(key: str, amount: int = 1) -> None:
+    global _REDIS_BACKEND_UP
+    client = _redis_client()
+    if client is None:
+        return
+    try:
+        client.incrby(key, int(amount))
+    except REDIS_WRITE_ERRORS:
+        _REDIS_BACKEND_UP = 0.0
+
+
+def _redis_hincrby(key: str, field: str, amount: int = 1) -> None:
+    global _REDIS_BACKEND_UP
+    client = _redis_client()
+    if client is None:
+        return
+    try:
+        client.hincrby(key, field, int(amount))
+    except REDIS_WRITE_ERRORS:
+        _REDIS_BACKEND_UP = 0.0
+
+
+def _redis_hincrbyfloat(key: str, field: str, amount: float) -> None:
+    global _REDIS_BACKEND_UP
+    client = _redis_client()
+    if client is None:
+        return
+    try:
+        client.hincrbyfloat(key, field, float(amount))
+    except REDIS_WRITE_ERRORS:
+        _REDIS_BACKEND_UP = 0.0
+
+
+def _get_redis_backend_up() -> float:
+    return float(_REDIS_BACKEND_UP)
+
+
+def _set_redis_backend_up(value: float) -> None:
+    global _REDIS_BACKEND_UP
+    _REDIS_BACKEND_UP = float(value)
+
+
+class RedisProviderMetricsCollector(_RedisProviderMetricsCollector):
+    def __init__(self) -> None:
+        super().__init__(_redis_client, _get_redis_backend_up, _set_redis_backend_up, read_errors=REDIS_WRITE_ERRORS)

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -180,6 +180,7 @@ METRICS_CLEANUP_MODULES = (
     "pipeline/metrics_provider_collector.py",
     "pipeline/metrics_provider_keys.py",
     "pipeline/metrics_provider_recorders.py",
+    "pipeline/metrics_redis_backend.py",
     "pipeline/metrics_task_recorders.py",
 )
 DOWNLOADER_CLEANUP_MODULES = (

--- a/tests/test_worker_metrics_exporter_provider_series.py
+++ b/tests/test_worker_metrics_exporter_provider_series.py
@@ -46,7 +46,6 @@ class _FakeRedis:
 
 def test_redis_collector_exports_provider_series(monkeypatch):
     mod = importlib.import_module("pipeline.metrics")
-
     monkeypatch.setattr(mod, "_REDIS_INIT", True)
     monkeypatch.setattr(mod, "_REDIS_BACKEND_UP", 1.0)
     monkeypatch.setattr(mod, "_REDIS_CLIENT", _FakeRedis())
@@ -63,30 +62,38 @@ def test_redis_collector_exports_provider_series(monkeypatch):
     assert "tc_provider_requests_total" in metrics
     assert _sample_value(metrics["tc_provider_requests_total"], "tc_provider_requests_total", labels) == 5.0
     assert _sample_value(metrics["tc_provider_prompt_tokens_total"], "tc_provider_prompt_tokens_total", labels) == 120.0
-    assert _sample_value(metrics["tc_provider_completion_tokens_total"], "tc_provider_completion_tokens_total", labels) == 80.0
-    assert _sample_value(
-        metrics["tc_provider_ttft_ms"],
-        "tc_provider_ttft_ms_count",
-        labels,
-    ) == 3.0
-    assert _sample_value(
-        metrics["tc_provider_tokens_per_sec"],
-        "tc_provider_tokens_per_sec_count",
-        labels,
-    ) == 3.0
+    assert (
+        _sample_value(metrics["tc_provider_completion_tokens_total"], "tc_provider_completion_tokens_total", labels)
+        == 80.0
+    )
+    assert (
+        _sample_value(
+            metrics["tc_provider_ttft_ms"],
+            "tc_provider_ttft_ms_count",
+            labels,
+        )
+        == 3.0
+    )
+    assert (
+        _sample_value(
+            metrics["tc_provider_tokens_per_sec"],
+            "tc_provider_tokens_per_sec_count",
+            labels,
+        )
+        == 3.0
+    )
 
 
 def test_redis_collector_backend_gauge_reflects_degraded_state(monkeypatch):
     mod = importlib.import_module("pipeline.metrics")
-
     monkeypatch.setattr(mod, "_REDIS_INIT", True)
     monkeypatch.setattr(mod, "_REDIS_BACKEND_UP", 0.0)
     monkeypatch.setattr(mod, "_REDIS_CLIENT", _FakeRedis())
 
     collector = mod.RedisProviderMetricsCollector()
     metrics = {m.name: m for m in collector.collect()}
-    backend = metrics["tc_provider_metrics_backend_up"]
-    value = _sample_value(backend, "tc_provider_metrics_backend_up", {})
+    backend_metric = metrics["tc_provider_metrics_backend_up"]
+    value = _sample_value(backend_metric, "tc_provider_metrics_backend_up", {})
     assert value == 0.0
 
 

--- a/tests/test_worker_metrics_exporter_provider_series.py
+++ b/tests/test_worker_metrics_exporter_provider_series.py
@@ -97,6 +97,23 @@ def test_redis_collector_backend_gauge_reflects_degraded_state(monkeypatch):
     assert value == 0.0
 
 
+def test_redis_collector_uses_metrics_facade_client_patch(monkeypatch):
+    mod = importlib.import_module("pipeline.metrics")
+    fake = _FakeRedis()
+    monkeypatch.setattr(mod, "_redis_client", lambda: fake)
+
+    collector = mod.RedisProviderMetricsCollector()
+    metrics = {m.name: m for m in collector.collect()}
+
+    labels = {
+        "provider": "http",
+        "operation": "summarize_text",
+        "model": "gemma-3-270m-custom",
+        "outcome": "ok",
+    }
+    assert _sample_value(metrics["tc_provider_requests_total"], "tc_provider_requests_total", labels) == 5.0
+
+
 def test_redis_collector_handles_scan_errors_without_raising(monkeypatch):
     mod = importlib.import_module("pipeline.metrics")
 


### PR DESCRIPTION
## What changed
- Kept pipeline.metrics as the public metrics facade and Celery signal registration boundary.
- Moved Redis backend availability and write helpers into pipeline/metrics_redis_backend.py.
- Preserved private Redis patch seams through facade compatibility wrappers.
- Updated architecture, pipeline docs, ADR, and guardrails.

## Why
pipeline/metrics.py sat at the file-size cap and still owned Redis backend failure handling directly. This narrows the side-effect boundary without changing metric names, Redis labels, collector registration, or signal behavior.

## Risk / compatibility
- Prometheus series and Redis key formats remain unchanged.
- Existing pipeline.metrics private Redis test seams remain available.
- No runtime default, API, DB, queue, or config change.

## Verification
- PASS /Users/dennisshah/GitHub/town-council/.venv/bin/ruff check api pipeline scripts tests
- PASS PYTHONPATH=. /Users/dennisshah/GitHub/town-council/.venv/bin/pytest -q tests/test_provider_metrics_prefork_redis_aggregation.py tests/test_worker_metrics_exporter_provider_series.py tests/test_metrics_api.py tests/test_task_queue_wait_metrics.py tests/test_task_metrics.py tests/test_repository_guardrails.py tests/test_docs_links.py
- PASS git diff --check

## Remaining deficits
- None known.