### PR TITLE
Refactor vote extraction item handling

### DIFF
--- a/pipeline/vote_extraction_item.py
+++ b/pipeline/vote_extraction_item.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import logging
+
+from pipeline.vote_extraction_contracts import (
+    LLM_EXTRACTED_VOTE_SOURCE,
+    SKIP_REASON_ALREADY_HIGH_CONFIDENCE,
+    SKIP_REASON_EXISTING_RESULT,
+    SKIP_REASON_MISSING_TITLE,
+    SKIP_REASON_TRUSTED_SOURCE,
+    AgendaItemLike,
+    CatalogLike,
+    VoteExtractionCounters,
+    VoteExtractionRuntimeHooks,
+    VoteExtractionSettings,
+    VoteExtractionResult,
+)
+from pipeline.vote_extraction_policy import (
+    has_non_unknown_result,
+    is_high_confidence_existing_llm_vote,
+    is_trusted_existing_vote,
+    result_text_from_label,
+)
+
+
+def empty_vote_counters() -> VoteExtractionCounters:
+    return {
+        "processed_items": 0,
+        "updated_items": 0,
+        "skipped_items": 0,
+        "failed_items": 0,
+        "skip_reasons": {},
+    }
+
+
+def count_processed_item(counters: VoteExtractionCounters) -> None:
+    counters["processed_items"] += 1
+
+
+def count_updated_item(counters: VoteExtractionCounters) -> None:
+    counters["updated_items"] += 1
+
+
+def count_skipped_item(counters: VoteExtractionCounters, reason: str) -> None:
+    counters["skipped_items"] += 1
+    counters["skip_reasons"][reason] = counters["skip_reasons"].get(reason, 0) + 1
+
+
+def count_failed_item(counters: VoteExtractionCounters) -> None:
+    counters["failed_items"] += 1
+
+
+def skip_reason_before_extraction(
+    item: AgendaItemLike,
+    *,
+    item_title: str,
+    force: bool,
+    settings: VoteExtractionSettings,
+    runtime_hooks: VoteExtractionRuntimeHooks,
+) -> str | None:
+    if not item_title:
+        return SKIP_REASON_MISSING_TITLE
+    trusted_vote_checker = runtime_hooks.trusted_vote_checker or is_trusted_existing_vote
+    high_confidence_vote_checker = runtime_hooks.high_confidence_vote_checker
+    existing_result_checker = runtime_hooks.existing_result_checker or has_non_unknown_result
+    if trusted_vote_checker(getattr(item, "votes", None)):
+        return SKIP_REASON_TRUSTED_SOURCE
+    if (
+        not force
+        and high_confidence_vote_checker is not None
+        and high_confidence_vote_checker(getattr(item, "votes", None))
+    ):
+        return SKIP_REASON_ALREADY_HIGH_CONFIDENCE
+    if (
+        not force
+        and high_confidence_vote_checker is None
+        and is_high_confidence_existing_llm_vote(
+            getattr(item, "votes", None),
+            confidence_threshold=settings.confidence_threshold,
+        )
+    ):
+        return SKIP_REASON_ALREADY_HIGH_CONFIDENCE
+    if not force and existing_result_checker(getattr(item, "result", None)):
+        return SKIP_REASON_EXISTING_RESULT
+    return None
+
+
+def build_vote_payload(extracted: VoteExtractionResult, *, extracted_at: datetime | None = None) -> dict[str, object]:
+    timestamp = extracted_at or datetime.now(timezone.utc)
+    return {
+        "outcome_label": extracted.outcome_label,
+        "motion_text": extracted.motion_text,
+        "vote_tally_raw": extracted.vote_tally_raw,
+        "yes_count": extracted.yes_count,
+        "no_count": extracted.no_count,
+        "abstain_count": extracted.abstain_count,
+        "absent_count": extracted.absent_count,
+        "confidence": extracted.confidence,
+        "evidence_snippet": extracted.evidence_snippet,
+        "source": LLM_EXTRACTED_VOTE_SOURCE,
+        "extracted_at": timestamp.isoformat(),
+    }
+
+
+def update_item_vote(
+    item: AgendaItemLike,
+    extracted: VoteExtractionResult,
+    *,
+    logger: logging.Logger,
+    catalog: CatalogLike,
+    runtime_hooks: VoteExtractionRuntimeHooks,
+) -> None:
+    result_text_builder = runtime_hooks.result_text_builder or result_text_from_label
+    item.result = result_text_builder(extracted.outcome_label)
+    item.votes = build_vote_payload(extracted)
+    logger.info(
+        "vote_extraction.updated catalog_id=%s agenda_item_id=%s outcome=%s confidence=%.2f",
+        catalog.id,
+        getattr(item, "id", None),
+        extracted.outcome_label,
+        extracted.confidence,
+    )
+
+
+def log_extraction_failure(
+    item: AgendaItemLike,
+    *,
+    catalog: CatalogLike,
+    logger: logging.Logger,
+    error: Exception,
+) -> None:
+    logger.warning(
+        "vote_extraction.failed catalog_id=%s agenda_item_id=%s error=%s",
+        catalog.id,
+        getattr(item, "id", None),
+        error.__class__.__name__,
+    )

--- a/pipeline/vote_extraction_runner.py
+++ b/pipeline/vote_extraction_runner.py
@@ -1,18 +1,12 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from datetime import datetime, timezone
 import logging
 
 from pipeline.models import AgendaItem
 from pipeline.vote_extraction_context import build_meeting_context, build_vote_context_text
 from pipeline.vote_extraction_contracts import (
-    LLM_EXTRACTED_VOTE_SOURCE,
-    SKIP_REASON_ALREADY_HIGH_CONFIDENCE,
-    SKIP_REASON_EXISTING_RESULT,
     SKIP_REASON_INSUFFICIENT_TEXT,
-    SKIP_REASON_MISSING_TITLE,
-    SKIP_REASON_TRUSTED_SOURCE,
     AgendaItemLike,
     AgendaItemSession,
     CatalogLike,
@@ -26,13 +20,19 @@ from pipeline.vote_extraction_contracts import (
     VoteExtractionSettings,
     VoteExtractionResult,
 )
+from pipeline.vote_extraction_item import (
+    count_failed_item,
+    count_processed_item,
+    count_skipped_item,
+    count_updated_item,
+    empty_vote_counters,
+    log_extraction_failure,
+    skip_reason_before_extraction,
+    update_item_vote,
+)
 from pipeline.vote_extraction_parser import parse_vote_extraction_response
 from pipeline.vote_extraction_policy import (
     apply_ambiguity_penalty,
-    has_non_unknown_result,
-    is_high_confidence_existing_llm_vote,
-    is_trusted_existing_vote,
-    result_text_from_label,
     skip_reason_after_extraction,
 )
 from pipeline.vote_extraction_prompting import prepare_vote_extraction_prompt
@@ -75,7 +75,7 @@ def run_vote_extraction_for_catalog(
     runtime_hooks: VoteExtractionRuntimeHooks = DEFAULT_RUNTIME_HOOKS,
 ) -> VoteExtractionCounters:
     items = _agenda_items_for_catalog(db, catalog, agenda_items)
-    counters = _empty_vote_counters()
+    counters = empty_vote_counters()
     if not items:
         return counters
 
@@ -108,16 +108,6 @@ def _agenda_items_for_catalog(
     return db.query(AgendaItem).filter_by(catalog_id=catalog.id).order_by(AgendaItem.order).all()
 
 
-def _empty_vote_counters() -> VoteExtractionCounters:
-    return {
-        "processed_items": 0,
-        "updated_items": 0,
-        "skipped_items": 0,
-        "failed_items": 0,
-        "skip_reasons": {},
-    }
-
-
 def _process_agenda_item(
     item: AgendaItemLike,
     *,
@@ -140,7 +130,7 @@ def _process_agenda_item(
         runtime_hooks=runtime_hooks,
     )
     if skip_reason:
-        _count_skip(counters, skip_reason)
+        count_skipped_item(counters, skip_reason)
         return
 
     context_builder = runtime_hooks.context_builder
@@ -157,7 +147,7 @@ def _process_agenda_item(
             context_after_chars=settings.context_after_chars,
         )
     if len(context_text) < settings.min_text_chars:
-        _count_skip(counters, SKIP_REASON_INSUFFICIENT_TEXT)
+        count_skipped_item(counters, SKIP_REASON_INSUFFICIENT_TEXT)
         return
 
     extracted = _extract_vote_for_item(
@@ -178,10 +168,10 @@ def _process_agenda_item(
 
     skip_reason = skip_reason_after_extraction(extracted, settings=settings)
     if skip_reason:
-        _count_skip(counters, skip_reason)
+        count_skipped_item(counters, skip_reason)
         return
-    _update_item_vote(item, extracted, logger=logger, catalog=catalog, runtime_hooks=runtime_hooks)
-    counters["updated_items"] += 1
+    update_item_vote(item, extracted, logger=logger, catalog=catalog, runtime_hooks=runtime_hooks)
+    count_updated_item(counters)
 
 
 def _skip_reason_before_extraction(
@@ -192,31 +182,13 @@ def _skip_reason_before_extraction(
     settings: VoteExtractionSettings,
     runtime_hooks: VoteExtractionRuntimeHooks,
 ) -> str | None:
-    if not item_title:
-        return SKIP_REASON_MISSING_TITLE
-    trusted_vote_checker = runtime_hooks.trusted_vote_checker or is_trusted_existing_vote
-    high_confidence_vote_checker = runtime_hooks.high_confidence_vote_checker
-    existing_result_checker = runtime_hooks.existing_result_checker or has_non_unknown_result
-    if trusted_vote_checker(getattr(item, "votes", None)):
-        return SKIP_REASON_TRUSTED_SOURCE
-    if (
-        not force
-        and high_confidence_vote_checker is not None
-        and high_confidence_vote_checker(getattr(item, "votes", None))
-    ):
-        return SKIP_REASON_ALREADY_HIGH_CONFIDENCE
-    if (
-        not force
-        and high_confidence_vote_checker is None
-        and is_high_confidence_existing_llm_vote(
-            getattr(item, "votes", None),
-            confidence_threshold=settings.confidence_threshold,
-        )
-    ):
-        return SKIP_REASON_ALREADY_HIGH_CONFIDENCE
-    if not force and existing_result_checker(getattr(item, "result", None)):
-        return SKIP_REASON_EXISTING_RESULT
-    return None
+    return skip_reason_before_extraction(
+        item,
+        item_title=item_title,
+        force=force,
+        settings=settings,
+        runtime_hooks=runtime_hooks,
+    )
 
 
 def _extract_vote_for_item(
@@ -233,7 +205,7 @@ def _extract_vote_for_item(
     prompt_builder: PromptBuilder,
     vote_extractor: CatalogVoteExtractor | None,
 ) -> VoteExtractionResult | None:
-    counters["processed_items"] += 1
+    count_processed_item(counters)
     try:
         if vote_extractor is not None:
             return vote_extractor(local_ai, item_title, context_text, meeting_context)
@@ -247,48 +219,6 @@ def _extract_vote_for_item(
             prompt_builder=prompt_builder,
         )
     except Exception as exc:
-        counters["failed_items"] += 1
-        logger.warning(
-            "vote_extraction.failed catalog_id=%s agenda_item_id=%s error=%s",
-            catalog.id,
-            getattr(item, "id", None),
-            exc.__class__.__name__,
-        )
+        count_failed_item(counters)
+        log_extraction_failure(item, catalog=catalog, logger=logger, error=exc)
         return None
-
-
-def _update_item_vote(
-    item: AgendaItemLike,
-    extracted: VoteExtractionResult,
-    *,
-    logger: logging.Logger,
-    catalog: CatalogLike,
-    runtime_hooks: VoteExtractionRuntimeHooks,
-) -> None:
-    result_text_builder = runtime_hooks.result_text_builder or result_text_from_label
-    item.result = result_text_builder(extracted.outcome_label)
-    item.votes = {
-        "outcome_label": extracted.outcome_label,
-        "motion_text": extracted.motion_text,
-        "vote_tally_raw": extracted.vote_tally_raw,
-        "yes_count": extracted.yes_count,
-        "no_count": extracted.no_count,
-        "abstain_count": extracted.abstain_count,
-        "absent_count": extracted.absent_count,
-        "confidence": extracted.confidence,
-        "evidence_snippet": extracted.evidence_snippet,
-        "source": LLM_EXTRACTED_VOTE_SOURCE,
-        "extracted_at": datetime.now(timezone.utc).isoformat(),
-    }
-    logger.info(
-        "vote_extraction.updated catalog_id=%s agenda_item_id=%s outcome=%s confidence=%.2f",
-        catalog.id,
-        getattr(item, "id", None),
-        extracted.outcome_label,
-        extracted.confidence,
-    )
-
-
-def _count_skip(counters: VoteExtractionCounters, reason: str) -> None:
-    counters["skipped_items"] += 1
-    counters["skip_reasons"][reason] = counters["skip_reasons"].get(reason, 0) + 1

--- a/tests/test_vote_extraction_confidence_gate.py
+++ b/tests/test_vote_extraction_confidence_gate.py
@@ -1,6 +1,6 @@
 from types import SimpleNamespace
 
-from pipeline.vote_extraction_contracts import VoteExtractionResult
+from pipeline.vote_extraction_contracts import LLM_EXTRACTED_VOTE_SOURCE, VoteExtractionResult
 from pipeline.vote_extractor import run_vote_extraction_for_catalog
 
 
@@ -271,3 +271,86 @@ def test_facade_result_text_patch_controls_runner(monkeypatch):
 
     assert counters["updated_items"] == 1
     assert item.result == "Patched Result"
+
+
+def test_updated_vote_payload_preserves_shape_and_count_fields():
+    item = SimpleNamespace(
+        id=10,
+        title="Budget Motion",
+        description=" ".join(["Motion was seconded and passed."] * 30),
+        result="",
+        votes=None,
+    )
+    catalog = SimpleNamespace(id=1, content="")
+    doc = SimpleNamespace(category="minutes", event=None)
+    local_ai = _StubLocalAI(
+        '{"outcome_label":"passed","motion_text":"Budget motion","vote_tally_raw":"Ayes: 4; Noes: 1",'
+        '"yes_count":4,"no_count":1,"abstain_count":2,"absent_count":3,'
+        '"confidence":0.95,"evidence_snippet":"motion passed 4-1"}'
+    )
+
+    counters = run_vote_extraction_for_catalog(
+        db=None,
+        local_ai=local_ai,
+        catalog=catalog,
+        doc=doc,
+        force=False,
+        agenda_items=[item],
+    )
+
+    assert counters["processed_items"] == 1
+    assert counters["updated_items"] == 1
+    assert item.votes.keys() == {
+        "outcome_label",
+        "motion_text",
+        "vote_tally_raw",
+        "yes_count",
+        "no_count",
+        "abstain_count",
+        "absent_count",
+        "confidence",
+        "evidence_snippet",
+        "source",
+        "extracted_at",
+    }
+    assert item.votes["yes_count"] == 4
+    assert item.votes["no_count"] == 1
+    assert item.votes["abstain_count"] == 2
+    assert item.votes["absent_count"] == 3
+    assert item.votes["source"] == LLM_EXTRACTED_VOTE_SOURCE
+    assert isinstance(item.votes["extracted_at"], str)
+
+
+def test_extraction_exception_counts_failed_item_and_logs_warning(monkeypatch, caplog):
+    item = SimpleNamespace(
+        id=10,
+        title="Budget Motion",
+        description=" ".join(["Motion was seconded and passed."] * 30),
+        result="",
+        votes=None,
+    )
+    catalog = SimpleNamespace(id=1, content="")
+    doc = SimpleNamespace(category="minutes", event=None)
+    local_ai = _StubLocalAI("{}")
+
+    def patched_extract_vote_outcome(local_ai, item_title, item_text, meeting_context=""):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("pipeline.vote_extractor.extract_vote_outcome", patched_extract_vote_outcome)
+
+    with caplog.at_level("WARNING", logger="vote-extractor"):
+        counters = run_vote_extraction_for_catalog(
+            db=None,
+            local_ai=local_ai,
+            catalog=catalog,
+            doc=doc,
+            force=False,
+            agenda_items=[item],
+        )
+
+    assert counters["processed_items"] == 1
+    assert counters["updated_items"] == 0
+    assert counters["failed_items"] == 1
+    assert item.result == ""
+    assert item.votes is None
+    assert "vote_extraction.failed catalog_id=1 agenda_item_id=10 error=RuntimeError" in caplog.text

--- a/tests/test_vote_extraction_low_signal_skip.py
+++ b/tests/test_vote_extraction_low_signal_skip.py
@@ -1,5 +1,14 @@
 from types import SimpleNamespace
 
+from pipeline.vote_extraction_contracts import (
+    SKIP_REASON_ALREADY_HIGH_CONFIDENCE,
+    SKIP_REASON_EXISTING_RESULT,
+    SKIP_REASON_MISSING_TITLE,
+    SKIP_REASON_TRUSTED_SOURCE,
+    VoteExtractionRuntimeHooks,
+    VoteExtractionSettings,
+)
+from pipeline.vote_extraction_item import skip_reason_before_extraction
 from pipeline.vote_extractor import run_vote_extraction_for_catalog
 
 
@@ -31,3 +40,77 @@ def test_short_context_skips_vote_extraction():
     assert counters["processed_items"] == 0
     assert counters["updated_items"] == 0
     assert counters["skip_reasons"]["insufficient_text"] == 1
+
+
+def _settings() -> VoteExtractionSettings:
+    return VoteExtractionSettings(
+        confidence_threshold=0.7,
+        context_after_chars=1000,
+        context_before_chars=500,
+        max_tokens=256,
+        min_text_chars=200,
+    )
+
+
+def test_skip_helper_preserves_pre_extraction_skip_order_and_force_behavior():
+    missing_title_item = SimpleNamespace(id=1, title="", description="", result="", votes=None)
+    trusted_item = SimpleNamespace(id=2, title="Item", description="", result="", votes={"source": "legistar"})
+    existing_result_item = SimpleNamespace(id=3, title="Item", description="", result="Passed", votes=None)
+    high_confidence_item = SimpleNamespace(
+        id=4,
+        title="Item",
+        description="",
+        result="",
+        votes={"source": "llm_extracted", "confidence": 0.95, "outcome_label": "passed"},
+    )
+
+    assert (
+        skip_reason_before_extraction(
+            missing_title_item,
+            item_title="",
+            force=False,
+            settings=_settings(),
+            runtime_hooks=VoteExtractionRuntimeHooks(),
+        )
+        == SKIP_REASON_MISSING_TITLE
+    )
+    assert (
+        skip_reason_before_extraction(
+            trusted_item,
+            item_title="Item",
+            force=True,
+            settings=_settings(),
+            runtime_hooks=VoteExtractionRuntimeHooks(),
+        )
+        == SKIP_REASON_TRUSTED_SOURCE
+    )
+    assert (
+        skip_reason_before_extraction(
+            high_confidence_item,
+            item_title="Item",
+            force=False,
+            settings=_settings(),
+            runtime_hooks=VoteExtractionRuntimeHooks(),
+        )
+        == SKIP_REASON_ALREADY_HIGH_CONFIDENCE
+    )
+    assert (
+        skip_reason_before_extraction(
+            existing_result_item,
+            item_title="Item",
+            force=False,
+            settings=_settings(),
+            runtime_hooks=VoteExtractionRuntimeHooks(),
+        )
+        == SKIP_REASON_EXISTING_RESULT
+    )
+    assert (
+        skip_reason_before_extraction(
+            existing_result_item,
+            item_title="Item",
+            force=True,
+            settings=_settings(),
+            runtime_hooks=VoteExtractionRuntimeHooks(),
+        )
+        is None
+    )

--- a/tests/test_vote_extractor_parser.py
+++ b/tests/test_vote_extractor_parser.py
@@ -65,6 +65,7 @@ def test_vote_extraction_modules_do_not_import_facade():
         Path("pipeline/vote_extraction_parser.py"),
         Path("pipeline/vote_extraction_context.py"),
         Path("pipeline/vote_extraction_policy.py"),
+        Path("pipeline/vote_extraction_item.py"),
         Path("pipeline/vote_extraction_runner.py"),
     ]
     offenders: list[str] = []


### PR DESCRIPTION
## What changed
- Extracted vote item skip, payload, logging, and counter mutation helpers from the runner.
- Preserved trusted-source protection, force behavior, confidence gates, warning logs, and vote payload shape.
- Added coverage for skip order, payload fields, and extraction failure counters/logging.

## Why
Keep vote extraction runner small while preserving item-level mutation behavior.

## Risk / compatibility
Low. Public facade imports and vote payload contract stay unchanged.

## Verification
- PASS: `/Users/dennisshah/GitHub/town-council/.venv/bin/ruff check api pipeline scripts tests`
- PASS: `/Users/dennisshah/GitHub/town-council/.venv/bin/mypy`
- PASS: `PYTHONPATH=. /Users/dennisshah/GitHub/town-council/.venv/bin/pytest -q tests/test_vote_extraction_confidence_gate.py tests/test_vote_extraction_low_signal_skip.py tests/test_vote_extractor_parser.py tests/test_vote_extractor_prompt_contract.py tests/test_repository_guardrails.py`
- PASS: `git diff --check`

## Deferred
Docs/source-map, typed-scope, formatter-scope, and cleanup-family guardrail enrollment stay in separate Batch D docs/guardrails PR after code lanes merge.