### PR TITLE
Track Batch E docs and guardrails

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -207,6 +207,8 @@ Primary owners:
   `pipeline/agenda_resolver_contracts.py`, `pipeline/agenda_resolver_quality.py`,
   `pipeline/agenda_resolver_legistar_policy.py`, `pipeline/agenda_resolver_html.py`,
   `pipeline/agenda_resolver_enrichment.py`, and `pipeline/agenda_resolver_runner.py`
+- `pipeline/agenda_qa.py` owns report/regeneration scoring for stored agenda items,
+  while `pipeline/agenda_resolver_quality.py` owns source-selection quality scoring.
 
 #### Vote Extraction (Stable)
 
@@ -326,7 +328,7 @@ Primary owners:
 - Frontend query/task UX: `frontend/app/page.js`, `frontend/state/search-state.js`, `frontend/components/ResultCard.js`
 - Data model and persistence: `pipeline/models.py` facade plus focused `pipeline/model_*` modules, `pipeline/db_migrate.py` facade plus focused `pipeline/db_migration_*` helpers, `pipeline/migrate_v8.py` and `pipeline/migrate_v9.py` compatibility wrappers, descriptive `pipeline/migration_*` modules
 - Onboarding orchestration and evaluation: `scripts/onboard_city_wave.sh`, `scripts/check_city_crawl_evidence.py`, `scripts/evaluate_city_onboarding.py` facade plus focused `pipeline/city_onboarding_*` helpers
-- Operator profiling and soak reports: `scripts/profile_pipeline.py` facade, `scripts/profile_pipeline_runner.py`, focused `scripts/profile_pipeline_*` helpers, and focused `scripts/operator_profile_*` helpers
+- Operator profiling and soak reports: `scripts/profile_pipeline.py` facade, `scripts/profile_pipeline_runner.py`, focused `scripts/profile_pipeline_*` helpers, focused `scripts/operator_profile_*` helpers, `scripts/evaluate_soak_week.py` plus `scripts/evaluate_soak_week_gates.py`, and `scripts/collect_ab_results.py` plus `scripts/collect_ab_results_rows.py`
 - Laserfiche repair: `scripts/repair_san_mateo_laserfiche_backlog.py` facade plus focused `scripts/laserfiche_repair_*` helpers
 
 ### Runtime Lifecycles

--- a/docs/ADR.md
+++ b/docs/ADR.md
@@ -8,6 +8,26 @@ Use each entry to record:
 - the affected boundary or contract
 - links to the canonical docs that carry the ongoing operational or architecture detail
 
+## 2026-05-11: Track Batch E cleanup helpers and audit tools
+
+- Status: Accepted
+- Decision:
+  - `scripts/evaluate_soak_week.py` and `scripts/collect_ab_results.py` remain operator CLI facades while gate evaluation and A/B row normalization live behind focused helper modules.
+  - `pipeline/cli_logging.py` and `scripts/operator_numeric.py` own shared helper behavior extracted during Batch E.
+  - `pipeline/agenda_qa.py`, `pipeline/agenda_resolver_quality.py`, and `pipeline/utils_names.py` remain tracked agenda/person scoring surfaces.
+  - `vulture==2.16` and `radon==6.0.1` are pinned as development-only local audit tools, not CI gates.
+- Why:
+  - Batch E reduced dead code, duplicate helper drift, and high-complexity reporting/quality code without changing runtime behavior.
+  - Keeping docs and guardrail enrollment in one follow-up PR avoids source-map conflicts across parallel code PRs.
+- Affected boundaries:
+  - Operator commands, JSON/stdout contracts, API behavior, runtime defaults, and CI policy scope stay unchanged.
+  - Guardrails track the new helper families under the 300-line cleanup target and keep helper modules from importing their facades.
+- Canonical references:
+  - [ARCHITECTURE.md](../ARCHITECTURE.md)
+  - [docs/OPERATIONS.md](OPERATIONS.md)
+  - [docs/PERFORMANCE.md](PERFORMANCE.md)
+  - [docs/ENGINEERING_GUARDRAILS.md](ENGINEERING_GUARDRAILS.md)
+
 ## 2026-05-10: Split LocalAI compatibility helpers behind the facade
 
 - Status: Accepted

--- a/docs/ENGINEERING_GUARDRAILS.md
+++ b/docs/ENGINEERING_GUARDRAILS.md
@@ -22,6 +22,21 @@ PYTHONPATH=. .venv/bin/pytest -q tests/test_repository_guardrails.py
 
 The first pass is intentionally moderate. It is meant to block lazy hygiene regressions without forcing a repo-wide style migration.
 
+## Optional local dead-code and complexity audit
+
+`pipeline/requirements-dev.txt` pins the local audit tools used during Batch E:
+
+- `vulture==2.16`
+- `radon==6.0.1`
+
+These commands are advisory local audits, not CI gates:
+
+```bash
+cd <REPO_ROOT>
+./.venv/bin/python -m vulture api pipeline scripts tests --min-confidence 80
+./.venv/bin/python -m radon cc api pipeline scripts -s -n C
+```
+
 ## What the smell tests protect
 
 - no personal absolute paths in tracked repo files
@@ -29,7 +44,12 @@ The first pass is intentionally moderate. It is meant to block lazy hygiene regr
 - no raw `print(...)` in non-CLI pipeline modules
 - no silent broad exception handlers or broad exception allowlist drift
 - existing Town Council policy tests for fail-fast runtime behavior, freshness contracts, and profile comparability
-- cleanup module families for downloader, NLP entities, segment-city CLI, hydration CLIs, models, DB migrations, LocalAI, indexing, semantic backends, summary text and backfill, vote extraction, provider/person utilities, reporting/profile scripts, task/API/search helpers, onboarding/repair scripts, and prior facade splits stay under the 300-line target
+- cleanup module families for downloader, NLP entities, segment-city CLI, hydration CLIs, models, DB migrations, LocalAI, indexing, semantic backends, summary text and backfill, vote extraction, provider/person utilities, reporting/profile scripts, shared helper utilities, agenda QA, task/API/search helpers, onboarding/repair scripts, and prior facade splits stay under the 300-line target
+
+Batch E cleanup coverage includes:
+- reporting facades and helpers: `scripts/evaluate_soak_week.py`, `scripts/evaluate_soak_week_gates.py`, `scripts/collect_ab_results.py`, `scripts/collect_ab_results_rows.py`
+- shared helper utilities: `pipeline/cli_logging.py`, `scripts/operator_numeric.py`
+- agenda QA/scoring surfaces: `pipeline/agenda_qa.py`, `pipeline/agenda_resolver_quality.py`, `pipeline/utils_names.py`
 
 ## How to request an exception
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,6 +1,6 @@
 # Operations Runbook
 
-Last updated: 2026-04-05
+Last updated: 2026-05-11
 
 ## Core workflow
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -625,6 +625,7 @@ Provider token/latency telemetry (HTTP backend):
 A/B artifact integration (v1):
 - `scripts/run_ab_eval.sh` captures best-effort provider telemetry from final task payloads.
 - `scripts/collect_ab_results.py` carries telemetry into `ab_rows.csv` / `ab_rows.json`.
+  The CLI remains stable; row loading and field normalization live behind `scripts/collect_ab_results_rows.py`.
 - `scripts/score_ab_results.py` reports TTFT/TPS/token rollups and deltas.
 - These telemetry metrics are reporting-only in this phase and are not part of pass/fail gates.
 
@@ -841,6 +842,7 @@ Scripts:
   - reads an arbitrary window via `--window-days` and emits:
     - `experiments/results/soak/soak_eval_<N>d.json`
     - `experiments/results/soak/soak_eval_<N>d.md`
+  - keeps gate/evidence evaluation behind `scripts/evaluate_soak_week_gates.py`; command and output contracts stay unchanged
   - treats run-local provider deltas as the only trustworthy timeout evidence for either tier
   - treats legacy cumulative-only summaries as diagnostic and marks timeout-rate gate `INCONCLUSIVE`
   - emits `overall_status` (`PASS|FAIL|INCONCLUSIVE`) while keeping `overall_pass` for compatibility
@@ -971,6 +973,10 @@ docker compose run --rm pipeline python run_agenda_qa.py --regenerate --max 50
 Outputs:
 - `data/reports/agenda_qa_<timestamp>.json`
 - `data/reports/agenda_qa_<timestamp>.csv`
+
+Implementation owners:
+- `pipeline/agenda_qa.py` owns stored-item report/regeneration scoring.
+- `pipeline/agenda_resolver_quality.py` owns resolver source-selection quality scoring.
 
 ## Agenda Segmentation Precision Tuning
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -297,6 +297,7 @@ Weekly evaluation (`scripts/evaluate_soak_week.py`) uses:
 - run-local provider deltas captured from `run_manifest.json` baseline counters plus the post-run worker scrape
 - cumulative provider totals remain observational only
 - a successful pre-run worker scrape with no provider series yet counts as a zero baseline, not missing evidence
+- gate and evidence evaluation from `scripts/evaluate_soak_week_gates.py` behind the same CLI/output contract
 
 Why:
 - Prometheus counters are cumulative across runs; promotion gates need per-run evidence so the first day of a window is not contaminated by pre-window history.

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1,6 +1,6 @@
 # Performance
 
-Last updated: 2026-04-03
+Last updated: 2026-05-11
 
 This page describes how to interpret and reproduce performance evidence for local Docker runs.
 For operational troubleshooting and sorting diagnostics, use `docs/OPERATIONS.md`.

--- a/pipeline/requirements-dev.txt
+++ b/pipeline/requirements-dev.txt
@@ -8,3 +8,5 @@ locust==2.33.0
 ruff==0.15.9
 pre-commit==4.5.1
 mypy==1.20.0
+vulture==2.16
+radon==6.0.1

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -222,6 +222,9 @@ AGENDA_RESOLVER_CLEANUP_MODULES = (
     "pipeline/agenda_resolver_enrichment.py",
     "pipeline/agenda_resolver_runner.py",
 )
+AGENDA_QA_CLEANUP_MODULES = (
+    "pipeline/agenda_qa.py",
+)
 AGENDA_SUMMARY_MAINTENANCE_CLEANUP_MODULES = (
     "pipeline/agenda_summary_maintenance.py",
     "pipeline/agenda_summary_contracts.py",
@@ -299,8 +302,11 @@ PERSON_UTILS_CLEANUP_MODULES = (
 )
 REPORTING_SCRIPTS_CLEANUP_MODULES = (
     "scripts/analyze_pipeline_profile.py",
+    "scripts/collect_ab_results.py",
+    "scripts/collect_ab_results_rows.py",
     "scripts/collect_soak_metrics.py",
     "scripts/evaluate_soak_week.py",
+    "scripts/evaluate_soak_week_gates.py",
     "scripts/operator_profile_ab.py",
     "scripts/operator_profile_artifacts.py",
     "scripts/operator_profile_metric_deltas.py",
@@ -316,6 +322,10 @@ REPORTING_SCRIPTS_CLEANUP_MODULES = (
     "scripts/profile_pipeline_results.py",
     "scripts/profile_pipeline_selection.py",
     "scripts/score_ab_results.py",
+)
+SHARED_HELPER_CLEANUP_MODULES = (
+    "pipeline/cli_logging.py",
+    "scripts/operator_numeric.py",
 )
 TASK_API_FACADE_CLEANUP_MODULES = (
     "pipeline/tasks.py",
@@ -448,6 +458,7 @@ def _broad_exception_scan_files() -> list[Path]:
         *AGENDA_EXTRACTION_CLEANUP_MODULES,
         *AGENDA_TEXT_HEURISTICS_CLEANUP_MODULES,
         *AGENDA_RESOLVER_CLEANUP_MODULES,
+        *AGENDA_QA_CLEANUP_MODULES,
         *AGENDA_SUMMARY_MAINTENANCE_CLEANUP_MODULES,
         *AGENDA_SUMMARY_RUNTIME_CLEANUP_MODULES,
         *PROFILE_MANIFEST_CLEANUP_MODULES,
@@ -461,6 +472,7 @@ def _broad_exception_scan_files() -> list[Path]:
         *HTTP_PROVIDER_CLEANUP_MODULES,
         *PERSON_UTILS_CLEANUP_MODULES,
         *REPORTING_SCRIPTS_CLEANUP_MODULES,
+        *SHARED_HELPER_CLEANUP_MODULES,
         *TASK_API_FACADE_CLEANUP_MODULES,
         *SEARCH_SUPPORT_CLEANUP_MODULES,
         *CITY_ONBOARDING_EVALUATOR_CLEANUP_MODULES,
@@ -796,6 +808,16 @@ def test_agenda_resolver_cleanup_modules_stay_under_size_target():
     assert oversized_modules == []
 
 
+def test_agenda_qa_cleanup_modules_stay_under_size_target():
+    oversized_modules = [
+        module_path
+        for module_path in AGENDA_QA_CLEANUP_MODULES
+        if len((ROOT / module_path).read_text(encoding="utf-8").splitlines()) > 300
+    ]
+
+    assert oversized_modules == []
+
+
 def test_agenda_summary_maintenance_cleanup_modules_stay_under_size_target():
     oversized_modules = [
         module_path
@@ -912,6 +934,32 @@ def test_reporting_scripts_cleanup_modules_stay_under_size_target():
     oversized_modules = [
         module_path
         for module_path in REPORTING_SCRIPTS_CLEANUP_MODULES
+        if len((ROOT / module_path).read_text(encoding="utf-8").splitlines()) > 300
+    ]
+
+    assert oversized_modules == []
+
+
+def test_batch_e_reporting_helpers_do_not_import_facades():
+    forbidden_imports: list[str] = []
+    for module_path in (
+        ROOT / "scripts" / "collect_ab_results_rows.py",
+        ROOT / "scripts" / "evaluate_soak_week_gates.py",
+    ):
+        forbidden_imports.extend(
+            _forbidden_imports(
+                module_path,
+                {"scripts.collect_ab_results", "scripts.evaluate_soak_week"},
+            )
+        )
+
+    assert forbidden_imports == []
+
+
+def test_shared_helper_cleanup_modules_stay_under_size_target():
+    oversized_modules = [
+        module_path
+        for module_path in SHARED_HELPER_CLEANUP_MODULES
         if len((ROOT / module_path).read_text(encoding="utf-8").splitlines()) > 300
     ]
 


### PR DESCRIPTION
## What changed
- Enrolled Batch E reporting, shared-helper, and agenda QA modules in repository guardrails.
- Added facade-import guardrails for the new reporting helper modules.
- Updated architecture, operations, performance, guardrail, and ADR docs to reflect the Batch E ownership split.
- Pinned `vulture==2.16` and `radon==6.0.1` as dev-only local audit tools.

## Why
Batch E split dead-code, duplicate-helper, and complexity cleanup into code PRs. This follow-up keeps docs and guardrails aligned without mixing source-map updates into those parallel implementation PRs.

## Risk / compatibility
- No runtime behavior changes.
- No API, CLI, JSON/stdout, migration, runtime default, workflow, mypy scope, or formatter scope changes.
- Dev requirements gain local audit tooling only.

## Verification
- PASS `./.venv/bin/ruff check api pipeline scripts tests`
- PASS `./.venv/bin/mypy`
- PASS `PYTHONPATH=. .venv/bin/pytest -q tests/test_repository_guardrails.py`
- PASS `PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py`
- PASS `git diff --check`
- PASS `./.venv/bin/python -m vulture api pipeline scripts tests --min-confidence 80`
- PASS `./.venv/bin/python -m radon cc scripts/evaluate_soak_week.py scripts/evaluate_soak_week_gates.py scripts/collect_ab_results.py scripts/collect_ab_results_rows.py pipeline/agenda_resolver_quality.py pipeline/agenda_qa.py pipeline/utils_names.py -s -n C`

## Remaining deficits
None.
