### PR TITLE
Refactor city coverage audit assembly

### DIFF
--- a/pipeline/city_coverage_assembly.py
+++ b/pipeline/city_coverage_assembly.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from pipeline.city_coverage_buckets import MonthlyCoverageBucket
+from pipeline.city_coverage_contracts import MonthlyCoverageRow
+
+
+@dataclass(frozen=True)
+class CoverageSummary:
+    monthly_rows: list[MonthlyCoverageRow]
+    suspicious_months: list[dict[str, object]]
+    totals: dict[str, int]
+    source_counts: dict[str, int]
+
+
+def build_coverage_summary(
+    buckets: dict[str, MonthlyCoverageBucket],
+    *,
+    current_month_key: str,
+    meeting_cadence_threshold: int | None,
+) -> CoverageSummary:
+    monthly_rows: list[MonthlyCoverageRow] = []
+    suspicious_months: list[dict[str, object]] = []
+    total_event_ids: set[int] = set()
+    total_meeting_keys: set[str] = set()
+    total_agenda_doc_ids: set[int] = set()
+    total_agenda_catalog_ids: set[int] = set()
+    total_content_catalog_ids: set[int] = set()
+    total_summary_catalog_ids: set[int] = set()
+    total_source_event_ids: dict[str, set[int]] = {}
+
+    for key, bucket in buckets.items():
+        row = build_monthly_coverage_row(
+            key,
+            bucket,
+            current_month_key=current_month_key,
+            meeting_cadence_threshold=meeting_cadence_threshold,
+        )
+        monthly_rows.append(row)
+        if row.flags:
+            suspicious_months.append({"month": key, "flags": list(row.flags)})
+
+        total_event_ids.update(bucket.event_ids)
+        total_meeting_keys.update(bucket.meeting_keys)
+        total_agenda_doc_ids.update(bucket.agenda_doc_ids)
+        total_agenda_catalog_ids.update(bucket.agenda_catalog_ids)
+        total_content_catalog_ids.update(bucket.content_catalog_ids)
+        total_summary_catalog_ids.update(bucket.summary_catalog_ids)
+        for source, event_ids in bucket.source_event_ids.items():
+            total_source_event_ids.setdefault(source, set()).update(event_ids)
+
+    return CoverageSummary(
+        monthly_rows=monthly_rows,
+        suspicious_months=suspicious_months,
+        totals={
+            "event_count": len(total_event_ids),
+            "meeting_count": len(total_meeting_keys),
+            "agenda_document_count": len(total_agenda_doc_ids),
+            "agenda_catalog_count": len(total_agenda_catalog_ids),
+            "agenda_catalogs_with_content": len(total_content_catalog_ids),
+            "agenda_catalogs_with_summary": len(total_summary_catalog_ids),
+        },
+        source_counts={source: len(event_ids) for source, event_ids in sorted(total_source_event_ids.items())},
+    )
+
+
+def build_monthly_coverage_row(
+    month: str,
+    bucket: MonthlyCoverageBucket,
+    *,
+    current_month_key: str,
+    meeting_cadence_threshold: int | None,
+) -> MonthlyCoverageRow:
+    flags = build_monthly_flags(
+        month,
+        event_count=len(bucket.event_ids),
+        agenda_document_count=len(bucket.agenda_doc_ids),
+        agenda_catalogs_with_content=len(bucket.content_catalog_ids),
+        agenda_catalogs_with_summary=len(bucket.summary_catalog_ids),
+        meeting_count=len(bucket.meeting_keys),
+        current_month_key=current_month_key,
+        meeting_cadence_threshold=meeting_cadence_threshold,
+    )
+    return MonthlyCoverageRow(
+        month=month,
+        event_count=len(bucket.event_ids),
+        meeting_count=len(bucket.meeting_keys),
+        agenda_document_count=len(bucket.agenda_doc_ids),
+        agenda_catalog_count=len(bucket.agenda_catalog_ids),
+        agenda_catalogs_with_content=len(bucket.content_catalog_ids),
+        agenda_catalogs_with_summary=len(bucket.summary_catalog_ids),
+        source_event_counts={source: len(event_ids) for source, event_ids in sorted(bucket.source_event_ids.items())},
+        source_meeting_counts={source: len(keys) for source, keys in sorted(bucket.source_meeting_keys.items())},
+        flags=flags,
+    )
+
+
+def build_monthly_flags(
+    month: str,
+    *,
+    event_count: int,
+    agenda_document_count: int,
+    agenda_catalogs_with_content: int,
+    agenda_catalogs_with_summary: int,
+    meeting_count: int,
+    current_month_key: str,
+    meeting_cadence_threshold: int | None,
+) -> list[str]:
+    monthly_flag_checks = [
+        ("no_events", event_count == 0),
+        ("events_but_no_agendas", event_count > 0 and agenda_document_count == 0),
+        ("agendas_but_no_content", agenda_document_count > 0 and agenda_catalogs_with_content == 0),
+        ("content_but_no_summaries", agenda_catalogs_with_content > 0 and agenda_catalogs_with_summary == 0),
+        (
+            "below_expected_cadence",
+            meeting_cadence_threshold is not None and month != current_month_key and meeting_count < meeting_cadence_threshold,
+        ),
+    ]
+    return [flag for flag, should_report in monthly_flag_checks if should_report]

--- a/pipeline/city_coverage_audit.py
+++ b/pipeline/city_coverage_audit.py
@@ -1,98 +1,26 @@
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass
 from datetime import date
-import math
-import re
-import statistics
 
+from sqlalchemy.orm import Session
+
+from pipeline.city_coverage_assembly import build_coverage_summary
+from pipeline.city_coverage_buckets import create_monthly_coverage_buckets
+from pipeline.city_coverage_contracts import CityCoverageAudit as CityCoverageAudit
+from pipeline.city_coverage_contracts import MonthlyCoverageRow as MonthlyCoverageRow
+from pipeline.city_coverage_queries import ingest_coverage_rows, load_agenda_coverage_rows, load_event_coverage_rows
+from pipeline.city_coverage_windows import (
+    build_month_window,
+    compute_expected_monthly_event_baseline,
+    month_key,
+    month_start,
+    normalize_meeting_name as normalize_meeting_name,
+)
 from pipeline.city_scope import source_aliases_for_city
-from pipeline.models import Catalog, Document, Event
-
-
-def _month_start(value: date) -> date:
-    return value.replace(day=1)
-
-
-def _shift_month(value: date, delta: int) -> date:
-    year = value.year + ((value.month - 1 + delta) // 12)
-    month = ((value.month - 1 + delta) % 12) + 1
-    return date(year, month, 1)
-
-
-def build_month_window(months: int, as_of: date | None = None) -> list[date]:
-    if months <= 0:
-        raise ValueError("months must be positive")
-    anchor = _month_start(as_of or date.today())
-    start = _shift_month(anchor, -(months - 1))
-    return [_shift_month(start, idx) for idx in range(months)]
-
-
-def month_key(value: date) -> str:
-    return value.strftime("%Y-%m")
-
-
-def normalize_meeting_name(value: str | None) -> str:
-    normalized = re.sub(r"\s+", " ", str(value or "").strip().lower())
-    return normalized or "(missing)"
-
-
-def compute_expected_monthly_event_baseline(event_counts: list[int]) -> tuple[float, int | None]:
-    if not event_counts:
-        return 0.0, None
-    baseline = float(statistics.median(event_counts))
-    if baseline < 2.0:
-        return baseline, None
-    # Keep this conservative so the audit highlights suspicious troughs
-    # without pretending to know each city's exact meeting cadence.
-    threshold = max(1, int(math.ceil(baseline * 0.5)))
-    return baseline, threshold
-
-
-@dataclass(frozen=True)
-class MonthlyCoverageRow:
-    month: str
-    event_count: int
-    meeting_count: int
-    agenda_document_count: int
-    agenda_catalog_count: int
-    agenda_catalogs_with_content: int
-    agenda_catalogs_with_summary: int
-    source_event_counts: dict[str, int]
-    source_meeting_counts: dict[str, int]
-    flags: list[str]
-
-
-@dataclass(frozen=True)
-class CityCoverageAudit:
-    city: str
-    months: int
-    date_from: str
-    date_to: str
-    expected_monthly_event_baseline: float
-    below_expected_cadence_threshold: int | None
-    expected_monthly_meeting_baseline: float
-    below_expected_meeting_cadence_threshold: int | None
-    totals: dict[str, int]
-    source_counts: dict[str, int]
-    monthly: list[MonthlyCoverageRow]
-    suspicious_months: list[dict[str, object]]
-
-    def to_dict(self) -> dict[str, object]:
-        payload = asdict(self)
-        payload["metric_semantics"] = {
-            "event_count": "distinct_events_by_record_month",
-            "agenda_document_count": "distinct_agenda_documents_by_event_month",
-            "agenda_catalog_count": "distinct_agenda_catalogs_by_event_month",
-            "agenda_catalogs_with_content": "distinct_agenda_catalogs_with_non_empty_content_by_event_month",
-            "agenda_catalogs_with_summary": "distinct_agenda_catalogs_with_non_empty_summary_by_event_month",
-            "meeting_count": "distinct_record_date_plus_normalized_event_name_by_record_month",
-        }
-        return payload
 
 
 def build_city_coverage_audit(
-    db_session,
+    db_session: Session,
     *,
     city: str,
     months: int = 12,
@@ -102,155 +30,33 @@ def build_city_coverage_audit(
     start_date = month_starts[0]
     end_date = as_of or date.today()
     source_aliases = sorted(source_aliases_for_city(city))
+    buckets = create_monthly_coverage_buckets(month_starts)
 
-    monthly_sets: dict[str, dict[str, object]] = {}
-    for month_start in month_starts:
-        key = month_key(month_start)
-        monthly_sets[key] = {
-            "event_ids": set(),
-            "meeting_keys": set(),
-            "agenda_doc_ids": set(),
-            "agenda_catalog_ids": set(),
-            "content_catalog_ids": set(),
-            "summary_catalog_ids": set(),
-            "source_event_ids": {},
-            "source_meeting_keys": {},
-        }
-
-    event_rows = (
-        db_session.query(Event.id, Event.record_date, Event.source, Event.name)
-        .filter(
-            Event.source.in_(source_aliases),
-            Event.record_date.isnot(None),
-            Event.record_date >= start_date,
-            Event.record_date <= end_date,
-        )
-        .all()
+    ingest_coverage_rows(
+        buckets,
+        event_rows=load_event_coverage_rows(
+            db_session,
+            source_aliases=source_aliases,
+            start_date=start_date,
+            end_date=end_date,
+        ),
+        agenda_rows=load_agenda_coverage_rows(
+            db_session,
+            source_aliases=source_aliases,
+            start_date=start_date,
+            end_date=end_date,
+        ),
     )
-    for event_id, record_date, source, name in event_rows:
-        key = month_key(_month_start(record_date))
-        bucket = monthly_sets.get(key)
-        if bucket is None:
-            continue
-        bucket["event_ids"].add(int(event_id))
-        # Cadence should approximate distinct meetings, not item-level event rows
-        # emitted by some sources for the same meeting date/title combination.
-        meeting_key = f"{record_date.isoformat()}::{normalize_meeting_name(name)}"
-        bucket["meeting_keys"].add(meeting_key)
-        source_event_ids = bucket["source_event_ids"]
-        source_event_ids.setdefault(str(source), set()).add(int(event_id))
-        source_meeting_keys = bucket["source_meeting_keys"]
-        source_meeting_keys.setdefault(str(source), set()).add(meeting_key)
 
-    agenda_rows = (
-        db_session.query(
-            Event.record_date,
-            Document.id,
-            Document.catalog_id,
-            Catalog.content,
-            Catalog.summary,
-        )
-        .join(Document, Document.event_id == Event.id)
-        .outerjoin(Catalog, Catalog.id == Document.catalog_id)
-        .filter(
-            Event.source.in_(source_aliases),
-            Event.record_date.isnot(None),
-            Event.record_date >= start_date,
-            Event.record_date <= end_date,
-            Document.category == "agenda",
-        )
-        .all()
-    )
-    for record_date, document_id, catalog_id, content, summary in agenda_rows:
-        key = month_key(_month_start(record_date))
-        bucket = monthly_sets.get(key)
-        if bucket is None:
-            continue
-        bucket["agenda_doc_ids"].add(int(document_id))
-        if catalog_id is not None:
-            normalized_catalog_id = int(catalog_id)
-            bucket["agenda_catalog_ids"].add(normalized_catalog_id)
-            if str(content or "").strip():
-                bucket["content_catalog_ids"].add(normalized_catalog_id)
-            if str(summary or "").strip():
-                bucket["summary_catalog_ids"].add(normalized_catalog_id)
-
-    event_counts = [len(bucket["event_ids"]) for bucket in monthly_sets.values()]
-    meeting_counts = [len(bucket["meeting_keys"]) for bucket in monthly_sets.values()]
+    event_counts = [len(bucket.event_ids) for bucket in buckets.values()]
+    meeting_counts = [len(bucket.meeting_keys) for bucket in buckets.values()]
     event_baseline, event_cadence_threshold = compute_expected_monthly_event_baseline(event_counts)
     meeting_baseline, meeting_cadence_threshold = compute_expected_monthly_event_baseline(meeting_counts)
-    current_month_key = month_key(_month_start(end_date))
-
-    monthly_rows: list[MonthlyCoverageRow] = []
-    suspicious_months: list[dict[str, object]] = []
-    total_event_ids: set[int] = set()
-    total_meeting_keys: set[str] = set()
-    total_agenda_doc_ids: set[int] = set()
-    total_agenda_catalog_ids: set[int] = set()
-    total_content_catalog_ids: set[int] = set()
-    total_summary_catalog_ids: set[int] = set()
-    total_source_event_ids: dict[str, set[int]] = {}
-    total_source_meeting_keys: dict[str, set[str]] = {}
-
-    for key, bucket in monthly_sets.items():
-        event_ids = bucket["event_ids"]
-        meeting_keys = bucket["meeting_keys"]
-        agenda_doc_ids = bucket["agenda_doc_ids"]
-        agenda_catalog_ids = bucket["agenda_catalog_ids"]
-        content_catalog_ids = bucket["content_catalog_ids"]
-        summary_catalog_ids = bucket["summary_catalog_ids"]
-        source_event_ids = bucket["source_event_ids"]
-        source_meeting_keys = bucket["source_meeting_keys"]
-
-        event_count = len(event_ids)
-        meeting_count = len(meeting_keys)
-        agenda_document_count = len(agenda_doc_ids)
-        agenda_catalog_count = len(agenda_catalog_ids)
-        agenda_catalogs_with_content = len(content_catalog_ids)
-        agenda_catalogs_with_summary = len(summary_catalog_ids)
-
-        flags: list[str] = []
-        if event_count == 0:
-            flags.append("no_events")
-        if event_count > 0 and agenda_document_count == 0:
-            flags.append("events_but_no_agendas")
-        if agenda_document_count > 0 and agenda_catalogs_with_content == 0:
-            flags.append("agendas_but_no_content")
-        if agenda_catalogs_with_content > 0 and agenda_catalogs_with_summary == 0:
-            flags.append("content_but_no_summaries")
-        if (
-            meeting_cadence_threshold is not None
-            and key != current_month_key
-            and meeting_count < meeting_cadence_threshold
-        ):
-            flags.append("below_expected_cadence")
-
-        row = MonthlyCoverageRow(
-            month=key,
-            event_count=event_count,
-            meeting_count=meeting_count,
-            agenda_document_count=agenda_document_count,
-            agenda_catalog_count=agenda_catalog_count,
-            agenda_catalogs_with_content=agenda_catalogs_with_content,
-            agenda_catalogs_with_summary=agenda_catalogs_with_summary,
-            source_event_counts={source: len(ids) for source, ids in sorted(source_event_ids.items())},
-            source_meeting_counts={source: len(keys) for source, keys in sorted(source_meeting_keys.items())},
-            flags=flags,
-        )
-        monthly_rows.append(row)
-        if flags:
-            suspicious_months.append({"month": key, "flags": list(flags)})
-
-        total_event_ids.update(event_ids)
-        total_meeting_keys.update(meeting_keys)
-        total_agenda_doc_ids.update(agenda_doc_ids)
-        total_agenda_catalog_ids.update(agenda_catalog_ids)
-        total_content_catalog_ids.update(content_catalog_ids)
-        total_summary_catalog_ids.update(summary_catalog_ids)
-        for source, ids in source_event_ids.items():
-            total_source_event_ids.setdefault(source, set()).update(ids)
-        for source, keys in source_meeting_keys.items():
-            total_source_meeting_keys.setdefault(source, set()).update(keys)
+    summary = build_coverage_summary(
+        buckets,
+        current_month_key=month_key(month_start(end_date)),
+        meeting_cadence_threshold=meeting_cadence_threshold,
+    )
 
     return CityCoverageAudit(
         city=city,
@@ -261,15 +67,8 @@ def build_city_coverage_audit(
         below_expected_cadence_threshold=event_cadence_threshold,
         expected_monthly_meeting_baseline=meeting_baseline,
         below_expected_meeting_cadence_threshold=meeting_cadence_threshold,
-        totals={
-            "event_count": len(total_event_ids),
-            "meeting_count": len(total_meeting_keys),
-            "agenda_document_count": len(total_agenda_doc_ids),
-            "agenda_catalog_count": len(total_agenda_catalog_ids),
-            "agenda_catalogs_with_content": len(total_content_catalog_ids),
-            "agenda_catalogs_with_summary": len(total_summary_catalog_ids),
-        },
-        source_counts={source: len(ids) for source, ids in sorted(total_source_event_ids.items())},
-        monthly=monthly_rows,
-        suspicious_months=suspicious_months,
+        totals=summary.totals,
+        source_counts=summary.source_counts,
+        monthly=summary.monthly_rows,
+        suspicious_months=summary.suspicious_months,
     )

--- a/pipeline/city_coverage_buckets.py
+++ b/pipeline/city_coverage_buckets.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date
+
+from pipeline.city_coverage_windows import month_key, month_start, normalize_meeting_name
+
+
+@dataclass
+class MonthlyCoverageBucket:
+    event_ids: set[int] = field(default_factory=set)
+    meeting_keys: set[str] = field(default_factory=set)
+    agenda_doc_ids: set[int] = field(default_factory=set)
+    agenda_catalog_ids: set[int] = field(default_factory=set)
+    content_catalog_ids: set[int] = field(default_factory=set)
+    summary_catalog_ids: set[int] = field(default_factory=set)
+    source_event_ids: dict[str, set[int]] = field(default_factory=dict)
+    source_meeting_keys: dict[str, set[str]] = field(default_factory=dict)
+
+
+def create_monthly_coverage_buckets(month_starts: list[date]) -> dict[str, MonthlyCoverageBucket]:
+    return {month_key(month_start): MonthlyCoverageBucket() for month_start in month_starts}
+
+
+def add_event_to_monthly_bucket(
+    buckets: dict[str, MonthlyCoverageBucket],
+    *,
+    event_id: int,
+    record_date: date,
+    source: str,
+    name: str | None,
+) -> None:
+    bucket = buckets.get(month_key(month_start(record_date)))
+    if bucket is None:
+        return
+
+    normalized_event_id = int(event_id)
+    meeting_key = f"{record_date.isoformat()}::{normalize_meeting_name(name)}"
+    bucket.event_ids.add(normalized_event_id)
+    bucket.meeting_keys.add(meeting_key)
+    bucket.source_event_ids.setdefault(str(source), set()).add(normalized_event_id)
+    bucket.source_meeting_keys.setdefault(str(source), set()).add(meeting_key)
+
+
+def add_agenda_to_monthly_bucket(
+    buckets: dict[str, MonthlyCoverageBucket],
+    *,
+    record_date: date,
+    document_id: int,
+    catalog_id: int | None,
+    content: str | None,
+    summary: str | None,
+) -> None:
+    bucket = buckets.get(month_key(month_start(record_date)))
+    if bucket is None:
+        return
+
+    bucket.agenda_doc_ids.add(int(document_id))
+    if catalog_id is None:
+        return
+
+    normalized_catalog_id = int(catalog_id)
+    bucket.agenda_catalog_ids.add(normalized_catalog_id)
+    if str(content or "").strip():
+        bucket.content_catalog_ids.add(normalized_catalog_id)
+    if str(summary or "").strip():
+        bucket.summary_catalog_ids.add(normalized_catalog_id)

--- a/pipeline/city_coverage_contracts.py
+++ b/pipeline/city_coverage_contracts.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+
+
+METRIC_SEMANTICS = {
+    "event_count": "distinct_events_by_record_month",
+    "agenda_document_count": "distinct_agenda_documents_by_event_month",
+    "agenda_catalog_count": "distinct_agenda_catalogs_by_event_month",
+    "agenda_catalogs_with_content": "distinct_agenda_catalogs_with_non_empty_content_by_event_month",
+    "agenda_catalogs_with_summary": "distinct_agenda_catalogs_with_non_empty_summary_by_event_month",
+    "meeting_count": "distinct_record_date_plus_normalized_event_name_by_record_month",
+}
+
+
+@dataclass(frozen=True)
+class MonthlyCoverageRow:
+    month: str
+    event_count: int
+    meeting_count: int
+    agenda_document_count: int
+    agenda_catalog_count: int
+    agenda_catalogs_with_content: int
+    agenda_catalogs_with_summary: int
+    source_event_counts: dict[str, int]
+    source_meeting_counts: dict[str, int]
+    flags: list[str]
+
+
+@dataclass(frozen=True)
+class CityCoverageAudit:
+    city: str
+    months: int
+    date_from: str
+    date_to: str
+    expected_monthly_event_baseline: float
+    below_expected_cadence_threshold: int | None
+    expected_monthly_meeting_baseline: float
+    below_expected_meeting_cadence_threshold: int | None
+    totals: dict[str, int]
+    source_counts: dict[str, int]
+    monthly: list[MonthlyCoverageRow]
+    suspicious_months: list[dict[str, object]]
+
+    def to_dict(self) -> dict[str, object]:
+        payload = asdict(self)
+        payload["metric_semantics"] = METRIC_SEMANTICS
+        return payload

--- a/pipeline/city_coverage_queries.py
+++ b/pipeline/city_coverage_queries.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from datetime import date
+from typing import NamedTuple
+
+from sqlalchemy.orm import Session
+
+from pipeline.city_coverage_buckets import (
+    MonthlyCoverageBucket,
+    add_agenda_to_monthly_bucket,
+    add_event_to_monthly_bucket,
+)
+from pipeline.models import Catalog, Document, Event
+
+
+class EventCoverageRow(NamedTuple):
+    event_id: int
+    record_date: date
+    source: str
+    name: str | None
+
+
+class AgendaCoverageRow(NamedTuple):
+    record_date: date
+    document_id: int
+    catalog_id: int | None
+    content: str | None
+    summary: str | None
+
+
+def load_event_coverage_rows(
+    db_session: Session,
+    *,
+    source_aliases: list[str],
+    start_date: date,
+    end_date: date,
+) -> list[EventCoverageRow]:
+    rows = (
+        db_session.query(Event.id, Event.record_date, Event.source, Event.name)
+        .filter(
+            Event.source.in_(source_aliases),
+            Event.record_date.isnot(None),
+            Event.record_date >= start_date,
+            Event.record_date <= end_date,
+        )
+        .all()
+    )
+    return [EventCoverageRow(int(event_id), record_date, str(source), name) for event_id, record_date, source, name in rows]
+
+
+def load_agenda_coverage_rows(
+    db_session: Session,
+    *,
+    source_aliases: list[str],
+    start_date: date,
+    end_date: date,
+) -> list[AgendaCoverageRow]:
+    rows = (
+        db_session.query(
+            Event.record_date,
+            Document.id,
+            Document.catalog_id,
+            Catalog.content,
+            Catalog.summary,
+        )
+        .join(Document, Document.event_id == Event.id)
+        .outerjoin(Catalog, Catalog.id == Document.catalog_id)
+        .filter(
+            Event.source.in_(source_aliases),
+            Event.record_date.isnot(None),
+            Event.record_date >= start_date,
+            Event.record_date <= end_date,
+            Document.category == "agenda",
+        )
+        .all()
+    )
+    return [
+        AgendaCoverageRow(record_date, int(document_id), catalog_id, content, summary)
+        for record_date, document_id, catalog_id, content, summary in rows
+    ]
+
+
+def ingest_coverage_rows(
+    buckets: dict[str, MonthlyCoverageBucket],
+    *,
+    event_rows: list[EventCoverageRow],
+    agenda_rows: list[AgendaCoverageRow],
+) -> None:
+    for event_row in event_rows:
+        add_event_to_monthly_bucket(
+            buckets,
+            event_id=event_row.event_id,
+            record_date=event_row.record_date,
+            source=event_row.source,
+            name=event_row.name,
+        )
+    for agenda_row in agenda_rows:
+        add_agenda_to_monthly_bucket(
+            buckets,
+            record_date=agenda_row.record_date,
+            document_id=agenda_row.document_id,
+            catalog_id=agenda_row.catalog_id,
+            content=agenda_row.content,
+            summary=agenda_row.summary,
+        )

--- a/pipeline/city_coverage_windows.py
+++ b/pipeline/city_coverage_windows.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from datetime import date
+import math
+import re
+import statistics
+
+
+def month_start(value: date) -> date:
+    return value.replace(day=1)
+
+
+def shift_month(value: date, delta: int) -> date:
+    year = value.year + ((value.month - 1 + delta) // 12)
+    month = ((value.month - 1 + delta) % 12) + 1
+    return date(year, month, 1)
+
+
+def build_month_window(months: int, as_of: date | None = None) -> list[date]:
+    if months <= 0:
+        raise ValueError("months must be positive")
+    anchor = month_start(as_of or date.today())
+    start = shift_month(anchor, -(months - 1))
+    return [shift_month(start, idx) for idx in range(months)]
+
+
+def month_key(value: date) -> str:
+    return value.strftime("%Y-%m")
+
+
+def normalize_meeting_name(value: str | None) -> str:
+    normalized = re.sub(r"\s+", " ", str(value or "").strip().lower())
+    return normalized or "(missing)"
+
+
+def compute_expected_monthly_event_baseline(event_counts: list[int]) -> tuple[float, int | None]:
+    if not event_counts:
+        return 0.0, None
+    baseline = float(statistics.median(event_counts))
+    if baseline < 2.0:
+        return baseline, None
+    # Conservative threshold highlights suspicious troughs without assuming each city's exact cadence.
+    threshold = max(1, int(math.ceil(baseline * 0.5)))
+    return baseline, threshold


### PR DESCRIPTION
## What changed
- Split city coverage contracts, month helpers, bucket mutation, SQL row loading, and summary assembly into focused modules.
- Kept `pipeline.city_coverage_audit` as the public facade.

## Why
`build_city_coverage_audit` was the highest remaining Radon hotspot. This keeps the audit output contract stable while making the logic reviewable.

## Risk / compatibility
- No CLI, DB, output key, source alias, cadence, flag, or summary behavior changes.
- Existing imports for `build_city_coverage_audit`, `build_month_window`, and `compute_expected_monthly_event_baseline` remain valid.

## Verification
PASS `PYTHONPATH=. .venv/bin/pytest -q tests/test_city_coverage_audit.py`
PASS `./.venv/bin/ruff check pipeline/city_coverage_audit.py pipeline/city_coverage_*.py tests/test_city_coverage_audit.py`
PASS `./.venv/bin/python -m radon cc pipeline/city_coverage_audit.py pipeline/city_coverage_*.py -s -n C`
PASS `./.venv/bin/ruff check api pipeline scripts tests`
PASS `./.venv/bin/mypy`
PASS `PYTHONPATH=. .venv/bin/pytest -q tests/test_repository_guardrails.py`
PASS `git diff --check`

## Remaining deficits
- Docs/guardrail enrollment is deferred to the Batch F docs/guardrails PR after code PRs merge.