### PR TITLE
Refactor lineage graph assignment

### DIFF
--- a/pipeline/lineage_assignment.py
+++ b/pipeline/lineage_assignment.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from pipeline.models import Catalog
+
+
+@dataclass(frozen=True)
+class LineageMutationSummary:
+    merge_count: int
+    updated_count: int
+
+
+def assign_lineage_components(
+    catalogs_by_id: dict[int, Catalog],
+    adjacency: dict[int, set[int]],
+    components: list[list[int]],
+    *,
+    updated_at: datetime,
+) -> LineageMutationSummary:
+    merge_count = 0
+    updated_count = 0
+    for component in components:
+        if component_merges_prior_lineages(catalogs_by_id, component):
+            merge_count += 1
+        updated_count += assign_lineage_component(
+            catalogs_by_id,
+            adjacency,
+            component,
+            updated_at=updated_at,
+        )
+    return LineageMutationSummary(merge_count=merge_count, updated_count=updated_count)
+
+
+def component_merges_prior_lineages(catalogs_by_id: dict[int, Catalog], component: list[int]) -> bool:
+    prior_lineage_ids = {
+        (catalogs_by_id[catalog_id].lineage_id or "").strip()
+        for catalog_id in component
+        if (catalogs_by_id[catalog_id].lineage_id or "").strip()
+    }
+    return len(prior_lineage_ids) > 1
+
+
+def assign_lineage_component(
+    catalogs_by_id: dict[int, Catalog],
+    adjacency: dict[int, set[int]],
+    component: list[int],
+    *,
+    updated_at: datetime,
+) -> int:
+    lineage_id = f"lin-{component[0]}"
+    updated_count = 0
+    for catalog_id in component:
+        confidence = compute_lineage_confidence(
+            component_size=len(component),
+            degree=len(adjacency.get(catalog_id, set())),
+        )
+        if update_catalog_lineage(
+            catalogs_by_id[catalog_id],
+            lineage_id=lineage_id,
+            confidence=confidence,
+            updated_at=updated_at,
+        ):
+            updated_count += 1
+    return updated_count
+
+
+def compute_lineage_confidence(*, component_size: int, degree: int) -> float:
+    if component_size <= 1:
+        return 0.2
+    confidence = min(1.0, 0.3 + 0.2 * min(degree, 3) + 0.1 * min(component_size - 1, 5))
+    return round(float(confidence), 3)
+
+
+def update_catalog_lineage(
+    catalog: Catalog,
+    *,
+    lineage_id: str,
+    confidence: float,
+    updated_at: datetime,
+) -> bool:
+    confidence_changed = catalog.lineage_confidence is None or abs(float(catalog.lineage_confidence) - confidence) > 1e-9
+    if catalog.lineage_id == lineage_id and not confidence_changed:
+        return False
+    catalog.lineage_id = lineage_id
+    catalog.lineage_confidence = confidence
+    catalog.lineage_updated_at = updated_at
+    return True

--- a/pipeline/lineage_graph.py
+++ b/pipeline/lineage_graph.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+
+from pipeline.models import Catalog
+
+
+def related_ids_as_int_set(values: Iterable[object] | None) -> set[int]:
+    related_ids: set[int] = set()
+    for raw_related_id in values or []:
+        try:
+            related_ids.add(int(raw_related_id))
+        except (TypeError, ValueError):
+            continue
+    return related_ids
+
+
+def build_related_catalog_map(catalogs: Sequence[Catalog]) -> dict[int, set[int]]:
+    return {int(catalog.id): related_ids_as_int_set(catalog.related_ids or []) for catalog in catalogs}
+
+
+def build_lineage_adjacency(
+    catalog_ids: set[int],
+    related_catalog_ids: dict[int, set[int]],
+    *,
+    min_edge_confidence: float,
+    require_mutual_edges: bool,
+) -> dict[int, set[int]]:
+    adjacency: dict[int, set[int]] = {catalog_id: set() for catalog_id in catalog_ids}
+    for catalog_id, neighbor_ids in related_catalog_ids.items():
+        add_confident_edges(
+            adjacency,
+            catalog_id=catalog_id,
+            neighbor_ids=neighbor_ids,
+            catalog_ids=catalog_ids,
+            related_catalog_ids=related_catalog_ids,
+            min_edge_confidence=min_edge_confidence,
+            require_mutual_edges=require_mutual_edges,
+        )
+    return adjacency
+
+
+def add_confident_edges(
+    adjacency: dict[int, set[int]],
+    *,
+    catalog_id: int,
+    neighbor_ids: set[int],
+    catalog_ids: set[int],
+    related_catalog_ids: dict[int, set[int]],
+    min_edge_confidence: float,
+    require_mutual_edges: bool,
+) -> None:
+    for neighbor_id in neighbor_ids:
+        if should_link_catalogs(
+            catalog_id,
+            neighbor_id,
+            catalog_ids=catalog_ids,
+            related_catalog_ids=related_catalog_ids,
+            min_edge_confidence=min_edge_confidence,
+            require_mutual_edges=require_mutual_edges,
+        ):
+            adjacency[catalog_id].add(neighbor_id)
+            adjacency[neighbor_id].add(catalog_id)
+
+
+def should_link_catalogs(
+    catalog_id: int,
+    neighbor_id: int,
+    *,
+    catalog_ids: set[int],
+    related_catalog_ids: dict[int, set[int]],
+    min_edge_confidence: float,
+    require_mutual_edges: bool,
+) -> bool:
+    if neighbor_id not in catalog_ids:
+        return False
+    is_mutual = catalog_id in related_catalog_ids.get(neighbor_id, set())
+    if require_mutual_edges and not is_mutual:
+        return False
+    edge_confidence = 1.0 if is_mutual else 0.5
+    return edge_confidence >= min_edge_confidence
+
+
+def find_lineage_components(catalog_ids: set[int], adjacency: dict[int, set[int]]) -> list[list[int]]:
+    seen: set[int] = set()
+    components: list[list[int]] = []
+    for catalog_id in sorted(catalog_ids):
+        if catalog_id in seen:
+            continue
+        components.append(walk_lineage_component(catalog_id, adjacency, seen))
+    return components
+
+
+def walk_lineage_component(
+    start_catalog_id: int,
+    adjacency: dict[int, set[int]],
+    seen: set[int],
+) -> list[int]:
+    stack = [start_catalog_id]
+    component: list[int] = []
+    while stack:
+        catalog_id = stack.pop()
+        if catalog_id in seen:
+            continue
+        seen.add(catalog_id)
+        component.append(catalog_id)
+        stack.extend(neighbor_id for neighbor_id in sorted(adjacency.get(catalog_id, set()), reverse=True) if neighbor_id not in seen)
+    return sorted(component)

--- a/pipeline/lineage_service.py
+++ b/pipeline/lineage_service.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Iterable
 
+from sqlalchemy.orm import Session
+
+from pipeline.lineage_assignment import assign_lineage_components
+from pipeline.lineage_graph import build_lineage_adjacency, build_related_catalog_map, find_lineage_components
 from pipeline.models import Catalog
 
 
@@ -15,18 +18,8 @@ class LineageAssignmentResult:
     updated_count: int
 
 
-def _as_int_set(values: Iterable) -> set[int]:
-    out: set[int] = set()
-    for v in values or []:
-        try:
-            out.add(int(v))
-        except Exception:
-            continue
-    return out
-
-
 def compute_lineage_assignments(
-    db,
+    db: Session,
     min_edge_confidence: float = 0.5,
     require_mutual_edges: bool = False,
 ) -> LineageAssignmentResult:
@@ -41,75 +34,27 @@ def compute_lineage_assignments(
     if not catalogs:
         return LineageAssignmentResult(catalog_count=0, component_count=0, merge_count=0, updated_count=0)
 
-    existing_by_id = {int(c.id): c for c in catalogs}
-    related_map = {int(c.id): _as_int_set(c.related_ids or []) for c in catalogs}
-
-    adjacency: dict[int, set[int]] = {cid: set() for cid in existing_by_id.keys()}
-    for cid, neighbors in related_map.items():
-        for nid in neighbors:
-            if nid not in existing_by_id:
-                continue
-            is_mutual = cid in related_map.get(nid, set())
-            edge_conf = 1.0 if is_mutual else 0.5
-            if require_mutual_edges and not is_mutual:
-                continue
-            if edge_conf < min_edge_confidence:
-                continue
-            adjacency[cid].add(nid)
-            adjacency[nid].add(cid)
-
-    seen: set[int] = set()
-    components: list[list[int]] = []
-    for cid in sorted(existing_by_id.keys()):
-        if cid in seen:
-            continue
-        stack = [cid]
-        comp: list[int] = []
-        while stack:
-            cur = stack.pop()
-            if cur in seen:
-                continue
-            seen.add(cur)
-            comp.append(cur)
-            for nxt in sorted(adjacency.get(cur, set()), reverse=True):
-                if nxt not in seen:
-                    stack.append(nxt)
-        components.append(sorted(comp))
-
-    now = datetime.now(timezone.utc)
-    updated_count = 0
-    merge_count = 0
-
-    for comp in components:
-        lineage_id = f"lin-{comp[0]}"
-        size = len(comp)
-        prior_ids = {
-            (existing_by_id[cid].lineage_id or "").strip()
-            for cid in comp
-            if (existing_by_id[cid].lineage_id or "").strip()
-        }
-        if len(prior_ids) > 1:
-            merge_count += 1
-
-        for cid in comp:
-            degree = len(adjacency.get(cid, set()))
-            if size <= 1:
-                confidence = 0.2
-            else:
-                confidence = min(1.0, 0.3 + 0.2 * min(degree, 3) + 0.1 * min(size - 1, 5))
-            confidence = round(float(confidence), 3)
-
-            row = existing_by_id[cid]
-            if row.lineage_id != lineage_id or (row.lineage_confidence is None or abs(float(row.lineage_confidence) - confidence) > 1e-9):
-                updated_count += 1
-                row.lineage_id = lineage_id
-                row.lineage_confidence = confidence
-                row.lineage_updated_at = now
+    catalogs_by_id = {int(catalog.id): catalog for catalog in catalogs}
+    catalog_ids = set(catalogs_by_id)
+    related_catalog_ids = build_related_catalog_map(catalogs)
+    adjacency = build_lineage_adjacency(
+        catalog_ids,
+        related_catalog_ids,
+        min_edge_confidence=min_edge_confidence,
+        require_mutual_edges=require_mutual_edges,
+    )
+    components = find_lineage_components(catalog_ids, adjacency)
+    mutation_summary = assign_lineage_components(
+        catalogs_by_id,
+        adjacency,
+        components,
+        updated_at=datetime.now(timezone.utc),
+    )
 
     db.flush()
     return LineageAssignmentResult(
         catalog_count=len(catalogs),
         component_count=len(components),
-        merge_count=merge_count,
-        updated_count=updated_count,
+        merge_count=mutation_summary.merge_count,
+        updated_count=mutation_summary.updated_count,
     )

--- a/tests/test_lineage_component_assignment.py
+++ b/tests/test_lineage_component_assignment.py
@@ -20,3 +20,78 @@ def test_lineage_component_assignment_deterministic_ids(db_session):
     assert rows[2].lineage_id == "lin-1"
     assert rows[3].lineage_id == "lin-1"
     assert rows[9].lineage_id == "lin-9"
+
+
+def test_lineage_ignores_invalid_and_missing_related_ids(db_session):
+    c1 = Catalog(id=1, url_hash="u1", related_ids=[2, "bad", None, 999])
+    c2 = Catalog(id=2, url_hash="u2", related_ids=[])
+    db_session.add_all([c1, c2])
+    db_session.commit()
+
+    result = compute_lineage_assignments(db_session, min_edge_confidence=0.5, require_mutual_edges=False)
+    db_session.commit()
+
+    rows = {c.id: c for c in db_session.query(Catalog).all()}
+    assert result.component_count == 1
+    assert rows[1].lineage_id == "lin-1"
+    assert rows[2].lineage_id == "lin-1"
+
+
+def test_lineage_require_mutual_edges_excludes_one_way_edges(db_session):
+    c1 = Catalog(id=1, url_hash="u1", related_ids=[2])
+    c2 = Catalog(id=2, url_hash="u2", related_ids=[])
+    db_session.add_all([c1, c2])
+    db_session.commit()
+
+    result = compute_lineage_assignments(db_session, min_edge_confidence=0.5, require_mutual_edges=True)
+    db_session.commit()
+
+    rows = {c.id: c for c in db_session.query(Catalog).all()}
+    assert result.component_count == 2
+    assert rows[1].lineage_id == "lin-1"
+    assert rows[2].lineage_id == "lin-2"
+    assert rows[1].lineage_confidence == 0.2
+    assert rows[2].lineage_confidence == 0.2
+
+
+def test_lineage_min_edge_confidence_keeps_only_mutual_edges_at_one(db_session):
+    c1 = Catalog(id=1, url_hash="u1", related_ids=[2])
+    c2 = Catalog(id=2, url_hash="u2", related_ids=[1])
+    c3 = Catalog(id=3, url_hash="u3", related_ids=[4])
+    c4 = Catalog(id=4, url_hash="u4", related_ids=[])
+    db_session.add_all([c1, c2, c3, c4])
+    db_session.commit()
+
+    result = compute_lineage_assignments(db_session, min_edge_confidence=1.0, require_mutual_edges=False)
+    db_session.commit()
+
+    rows = {c.id: c for c in db_session.query(Catalog).all()}
+    assert result.component_count == 3
+    assert rows[1].lineage_id == "lin-1"
+    assert rows[2].lineage_id == "lin-1"
+    assert rows[3].lineage_id == "lin-3"
+    assert rows[4].lineage_id == "lin-4"
+
+
+def test_lineage_confidence_and_unchanged_update_count_are_stable(db_session):
+    c1 = Catalog(id=1, url_hash="u1", related_ids=[2])
+    c2 = Catalog(id=2, url_hash="u2", related_ids=[1, 3])
+    c3 = Catalog(id=3, url_hash="u3", related_ids=[2])
+    db_session.add_all([c1, c2, c3])
+    db_session.commit()
+
+    first = compute_lineage_assignments(db_session, min_edge_confidence=0.5, require_mutual_edges=False)
+    db_session.commit()
+    rows = {c.id: c for c in db_session.query(Catalog).all()}
+    first_updated_at = {catalog_id: row.lineage_updated_at for catalog_id, row in rows.items()}
+
+    second = compute_lineage_assignments(db_session, min_edge_confidence=0.5, require_mutual_edges=False)
+    db_session.commit()
+    refreshed = {c.id: c for c in db_session.query(Catalog).all()}
+
+    assert first.updated_count == 3
+    assert second.updated_count == 0
+    assert refreshed[1].lineage_confidence == 0.7
+    assert refreshed[2].lineage_confidence == 0.9
+    assert refreshed[3].lineage_confidence == 0.7
+    assert {catalog_id: row.lineage_updated_at for catalog_id, row in refreshed.items()} == first_updated_at


### PR DESCRIPTION
## What changed
- Split related-id normalization, edge filtering, connected-component traversal, confidence calculation, and catalog mutation into focused lineage helpers.
- Kept `compute_lineage_assignments` as the public entrypoint.
- Added behavior locks for invalid related IDs, mutual-edge filtering, confidence thresholds, and unchanged-row update counts.

## Why
Lineage assignment was a remaining Radon D hotspot and has data-consistency risk, so this PR locks behavior before extraction.

## Risk / compatibility
- Preserves `lin-<min_catalog_id>`, merge counting, update counting, confidence values, `lineage_updated_at`, and final `db.flush()`.
- Replaces broad related-id parsing exception handling with `TypeError | ValueError`.

## Verification
PASS `PYTHONPATH=. .venv/bin/pytest -q tests/test_lineage_component_assignment.py tests/test_lineage_component_merge_rewrite.py tests/test_tasks_lineage_flow.py tests/test_catalog_lineage_endpoint.py`
PASS `./.venv/bin/ruff check pipeline/lineage_service.py pipeline/lineage_*.py tests/test_lineage_component_assignment.py tests/test_lineage_component_merge_rewrite.py`
PASS `./.venv/bin/python -m radon cc pipeline/lineage_service.py pipeline/lineage_*.py -s -n C`
PASS `./.venv/bin/ruff check api pipeline scripts tests`
PASS `./.venv/bin/mypy`
PASS `PYTHONPATH=. .venv/bin/pytest -q tests/test_repository_guardrails.py`
PASS `git diff --check`

## Remaining deficits
- Docs/guardrail enrollment is deferred to the Batch F docs/guardrails PR after code PRs merge.