### PR TITLE
Stabilize the full pytest suite

### DIFF
--- a/scripts/collect_soak_metrics.py
+++ b/scripts/collect_soak_metrics.py
@@ -10,7 +10,6 @@ from scripts.operator_prometheus import PROM_LINE as PROM_LINE
 from scripts.operator_prometheus import parse_metrics as _parse_metrics
 from scripts.operator_prometheus import sum_metric as _sum_metric
 from scripts.operator_profile_metrics import fetch_text as _fetch_text
-from scripts.operator_profile_metrics import fetch_worker_metrics_via_docker as _fetch_worker_metrics_via_docker
 from scripts.operator_profile_metrics import hist_quantile as _hist_quantile
 from scripts.operator_profile_metrics import load_run_manifest as _load_run_manifest
 from scripts.operator_profile_metrics import load_tasks_rows as _load_tasks_rows
@@ -18,6 +17,15 @@ from scripts.operator_profile_metrics import provider_metrics_state as _provider
 from scripts.operator_profile_metrics import slowest_task as _slowest_task
 from scripts.operator_profile_metrics import submission_failure_breakdown as _submission_failure_breakdown
 from scripts.operator_profile_metric_deltas import provider_run_deltas_from_manifest as _provider_run_deltas_from_manifest
+from scripts.operator_profile_worker_metrics import docker_exec_python as _profile_docker_exec_python
+from scripts.operator_profile_worker_metrics import fetch_worker_metrics_via_docker as _fetch_worker_metrics_with_exec
+
+
+_docker_exec_python = _profile_docker_exec_python
+
+
+def _fetch_worker_metrics_via_docker() -> tuple[str, str | None]:
+    return _fetch_worker_metrics_with_exec(exec_python=_docker_exec_python)
 
 
 def _search_p95_ms(api_url: str) -> float | None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,10 @@ OPTIONAL_NLP_IMPORT_ERRORS = (ImportError, ModuleNotFoundError, OSError, Runtime
 # agnostic behavior rather than the PostgreSQL runtime contract.
 TEST_DB_URL = f"sqlite:///file:tc_testdb_{os.getpid()}?mode=memory&cache=shared&uri=true"
 
+# Test collection can import app modules that initialize DB engines immediately.
+# Pytest owns this value so collection never touches a developer's real DB.
+os.environ["DATABASE_URL"] = TEST_DB_URL
+
 @pytest.fixture(scope="session", autouse=True)
 def shared_engine():
     """
@@ -36,11 +40,14 @@ def shared_engine():
 @pytest.fixture(autouse=True)
 def mock_db_connect(monkeypatch, shared_engine):
     """
-    Monkeypatch ALL workers to use the shared test database.
+    Keep test DB ownership centralized without weakening runtime DB contracts.
     """
     monkeypatch.setenv("DATABASE_URL", TEST_DB_URL)
+    import pipeline.db_session as db_session_module
+
+    db_session_module._SessionLocal = None
     
-    # We patch db_connect in multiple modules where it might be imported
+    # Patch DB factory seams proven by tests; direct db_session imports use this module.
     targets = [
         "pipeline.models.db_connect",
         "pipeline.agenda_worker.db_connect",
@@ -48,6 +55,7 @@ def mock_db_connect(monkeypatch, shared_engine):
         "pipeline.nlp_worker.db_connect",
         "pipeline.promote_stage.db_connect",
         "pipeline.downloader.db_connect",
+        "api.app_setup.db_connect",
         "api.main.db_connect"
     ]
     for target in targets:
@@ -57,7 +65,41 @@ def mock_db_connect(monkeypatch, shared_engine):
             # Some optional modules (for example spaCy stack on Py3.14) can fail
             # during import; skip patching those modules so other tests still run.
             pass
+    try:
+        import api.app_setup as app_setup
+
+        app_setup.SessionLocal = None
+        app_setup._db_init_error = None
+    except OPTIONAL_NLP_IMPORT_ERRORS:
+        pass
     yield
+    db_session_module._SessionLocal = None
+
+
+@pytest.fixture(autouse=True)
+def reset_api_test_state():
+    """
+    Prevent API dependency overrides and rate-limit counters from leaking.
+    """
+    def _reset_state() -> None:
+        api_main = sys.modules.get("api.main")
+        if api_main is None:
+            return
+        app = getattr(api_main, "app", None)
+        if app is not None:
+            app.dependency_overrides.clear()
+            limiter = getattr(getattr(app, "state", None), "limiter", None)
+            reset = getattr(limiter, "reset", None)
+            if callable(reset):
+                reset()
+            storage = getattr(getattr(limiter, "limiter", None), "storage", None)
+            storage_reset = getattr(storage, "reset", None)
+            if callable(storage_reset):
+                storage_reset()
+
+    _reset_state()
+    yield
+    _reset_state()
 
 @pytest.fixture(autouse=True)
 def reset_nlp_cache():

--- a/tests/test_check_city_crawl_evidence.py
+++ b/tests/test_check_city_crawl_evidence.py
@@ -1,46 +1,32 @@
 from datetime import datetime
 
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
-
-from pipeline.models import Base, EventStage, UrlStage
+from pipeline.models import EventStage, UrlStage
 from scripts import check_city_crawl_evidence as mod
 
 
-def test_collect_crawl_evidence_includes_rows_in_end_second(tmp_path, monkeypatch):
-    db_path = tmp_path / "crawl_evidence.sqlite"
-    engine = create_engine(f"sqlite:///{db_path}")
-    Base.metadata.create_all(engine)
-    Session = sessionmaker(bind=engine)
-    session = Session()
-    try:
-        session.add(
-            EventStage(
-                ocd_division_id="ocd-division/country:us/state:ca/place:san_leandro",
-                source="san_leandro",
-                scraped_datetime=datetime(2026, 3, 15, 2, 14, 23, 157000),
-                record_date=datetime(2026, 3, 15).date(),
-                name="City Council",
-                source_url="https://sanleandro.legistar.com/Calendar.aspx",
-            )
+def test_collect_crawl_evidence_includes_rows_in_end_second(db_session):
+    db_session.add(
+        EventStage(
+            ocd_division_id="ocd-division/country:us/state:ca/place:san_leandro",
+            source="san_leandro",
+            scraped_datetime=datetime(2026, 3, 15, 2, 14, 23, 157000),
+            record_date=datetime(2026, 3, 15).date(),
+            name="City Council",
+            source_url="https://sanleandro.legistar.com/Calendar.aspx",
         )
-        session.add(
-            UrlStage(
-                ocd_division_id="ocd-division/country:us/state:ca/place:san_leandro",
-                created_at=datetime(2026, 3, 15, 2, 14, 23, 157000),
-                url="https://example.com/agenda.pdf",
-                url_hash="abc123",
-                category="agenda",
-                event="City Council",
-                event_date=datetime(2026, 3, 15).date(),
-            )
+    )
+    db_session.add(
+        UrlStage(
+            ocd_division_id="ocd-division/country:us/state:ca/place:san_leandro",
+            created_at=datetime(2026, 3, 15, 2, 14, 23, 157000),
+            url="https://example.com/agenda.pdf",
+            url_hash="abc123",
+            category="agenda",
+            event="City Council",
+            event_date=datetime(2026, 3, 15).date(),
         )
-        session.commit()
-    finally:
-        session.close()
-        engine.dispose()
-
-    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+    )
+    db_session.commit()
 
     payload = mod._collect_crawl_evidence(
         "san_leandro",

--- a/tests/test_collect_soak_metrics_worker_python_scrape.py
+++ b/tests/test_collect_soak_metrics_worker_python_scrape.py
@@ -29,7 +29,7 @@ def test_worker_scrape_falls_back_to_registry_strategy(monkeypatch):
     def _fake_exec(script: str):
         calls["n"] += 1
         if "localhost:8001/metrics" in script:
-            raise RuntimeError("http probe failed")
+            raise subprocess.SubprocessError("http probe failed")
         assert "RedisProviderMetricsCollector" in script
         return "tc_provider_requests_total 1\n"
 

--- a/tests/test_docker_build_contracts.py
+++ b/tests/test_docker_build_contracts.py
@@ -67,7 +67,7 @@ def test_worker_runtime_requirements_exclude_dev_benchmark_tooling():
     runtime = Path("pipeline/requirements.txt").read_text(encoding="utf-8")
     dev = Path("pipeline/requirements-dev.txt").read_text(encoding="utf-8")
 
-    for package in ("pytest==8.3.4", "pytest-mock==3.12.0", "pytest-benchmark==5.1.0", "locust==2.33.0"):
+    for package in ("pytest==9.0.3", "pytest-mock==3.12.0", "pytest-benchmark==5.1.0", "locust==2.33.0"):
         assert package not in runtime
         assert package in dev
 
@@ -89,7 +89,7 @@ def test_worker_live_and_batch_requirements_split_table_stack_only():
         assert package not in core
         assert package in batch
 
-    for package in ("spacy==3.7.4", "pytextrank==3.3.0", "scikit-learn==1.5.0", "pypdf==6.10.0"):
+    for package in ("spacy==3.7.4", "pytextrank==3.3.0", "scikit-learn==1.5.0", "pypdf==6.10.2"):
         assert package not in core
         assert package in batch
 

--- a/tests/test_extract_endpoint.py
+++ b/tests/test_extract_endpoint.py
@@ -3,7 +3,11 @@ import os
 from unittest.mock import MagicMock
 from kombu.exceptions import OperationalError
 
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from slowapi import Limiter, _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
+from slowapi.util import get_remote_address
 
 # Add the project root to the path so we can import from api/main.py
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
@@ -39,6 +43,37 @@ def test_extract_404_when_catalog_missing(mocker):
         assert resp.status_code == 404
     finally:
         del app.dependency_overrides[get_db]
+
+
+def test_extract_rate_limit_still_enforced():
+    from api.task_routes import build_task_router
+
+    db = MagicMock()
+    db.get.return_value = None
+
+    def _mock_get_db():
+        yield db
+
+    async def _verify_api_key():
+        return None
+
+    rate_limiter = Limiter(key_func=get_remote_address)
+    rate_limit_app = FastAPI()
+    rate_limit_app.state.limiter = rate_limiter
+    rate_limit_app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+    rate_limit_app.include_router(
+        build_task_router(
+            limiter=rate_limiter,
+            get_db_dependency=_mock_get_db,
+            verify_api_key_dependency=_verify_api_key,
+            task_facade=MagicMock(),
+        )
+    )
+
+    rate_limit_client = TestClient(rate_limit_app, client=("extract-rate-limit-test", 50000))
+    responses = [rate_limit_client.post("/extract/123") for _ in range(6)]
+    assert [response.status_code for response in responses[:5]] == [404, 404, 404, 404, 404]
+    assert responses[5].status_code == 429
 
 
 def test_extract_cached_when_content_exists_and_not_forced(mocker):

--- a/tests/test_startup_purge_gating.py
+++ b/tests/test_startup_purge_gating.py
@@ -35,7 +35,7 @@ def test_run_startup_purge_allows_non_dev_with_override(monkeypatch):
     fake_session.query.return_value.update.return_value = 0
 
     monkeypatch.setattr(startup_purge, "db_connect", lambda: fake_engine)
-    monkeypatch.setattr(startup_purge, "sessionmaker", lambda _bind: lambda: fake_session)
+    monkeypatch.setattr(startup_purge, "sessionmaker", lambda bind: lambda: fake_session)
 
     result = startup_purge.run_startup_purge_if_enabled()
     assert result["status"] == "completed"

--- a/tests/test_startup_purge_locking.py
+++ b/tests/test_startup_purge_locking.py
@@ -18,7 +18,7 @@ def test_run_startup_purge_skips_when_lock_not_acquired(monkeypatch):
     fake_session.execute.return_value.scalar.return_value = False
 
     monkeypatch.setattr(startup_purge, "db_connect", lambda: fake_engine)
-    monkeypatch.setattr(startup_purge, "sessionmaker", lambda _bind: lambda: fake_session)
+    monkeypatch.setattr(startup_purge, "sessionmaker", lambda bind: lambda: fake_session)
 
     result = startup_purge.run_startup_purge_if_enabled()
     assert result["status"] == "skipped"
@@ -45,7 +45,7 @@ def test_run_startup_purge_runs_when_lock_acquired(monkeypatch):
     fake_session.query.return_value = fake_query
 
     monkeypatch.setattr(startup_purge, "db_connect", lambda: fake_engine)
-    monkeypatch.setattr(startup_purge, "sessionmaker", lambda _bind: lambda: fake_session)
+    monkeypatch.setattr(startup_purge, "sessionmaker", lambda bind: lambda: fake_session)
 
     result = startup_purge.run_startup_purge_if_enabled()
     assert result["status"] == "completed"

--- a/tests/test_verification_service.py
+++ b/tests/test_verification_service.py
@@ -30,7 +30,7 @@ def test_verify_item_sets_coords_and_result_on_direct_match(mocker):
         result=None,
     )
     db.get.return_value = SimpleNamespace(location="/tmp/agenda.pdf")
-    mocker.patch("pipeline.verification_service._find_verification_locations", return_value=[{"page": 1, "x": 1.0, "y": 2.0}])
+    mocker.patch.object(verification_module, "_find_verification_locations", return_value=[{"page": 1, "x": 1.0, "y": 2.0}])
 
     service.verify_item(item, db=db)
 
@@ -52,8 +52,9 @@ def test_verify_item_uses_vote_tally_fallback(mocker):
         result=None,
     )
     db.get.return_value = SimpleNamespace(location="/tmp/agenda.pdf")
-    mocker.patch(
-        "pipeline.verification_service._find_verification_locations",
+    mocker.patch.object(
+        verification_module,
+        "_find_verification_locations",
         side_effect=[[], [{"page": 3, "x": 5.0, "y": 9.0}]],
     )
 
@@ -77,7 +78,7 @@ def test_verify_item_rolls_back_when_commit_fails(mocker):
     )
     db.get.return_value = SimpleNamespace(location="/tmp/agenda.pdf")
     db.commit.side_effect = SQLAlchemyError("commit failed")
-    mocker.patch("pipeline.verification_service._find_verification_locations", return_value=[{"page": 2}])
+    mocker.patch.object(verification_module, "_find_verification_locations", return_value=[{"page": 2}])
 
     service.verify_item(item, db=db)
 


### PR DESCRIPTION
## What changed
- Own test DATABASE_URL during pytest collection so app imports cannot touch a caller's real DB.
- Reset canonical test DB/session state and API limiter/dependency state between tests.
- Preserve collect_soak_metrics worker scrape patch seam after helper extraction.
- Refresh stale dependency contract expectations and test doubles for startup purge and verification service.
- Add focused extract endpoint rate-limit coverage.

## Why
The full pytest suite had isolation, order-dependence, stale contract, and mock seam failures. This makes the existing full-suite command reliable from a clean shell.

## Risk / compatibility
- Runtime DB behavior unchanged; production still fails fast without DATABASE_URL.
- No API, CLI, migration, docs, or runtime config changes.
- Test harness now owns DATABASE_URL during pytest collection to avoid accidental real DB access.

## Verification
- PASS: env -u DATABASE_URL PYTHONPATH=. .venv/bin/pytest -q tests/test_search_pgvector_hybrid_rerank.py tests/test_semantic_recall_filters.py
- PASS: DATABASE_URL=postgresql://real.example.invalid/prod PYTHONPATH=. .venv/bin/pytest -q tests/test_search_pgvector_hybrid_rerank.py tests/test_semantic_recall_filters.py
- PASS: PYTHONPATH=. .venv/bin/pytest -q
- PASS: ./.venv/bin/ruff check api pipeline scripts tests
- PASS: ./.venv/bin/mypy
- PASS: git diff --check

## Review
Independent review found one P2 around setdefault using caller DATABASE_URL. Fixed by assigning test DATABASE_URL unconditionally in tests/conftest.py. Re-review approved.

## Remaining deficits
- Existing warnings remain, mostly dependency deprecations and benchmark output. No new docs PR needed because command behavior stayed unchanged.