### PR TITLE
Refactor profile runner helpers

### DIFF
--- a/scripts/operator_profile_metrics.py
+++ b/scripts/operator_profile_metrics.py
@@ -9,7 +9,7 @@ from urllib import request
 def safe_float(value: Any) -> float | None:
     try:
         return float(value)
-    except TypeError, ValueError:
+    except (TypeError, ValueError):
         return None
 
 
@@ -68,7 +68,7 @@ def hist_quantile(rows: list[dict[str, Any]], base_name: str, labels: dict[str, 
         else:
             try:
                 upper = float(le)
-            except TypeError, ValueError:
+            except (TypeError, ValueError):
                 continue
         buckets[upper] = float(row["value"])
 
@@ -106,7 +106,7 @@ def provider_metrics_state(rows: list[dict[str, Any]], worker_metrics_error: str
 def load_json_file(path: Path) -> dict[str, Any]:
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
-    except json.JSONDecodeError, OSError:
+    except (json.JSONDecodeError, OSError):
         return {}
     return data if isinstance(data, dict) else {}
 
@@ -140,12 +140,12 @@ def task_duration(rows: list[dict[str, Any]], phase: str) -> list[tuple[int | No
             continue
         try:
             duration = float(row.get("duration_s") or 0.0)
-        except TypeError, ValueError:
+        except (TypeError, ValueError):
             duration = 0.0
         catalog_id = row.get("catalog_id")
         try:
             catalog_value = int(catalog_id)
-        except TypeError, ValueError:
+        except (TypeError, ValueError):
             catalog_value = None
         out.append((catalog_value, duration))
     return out
@@ -161,13 +161,13 @@ def slowest_task(rows: list[dict[str, Any]]) -> dict[str, Any]:
     for row in rows:
         try:
             duration = float(row.get("duration_s") or 0.0)
-        except TypeError, ValueError:
+        except (TypeError, ValueError):
             duration = 0.0
         phase = str(row.get("phase") or "")
         catalog_id = row.get("catalog_id")
         try:
             catalog_value = int(catalog_id)
-        except TypeError, ValueError:
+        except (TypeError, ValueError):
             catalog_value = None
 
         if duration >= slowest_duration_s:

--- a/scripts/operator_profile_metrics.py
+++ b/scripts/operator_profile_metrics.py
@@ -1,21 +1,15 @@
 from __future__ import annotations
 
 import json
-import subprocess
-import time
 from pathlib import Path
 from typing import Any
 from urllib import request
 
 
-WORKER_METRICS_SCRAPE_ATTEMPTS = 2
-WORKER_METRICS_BACKOFF_SECONDS = 0.5
-
-
 def safe_float(value: Any) -> float | None:
     try:
         return float(value)
-    except (TypeError, ValueError):
+    except TypeError, ValueError:
         return None
 
 
@@ -42,66 +36,15 @@ def fetch_text(url: str, timeout: int = 10) -> str:
 
 
 def docker_exec_python(script: str) -> str:
-    cmd = [
-        "docker",
-        "compose",
-        "exec",
-        "-T",
-        "worker",
-        "python",
-        "-c",
-        script,
-    ]
-    return subprocess.check_output(cmd, text=True, stderr=subprocess.STDOUT, timeout=30)
+    from scripts.operator_profile_worker_metrics import docker_exec_python as _docker_exec_python
+
+    return _docker_exec_python(script)
 
 
 def fetch_worker_metrics_via_docker() -> tuple[str, str | None]:
-    # Strategy order is intentional: prefer the worker metrics HTTP endpoint first,
-    # then fall back to direct process-registry exposition when the endpoint is unavailable.
-    strategies = [
-        (
-            "worker_http",
-            (
-                "import urllib.request; "
-                "print(urllib.request.urlopen('http://localhost:8001/metrics', timeout=10)"
-                ".read().decode('utf-8', errors='replace'))"
-            ),
-        ),
-        (
-            "worker_registry",
-            (
-                "from prometheus_client import CollectorRegistry, generate_latest; "
-                "from pipeline.metrics import RedisProviderMetricsCollector; "
-                "registry = CollectorRegistry(); "
-                "registry.register(RedisProviderMetricsCollector()); "
-                "print(generate_latest(registry).decode('utf-8', errors='replace'))"
-            ),
-        ),
-    ]
-    errors: list[str] = []
-    for strategy_name, script in strategies:
-        for attempt in range(1, WORKER_METRICS_SCRAPE_ATTEMPTS + 1):
-            try:
-                raw = docker_exec_python(script)
-                if raw.strip():
-                    # HTTP scrape can return generic process metrics without provider
-                    # series; in that case continue to the collector fallback path.
-                    if strategy_name == "worker_http":
-                        provider_sample_present = any(
-                            line.startswith("tc_provider_") and not line.startswith("#")
-                            for line in raw.splitlines()
-                        )
-                        if not provider_sample_present:
-                            errors.append(f"{strategy_name}[attempt={attempt}] missing_provider_series")
-                            continue
-                    return raw, None
-                errors.append(f"{strategy_name}[attempt={attempt}] empty_output")
-            except (subprocess.SubprocessError, OSError, TimeoutError) as exc:
-                errors.append(f"{strategy_name}[attempt={attempt}] {exc}")
-            if attempt < WORKER_METRICS_SCRAPE_ATTEMPTS:
-                time.sleep(WORKER_METRICS_BACKOFF_SECONDS)
-    joined = "; ".join(errors).strip()
-    return "", joined or "worker metrics scrape failed"
+    from scripts.operator_profile_worker_metrics import fetch_worker_metrics_via_docker as _fetch_worker_metrics
+
+    return _fetch_worker_metrics(exec_python=docker_exec_python)
 
 
 def hist_quantile(rows: list[dict[str, Any]], base_name: str, labels: dict[str, str], quantile: float) -> float | None:
@@ -125,7 +68,7 @@ def hist_quantile(rows: list[dict[str, Any]], base_name: str, labels: dict[str, 
         else:
             try:
                 upper = float(le)
-            except (TypeError, ValueError):
+            except TypeError, ValueError:
                 continue
         buckets[upper] = float(row["value"])
 
@@ -163,7 +106,7 @@ def provider_metrics_state(rows: list[dict[str, Any]], worker_metrics_error: str
 def load_json_file(path: Path) -> dict[str, Any]:
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError):
+    except json.JSONDecodeError, OSError:
         return {}
     return data if isinstance(data, dict) else {}
 
@@ -197,12 +140,12 @@ def task_duration(rows: list[dict[str, Any]], phase: str) -> list[tuple[int | No
             continue
         try:
             duration = float(row.get("duration_s") or 0.0)
-        except (TypeError, ValueError):
+        except TypeError, ValueError:
             duration = 0.0
         catalog_id = row.get("catalog_id")
         try:
             catalog_value = int(catalog_id)
-        except (TypeError, ValueError):
+        except TypeError, ValueError:
             catalog_value = None
         out.append((catalog_value, duration))
     return out
@@ -218,13 +161,13 @@ def slowest_task(rows: list[dict[str, Any]]) -> dict[str, Any]:
     for row in rows:
         try:
             duration = float(row.get("duration_s") or 0.0)
-        except (TypeError, ValueError):
+        except TypeError, ValueError:
             duration = 0.0
         phase = str(row.get("phase") or "")
         catalog_id = row.get("catalog_id")
         try:
             catalog_value = int(catalog_id)
-        except (TypeError, ValueError):
+        except TypeError, ValueError:
             catalog_value = None
 
         if duration >= slowest_duration_s:

--- a/scripts/operator_profile_worker_metrics.py
+++ b/scripts/operator_profile_worker_metrics.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import subprocess
+import time
+from typing import Callable
+
+
+WORKER_METRICS_SCRAPE_ATTEMPTS = 2
+WORKER_METRICS_BACKOFF_SECONDS = 0.5
+
+WORKER_HTTP_METRICS_PROBE = (
+    "import urllib.request; "
+    "print(urllib.request.urlopen('http://localhost:8001/metrics', timeout=10)"
+    ".read().decode('utf-8', errors='replace'))"
+)
+WORKER_REGISTRY_METRICS_PROBE = (
+    "from prometheus_client import CollectorRegistry, generate_latest; "
+    "from pipeline.metrics import RedisProviderMetricsCollector; "
+    "registry = CollectorRegistry(); "
+    "registry.register(RedisProviderMetricsCollector()); "
+    "print(generate_latest(registry).decode('utf-8', errors='replace'))"
+)
+
+
+def docker_exec_python(script: str) -> str:
+    cmd = [
+        "docker",
+        "compose",
+        "exec",
+        "-T",
+        "worker",
+        "python",
+        "-c",
+        script,
+    ]
+    return subprocess.check_output(cmd, text=True, stderr=subprocess.STDOUT, timeout=30)
+
+
+def fetch_worker_metrics_via_docker(
+    exec_python: Callable[[str], str] | None = None,
+) -> tuple[str, str | None]:
+    run_probe = exec_python or docker_exec_python
+    strategies = [
+        ("worker_http", WORKER_HTTP_METRICS_PROBE),
+        ("worker_registry", WORKER_REGISTRY_METRICS_PROBE),
+    ]
+    errors: list[str] = []
+    for strategy_name, script in strategies:
+        for attempt in range(1, WORKER_METRICS_SCRAPE_ATTEMPTS + 1):
+            try:
+                raw = run_probe(script)
+                if raw.strip():
+                    if strategy_name == "worker_http" and not _has_provider_series(raw):
+                        errors.append(f"{strategy_name}[attempt={attempt}] missing_provider_series")
+                        continue
+                    return raw, None
+                errors.append(f"{strategy_name}[attempt={attempt}] empty_output")
+            except (subprocess.SubprocessError, OSError, TimeoutError) as exc:
+                errors.append(f"{strategy_name}[attempt={attempt}] {exc}")
+            if attempt < WORKER_METRICS_SCRAPE_ATTEMPTS:
+                time.sleep(WORKER_METRICS_BACKOFF_SECONDS)
+    joined = "; ".join(errors).strip()
+    return "", joined or "worker metrics scrape failed"
+
+
+def _has_provider_series(raw: str) -> bool:
+    return any(line.startswith("tc_provider_") and not line.startswith("#") for line in raw.splitlines())

--- a/scripts/profile_pipeline_commands.py
+++ b/scripts/profile_pipeline_commands.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import os
+from typing import Any
+
+
+def profile_env(
+    *, run_id: str, mode: str, artifact_dir: str, baseline_valid: bool, manifest_path: str
+) -> dict[str, str]:
+    env = os.environ.copy()
+    env["TC_PROFILE_RUN_ID"] = run_id
+    env["TC_PROFILE_MODE"] = mode
+    env["TC_PROFILE_ARTIFACT_DIR"] = artifact_dir
+    env["TC_PROFILE_BASELINE_VALID"] = "1" if baseline_valid else "0"
+    env["TC_PROFILE_CATALOG_MANIFEST"] = manifest_path
+    env["TC_PROFILE_WORKLOAD_ONLY"] = "1"
+    return env
+
+
+def profile_command(
+    *,
+    service: str,
+    script_name: str,
+    run_id: str,
+    mode: str,
+    artifact_dir_rel: str,
+    manifest_rel: str,
+) -> list[str]:
+    return [
+        "docker",
+        "compose",
+        "exec",
+        "-T",
+        "-e",
+        f"TC_PROFILE_RUN_ID={run_id}",
+        "-e",
+        f"TC_PROFILE_MODE={mode}",
+        "-e",
+        f"TC_PROFILE_ARTIFACT_DIR={artifact_dir_rel}",
+        "-e",
+        f"TC_PROFILE_BASELINE_VALID={'1' if mode == 'baseline' else '0'}",
+        "-e",
+        f"TC_PROFILE_CATALOG_MANIFEST={manifest_rel}",
+        "-e",
+        "TC_PROFILE_WORKLOAD_ONLY=1",
+        "-w",
+        "/app/pipeline",
+        service,
+        "python",
+        script_name,
+    ]
+
+
+def build_profile_commands(
+    *,
+    args: Any,
+    core_service: str,
+    batch_service: str,
+    run_id: str,
+    artifact_dir_rel: str,
+    manifest_rel: str,
+) -> list[list[str]]:
+    commands = [
+        profile_command(
+            service=core_service,
+            script_name="run_pipeline.py",
+            run_id=run_id,
+            mode=args.mode,
+            artifact_dir_rel=artifact_dir_rel,
+            manifest_rel=manifest_rel,
+        )
+    ]
+    if not args.skip_batch:
+        commands.append(
+            profile_command(
+                service=batch_service,
+                script_name="run_batch_enrichment.py",
+                run_id=run_id,
+                mode=args.mode,
+                artifact_dir_rel=artifact_dir_rel,
+                manifest_rel=manifest_rel,
+            )
+        )
+    return commands

--- a/scripts/profile_pipeline_results.py
+++ b/scripts/profile_pipeline_results.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from typing import Any, Callable
+
+from scripts.operator_profile_artifacts import build_result_payload
+
+
+def _manifest_package_summary(manifest_package: dict) -> dict[str, Any]:
+    return {
+        "schema_version": int(manifest_package.get("schema_version") or 0),
+        "manifest_name": manifest_package.get("manifest_name"),
+        "phase_selected_counts": {key: len(value) for key, value in (manifest_package.get("strata") or {}).items()},
+        "expected_phase_coverage": dict(manifest_package.get("expected_phase_coverage") or {}),
+    }
+
+
+def write_run_manifest(
+    *,
+    write_json: Callable[[Path, dict], None],
+    utc_now_iso: Callable[[], str],
+    run_dir: Path,
+    run_id: str,
+    mode: str,
+    city: str | None,
+    include_batch: bool,
+    catalog_ids: list[int],
+    provider_counters_before_run: dict[str, float] | None,
+    manifest_package: dict | None,
+) -> dict[str, Any]:
+    run_manifest: dict[str, Any] = {
+        "run_id": run_id,
+        "mode": mode,
+        "started_at": utc_now_iso(),
+        "baseline_valid": mode == "baseline",
+        "catalog_ids": catalog_ids,
+        "catalog_count": len(catalog_ids),
+        "city": city,
+        "include_batch": include_batch,
+        "workload_only": True,
+        "profile": {
+            key: os.getenv(key)
+            for key in (
+                "LOCAL_AI_BACKEND",
+                "LOCAL_AI_HTTP_PROFILE",
+                "LOCAL_AI_HTTP_MODEL",
+                "WORKER_CONCURRENCY",
+                "WORKER_POOL",
+                "OLLAMA_NUM_PARALLEL",
+            )
+            if os.getenv(key) is not None
+        },
+        "provider_counters_before_run": provider_counters_before_run,
+    }
+    if manifest_package is not None:
+        run_manifest["manifest_package"] = _manifest_package_summary(manifest_package)
+    write_json(run_dir / "run_manifest.json", run_manifest)
+    return run_manifest
+
+
+def write_result_manifest(
+    *,
+    write_json: Callable[[Path, dict], None],
+    segment_status_from_log: Callable[[Path], dict],
+    utc_now_iso: Callable[[], str],
+    run_dir: Path,
+    run_id: str,
+    status: str,
+    started_at: str,
+    started: float,
+    include_batch: bool,
+    command_segments: list[dict[str, Any]],
+    command_log: Path,
+    error_message: str | None,
+) -> None:
+    write_json(
+        run_dir / "result.json",
+        build_result_payload(
+            run_id=run_id,
+            status=status,
+            started_at=started_at,
+            finished_at=utc_now_iso(),
+            elapsed_seconds=time.perf_counter() - started,
+            include_batch=include_batch,
+            segments=command_segments,
+            error_message=error_message,
+            quality=segment_status_from_log(command_log),
+        ),
+    )

--- a/scripts/profile_pipeline_runner.py
+++ b/scripts/profile_pipeline_runner.py
@@ -10,6 +10,8 @@ import time
 from typing import Any, Callable
 
 from pipeline.profile_manifest import load_manifest_package, sidecar_path_for_manifest, validate_manifest_package
+from scripts.profile_pipeline_commands import build_profile_commands, profile_env
+from scripts.profile_pipeline_results import write_result_manifest, write_run_manifest
 
 
 @dataclass(frozen=True)
@@ -33,68 +35,6 @@ class ProfilePipelineDeps:
     write_json: Callable[[Path, dict], None]
 
 
-def _profile_env(*, run_id: str, mode: str, artifact_dir: str, baseline_valid: bool, manifest_path: str) -> dict[str, str]:
-    env = os.environ.copy()
-    env["TC_PROFILE_RUN_ID"] = run_id
-    env["TC_PROFILE_MODE"] = mode
-    env["TC_PROFILE_ARTIFACT_DIR"] = artifact_dir
-    env["TC_PROFILE_BASELINE_VALID"] = "1" if baseline_valid else "0"
-    env["TC_PROFILE_CATALOG_MANIFEST"] = manifest_path
-    env["TC_PROFILE_WORKLOAD_ONLY"] = "1"
-    return env
-
-
-def _profile_command(*, service: str, script_name: str, run_id: str, mode: str, artifact_dir_rel: str, manifest_rel: str) -> list[str]:
-    return [
-        "docker",
-        "compose",
-        "exec",
-        "-T",
-        "-e",
-        f"TC_PROFILE_RUN_ID={run_id}",
-        "-e",
-        f"TC_PROFILE_MODE={mode}",
-        "-e",
-        f"TC_PROFILE_ARTIFACT_DIR={artifact_dir_rel}",
-        "-e",
-        f"TC_PROFILE_BASELINE_VALID={'1' if mode == 'baseline' else '0'}",
-        "-e",
-        f"TC_PROFILE_CATALOG_MANIFEST={manifest_rel}",
-        "-e",
-        "TC_PROFILE_WORKLOAD_ONLY=1",
-        "-w",
-        "/app/pipeline",
-        service,
-        "python",
-        script_name,
-    ]
-
-
-def _build_commands(args: Any, deps: ProfilePipelineDeps, run_id: str, artifact_dir_rel: str, manifest_rel: str) -> list[list[str]]:
-    commands = [
-        _profile_command(
-            service=deps.core_service,
-            script_name="run_pipeline.py",
-            run_id=run_id,
-            mode=args.mode,
-            artifact_dir_rel=artifact_dir_rel,
-            manifest_rel=manifest_rel,
-        )
-    ]
-    if not args.skip_batch:
-        commands.append(
-            _profile_command(
-                service=deps.batch_service,
-                script_name="run_batch_enrichment.py",
-                run_id=run_id,
-                mode=args.mode,
-                artifact_dir_rel=artifact_dir_rel,
-                manifest_rel=manifest_rel,
-            )
-        )
-    return commands
-
-
 def _catalog_ids_for_args(args: Any, deps: ProfilePipelineDeps) -> tuple[list[int], dict | None, Path | None]:
     manifest_path = Path(args.manifest) if args.manifest else None
     if args.mode != "baseline":
@@ -108,59 +48,26 @@ def _catalog_ids_for_args(args: Any, deps: ProfilePipelineDeps) -> tuple[list[in
     return catalog_ids, manifest_package, manifest_path
 
 
-def _manifest_package_summary(manifest_package: dict) -> dict[str, Any]:
-    return {
-        "schema_version": int(manifest_package.get("schema_version") or 0),
-        "manifest_name": manifest_package.get("manifest_name"),
-        "phase_selected_counts": {key: len(value) for key, value in (manifest_package.get("strata") or {}).items()},
-        "expected_phase_coverage": dict(manifest_package.get("expected_phase_coverage") or {}),
-    }
-
-
-def _write_run_manifest(
-    *,
-    deps: ProfilePipelineDeps,
-    run_dir: Path,
-    run_id: str,
-    args: Any,
-    catalog_ids: list[int],
-    provider_counters_before_run: dict[str, float] | None,
-    manifest_package: dict | None,
-) -> dict[str, Any]:
-    run_manifest: dict[str, Any] = {
-        "run_id": run_id,
-        "mode": args.mode,
-        "started_at": deps.utc_now_iso(),
-        "baseline_valid": args.mode == "baseline",
-        "catalog_ids": catalog_ids,
-        "catalog_count": len(catalog_ids),
-        "city": args.city,
-        "include_batch": not args.skip_batch,
-        "workload_only": True,
-        "profile": {
-            key: os.getenv(key)
-            for key in (
-                "LOCAL_AI_BACKEND",
-                "LOCAL_AI_HTTP_PROFILE",
-                "LOCAL_AI_HTTP_MODEL",
-                "WORKER_CONCURRENCY",
-                "WORKER_POOL",
-                "OLLAMA_NUM_PARALLEL",
-            )
-            if os.getenv(key) is not None
-        },
-        "provider_counters_before_run": provider_counters_before_run,
-    }
-    if manifest_package is not None:
-        run_manifest["manifest_package"] = _manifest_package_summary(manifest_package)
-    deps.write_json(run_dir / "run_manifest.json", run_manifest)
-    return run_manifest
-
-
 def _run_post_processors(args: Any, deps: ProfilePipelineDeps, run_id: str, output_root: Path) -> None:
     for command in (
-        [deps.sys_executable, str(deps.repo_root / "scripts" / "collect_soak_metrics.py"), "--run-id", run_id, "--output-dir", str(output_root), "--api-url", args.api_url],
-        [deps.sys_executable, str(deps.repo_root / "scripts" / "analyze_pipeline_profile.py"), "--run-id", run_id, "--output-dir", str(output_root)],
+        [
+            deps.sys_executable,
+            str(deps.repo_root / "scripts" / "collect_soak_metrics.py"),
+            "--run-id",
+            run_id,
+            "--output-dir",
+            str(output_root),
+            "--api-url",
+            args.api_url,
+        ],
+        [
+            deps.sys_executable,
+            str(deps.repo_root / "scripts" / "analyze_pipeline_profile.py"),
+            "--run-id",
+            run_id,
+            "--output-dir",
+            str(output_root),
+        ],
     ):
         deps.subprocess_module.run(command, cwd=str(deps.repo_root), check=True, env=os.environ.copy())
     if args.compare_to:
@@ -216,18 +123,34 @@ def run_profile(args: Any, deps: ProfilePipelineDeps) -> int:
         print(json.dumps(prepare_summary, indent=2, sort_keys=True))
         return 0
 
-    run_manifest = _write_run_manifest(
-        deps=deps,
+    run_manifest = write_run_manifest(
+        write_json=deps.write_json,
+        utc_now_iso=deps.utc_now_iso,
         run_dir=run_dir,
         run_id=run_id,
-        args=args,
+        mode=args.mode,
+        city=args.city,
+        include_batch=not args.skip_batch,
         catalog_ids=catalog_ids,
         provider_counters_before_run=provider_counters_before_run,
         manifest_package=manifest_package,
     )
     artifact_dir_rel = deps.path_for_profile_env(run_dir)
-    env = _profile_env(run_id=run_id, mode=args.mode, artifact_dir=artifact_dir_rel, baseline_valid=args.mode == "baseline", manifest_path=manifest_rel)
-    commands = _build_commands(args, deps, run_id, artifact_dir_rel, manifest_rel)
+    env = profile_env(
+        run_id=run_id,
+        mode=args.mode,
+        artifact_dir=artifact_dir_rel,
+        baseline_valid=args.mode == "baseline",
+        manifest_path=manifest_rel,
+    )
+    commands = build_profile_commands(
+        args=args,
+        core_service=deps.core_service,
+        batch_service=deps.batch_service,
+        run_id=run_id,
+        artifact_dir_rel=artifact_dir_rel,
+        manifest_rel=manifest_rel,
+    )
     started = time.perf_counter()
     started_at = deps.utc_now_iso()
     status = "failed"
@@ -241,8 +164,26 @@ def run_profile(args: Any, deps: ProfilePipelineDeps) -> int:
             segment_started = time.perf_counter()
             segment_name = "pipeline-batch" if "run_batch_enrichment.py" in command else "pipeline"
             deps.run_command(command, env=env, cwd=deps.repo_root, log_path=command_log)
-            command_segments.append({"name": segment_name, "command": command, "status": "completed", "elapsed_seconds": round(time.perf_counter() - segment_started, 3)})
-        _write_result(deps, run_dir, run_id, status="commands_completed", started_at=started_at, started=started, include_batch=not args.skip_batch, command_segments=command_segments, command_log=command_log, error_message=None)
+            command_segments.append(
+                {
+                    "name": segment_name,
+                    "command": command,
+                    "status": "completed",
+                    "elapsed_seconds": round(time.perf_counter() - segment_started, 3),
+                }
+            )
+        _write_result(
+            deps,
+            run_dir,
+            run_id,
+            status="commands_completed",
+            started_at=started_at,
+            started=started,
+            include_batch=not args.skip_batch,
+            command_segments=command_segments,
+            command_log=command_log,
+            error_message=None,
+        )
         _run_post_processors(args, deps, run_id, output_root)
         status = "completed"
         return 0
@@ -251,10 +192,23 @@ def run_profile(args: Any, deps: ProfilePipelineDeps) -> int:
         if isinstance(exc, subprocess.CalledProcessError):
             attempted = "pipeline-batch" if "run_batch_enrichment.py" in (exc.cmd or []) else "pipeline"
             if not command_segments or command_segments[-1]["name"] != attempted:
-                command_segments.append({"name": attempted, "command": exc.cmd, "status": "failed", "elapsed_seconds": 0.0})
+                command_segments.append(
+                    {"name": attempted, "command": exc.cmd, "status": "failed", "elapsed_seconds": 0.0}
+                )
         raise
     finally:
-        _write_result(deps, run_dir, run_id, status=status, started_at=started_at, started=started, include_batch=not args.skip_batch, command_segments=command_segments, command_log=command_log, error_message=error_message)
+        _write_result(
+            deps,
+            run_dir,
+            run_id,
+            status=status,
+            started_at=started_at,
+            started=started,
+            include_batch=not args.skip_batch,
+            command_segments=command_segments,
+            command_log=command_log,
+            error_message=error_message,
+        )
         print(json.dumps({"run_id": run_id, "run_dir": str(run_dir), "status": status}, indent=2))
 
 
@@ -271,19 +225,17 @@ def _write_result(
     command_log: Path,
     error_message: str | None,
 ) -> None:
-    from scripts.operator_profile_artifacts import build_result_payload
-
-    deps.write_json(
-        run_dir / "result.json",
-        build_result_payload(
-            run_id=run_id,
-            status=status,
-            started_at=started_at,
-            finished_at=deps.utc_now_iso(),
-            elapsed_seconds=time.perf_counter() - started,
-            include_batch=include_batch,
-            segments=command_segments,
-            error_message=error_message,
-            quality=deps.segment_status_from_log(command_log),
-        ),
+    write_result_manifest(
+        write_json=deps.write_json,
+        segment_status_from_log=deps.segment_status_from_log,
+        utc_now_iso=deps.utc_now_iso,
+        run_dir=run_dir,
+        run_id=run_id,
+        status=status,
+        started_at=started_at,
+        started=started,
+        include_batch=include_batch,
+        command_segments=command_segments,
+        command_log=command_log,
+        error_message=error_message,
     )

--- a/tests/test_operator_profile_helpers.py
+++ b/tests/test_operator_profile_helpers.py
@@ -1,9 +1,13 @@
 import json
 from pathlib import Path
+from types import SimpleNamespace
 
 from scripts import operator_profile_artifacts as artifacts
 from scripts import operator_profile_metrics as metrics
 from scripts import operator_profile_reports as reports
+from scripts import operator_profile_worker_metrics as worker_metrics
+from scripts import profile_pipeline_commands as pipeline_commands
+from scripts import profile_pipeline_results as pipeline_results
 
 
 def test_profile_artifact_helpers_preserve_result_payload_shape(tmp_path: Path):
@@ -33,6 +37,198 @@ def test_profile_artifact_helpers_preserve_result_payload_shape(tmp_path: Path):
     }
     assert persisted["profile"]["workload_only"] is True
     assert out.read_text(encoding="utf-8").endswith("\n")
+
+
+def test_profile_result_writer_preserves_result_manifest_keys(monkeypatch, tmp_path: Path):
+    perf_values = iter([10.0, 75.4321])
+    monkeypatch.setattr(pipeline_results.time, "perf_counter", lambda: next(perf_values))
+    written = {}
+
+    def _write_json(path: Path, payload: dict) -> None:
+        written["path"] = path
+        written["payload"] = payload
+
+    pipeline_results.write_result_manifest(
+        write_json=_write_json,
+        segment_status_from_log=lambda _path: {"notes": [], "flags": {}},
+        utc_now_iso=lambda: "2026-04-01T00:02:00+00:00",
+        run_dir=tmp_path,
+        run_id="profile_run",
+        status="completed",
+        started_at="2026-04-01T00:00:00+00:00",
+        started=10.0,
+        include_batch=False,
+        command_segments=[
+            {"name": "pipeline", "status": "completed", "elapsed_seconds": 12.3456},
+        ],
+        command_log=tmp_path / "commands.log",
+        error_message=None,
+    )
+
+    payload = written["payload"]
+    assert written["path"] == tmp_path / "result.json"
+    assert sorted(payload) == [
+        "elapsed_seconds",
+        "error",
+        "finished_at",
+        "include_batch",
+        "profile",
+        "quality",
+        "run_id",
+        "segments",
+        "started_at",
+        "status",
+        "totals",
+    ]
+    assert payload["totals"] == {
+        "core_elapsed_seconds": 12.346,
+        "batch_elapsed_seconds": None,
+        "combined_elapsed_seconds": 12.346,
+    }
+    assert payload["profile"]["workload_only"] is True
+
+
+def test_profile_run_manifest_writer_preserves_manifest_package_and_profile_env(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("LOCAL_AI_BACKEND", "http")
+    monkeypatch.delenv("WORKER_POOL", raising=False)
+    written = {}
+
+    def _write_json(path: Path, payload: dict) -> None:
+        written["path"] = path
+        written["payload"] = payload
+
+    run_manifest = pipeline_results.write_run_manifest(
+        write_json=_write_json,
+        utc_now_iso=lambda: "2026-04-01T00:00:00+00:00",
+        run_dir=tmp_path,
+        run_id="profile_run",
+        mode="baseline",
+        city="san_mateo",
+        include_batch=True,
+        catalog_ids=[101, 102],
+        provider_counters_before_run={"requests": 3.0},
+        manifest_package={
+            "schema_version": 1,
+            "manifest_name": "baseline-manifest",
+            "strata": {"segment": [101], "summary": [102]},
+            "expected_phase_coverage": {"segment": 1, "summary": 1},
+        },
+    )
+
+    assert written["path"] == tmp_path / "run_manifest.json"
+    assert written["payload"] == run_manifest
+    assert run_manifest["baseline_valid"] is True
+    assert run_manifest["catalog_count"] == 2
+    assert run_manifest["include_batch"] is True
+    assert run_manifest["profile"] == {"LOCAL_AI_BACKEND": "http"}
+    assert run_manifest["manifest_package"] == {
+        "schema_version": 1,
+        "manifest_name": "baseline-manifest",
+        "phase_selected_counts": {"segment": 1, "summary": 1},
+        "expected_phase_coverage": {"segment": 1, "summary": 1},
+    }
+
+
+def test_profile_command_helpers_preserve_env_and_docker_command(monkeypatch):
+    args = SimpleNamespace(mode="baseline", skip_batch=False)
+    monkeypatch.setenv("UNRELATED_OPERATOR_SETTING", "kept")
+
+    env = pipeline_commands.profile_env(
+        run_id="profile_run",
+        mode="baseline",
+        artifact_dir="experiments/results/profile_run",
+        baseline_valid=True,
+        manifest_path="experiments/results/profile_run/catalog_manifest.txt",
+    )
+    commands = pipeline_commands.build_profile_commands(
+        args=args,
+        core_service="api",
+        batch_service="worker",
+        run_id="profile_run",
+        artifact_dir_rel="experiments/results/profile_run",
+        manifest_rel="experiments/results/profile_run/catalog_manifest.txt",
+    )
+
+    assert env["UNRELATED_OPERATOR_SETTING"] == "kept"
+    assert env["TC_PROFILE_BASELINE_VALID"] == "1"
+    assert env["TC_PROFILE_WORKLOAD_ONLY"] == "1"
+    assert [command[-1] for command in commands] == ["run_pipeline.py", "run_batch_enrichment.py"]
+    assert commands[0][:4] == ["docker", "compose", "exec", "-T"]
+    assert "TC_PROFILE_BASELINE_VALID=1" in commands[0]
+    assert commands[1][commands[1].index("-w") + 1] == "/app/pipeline"
+
+
+def test_worker_metrics_prefers_endpoint_with_provider_series(monkeypatch):
+    calls = []
+
+    def _ok(cmd, **_kwargs):
+        calls.append(cmd)
+        return 'tc_provider_requests_total{provider="http"} 1\n'
+
+    monkeypatch.setattr(worker_metrics.subprocess, "check_output", _ok)
+    raw, err = worker_metrics.fetch_worker_metrics_via_docker()
+
+    assert raw == 'tc_provider_requests_total{provider="http"} 1\n'
+    assert err is None
+    assert len(calls) == 1
+    assert "localhost:8001/metrics" in calls[0][-1]
+
+
+def test_worker_metrics_compat_wrapper_uses_existing_docker_exec_seam(monkeypatch):
+    probes = []
+
+    def _compat_probe(script: str) -> str:
+        probes.append(script)
+        return 'tc_provider_requests_total{provider="http"} 2\n'
+
+    monkeypatch.setattr(metrics, "docker_exec_python", _compat_probe)
+    raw, err = metrics.fetch_worker_metrics_via_docker()
+
+    assert raw == 'tc_provider_requests_total{provider="http"} 2\n'
+    assert err is None
+    assert probes == [worker_metrics.WORKER_HTTP_METRICS_PROBE]
+
+
+def test_worker_metrics_falls_back_to_collector_when_endpoint_lacks_provider_series(monkeypatch):
+    responses = iter(
+        [
+            "python_gc_objects_collected_total 1\n",
+            "python_gc_objects_collected_total 2\n",
+            'tc_provider_requests_total{provider="http"} 3\n',
+        ]
+    )
+    calls = []
+
+    def _sequenced(cmd, **_kwargs):
+        calls.append(cmd)
+        return next(responses)
+
+    monkeypatch.setattr(worker_metrics.subprocess, "check_output", _sequenced)
+    monkeypatch.setattr(worker_metrics.time, "sleep", lambda *_args, **_kwargs: None)
+    raw, err = worker_metrics.fetch_worker_metrics_via_docker()
+
+    assert raw == 'tc_provider_requests_total{provider="http"} 3\n'
+    assert err is None
+    assert len(calls) == 3
+    assert "localhost:8001/metrics" in calls[0][-1]
+    assert "localhost:8001/metrics" in calls[1][-1]
+    assert "RedisProviderMetricsCollector" in calls[2][-1]
+
+
+def test_worker_metrics_reports_aggregated_strategy_errors(monkeypatch):
+    def _empty(_cmd, **_kwargs):
+        return ""
+
+    monkeypatch.setattr(worker_metrics.subprocess, "check_output", _empty)
+    monkeypatch.setattr(worker_metrics.time, "sleep", lambda *_args, **_kwargs: None)
+    raw, err = worker_metrics.fetch_worker_metrics_via_docker()
+
+    assert raw == ""
+    assert err is not None
+    assert "worker_http[attempt=1] empty_output" in err
+    assert "worker_http[attempt=2] empty_output" in err
+    assert "worker_registry[attempt=1] empty_output" in err
+    assert "worker_registry[attempt=2] empty_output" in err
 
 
 def test_profile_manifest_loader_deduplicates_and_ignores_comments(tmp_path: Path):


### PR DESCRIPTION
## What changed
- Extracted worker metrics scrape strategy from operator profile metrics.
- Extracted profile Docker command/env helpers and result manifest writing from the runner.
- Preserved artifact keys, Docker command order, worker scrape fallback, malformed metric tolerance, and wrapper seams.

## Why
Move near-cap operator profiling modules away from the size limit without changing CLI contracts.

## Risk / compatibility
Low. CLI entrypoints and JSON artifact contracts stay unchanged.

## Verification
- PASS: `/Users/dennisshah/GitHub/town-council/.venv/bin/ruff check api pipeline scripts tests`
- PASS: `PYTHONPATH=. /Users/dennisshah/GitHub/town-council/.venv/bin/pytest -q tests/test_operator_profile_helpers.py tests/test_collect_soak_metrics_schema.py tests/test_collect_soak_metrics_confidence_flags.py tests/test_pipeline_profile_report.py tests/test_profile_pipeline_cli.py tests/test_repository_guardrails.py`
- PASS: `git diff --check`

## Deferred
Docs/source-map and cleanup-family guardrail enrollment stay in separate Batch D docs/guardrails PR after code lanes merge.