### PR TITLE
Refactor Laserfiche generated PDF retries

### DIFF
--- a/scripts/laserfiche_repair_downloads.py
+++ b/scripts/laserfiche_repair_downloads.py
@@ -81,7 +81,7 @@ def classify_target(target: RepairTarget) -> RepairTarget:
     info: dict[str, object] = {}
     try:
         info = fetch_basic_document_info(worker_session(), entry_id=entry_id, repo=repo)
-    except requests.RequestException, ValueError, TypeError, KeyError:
+    except (requests.RequestException, ValueError, TypeError, KeyError):
         info = {}
 
     page_count = int(info.get("pageCount") or 0) if info else 0

--- a/scripts/laserfiche_repair_downloads.py
+++ b/scripts/laserfiche_repair_downloads.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import requests
@@ -22,6 +21,7 @@ from scripts.laserfiche_repair_contracts import (
     target_path,
     url_to_md5,
 )
+from scripts import laserfiche_repair_generated_pdf as _generated_pdf
 from scripts.laserfiche_repair_pdf_io import laserfiche_headers, worker_session, write_validated_pdf_response
 
 
@@ -42,7 +42,7 @@ def fetch_basic_document_info(session: requests.Session, *, entry_id: int, repo:
 
 def build_page_range(page_count: int) -> str:
     if page_count <= 0:
-        raise ValueError("Laserfiche document has no pages to export")
+        raise RepairNonRetryableError("invalid_page_count", "Laserfiche document has no pages to export")
     return f"1 - {page_count}"
 
 
@@ -81,7 +81,7 @@ def classify_target(target: RepairTarget) -> RepairTarget:
     info: dict[str, object] = {}
     try:
         info = fetch_basic_document_info(worker_session(), entry_id=entry_id, repo=repo)
-    except (requests.RequestException, ValueError, TypeError, KeyError):
+    except requests.RequestException, ValueError, TypeError, KeyError:
         info = {}
 
     page_count = int(info.get("pageCount") or 0) if info else 0
@@ -120,6 +120,9 @@ def download_generated_pdf(
     final_path: str,
     catalog_id: int,
     pdf_transition_timeout_seconds: int = PDF_TRANSITION_TIMEOUT_SECONDS,
+    pdf_transition_poll_interval_seconds: int | None = None,
+    generated_pdf_fetch_retries: int | None = None,
+    generated_pdf_fetch_retry_delay_seconds: int | None = None,
 ) -> int:
     page_range = build_page_range(page_count).replace(" ", "+")
     generate = session.post(
@@ -133,7 +136,18 @@ def download_generated_pdf(
     if not token:
         raise ValueError(f"Laserfiche PDF generation token missing for catalog {catalog_id}")
 
-    _wait_for_generated_pdf(session, token=token, catalog_id=catalog_id, timeout_seconds=pdf_transition_timeout_seconds)
+    _wait_for_generated_pdf(
+        session,
+        token=token,
+        catalog_id=catalog_id,
+        timeout_seconds=pdf_transition_timeout_seconds,
+        request_timeout_seconds=DOWNLOAD_TIMEOUT_SECONDS,
+        poll_interval_seconds=(
+            PDF_TRANSITION_POLL_INTERVAL_SECONDS
+            if pdf_transition_poll_interval_seconds is None
+            else pdf_transition_poll_interval_seconds
+        ),
+    )
     return _fetch_generated_pdf(
         session,
         token=token,
@@ -141,6 +155,15 @@ def download_generated_pdf(
         temp_path=temp_path,
         final_path=final_path,
         catalog_id=catalog_id,
+        request_timeout_seconds=DOWNLOAD_TIMEOUT_SECONDS,
+        fetch_retries=GENERATED_PDF_FETCH_RETRIES
+        if generated_pdf_fetch_retries is None
+        else generated_pdf_fetch_retries,
+        retry_delay_seconds=(
+            GENERATED_PDF_FETCH_RETRY_DELAY_SECONDS
+            if generated_pdf_fetch_retry_delay_seconds is None
+            else generated_pdf_fetch_retry_delay_seconds
+        ),
     )
 
 
@@ -150,25 +173,19 @@ def _wait_for_generated_pdf(
     token: str,
     catalog_id: int,
     timeout_seconds: int,
+    request_timeout_seconds: int = DOWNLOAD_TIMEOUT_SECONDS,
+    poll_interval_seconds: int | None = None,
 ) -> None:
-    deadline = time.time() + timeout_seconds
-    while True:
-        progress = session.post(
-            "https://portal.laserfiche.com/Portal/DocumentService.aspx/PDFTransition",
-            headers=laserfiche_headers(),
-            json={"Key": token},
-            timeout=DOWNLOAD_TIMEOUT_SECONDS,
-        )
-        progress.raise_for_status()
-        progress_payload = progress.json().get("data") or {}
-        if progress_payload.get("finished"):
-            if not progress_payload.get("success"):
-                message = progress_payload.get("errMsg") or "unknown error"
-                raise ValueError(f"Laserfiche PDF generation failed for catalog {catalog_id}: {message}")
-            return
-        if time.time() >= deadline:
-            raise ValueError(f"Laserfiche PDF generation timed out for catalog {catalog_id}")
-        time.sleep(PDF_TRANSITION_POLL_INTERVAL_SECONDS)
+    _generated_pdf.wait_for_generated_pdf(
+        session,
+        token=token,
+        catalog_id=catalog_id,
+        timeout_seconds=timeout_seconds,
+        request_timeout_seconds=request_timeout_seconds,
+        poll_interval_seconds=(
+            PDF_TRANSITION_POLL_INTERVAL_SECONDS if poll_interval_seconds is None else poll_interval_seconds
+        ),
+    )
 
 
 def _fetch_generated_pdf(
@@ -179,43 +196,27 @@ def _fetch_generated_pdf(
     temp_path: str,
     final_path: str,
     catalog_id: int,
+    request_timeout_seconds: int = DOWNLOAD_TIMEOUT_SECONDS,
+    fetch_retries: int | None = None,
+    retry_delay_seconds: int | None = None,
 ) -> int:
-    last_error: Exception | None = None
-    for attempt in range(1, GENERATED_PDF_FETCH_RETRIES + 1):
-        try:
-            download = session.get(
-                f"https://portal.laserfiche.com/Portal/PDF10/{token}/{entry_id}",
-                stream=True,
-                timeout=DOWNLOAD_TIMEOUT_SECONDS,
-            )
-            download.raise_for_status()
-            size = write_validated_pdf_response(
-                download,
-                temp_path=temp_path,
-                final_path=final_path,
-                catalog_id=catalog_id,
-            )
-            setattr(THREAD_STATE, "last_generated_pdf_fetch_retries", attempt - 1)
-            return size
-        except requests.exceptions.ReadTimeout as exc:
-            last_error = RepairRetryableError("read_timeout", f"Read timeout while fetching generated PDF: {exc}")
-        except requests.exceptions.ConnectionError as exc:
-            last_error = _classify_fetch_connection_error(exc)
-        except RepairRetryableError as exc:
-            last_error = exc
-        if attempt < GENERATED_PDF_FETCH_RETRIES:
-            time.sleep(GENERATED_PDF_FETCH_RETRY_DELAY_SECONDS * attempt)
-    assert last_error is not None
-    raise last_error
+    return _generated_pdf.fetch_generated_pdf(
+        session,
+        token=token,
+        entry_id=entry_id,
+        temp_path=temp_path,
+        final_path=final_path,
+        catalog_id=catalog_id,
+        request_timeout_seconds=request_timeout_seconds,
+        fetch_retries=GENERATED_PDF_FETCH_RETRIES if fetch_retries is None else fetch_retries,
+        retry_delay_seconds=GENERATED_PDF_FETCH_RETRY_DELAY_SECONDS
+        if retry_delay_seconds is None
+        else retry_delay_seconds,
+    )
 
 
 def _classify_fetch_connection_error(exc: requests.exceptions.ConnectionError) -> RepairRetryableError:
-    message = str(exc).lower()
-    if "remotedisconnected" in message:
-        return RepairRetryableError("remote_disconnected", f"Remote disconnected while fetching generated PDF: {exc}")
-    if "incompleteread" in message:
-        return RepairRetryableError("incomplete_read", f"Incomplete generated PDF response: {exc}")
-    return RepairRetryableError("connection_error", f"Connection error while fetching generated PDF: {exc}")
+    return _generated_pdf.classify_fetch_connection_error(exc)
 
 
 def download_repaired_pdf(

--- a/scripts/laserfiche_repair_generated_pdf.py
+++ b/scripts/laserfiche_repair_generated_pdf.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import time
+
+import requests
+
+from scripts.laserfiche_repair_contracts import (
+    GENERATED_PDF_FETCH_RETRIES,
+    GENERATED_PDF_FETCH_RETRY_DELAY_SECONDS,
+    PDF_TRANSITION_POLL_INTERVAL_SECONDS,
+    RepairNonRetryableError,
+    RepairRetryableError,
+    THREAD_STATE,
+)
+from scripts.laserfiche_repair_pdf_io import laserfiche_headers, write_validated_pdf_response
+
+
+def wait_for_generated_pdf(
+    session: requests.Session,
+    *,
+    token: str,
+    catalog_id: int,
+    timeout_seconds: int,
+    request_timeout_seconds: int,
+    poll_interval_seconds: int = PDF_TRANSITION_POLL_INTERVAL_SECONDS,
+) -> None:
+    deadline = time.time() + timeout_seconds
+    while True:
+        progress = session.post(
+            "https://portal.laserfiche.com/Portal/DocumentService.aspx/PDFTransition",
+            headers=laserfiche_headers(),
+            json={"Key": token},
+            timeout=request_timeout_seconds,
+        )
+        progress.raise_for_status()
+        progress_payload = progress.json().get("data") or {}
+        if progress_payload.get("finished"):
+            if not progress_payload.get("success"):
+                message = progress_payload.get("errMsg") or "unknown error"
+                raise RepairNonRetryableError(
+                    "generated_pdf_failed",
+                    f"Laserfiche PDF generation failed for catalog {catalog_id}: {message}",
+                )
+            return
+        if time.time() >= deadline:
+            raise ValueError(f"Laserfiche PDF generation timed out for catalog {catalog_id}")
+        time.sleep(poll_interval_seconds)
+
+
+def fetch_generated_pdf(
+    session: requests.Session,
+    *,
+    token: str,
+    entry_id: int,
+    temp_path: str,
+    final_path: str,
+    catalog_id: int,
+    request_timeout_seconds: int,
+    fetch_retries: int = GENERATED_PDF_FETCH_RETRIES,
+    retry_delay_seconds: int = GENERATED_PDF_FETCH_RETRY_DELAY_SECONDS,
+) -> int:
+    last_error: Exception | None = None
+    for attempt in range(1, fetch_retries + 1):
+        try:
+            download = session.get(
+                f"https://portal.laserfiche.com/Portal/PDF10/{token}/{entry_id}",
+                stream=True,
+                timeout=request_timeout_seconds,
+            )
+            download.raise_for_status()
+            size = write_validated_pdf_response(
+                download,
+                temp_path=temp_path,
+                final_path=final_path,
+                catalog_id=catalog_id,
+            )
+            setattr(THREAD_STATE, "last_generated_pdf_fetch_retries", attempt - 1)
+            return size
+        except requests.exceptions.ReadTimeout as exc:
+            last_error = RepairRetryableError("read_timeout", f"Read timeout while fetching generated PDF: {exc}")
+        except requests.exceptions.ConnectionError as exc:
+            last_error = classify_fetch_connection_error(exc)
+        except RepairRetryableError as exc:
+            last_error = exc
+        if attempt < fetch_retries:
+            time.sleep(retry_delay_seconds * attempt)
+    assert last_error is not None
+    raise last_error
+
+
+def classify_fetch_connection_error(exc: requests.exceptions.ConnectionError) -> RepairRetryableError:
+    message = str(exc).lower()
+    if "remotedisconnected" in message:
+        return RepairRetryableError("remote_disconnected", f"Remote disconnected while fetching generated PDF: {exc}")
+    if "incompleteread" in message:
+        return RepairRetryableError("incomplete_read", f"Incomplete generated PDF response: {exc}")
+    return RepairRetryableError("connection_error", f"Connection error while fetching generated PDF: {exc}")

--- a/tests/test_repair_san_mateo_laserfiche_backlog.py
+++ b/tests/test_repair_san_mateo_laserfiche_backlog.py
@@ -1,7 +1,9 @@
 import importlib.util
-from requests.exceptions import ConnectionError as RequestsConnectionError
 from pathlib import Path
 import sys
+
+from requests.exceptions import ConnectionError as RequestsConnectionError
+from requests.exceptions import ReadTimeout as RequestsReadTimeout
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
@@ -64,7 +66,15 @@ def test_target_path_reuses_existing_catalog_directory():
 
 
 class _FakeResponse:
-    def __init__(self, *, content_type: str | None, chunks: list[bytes], status_code: int = 200, text: str | None = None, json_data=None):
+    def __init__(
+        self,
+        *,
+        content_type: str | None,
+        chunks: list[bytes],
+        status_code: int = 200,
+        text: str | None = None,
+        json_data=None,
+    ):
         self.headers = {}
         if content_type is not None:
             self.headers["Content-Type"] = content_type
@@ -95,11 +105,17 @@ class _FakeSession:
 
     def get(self, url, stream=True, timeout=None):
         self.get_calls.append((url, stream, timeout))
-        return self.responses.pop(0)
+        response = self.responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
 
     def post(self, url, headers=None, json=None, data=None, timeout=None):
         self.post_calls.append((url, json, data, timeout))
-        return self.responses.pop(0)
+        response = self.responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
 
 
 def test_download_repaired_pdf_writes_validated_pdf_to_final_path(tmp_path, monkeypatch):
@@ -143,7 +159,8 @@ def test_download_repaired_pdf_rejects_html_and_leaves_no_artifact(tmp_path, mon
 
     try:
         mod._download_repaired_pdf(target)
-    except ValueError as exc:
+    except mod.RepairNonRetryableError as exc:
+        assert exc.reason == "invalid_page_count"
         assert "no pages to export" in str(exc)
     else:  # pragma: no cover
         raise AssertionError("expected html response to fail")
@@ -214,7 +231,8 @@ def test_download_repaired_pdf_rejects_zero_byte_pdf(tmp_path, monkeypatch):
 
     try:
         mod._download_repaired_pdf(target)
-    except ValueError as exc:
+    except mod.RepairNonRetryableError as exc:
+        assert exc.reason == "invalid_page_count"
         assert "no pages to export" in str(exc)
     else:  # pragma: no cover
         raise AssertionError("expected zero-byte response to fail")
@@ -338,10 +356,126 @@ def test_download_repaired_pdf_salvage_surfaces_generated_pdf_failure(tmp_path, 
 
     try:
         mod._download_repaired_pdf(target)
-    except ValueError as exc:
+    except mod.RepairNonRetryableError as exc:
+        assert exc.reason == "generated_pdf_failed"
         assert "Laserfiche PDF generation failed" in str(exc)
     else:  # pragma: no cover
         raise AssertionError("expected generated PDF failure to surface")
+
+
+def test_download_generated_pdf_retries_read_timeout_then_writes_pdf(tmp_path):
+    fake_session = _FakeSession(
+        [
+            _FakeResponse(
+                content_type="text/plain",
+                chunks=[b"token-123\r\n<html></html>"],
+                text="token-123\r\n<html></html>",
+            ),
+            _FakeResponse(
+                content_type="application/json",
+                chunks=[b'{"data":{"finished":true,"success":true,"completion":100}}'],
+                json_data={"data": {"finished": True, "success": True, "completion": 100}},
+            ),
+            RequestsReadTimeout("slow generated PDF read"),
+            _FakeResponse(content_type="application/pdf", chunks=[b"%PDF-1.7\nretry\n%%EOF"]),
+        ]
+    )
+
+    size = mod._download_generated_pdf(
+        fake_session,
+        entry_id=2038682,
+        repo="r-98a383e2",
+        page_count=7,
+        temp_path=str(tmp_path / "retry.pdf.tmp"),
+        final_path=str(tmp_path / "retry.pdf"),
+        catalog_id=17,
+        pdf_transition_poll_interval_seconds=0,
+        generated_pdf_fetch_retry_delay_seconds=0,
+    )
+
+    assert size == len(b"%PDF-1.7\nretry\n%%EOF")
+    assert (tmp_path / "retry.pdf").read_bytes() == b"%PDF-1.7\nretry\n%%EOF"
+    assert len(fake_session.get_calls) == 2
+    assert mod._THREAD_STATE.last_generated_pdf_fetch_retries == 1
+
+
+def test_download_generated_pdf_retries_connection_error_then_writes_pdf(tmp_path):
+    fake_session = _FakeSession(
+        [
+            _FakeResponse(
+                content_type="text/plain",
+                chunks=[b"token-456\r\n<html></html>"],
+                text="token-456\r\n<html></html>",
+            ),
+            _FakeResponse(
+                content_type="application/json",
+                chunks=[b'{"data":{"finished":true,"success":true,"completion":100}}'],
+                json_data={"data": {"finished": True, "success": True, "completion": 100}},
+            ),
+            RequestsConnectionError("socket reset"),
+            _FakeResponse(content_type="application/pdf", chunks=[b"%PDF-1.7\nconnected\n%%EOF"]),
+        ]
+    )
+
+    size = mod._download_generated_pdf(
+        fake_session,
+        entry_id=2038683,
+        repo="r-98a383e2",
+        page_count=4,
+        temp_path=str(tmp_path / "connection.pdf.tmp"),
+        final_path=str(tmp_path / "connection.pdf"),
+        catalog_id=18,
+        pdf_transition_poll_interval_seconds=0,
+        generated_pdf_fetch_retry_delay_seconds=0,
+    )
+
+    assert size == len(b"%PDF-1.7\nconnected\n%%EOF")
+    assert (tmp_path / "connection.pdf").read_bytes() == b"%PDF-1.7\nconnected\n%%EOF"
+    assert len(fake_session.get_calls) == 2
+    assert mod._THREAD_STATE.last_generated_pdf_fetch_retries == 1
+
+
+def test_download_generated_pdf_wrapper_preserves_monkeypatched_poll_and_retry_constants(tmp_path, monkeypatch):
+    from scripts import laserfiche_repair_generated_pdf
+
+    sleep_calls = []
+    monkeypatch.setattr(mod, "PDF_TRANSITION_POLL_INTERVAL_SECONDS", 9)
+    monkeypatch.setattr(mod, "GENERATED_PDF_FETCH_RETRY_DELAY_SECONDS", 7)
+    monkeypatch.setattr(laserfiche_repair_generated_pdf.time, "sleep", sleep_calls.append)
+    fake_session = _FakeSession(
+        [
+            _FakeResponse(
+                content_type="text/plain",
+                chunks=[b"token-789\r\n<html></html>"],
+                text="token-789\r\n<html></html>",
+            ),
+            _FakeResponse(
+                content_type="application/json",
+                chunks=[b'{"data":{"finished":false,"success":false,"completion":10}}'],
+                json_data={"data": {"finished": False, "success": False, "completion": 10}},
+            ),
+            _FakeResponse(
+                content_type="application/json",
+                chunks=[b'{"data":{"finished":true,"success":true,"completion":100}}'],
+                json_data={"data": {"finished": True, "success": True, "completion": 100}},
+            ),
+            RequestsReadTimeout("slow generated PDF read"),
+            _FakeResponse(content_type="application/pdf", chunks=[b"%PDF-1.7\npatched\n%%EOF"]),
+        ]
+    )
+
+    size = mod._download_generated_pdf(
+        fake_session,
+        entry_id=2038684,
+        repo="r-98a383e2",
+        page_count=4,
+        temp_path=str(tmp_path / "patched.pdf.tmp"),
+        final_path=str(tmp_path / "patched.pdf"),
+        catalog_id=19,
+    )
+
+    assert size == len(b"%PDF-1.7\npatched\n%%EOF")
+    assert sleep_calls == [9, 7]
 
 
 def test_classify_target_prefers_generated_pdf_when_no_edoc_signal(monkeypatch, tmp_path):
@@ -361,7 +495,9 @@ def test_classify_target_prefers_generated_pdf_when_no_edoc_signal(monkeypatch, 
 
     assert classified.preferred_method == "generated_pdf"
     assert classified.page_count == 8
-    assert classified.new_url == "https://portal.laserfiche.com/Portal/ElectronicFile.aspx?docid=2040900&repo=r-98a383e2"
+    assert (
+        classified.new_url == "https://portal.laserfiche.com/Portal/ElectronicFile.aspx?docid=2040900&repo=r-98a383e2"
+    )
 
 
 def test_download_repaired_pdf_skips_direct_fetch_for_generated_pdf_targets(tmp_path, monkeypatch):
@@ -397,7 +533,9 @@ def test_download_repaired_pdf_skips_direct_fetch_for_generated_pdf_targets(tmp_
     repair = mod._download_repaired_pdf(target)
 
     assert repair["retrieval_type"] == "generated_pdf"
-    assert fake_session.get_calls[0][0] == "https://portal.laserfiche.com/Portal/DocView.aspx?id=2038682&repo=r-98a383e2"
+    assert (
+        fake_session.get_calls[0][0] == "https://portal.laserfiche.com/Portal/DocView.aspx?id=2038682&repo=r-98a383e2"
+    )
 
 
 def test_main_retries_timeout_and_token_missing_failures(mocker, capsys):
@@ -413,8 +551,26 @@ def test_main_retries_timeout_and_token_missing_failures(mocker, capsys):
         side_effect=[
             ValueError("Laserfiche PDF generation timed out for catalog 31"),
             ValueError("Laserfiche PDF generation token missing for catalog 32"),
-            {"catalog_id": 31, "new_url": "u1", "new_hash": "h1", "path": "p1", "filename": "f1", "size": 1, "method": "generated_pdf", "retrieval_type": "generated_pdf"},
-            {"catalog_id": 32, "new_url": "u2", "new_hash": "h2", "path": "p2", "filename": "f2", "size": 1, "method": "generated_pdf", "retrieval_type": "generated_pdf"},
+            {
+                "catalog_id": 31,
+                "new_url": "u1",
+                "new_hash": "h1",
+                "path": "p1",
+                "filename": "f1",
+                "size": 1,
+                "method": "generated_pdf",
+                "retrieval_type": "generated_pdf",
+            },
+            {
+                "catalog_id": 32,
+                "new_url": "u2",
+                "new_hash": "h2",
+                "path": "p2",
+                "filename": "f2",
+                "size": 1,
+                "method": "generated_pdf",
+                "retrieval_type": "generated_pdf",
+            },
         ],
     )
     apply_repairs = mocker.patch.object(mod, "_apply_repairs", return_value={"updated": 2, "skipped_duplicate_hash": 0})


### PR DESCRIPTION
## What changed
- Extracted generated-PDF transition polling and fetch retry helpers from Laserfiche repair downloads.
- Preserved wrapper monkeypatch seams, retryable error classification, chunked writes, and PDF validation.
- Added coverage for read timeout, connection retry, invalid page count, transition failure, and patched poll/retry constants.

## Why
Reduce near-cap Laserfiche repair code while keeping operator repair behavior stable.

## Risk / compatibility
Low. Import surface and repair output shape stay unchanged.

## Verification
- PASS: `/Users/dennisshah/GitHub/town-council/.venv/bin/ruff check api pipeline scripts tests`
- PASS: `PYTHONPATH=. /Users/dennisshah/GitHub/town-council/.venv/bin/pytest -q tests/test_repair_san_mateo_laserfiche_backlog.py tests/test_backlog_maintenance_laserfiche_guard.py tests/test_repository_guardrails.py`
- PASS: `git diff --check`

## Deferred
Docs/source-map and cleanup-family guardrail enrollment stay in separate Batch D docs/guardrails PR after code lanes merge.