### PR TITLE
Refactor summary backfill progress helpers

### DIFF
--- a/pipeline/summary_backfill_progress.py
+++ b/pipeline/summary_backfill_progress.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+
+from pipeline.backlog_maintenance import (
+    AGENDA_SUMMARY_BUNDLE_BUILD_MS,
+    AGENDA_SUMMARY_EMBED_DISPATCH_MS,
+    AGENDA_SUMMARY_PERSIST_MS,
+    AGENDA_SUMMARY_REINDEX_MS,
+    AGENDA_SUMMARY_RENDER_MS,
+)
+from pipeline.task_runtime import logger
+
+
+def initial_summary_backfill_counts(*, selected: int) -> dict[str, int]:
+    return {
+        "selected": selected,
+        "complete": 0,
+        "changed_catalogs": 0,
+        "cached": 0,
+        "stale": 0,
+        "blocked_low_signal": 0,
+        "blocked_ungrounded": 0,
+        "not_generated_yet": 0,
+        "error": 0,
+        "other": 0,
+        "agenda_deterministic_complete": 0,
+        "llm_complete": 0,
+        "deterministic_fallback_complete": 0,
+        "reindexed": 0,
+        "reindex_failed": 0,
+        "embed_enqueued": 0,
+        "embed_dispatch_failed": 0,
+        AGENDA_SUMMARY_BUNDLE_BUILD_MS: 0,
+        AGENDA_SUMMARY_RENDER_MS: 0,
+        AGENDA_SUMMARY_PERSIST_MS: 0,
+        AGENDA_SUMMARY_REINDEX_MS: 0,
+        AGENDA_SUMMARY_EMBED_DISPATCH_MS: 0,
+    }
+
+
+SummaryProgressCallback = Callable[[dict[str, object]], None]
+
+
+def _count_value(raw_count: object) -> int:
+    if not raw_count:
+        return 0
+    return int(raw_count)
+
+
+def _text_value(raw_text: object) -> str:
+    if raw_text is None:
+        return ""
+    return str(raw_text)
+
+
+def _mapping_value(raw_mapping: object) -> Mapping[str, object]:
+    if isinstance(raw_mapping, Mapping):
+        return raw_mapping
+    return {}
+
+
+def finish_empty_summary_backfill(
+    counts: dict[str, int],
+    progress_callback: SummaryProgressCallback | None,
+) -> None:
+    logger.info("summary_hydration_backfill selected=0")
+    if progress_callback:
+        progress_callback(
+            {
+                "event_type": "stage_finish",
+                "stage": "summary",
+                "counts": counts.copy(),
+                "detail": {"selected": 0},
+            }
+        )
+
+
+def emit_summary_stage_start(
+    counts: dict[str, int],
+    selected_count: int,
+    progress_callback: SummaryProgressCallback | None,
+) -> None:
+    if progress_callback:
+        progress_callback(
+            {
+                "event_type": "stage_start",
+                "stage": "summary",
+                "counts": counts.copy(),
+                "detail": {"selected": selected_count},
+            }
+        )
+
+
+def add_agenda_batch_counts(counts: dict[str, int], agenda_batch: Mapping[str, object]) -> None:
+    reindex_summary = _mapping_value(agenda_batch.get("reindex_summary"))
+    counts["reindexed"] += _count_value(reindex_summary.get("catalogs_reindexed"))
+    counts["reindex_failed"] += _count_value(reindex_summary.get("catalogs_failed"))
+    embed_summary = _mapping_value(agenda_batch.get("embed_summary"))
+    counts["embed_enqueued"] += _count_value(embed_summary.get("embed_enqueued"))
+    counts["embed_dispatch_failed"] += _count_value(embed_summary.get("embed_dispatch_failed"))
+    agenda_summary_timings = _mapping_value(agenda_batch.get("agenda_summary_timings"))
+    for metric_name in (
+        AGENDA_SUMMARY_BUNDLE_BUILD_MS,
+        AGENDA_SUMMARY_RENDER_MS,
+        AGENDA_SUMMARY_PERSIST_MS,
+        AGENDA_SUMMARY_REINDEX_MS,
+        AGENDA_SUMMARY_EMBED_DISPATCH_MS,
+    ):
+        counts[metric_name] += _count_value(agenda_summary_timings.get(metric_name))
+
+
+def record_summary_result_counts(counts: dict[str, int], summary_result: Mapping[str, object]) -> None:
+    status = _text_value(summary_result.get("status")) or "other"
+    counts[status if status in counts else "other"] += 1
+    counts["changed_catalogs"] += int(bool(summary_result.get("changed")))
+    counts["reindexed"] += _count_value(summary_result.get("reindexed"))
+    counts["reindex_failed"] += _count_value(summary_result.get("reindex_failed"))
+    counts["embed_enqueued"] += _count_value(summary_result.get("embed_enqueued"))
+    counts["embed_dispatch_failed"] += _count_value(summary_result.get("embed_dispatch_failed"))
+    completion_mode = _text_value(summary_result.get("completion_mode"))
+    if completion_mode == "agenda_deterministic":
+        counts["agenda_deterministic_complete"] += 1
+    elif completion_mode == "llm":
+        counts["llm_complete"] += 1
+    elif completion_mode == "deterministic_fallback":
+        counts["deterministic_fallback_complete"] += 1
+
+
+def emit_summary_progress(
+    *,
+    catalog_ids: list[int],
+    index: int,
+    catalog_id: int,
+    counts: dict[str, int],
+    summary_result: Mapping[str, object],
+    progress_callback: SummaryProgressCallback | None,
+    progress_every: int,
+) -> None:
+    if not progress_callback or not (index == 1 or index % progress_every == 0 or index == len(catalog_ids)):
+        return
+    progress_callback(
+        {
+            "event_type": "progress",
+            "stage": "summary",
+            "counts": counts.copy(),
+            "last_catalog_id": catalog_id,
+            "detail": {
+                "done": index,
+                "total": len(catalog_ids),
+                "last_status": _text_value(summary_result.get("status")) or "other",
+                "completion_mode": _text_value(summary_result.get("completion_mode")),
+                "error": _text_value(summary_result.get("error")),
+            },
+        }
+    )

--- a/pipeline/summary_backfill_runner.py
+++ b/pipeline/summary_backfill_runner.py
@@ -3,11 +3,6 @@ from __future__ import annotations
 from typing import Any, Callable
 
 from pipeline.backlog_maintenance import (
-    AGENDA_SUMMARY_BUNDLE_BUILD_MS,
-    AGENDA_SUMMARY_EMBED_DISPATCH_MS,
-    AGENDA_SUMMARY_PERSIST_MS,
-    AGENDA_SUMMARY_REINDEX_MS,
-    AGENDA_SUMMARY_RENDER_MS,
     build_deterministic_agenda_summary_payload,
     build_deterministic_agenda_summary_payloads,
     summarize_catalog_with_maintenance_mode,
@@ -17,11 +12,19 @@ from pipeline.indexer import reindex_catalog, reindex_catalogs
 from pipeline.semantic_tasks import embed_catalog_task
 from pipeline.summary_backfill_dispatch import enqueue_embed_catalogs
 from pipeline.summary_backfill_logging import log_backfill_counts
+from pipeline.summary_backfill_progress import (
+    add_agenda_batch_counts,
+    emit_summary_progress,
+    emit_summary_stage_start,
+    finish_empty_summary_backfill,
+    initial_summary_backfill_counts,
+    record_summary_result_counts,
+)
 from pipeline.summary_backfill_queries import (
     select_catalog_ids_for_summary_hydration,
     summary_doc_kind_map,
 )
-from pipeline.task_runtime import logger, task_session
+from pipeline.task_runtime import task_session
 
 
 def run_summary_hydration_backfill(
@@ -52,12 +55,12 @@ def run_summary_hydration_backfill(
         limit=limit,
         city=city,
     )
-    counts = _initial_counts(selected=len(catalog_ids))
+    counts = initial_summary_backfill_counts(selected=len(catalog_ids))
     if not catalog_ids:
-        _finish_empty_backfill(counts, progress_callback)
+        finish_empty_summary_backfill(counts, progress_callback)
         return counts
 
-    _emit_stage_start(counts, len(catalog_ids), progress_callback)
+    emit_summary_stage_start(counts, len(catalog_ids), progress_callback)
     doc_kind_by_catalog_id = _load_doc_kind_map(
         session_factory=session_factory,
         summary_doc_kind_map_callable=summary_doc_kind_map_callable,
@@ -87,33 +90,6 @@ def run_summary_hydration_backfill(
     return counts
 
 
-def _initial_counts(*, selected: int) -> dict[str, int]:
-    return {
-        "selected": selected,
-        "complete": 0,
-        "changed_catalogs": 0,
-        "cached": 0,
-        "stale": 0,
-        "blocked_low_signal": 0,
-        "blocked_ungrounded": 0,
-        "not_generated_yet": 0,
-        "error": 0,
-        "other": 0,
-        "agenda_deterministic_complete": 0,
-        "llm_complete": 0,
-        "deterministic_fallback_complete": 0,
-        "reindexed": 0,
-        "reindex_failed": 0,
-        "embed_enqueued": 0,
-        "embed_dispatch_failed": 0,
-        AGENDA_SUMMARY_BUNDLE_BUILD_MS: 0,
-        AGENDA_SUMMARY_RENDER_MS: 0,
-        AGENDA_SUMMARY_PERSIST_MS: 0,
-        AGENDA_SUMMARY_REINDEX_MS: 0,
-        AGENDA_SUMMARY_EMBED_DISPATCH_MS: 0,
-    }
-
-
 def _select_catalog_ids(
     *,
     session_factory: Callable[[], Any],
@@ -126,38 +102,6 @@ def _select_catalog_ids(
         return select_catalog_ids_callable(db, limit, city)
     finally:
         db.close()
-
-
-def _finish_empty_backfill(
-    counts: dict[str, int],
-    progress_callback: Callable[[dict[str, Any]], None] | None,
-) -> None:
-    logger.info("summary_hydration_backfill selected=0")
-    if progress_callback:
-        progress_callback(
-            {
-                "event_type": "stage_finish",
-                "stage": "summary",
-                "counts": counts.copy(),
-                "detail": {"selected": 0},
-            }
-        )
-
-
-def _emit_stage_start(
-    counts: dict[str, int],
-    selected_count: int,
-    progress_callback: Callable[[dict[str, Any]], None] | None,
-) -> None:
-    if progress_callback:
-        progress_callback(
-            {
-                "event_type": "stage_start",
-                "stage": "summary",
-                "counts": counts.copy(),
-                "detail": {"selected": selected_count},
-            }
-        )
 
 
 def _load_doc_kind_map(
@@ -191,26 +135,8 @@ def _run_agenda_batch(
         reindex_callback=reindex_catalogs,
         embed_callback=agenda_embed_callback,
     )
-    _add_agenda_batch_counts(counts, agenda_batch)
+    add_agenda_batch_counts(counts, agenda_batch)
     return dict(agenda_batch.get("results") or {})
-
-
-def _add_agenda_batch_counts(counts: dict[str, int], agenda_batch: dict[str, Any]) -> None:
-    reindex_summary = agenda_batch.get("reindex_summary") or {}
-    counts["reindexed"] += int(reindex_summary.get("catalogs_reindexed") or 0)
-    counts["reindex_failed"] += int(reindex_summary.get("catalogs_failed") or 0)
-    embed_summary = agenda_batch.get("embed_summary") or {}
-    counts["embed_enqueued"] += int(embed_summary.get("embed_enqueued") or 0)
-    counts["embed_dispatch_failed"] += int(embed_summary.get("embed_dispatch_failed") or 0)
-    agenda_summary_timings = agenda_batch.get("agenda_summary_timings") or {}
-    for metric_name in (
-        AGENDA_SUMMARY_BUNDLE_BUILD_MS,
-        AGENDA_SUMMARY_RENDER_MS,
-        AGENDA_SUMMARY_PERSIST_MS,
-        AGENDA_SUMMARY_REINDEX_MS,
-        AGENDA_SUMMARY_EMBED_DISPATCH_MS,
-    ):
-        counts[metric_name] += int(agenda_summary_timings.get(metric_name) or 0)
 
 
 def _run_backfill_loop(
@@ -240,59 +166,13 @@ def _run_backfill_loop(
                         embed_callback=lambda target_catalog_id: embed_catalog_task.delay(target_catalog_id),
                     ),
                 )
-            _record_result_counts(counts, result)
-            _emit_progress(
+            record_summary_result_counts(counts, result)
+            emit_summary_progress(
                 catalog_ids=catalog_ids,
                 index=index,
                 catalog_id=cid,
                 counts=counts,
-                result=result,
+                summary_result=result,
                 progress_callback=progress_callback,
                 progress_every=progress_every,
             )
-
-
-def _record_result_counts(counts: dict[str, int], result: dict[str, Any]) -> None:
-    status = str((result or {}).get("status") or "other")
-    counts[status if status in counts else "other"] += 1
-    counts["changed_catalogs"] += int(bool((result or {}).get("changed")))
-    counts["reindexed"] += int((result or {}).get("reindexed") or 0)
-    counts["reindex_failed"] += int((result or {}).get("reindex_failed") or 0)
-    counts["embed_enqueued"] += int((result or {}).get("embed_enqueued") or 0)
-    counts["embed_dispatch_failed"] += int((result or {}).get("embed_dispatch_failed") or 0)
-    completion_mode = str((result or {}).get("completion_mode") or "")
-    if completion_mode == "agenda_deterministic":
-        counts["agenda_deterministic_complete"] += 1
-    elif completion_mode == "llm":
-        counts["llm_complete"] += 1
-    elif completion_mode == "deterministic_fallback":
-        counts["deterministic_fallback_complete"] += 1
-
-
-def _emit_progress(
-    *,
-    catalog_ids: list[int],
-    index: int,
-    catalog_id: int,
-    counts: dict[str, int],
-    result: dict[str, Any],
-    progress_callback: Callable[[dict[str, Any]], None] | None,
-    progress_every: int,
-) -> None:
-    if not progress_callback or not (index == 1 or index % progress_every == 0 or index == len(catalog_ids)):
-        return
-    progress_callback(
-        {
-            "event_type": "progress",
-            "stage": "summary",
-            "counts": counts.copy(),
-            "last_catalog_id": catalog_id,
-            "detail": {
-                "done": index,
-                "total": len(catalog_ids),
-                "last_status": str((result or {}).get("status") or "other"),
-                "completion_mode": str((result or {}).get("completion_mode") or ""),
-                "error": str((result or {}).get("error") or ""),
-            },
-        }
-    )

--- a/tests/test_pipeline_batching.py
+++ b/tests/test_pipeline_batching.py
@@ -29,10 +29,10 @@ def test_document_chunk_worker(mocker):
     mock_catalog.location = "/tmp/test.pdf"
     mock_catalog.content = None
     mock_catalog.entities = None
-    
+
     mock_db = MagicMock()
     mock_db.get.return_value = mock_catalog
-    
+
     # Mock DB Connection context
     mock_session = MagicMock()
     mock_session.return_value = mock_db
@@ -84,7 +84,10 @@ def test_run_entity_backfill_uses_in_process_fast_path_for_small_snapshots(mocke
     mock_session.__exit__.return_value = False
     mocker.patch("pipeline.backfill_entities.db_session", return_value=mock_session)
     mocker.patch("pipeline.backfill_entities.select_catalog_ids_for_entity_backfill", return_value=[1, 2, 3])
-    mocker.patch("pipeline.backfill_entities._resolve_parallel_processing_settings", return_value={"mode": "global", "chunk_size": 10, "workers_override": None})
+    mocker.patch(
+        "pipeline.backfill_entities._resolve_parallel_processing_settings",
+        return_value={"mode": "global", "chunk_size": 10, "workers_override": None},
+    )
     process_chunk_spy = mocker.patch(
         "pipeline.backfill_entities.process_entity_chunk",
         return_value={"complete": 3, "updated_catalog_ids": [1, 2, 3]},
@@ -367,8 +370,26 @@ def test_select_catalog_ids_for_summary_hydration_includes_stale_agenda_but_skip
         summary="stale agenda summary",
         segmentation_status="complete",
     )
-    fresh_items = [{"order": 1, "title": "Item 1", "description": "Desc", "classification": "Agenda", "result": "", "page_number": 1}]
-    stale_items = [{"order": 1, "title": "Item 2", "description": "Desc", "classification": "Agenda", "result": "", "page_number": 1}]
+    fresh_items = [
+        {
+            "order": 1,
+            "title": "Item 1",
+            "description": "Desc",
+            "classification": "Agenda",
+            "result": "",
+            "page_number": 1,
+        }
+    ]
+    stale_items = [
+        {
+            "order": 1,
+            "title": "Item 2",
+            "description": "Desc",
+            "classification": "Agenda",
+            "result": "",
+            "page_number": 1,
+        }
+    ]
     fresh_hash = compute_agenda_items_hash(fresh_items)
     stale_hash = compute_agenda_items_hash(stale_items)
     fresh_agenda.agenda_items_hash = fresh_hash
@@ -396,7 +417,14 @@ def test_persist_agenda_items_updates_catalog_agenda_items_hash(batching_db):
         segmentation_status="complete",
     )
     items = [
-        {"order": 1, "title": "Item 1", "description": "Desc", "classification": "Agenda", "result": "", "page_number": 1}
+        {
+            "order": 1,
+            "title": "Item 1",
+            "description": "Desc",
+            "classification": "Agenda",
+            "result": "",
+            "page_number": 1,
+        }
     ]
 
     persist_agenda_items(db, agenda_catalog.id, event.id, items)
@@ -417,7 +445,14 @@ def test_persist_agenda_items_skips_rows_without_titles(batching_db):
         segmentation_status="complete",
     )
     items = [
-        {"order": 1, "title": "Kept Item", "description": "Desc", "classification": "Agenda", "result": "", "page_number": 1},
+        {
+            "order": 1,
+            "title": "Kept Item",
+            "description": "Desc",
+            "classification": "Agenda",
+            "result": "",
+            "page_number": 1,
+        },
         {"order": 2, "title": "", "description": "Skipped", "classification": "Agenda", "result": "", "page_number": 2},
     ]
 
@@ -432,9 +467,15 @@ def test_persist_agenda_items_skips_rows_without_titles(batching_db):
 def test_select_catalog_ids_for_agenda_segmentation_excludes_empty_terminal_state(batching_db):
     db, event, place = batching_db
     pending_catalog = _add_catalog(db, event, place, category="agenda", content="agenda text", segmentation_status=None)
-    failed_catalog = _add_catalog(db, event, place, category="agenda", content="agenda text", segmentation_status="failed")
-    empty_catalog = _add_catalog(db, event, place, category="agenda", content="agenda text", segmentation_status="empty")
-    complete_catalog = _add_catalog(db, event, place, category="agenda", content="agenda text", segmentation_status="complete")
+    failed_catalog = _add_catalog(
+        db, event, place, category="agenda", content="agenda text", segmentation_status="failed"
+    )
+    empty_catalog = _add_catalog(
+        db, event, place, category="agenda", content="agenda text", segmentation_status="empty"
+    )
+    complete_catalog = _add_catalog(
+        db, event, place, category="agenda", content="agenda text", segmentation_status="complete"
+    )
     db.add(AgendaItem(catalog_id=complete_catalog.id, event_id=event.id, order=1, title="Item 1", page_number=None))
     db.commit()
 
@@ -460,8 +501,18 @@ def test_run_summary_hydration_backfill_counts_outcomes(mocker):
                 2: {"status": "blocked_low_signal", "changed": False},
             },
             "changed_catalog_ids": [1],
-            "reindex_summary": {"catalogs_considered": 1, "catalogs_reindexed": 1, "catalogs_failed": 0, "failed_catalog_ids": []},
-            "embed_summary": {"catalogs_considered": 1, "embed_enqueued": 1, "embed_dispatch_failed": 0, "failed_catalog_ids": []},
+            "reindex_summary": {
+                "catalogs_considered": 1,
+                "catalogs_reindexed": 1,
+                "catalogs_failed": 0,
+                "failed_catalog_ids": [],
+            },
+            "embed_summary": {
+                "catalogs_considered": 1,
+                "embed_enqueued": 1,
+                "embed_dispatch_failed": 0,
+                "failed_catalog_ids": [],
+            },
             "agenda_summary_timings": {
                 "agenda_summary_bundle_build_ms": 11,
                 "agenda_summary_render_ms": 22,
@@ -473,7 +524,13 @@ def test_run_summary_hydration_backfill_counts_outcomes(mocker):
     )
     summarize_spy = mocker.patch(
         "pipeline.tasks.summarize_catalog_with_maintenance_mode",
-        return_value={"status": "complete", "completion_mode": "llm", "changed": True, "reindexed": 1, "embed_enqueued": 1},
+        return_value={
+            "status": "complete",
+            "completion_mode": "llm",
+            "changed": True,
+            "reindexed": 1,
+            "embed_enqueued": 1,
+        },
     )
 
     counts = run_summary_hydration_backfill()
@@ -498,6 +555,104 @@ def test_run_summary_hydration_backfill_counts_outcomes(mocker):
     summarize_spy.assert_called_once()
 
 
+def test_summary_backfill_progress_helpers_preserve_counts_and_empty_payload():
+    from pipeline.backlog_maintenance import (
+        AGENDA_SUMMARY_BUNDLE_BUILD_MS,
+        AGENDA_SUMMARY_EMBED_DISPATCH_MS,
+        AGENDA_SUMMARY_PERSIST_MS,
+        AGENDA_SUMMARY_REINDEX_MS,
+        AGENDA_SUMMARY_RENDER_MS,
+    )
+    from pipeline.summary_backfill_progress import (
+        add_agenda_batch_counts,
+        finish_empty_summary_backfill,
+        initial_summary_backfill_counts,
+        record_summary_result_counts,
+    )
+
+    empty_events = []
+    empty_counts = initial_summary_backfill_counts(selected=0)
+    finish_empty_summary_backfill(empty_counts, empty_events.append)
+
+    assert empty_events == [
+        {
+            "event_type": "stage_finish",
+            "stage": "summary",
+            "counts": empty_counts,
+            "detail": {"selected": 0},
+        }
+    ]
+
+    counts = initial_summary_backfill_counts(selected=2)
+    add_agenda_batch_counts(
+        counts,
+        {
+            "reindex_summary": {"catalogs_reindexed": "3", "catalogs_failed": 1.9},
+            "embed_summary": {"embed_enqueued": "5", "embed_dispatch_failed": 2.1},
+            "agenda_summary_timings": {
+                AGENDA_SUMMARY_BUNDLE_BUILD_MS: 11,
+                AGENDA_SUMMARY_RENDER_MS: 22,
+                AGENDA_SUMMARY_PERSIST_MS: 33,
+                AGENDA_SUMMARY_REINDEX_MS: 44,
+                AGENDA_SUMMARY_EMBED_DISPATCH_MS: 55,
+            },
+        },
+    )
+    record_summary_result_counts(
+        counts,
+        {"status": "complete", "changed": True, "completion_mode": "llm", "reindexed": 1, "embed_enqueued": 1},
+    )
+    record_summary_result_counts(
+        counts,
+        {
+            "status": "unknown_status",
+            "changed": False,
+            "completion_mode": "deterministic_fallback",
+            "reindex_failed": 1,
+            "embed_dispatch_failed": 1,
+        },
+    )
+
+    assert counts["complete"] == 1
+    assert counts["other"] == 1
+    assert counts["changed_catalogs"] == 1
+    assert counts["llm_complete"] == 1
+    assert counts["deterministic_fallback_complete"] == 1
+    assert counts["reindexed"] == 4
+    assert counts["reindex_failed"] == 2
+    assert counts["embed_enqueued"] == 6
+    assert counts["embed_dispatch_failed"] == 3
+    assert counts[AGENDA_SUMMARY_BUNDLE_BUILD_MS] == 11
+    assert counts[AGENDA_SUMMARY_RENDER_MS] == 22
+    assert counts[AGENDA_SUMMARY_PERSIST_MS] == 33
+    assert counts[AGENDA_SUMMARY_REINDEX_MS] == 44
+    assert counts[AGENDA_SUMMARY_EMBED_DISPATCH_MS] == 55
+
+
+def test_summary_backfill_progress_cadence_preserves_first_interval_and_final_events():
+    from pipeline.summary_backfill_progress import emit_summary_progress, initial_summary_backfill_counts
+
+    counts = initial_summary_backfill_counts(selected=5)
+    progress_events = []
+    catalog_ids = [10, 11, 12, 13, 14]
+
+    for index, catalog_id in enumerate(catalog_ids, start=1):
+        emit_summary_progress(
+            catalog_ids=catalog_ids,
+            index=index,
+            catalog_id=catalog_id,
+            counts=counts,
+            summary_result={"status": "complete", "completion_mode": "llm"},
+            progress_callback=progress_events.append,
+            progress_every=2,
+        )
+
+    assert [event["detail"]["done"] for event in progress_events] == [1, 2, 4, 5]
+    assert [event["last_catalog_id"] for event in progress_events] == [10, 11, 13, 14]
+    assert {event["detail"]["last_status"] for event in progress_events} == {"complete"}
+    assert {event["detail"]["completion_mode"] for event in progress_events} == {"llm"}
+
+
 def test_select_catalog_ids_for_summary_hydration_can_filter_by_city(batching_db):
     db, event, place = batching_db
     event.source = "san mateo"
@@ -519,7 +674,9 @@ def test_select_catalog_ids_for_summary_hydration_can_filter_by_city(batching_db
     )
     db.add(other_event)
     db.flush()
-    hayward_catalog = _add_catalog(db, other_event, other_place, category="minutes", content="minutes text", summary=None)
+    hayward_catalog = _add_catalog(
+        db, other_event, other_place, category="minutes", content="minutes text", summary=None
+    )
     db.commit()
 
     selected = select_catalog_ids_for_summary_hydration(db, city="san_mateo")


### PR DESCRIPTION
## What changed
- Extracted summary backfill count and progress payload helpers from the runner.
- Preserved `run_summary_hydration_backfill(...)`, count keys, timing fields, progress events, and logging.
- Added tests for empty-run payloads, count coercion, timing aggregation, and progress cadence.

## Why
Keep the summary backfill runner below the file-size cap without changing operator-visible behavior.

## Risk / compatibility
Low. Public runner signature and payload contracts stay unchanged.

## Verification
- PASS: `/Users/dennisshah/GitHub/town-council/.venv/bin/ruff check api pipeline scripts tests`
- PASS: `PYTHONPATH=. /Users/dennisshah/GitHub/town-council/.venv/bin/pytest -q tests/test_pipeline_batching.py tests/test_backfill_summaries.py`
- PASS: `PYTHONPATH=. /Users/dennisshah/GitHub/town-council/.venv/bin/pytest -q tests/test_repository_guardrails.py`
- PASS: `git diff --check`

## Deferred
Docs/source-map and cleanup-family guardrail enrollment stay in separate Batch D docs/guardrails PR after code lanes merge.