### PR TITLE
Refactor operator A/B aggregation

### DIFF
--- a/scripts/operator_profile_ab.py
+++ b/scripts/operator_profile_ab.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-import math
-from statistics import median
+from scripts.operator_profile_ab_aggregate import aggregate_arm
 
 
 DEFAULT_GATES = {
@@ -24,86 +23,6 @@ PROFILE_KEYS = (
     "WORKER_POOL",
     "OLLAMA_NUM_PARALLEL",
 )
-
-
-def to_bool(value):
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, (int, float)):
-        return bool(value)
-    text = str(value).strip().lower()
-    return text in {"1", "true", "yes", "y"}
-
-
-def to_float(value, default=0.0):
-    try:
-        return float(value)
-    except (TypeError, ValueError):
-        return float(default)
-
-
-def p95(values):
-    if not values:
-        return 0.0
-    ordered = sorted(values)
-    idx = max(0, int(math.ceil(0.95 * len(ordered))) - 1)
-    return float(ordered[idx])
-
-
-def aggregate_arm(rows):
-    total = len(rows)
-    if total == 0:
-        return {
-            "n": 0,
-            "section_compliance_rate": 0.0,
-            "fallback_rate": 0.0,
-            "grounding_rate": 0.0,
-            "failure_rate": 0.0,
-            "summary_p95_s": 0.0,
-            "segment_p95_s": 0.0,
-            "partial_disclosure_rate": 0.0,
-            "ttft_median_ms": 0.0,
-            "ttft_p95_ms": 0.0,
-            "ttft_n": 0,
-            "tokens_per_sec_median": 0.0,
-            "tokens_per_sec_n": 0,
-            "prompt_tokens_total": 0,
-            "completion_tokens_total": 0,
-            "total_tokens_total": 0,
-        }
-
-    section = sum(1 for r in rows if to_bool(r.get("section_compliance_pass"))) / total
-    fallback = sum(1 for r in rows if to_bool(r.get("fallback_used"))) / total
-    grounding = sum(1 for r in rows if to_bool(r.get("grounding_pass"))) / total
-    failed = sum(1 for r in rows if to_bool(r.get("task_failed"))) / total
-    partial = sum(1 for r in rows if to_bool(r.get("partial_coverage_disclosed"))) / total
-
-    summary_p95 = p95([to_float(r.get("summary_duration_s")) for r in rows])
-    segment_p95 = p95([to_float(r.get("segment_duration_s")) for r in rows])
-    ttft_values = [to_float(r.get("ttft_ms")) for r in rows if to_float(r.get("ttft_ms")) > 0]
-    tps_values = [to_float(r.get("tokens_per_sec")) for r in rows if to_float(r.get("tokens_per_sec")) > 0]
-    prompt_tokens_total = sum(int(to_float(r.get("prompt_tokens"), 0.0)) for r in rows)
-    completion_tokens_total = sum(int(to_float(r.get("completion_tokens"), 0.0)) for r in rows)
-    total_tokens_total = sum(int(to_float(r.get("total_tokens"), 0.0)) for r in rows)
-
-    return {
-        "n": total,
-        "section_compliance_rate": section,
-        "fallback_rate": fallback,
-        "grounding_rate": grounding,
-        "failure_rate": failed,
-        "summary_p95_s": summary_p95,
-        "segment_p95_s": segment_p95,
-        "partial_disclosure_rate": partial,
-        "ttft_median_ms": float(median(ttft_values)) if ttft_values else 0.0,
-        "ttft_p95_ms": p95(ttft_values) if ttft_values else 0.0,
-        "ttft_n": len(ttft_values),
-        "tokens_per_sec_median": float(median(tps_values)) if tps_values else 0.0,
-        "tokens_per_sec_n": len(tps_values),
-        "prompt_tokens_total": prompt_tokens_total,
-        "completion_tokens_total": completion_tokens_total,
-        "total_tokens_total": total_tokens_total,
-    }
 
 
 def compare_arms(control, treatment, gates=None):

--- a/scripts/operator_profile_ab_aggregate.py
+++ b/scripts/operator_profile_ab_aggregate.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping, Sequence
+from statistics import median
+from typing import Any
+
+
+def to_bool(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    text = str(value).strip().lower()
+    return text in {"1", "true", "yes", "y"}
+
+
+def to_float(value: object, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return float(default)
+
+
+def p95(values: Sequence[float]) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    idx = max(0, int(math.ceil(0.95 * len(ordered))) - 1)
+    return float(ordered[idx])
+
+
+def _empty_arm_payload() -> dict[str, float | int]:
+    return {
+        "n": 0,
+        "section_compliance_rate": 0.0,
+        "fallback_rate": 0.0,
+        "grounding_rate": 0.0,
+        "failure_rate": 0.0,
+        "summary_p95_s": 0.0,
+        "segment_p95_s": 0.0,
+        "partial_disclosure_rate": 0.0,
+        "ttft_median_ms": 0.0,
+        "ttft_p95_ms": 0.0,
+        "ttft_n": 0,
+        "tokens_per_sec_median": 0.0,
+        "tokens_per_sec_n": 0,
+        "prompt_tokens_total": 0,
+        "completion_tokens_total": 0,
+        "total_tokens_total": 0,
+    }
+
+
+def _flag_rate(rows: Sequence[Mapping[str, Any]], key: str) -> float:
+    return sum(1 for row in rows if to_bool(row.get(key))) / len(rows)
+
+
+def _positive_metric_values(rows: Sequence[Mapping[str, Any]], key: str) -> list[float]:
+    values: list[float] = []
+    for row in rows:
+        value = to_float(row.get(key))
+        if value > 0:
+            values.append(value)
+    return values
+
+
+def _metric_median(values: Sequence[float]) -> float:
+    return float(median(values)) if values else 0.0
+
+
+def _token_total(rows: Sequence[Mapping[str, Any]], key: str) -> int:
+    return sum(int(to_float(row.get(key), 0.0)) for row in rows)
+
+
+def aggregate_arm(rows: Sequence[Mapping[str, Any]]) -> dict[str, float | int]:
+    total = len(rows)
+    if total == 0:
+        return _empty_arm_payload()
+
+    ttft_values = _positive_metric_values(rows, "ttft_ms")
+    tokens_per_second_values = _positive_metric_values(rows, "tokens_per_sec")
+
+    return {
+        "n": total,
+        "section_compliance_rate": _flag_rate(rows, "section_compliance_pass"),
+        "fallback_rate": _flag_rate(rows, "fallback_used"),
+        "grounding_rate": _flag_rate(rows, "grounding_pass"),
+        "failure_rate": _flag_rate(rows, "task_failed"),
+        "summary_p95_s": p95([to_float(row.get("summary_duration_s")) for row in rows]),
+        "segment_p95_s": p95([to_float(row.get("segment_duration_s")) for row in rows]),
+        "partial_disclosure_rate": _flag_rate(rows, "partial_coverage_disclosed"),
+        "ttft_median_ms": _metric_median(ttft_values),
+        "ttft_p95_ms": p95(ttft_values),
+        "ttft_n": len(ttft_values),
+        "tokens_per_sec_median": _metric_median(tokens_per_second_values),
+        "tokens_per_sec_n": len(tokens_per_second_values),
+        "prompt_tokens_total": _token_total(rows, "prompt_tokens"),
+        "completion_tokens_total": _token_total(rows, "completion_tokens"),
+        "total_tokens_total": _token_total(rows, "total_tokens"),
+    }

--- a/tests/test_score_ab_results_provider_metrics_rollup.py
+++ b/tests/test_score_ab_results_provider_metrics_rollup.py
@@ -49,6 +49,94 @@ def test_aggregate_arm_rolls_up_provider_metrics():
     assert agg["total_tokens_total"] == 270
 
 
+def test_aggregate_arm_empty_payload_preserves_zero_contract():
+    assert mod.aggregate_arm([]) == {
+        "n": 0,
+        "section_compliance_rate": 0.0,
+        "fallback_rate": 0.0,
+        "grounding_rate": 0.0,
+        "failure_rate": 0.0,
+        "summary_p95_s": 0.0,
+        "segment_p95_s": 0.0,
+        "partial_disclosure_rate": 0.0,
+        "ttft_median_ms": 0.0,
+        "ttft_p95_ms": 0.0,
+        "ttft_n": 0,
+        "tokens_per_sec_median": 0.0,
+        "tokens_per_sec_n": 0,
+        "prompt_tokens_total": 0,
+        "completion_tokens_total": 0,
+        "total_tokens_total": 0,
+    }
+
+
+def test_aggregate_arm_tolerates_malformed_numeric_values():
+    rows = [
+        {
+            "section_compliance_pass": "yes",
+            "fallback_used": "no",
+            "grounding_pass": "true",
+            "task_failed": "",
+            "partial_coverage_disclosed": "1",
+            "summary_duration_s": "not-a-number",
+            "segment_duration_s": None,
+            "ttft_ms": "bad",
+            "tokens_per_sec": "-1",
+            "prompt_tokens": "bad",
+            "completion_tokens": None,
+            "total_tokens": "12.9",
+        }
+    ]
+
+    agg = mod.aggregate_arm(rows)
+
+    assert agg["section_compliance_rate"] == 1.0
+    assert agg["fallback_rate"] == 0.0
+    assert agg["grounding_rate"] == 1.0
+    assert agg["failure_rate"] == 0.0
+    assert agg["partial_disclosure_rate"] == 1.0
+    assert agg["summary_p95_s"] == 0.0
+    assert agg["segment_p95_s"] == 0.0
+    assert agg["ttft_n"] == 0
+    assert agg["tokens_per_sec_n"] == 0
+    assert agg["prompt_tokens_total"] == 0
+    assert agg["completion_tokens_total"] == 0
+    assert agg["total_tokens_total"] == 12
+
+
+def test_aggregate_arm_p95_uses_nearest_rank_contract():
+    rows = [
+        {"summary_duration_s": 1, "segment_duration_s": 10},
+        {"summary_duration_s": 2, "segment_duration_s": 20},
+        {"summary_duration_s": 3, "segment_duration_s": 30},
+    ]
+
+    agg = mod.aggregate_arm(rows)
+
+    assert agg["summary_p95_s"] == 3.0
+    assert agg["segment_p95_s"] == 30.0
+
+
+def test_render_report_keeps_markdown_sections_and_metric_rows():
+    control = mod.aggregate_arm([{"summary_duration_s": 1, "segment_duration_s": 2}])
+    treatment = mod.aggregate_arm([{"summary_duration_s": 1, "segment_duration_s": 2}])
+    comparison = mod.compare_arms(control, treatment)
+    markdown = mod._render_report(
+        control,
+        treatment,
+        comparison,
+        ["run-a", "run-b"],
+        {"A": {"run_id": "run-a", "model": "model-a"}, "B": {"run_id": "run-b", "model": "model-b"}},
+    )
+
+    assert "# A/B Report v1" in markdown
+    assert "## Arm Identity" in markdown
+    assert "## Arm Metrics" in markdown
+    assert "## Gate Evaluation" in markdown
+    assert "| Prompt tokens total | 0 | 0 |" in markdown
+    assert "- overall: FAIL" in markdown
+
+
 def test_compare_arms_includes_provider_metric_deltas_without_new_checks():
     control = {
         "n": 10,


### PR DESCRIPTION
## What changed
- Split A/B arm aggregation into `scripts/operator_profile_ab_aggregate.py`.
- Kept `scripts/operator_profile_ab.py` as the CLI/reporting facade.
- Added behavior locks for empty rows, malformed numeric values, p95 behavior, token totals, and markdown report sections.

## Why
Batch F targets remaining Radon D/E complexity hotspots without changing operator output contracts.

## Risk / compatibility
- No CLI argument, JSON, markdown, exit-code, or artifact-key changes.
- Existing C complexity remains in `arm_metadata` and `render_report`; no D/E remains in the aggregation split.

## Verification
PASS `PYTHONPATH=. .venv/bin/pytest -q tests/test_score_ab_results_provider_metrics_rollup.py tests/test_operator_profile_helpers.py tests/test_pipeline_profile_report.py`
PASS `./.venv/bin/ruff check scripts/operator_profile_ab.py scripts/operator_profile_ab_aggregate.py tests/test_score_ab_results_provider_metrics_rollup.py`
PASS `./.venv/bin/python -m radon cc scripts/operator_profile_ab.py scripts/operator_profile_ab_aggregate.py -s -n C`
PASS `./.venv/bin/ruff check api pipeline scripts tests`
PASS `./.venv/bin/mypy`
PASS `PYTHONPATH=. .venv/bin/pytest -q tests/test_repository_guardrails.py`
PASS `git diff --check`

## Remaining deficits
- Docs/guardrail enrollment is deferred to the Batch F docs/guardrails PR after code PRs merge.