### PR TITLE
Refactor search read route helpers

### DIFF
--- a/api/search_read_meilisearch.py
+++ b/api/search_read_meilisearch.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from fastapi import HTTPException
+from meilisearch.errors import MeilisearchCommunicationError, MeilisearchError, MeilisearchTimeoutError
+
+from api import search_support
+
+SORTABLE_DATE_REINDEX_DETAIL = (
+    "Meilisearch is not configured to sort by `date`. "
+    "Run `docker compose run --rm pipeline python reindex_only.py` and retry."
+)
+
+
+def run_lexical_search(index: object, query: str, search_params: dict[str, object]) -> dict[str, object]:
+    try:
+        return index.search(query, search_params)
+    except MeilisearchTimeoutError as exc:
+        search_support.logger.error("Search failed (Meilisearch timeout): %s", exc)
+        raise HTTPException(status_code=503, detail=search_support.SEARCH_ENGINE_TIMEOUT_DETAIL) from exc
+    except MeilisearchCommunicationError as exc:
+        search_support.logger.error("Search failed (Meilisearch unavailable): %s", exc)
+        raise HTTPException(status_code=503, detail=search_support.SEARCH_ENGINE_UNAVAILABLE_DETAIL) from exc
+    except MeilisearchError as exc:
+        raise map_meilisearch_error(exc) from exc
+
+
+def map_meilisearch_error(exc: MeilisearchError) -> HTTPException:
+    message = str(exc)
+    lowered = message.lower()
+    if "sort" in lowered and ("sortable" in lowered or "attribute" in lowered):
+        return HTTPException(status_code=400, detail=SORTABLE_DATE_REINDEX_DETAIL)
+    search_support.logger.error("Search failed (Meilisearch error): %s", exc)
+    return HTTPException(status_code=500, detail=search_support.INTERNAL_SEARCH_ENGINE_ERROR_DETAIL)

--- a/api/search_read_params.py
+++ b/api/search_read_params.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from fastapi import HTTPException
+
+from api import search_support
+
+SEARCH_LIMIT_DEFAULT = 20
+SEARCH_LIMIT_MAX = 100
+SORT_MODE_RELEVANCE = "relevance"
+SORT_MODE_NEWEST = "newest"
+SORT_MODE_OLDEST = "oldest"
+INVALID_SORT_MODE_DETAIL = "Invalid sort mode. Use newest|oldest|relevance."
+
+
+def validate_search_date_range(date_from: str | None, date_to: str | None) -> None:
+    if date_from:
+        search_support.validate_date_format(date_from)
+    if date_to:
+        search_support.validate_date_format(date_to)
+
+
+def build_lexical_search_params(
+    *,
+    city: str | None,
+    include_agenda_items: bool,
+    sort: str | None,
+    meeting_type: str | None,
+    org: str | None,
+    date_from: str | None,
+    date_to: str | None,
+    limit: int,
+    offset: int,
+) -> dict[str, object]:
+    search_params: dict[str, object] = {
+        "limit": limit,
+        "offset": offset,
+        "attributesToRetrieve": search_support.SEARCH_RESULT_ATTRIBUTES_TO_RETRIEVE,
+        "attributesToCrop": search_support.SEARCH_RESULT_ATTRIBUTES_TO_CROP,
+        "cropLength": search_support.SEARCH_RESULT_CROP_LENGTH,
+        "attributesToHighlight": search_support.SEARCH_RESULT_ATTRIBUTES_TO_HIGHLIGHT,
+        "highlightPreTag": search_support.SEARCH_HIGHLIGHT_PRE_TAG,
+        "highlightPostTag": search_support.SEARCH_HIGHLIGHT_POST_TAG,
+    }
+    apply_sort(search_params, sort)
+    apply_filters(
+        search_params,
+        city=city,
+        meeting_type=meeting_type,
+        org=org,
+        date_from=date_from,
+        date_to=date_to,
+        include_agenda_items=include_agenda_items,
+    )
+    return search_params
+
+
+def apply_sort(search_params: dict[str, object], sort: str | None) -> None:
+    if sort is None:
+        return
+    sort_mode = (sort or "").strip().lower()
+    if sort_mode in {"", SORT_MODE_RELEVANCE}:
+        return
+    if sort_mode == SORT_MODE_NEWEST:
+        search_params["sort"] = ["date:desc"]
+        return
+    if sort_mode == SORT_MODE_OLDEST:
+        search_params["sort"] = ["date:asc"]
+        return
+    raise HTTPException(status_code=400, detail=INVALID_SORT_MODE_DETAIL)
+
+
+def apply_filters(
+    search_params: dict[str, object],
+    *,
+    city: str | None,
+    meeting_type: str | None,
+    org: str | None,
+    date_from: str | None,
+    date_to: str | None,
+    include_agenda_items: bool,
+) -> None:
+    filter_builder = search_support.facade_callable(
+        "_build_meilisearch_filter_clauses",
+        search_support._build_meilisearch_filter_clauses,
+    )
+    filter_clauses = filter_builder(
+        city=city,
+        meeting_type=meeting_type,
+        org=org,
+        date_from=date_from,
+        date_to=date_to,
+        include_agenda_items=include_agenda_items,
+    )
+    if filter_clauses:
+        search_params["filter"] = filter_clauses

--- a/api/search_read_results.py
+++ b/api/search_read_results.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+PEOPLE_METADATA_MAX_ITEMS = 10
+
+
+def truncate_people_metadata(results: dict[str, object]) -> None:
+    for hit in results["hits"]:
+        if not isinstance(hit, dict):
+            continue
+        truncate_hit_people_metadata(hit)
+
+
+def truncate_hit_people_metadata(hit: dict[str, object]) -> None:
+    if "people_metadata" in hit and isinstance(hit["people_metadata"], list):
+        hit["people_metadata"] = hit["people_metadata"][:PEOPLE_METADATA_MAX_ITEMS]
+    formatted_hit = hit.get("_formatted")
+    if isinstance(formatted_hit, dict) and isinstance(formatted_hit.get("people_metadata"), list):
+        formatted_hit["people_metadata"] = formatted_hit["people_metadata"][:PEOPLE_METADATA_MAX_ITEMS]

--- a/api/search_read_routes.py
+++ b/api/search_read_routes.py
@@ -5,21 +5,13 @@ from meilisearch.errors import MeilisearchCommunicationError, MeilisearchError, 
 
 from api.cache import cached
 from api import search_support
+from api.search_read_meilisearch import run_lexical_search
+from api.search_read_params import SEARCH_LIMIT_DEFAULT, SEARCH_LIMIT_MAX, build_lexical_search_params, validate_search_date_range
+from api.search_read_results import truncate_people_metadata
 from api.search_semantic_routes import search_documents_semantic
 
-SEARCH_LIMIT_DEFAULT = 20
-SEARCH_LIMIT_MAX = 100
 SEARCH_METADATA_CACHE_SECONDS = 3600
 SEARCH_METADATA_CACHE_KEY = "metadata"
-SORT_MODE_RELEVANCE = "relevance"
-SORT_MODE_NEWEST = "newest"
-SORT_MODE_OLDEST = "oldest"
-INVALID_SORT_MODE_DETAIL = "Invalid sort mode. Use newest|oldest|relevance."
-SORTABLE_DATE_REINDEX_DETAIL = (
-    "Meilisearch is not configured to sort by `date`. "
-    "Run `docker compose run --rm pipeline python reindex_only.py` and retry."
-)
-PEOPLE_METADATA_MAX_ITEMS = 10
 
 router = APIRouter()
 
@@ -38,10 +30,7 @@ def search_documents(
     limit: int = Query(SEARCH_LIMIT_DEFAULT, ge=1, le=SEARCH_LIMIT_MAX),
     offset: int = Query(0, ge=0),
 ) -> dict[str, Any]:
-    if date_from:
-        search_support.validate_date_format(date_from)
-    if date_to:
-        search_support.validate_date_format(date_to)
+    validate_search_date_range(date_from, date_to)
 
     if semantic:
         semantic_search = search_support.facade_callable("search_documents_semantic", search_documents_semantic)
@@ -59,70 +48,19 @@ def search_documents(
 
     try:
         index = search_support.search_client().index(search_support.DOCUMENT_INDEX_NAME)
-        search_params: dict[str, Any] = {
-            "limit": limit,
-            "offset": offset,
-            "attributesToRetrieve": search_support.SEARCH_RESULT_ATTRIBUTES_TO_RETRIEVE,
-            "attributesToCrop": search_support.SEARCH_RESULT_ATTRIBUTES_TO_CROP,
-            "cropLength": search_support.SEARCH_RESULT_CROP_LENGTH,
-            "attributesToHighlight": search_support.SEARCH_RESULT_ATTRIBUTES_TO_HIGHLIGHT,
-            "highlightPreTag": search_support.SEARCH_HIGHLIGHT_PRE_TAG,
-            "highlightPostTag": search_support.SEARCH_HIGHLIGHT_POST_TAG,
-            "filter": [],
-        }
-
-        if sort is not None:
-            sort_mode = (sort or "").strip().lower()
-            if sort_mode in {"", SORT_MODE_RELEVANCE}:
-                pass
-            elif sort_mode == SORT_MODE_NEWEST:
-                search_params["sort"] = ["date:desc"]
-            elif sort_mode == SORT_MODE_OLDEST:
-                search_params["sort"] = ["date:asc"]
-            else:
-                raise HTTPException(status_code=400, detail=INVALID_SORT_MODE_DETAIL)
-
-        filter_builder = search_support.facade_callable(
-            "_build_meilisearch_filter_clauses",
-            search_support._build_meilisearch_filter_clauses,
-        )
-        search_params["filter"] = filter_builder(
+        search_params = build_lexical_search_params(
             city=city,
+            include_agenda_items=include_agenda_items,
+            sort=sort,
             meeting_type=meeting_type,
             org=org,
             date_from=date_from,
             date_to=date_to,
-            include_agenda_items=include_agenda_items,
+            limit=limit,
+            offset=offset,
         )
-
-        if not search_params["filter"]:
-            del search_params["filter"]
-
-        try:
-            results = index.search(q, search_params)
-        except MeilisearchTimeoutError as exc:
-            search_support.logger.error("Search failed (Meilisearch timeout): %s", exc)
-            raise HTTPException(status_code=503, detail=search_support.SEARCH_ENGINE_TIMEOUT_DETAIL) from exc
-        except MeilisearchCommunicationError as exc:
-            search_support.logger.error("Search failed (Meilisearch unavailable): %s", exc)
-            raise HTTPException(status_code=503, detail=search_support.SEARCH_ENGINE_UNAVAILABLE_DETAIL) from exc
-        except MeilisearchError as exc:
-            message = str(exc)
-            lowered = message.lower()
-            if "sort" in lowered and ("sortable" in lowered or "attribute" in lowered):
-                raise HTTPException(status_code=400, detail=SORTABLE_DATE_REINDEX_DETAIL) from exc
-            search_support.logger.error("Search failed (Meilisearch error): %s", exc)
-            raise HTTPException(status_code=500, detail=search_support.INTERNAL_SEARCH_ENGINE_ERROR_DETAIL) from exc
-
-        for hit in results["hits"]:
-            if "people_metadata" in hit and isinstance(hit["people_metadata"], list):
-                hit["people_metadata"] = hit["people_metadata"][:PEOPLE_METADATA_MAX_ITEMS]
-            if (
-                "_formatted" in hit
-                and "people_metadata" in hit["_formatted"]
-                and isinstance(hit["_formatted"]["people_metadata"], list)
-            ):
-                hit["_formatted"]["people_metadata"] = hit["_formatted"]["people_metadata"][:PEOPLE_METADATA_MAX_ITEMS]
+        results = run_lexical_search(index, q, search_params)
+        truncate_people_metadata(results)
 
         search_support.logger.info("Search query=%r city=%r returned %s hits", q, city, len(results["hits"]))
         return results

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5,7 +5,7 @@ import sys
 import os
 from unittest.mock import MagicMock
 from kombu.exceptions import OperationalError
-from meilisearch.errors import MeilisearchError
+from meilisearch.errors import MeilisearchCommunicationError, MeilisearchError, MeilisearchTimeoutError
 
 # Add the project root to the path so we can import from api/main.py
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
@@ -180,6 +180,61 @@ def test_search_sort_rejected_by_meilisearch_returns_actionable_400(mocker):
     response = client.get("/search?q=zoning&sort=newest", headers={"X-API-Key": VALID_KEY})
     assert response.status_code == 400
     assert "reindex_only.py" in response.json()["detail"]
+
+
+def test_search_truncates_people_metadata_in_hits_and_formatted_hits(mocker):
+    people_metadata = [{"name": f"Person {idx}"} for idx in range(12)]
+    mock_index = mocker.Mock()
+    mock_index.search.return_value = {
+        "hits": [
+            {
+                "people_metadata": list(people_metadata),
+                "_formatted": {"people_metadata": list(people_metadata)},
+            }
+        ],
+        "estimatedTotalHits": 1,
+    }
+    mocker.patch("api.main.client.index", return_value=mock_index)
+
+    response = client.get("/search?q=zoning", headers={"X-API-Key": VALID_KEY})
+
+    assert response.status_code == 200
+    hit = response.json()["hits"][0]
+    assert len(hit["people_metadata"]) == 10
+    assert len(hit["_formatted"]["people_metadata"]) == 10
+
+
+def test_search_timeout_returns_503(mocker):
+    mock_index = mocker.Mock()
+    mock_index.search.side_effect = MeilisearchTimeoutError("timeout")
+    mocker.patch("api.main.client.index", return_value=mock_index)
+
+    response = client.get("/search?q=zoning", headers={"X-API-Key": VALID_KEY})
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "Search engine timed out"
+
+
+def test_search_unavailable_returns_503(mocker):
+    mock_index = mocker.Mock()
+    mock_index.search.side_effect = MeilisearchCommunicationError("unavailable")
+    mocker.patch("api.main.client.index", return_value=mock_index)
+
+    response = client.get("/search?q=zoning", headers={"X-API-Key": VALID_KEY})
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "Search engine unavailable"
+
+
+def test_search_generic_meilisearch_error_returns_500(mocker):
+    mock_index = mocker.Mock()
+    mock_index.search.side_effect = MeilisearchError("unexpected")
+    mocker.patch("api.main.client.index", return_value=mock_index)
+
+    response = client.get("/search?q=zoning", headers={"X-API-Key": VALID_KEY})
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == "Internal search engine error"
 
 def test_search_injection_protection(mocker):
     """


### PR DESCRIPTION
## What changed
- Split lexical search parameter building, Meilisearch error mapping, and people metadata truncation into focused helper modules.
- Kept `api.search_read_routes` as the FastAPI route facade.
- Added behavior locks for raw/formatted people metadata truncation and timeout, unavailable, and generic Meilisearch error responses.

## Why
`search_documents` was a remaining Radon D hotspot. This keeps the `/search` contract stable while reducing route complexity.

## Risk / compatibility
- No route path, query parameter, response shape, log text, semantic delegation seam, or Meilisearch call behavior changes.
- `api.main.search_documents_semantic` remains the patch seam.

## Verification
PASS `PYTHONPATH=. .venv/bin/pytest -q tests/test_api.py tests/test_query_builder_filters.py tests/test_query_builder_parity_search_vs_trends.py tests/test_semantic_search_api.py`
PASS `./.venv/bin/ruff check api/search_read_routes.py api/search_read_*.py tests/test_api.py`
PASS `./.venv/bin/python -m radon cc api/search_read_routes.py api/search_read_*.py -s -n C`
PASS `./.venv/bin/ruff check api pipeline scripts tests`
PASS `./.venv/bin/mypy`
PASS `PYTHONPATH=. .venv/bin/pytest -q tests/test_repository_guardrails.py`
PASS `git diff --check`

## Remaining deficits
- Docs/guardrail enrollment is deferred to the Batch F docs/guardrails PR after code PRs merge.