### PR TITLE
Extract semantic service contract helpers

### DIFF
--- a/semantic_service/candidates.py
+++ b/semantic_service/candidates.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping, Protocol, TypeVar
+
+
+class SemanticCandidateLike(Protocol):
+    score: float
+    metadata: dict[str, Any]
+
+
+CandidateT = TypeVar("CandidateT", bound=SemanticCandidateLike)
+
+
+@dataclass
+class FallbackCandidate:
+    row_id: int
+    score: float
+    metadata: dict[str, Any]
+
+
+def semantic_candidate_matches_filters(meta: Mapping[str, Any], filters: Mapping[str, Any]) -> bool:
+    result_type = str(meta.get("result_type") or "")
+    if not filters.get("include_agenda_items") and result_type != "meeting":
+        return False
+    city = filters.get("city")
+    if city and str(meta.get("city") or "").lower() != str(city).lower():
+        return False
+    meeting_type = filters.get("meeting_type")
+    if meeting_type and str(meta.get("meeting_category") or "").lower() != str(meeting_type).lower():
+        return False
+    org = filters.get("org")
+    if org and str(meta.get("organization") or "").lower() != str(org).lower():
+        return False
+    date_val = str(meta.get("date") or "")
+    date_from = filters.get("date_from")
+    date_to = filters.get("date_to")
+    if date_from and (not date_val or date_val < date_from):
+        return False
+    if date_to and (not date_val or date_val > date_to):
+        return False
+    return True
+
+
+def dedupe_semantic_candidates(candidates: Iterable[CandidateT]) -> list[CandidateT]:
+    best_by_key: dict[tuple[str, int], CandidateT] = {}
+    for candidate in candidates:
+        key = semantic_candidate_key(candidate)
+        existing = best_by_key.get(key)
+        if existing is None or candidate.score > existing.score:
+            best_by_key[key] = candidate
+    deduped = list(best_by_key.values())
+    deduped.sort(key=lambda candidate: candidate.score, reverse=True)
+    return deduped
+
+
+def semantic_candidate_key(candidate: SemanticCandidateLike) -> tuple[str, int]:
+    meta = candidate.metadata
+    result_type = str(meta.get("result_type") or "meeting")
+    if result_type == "meeting":
+        return ("meeting", int(meta.get("catalog_id") or 0))
+    return ("agenda_item", int(meta.get("db_id") or 0))
+
+
+def lexical_hit_to_candidate(hit: Mapping[str, Any], order_idx: int) -> FallbackCandidate | None:
+    result_type = str(hit.get("result_type") or "meeting")
+    if result_type == "meeting":
+        metadata = _meeting_candidate_metadata(hit)
+    elif result_type == "agenda_item":
+        metadata = _agenda_candidate_metadata(hit)
+    else:
+        return None
+    if metadata is None:
+        return None
+    return FallbackCandidate(row_id=order_idx, score=-float(order_idx + 1), metadata=metadata)
+
+
+def _meeting_candidate_metadata(hit: Mapping[str, Any]) -> dict[str, Any] | None:
+    db_id = _candidate_db_id(hit, prefix="doc_")
+    catalog_id = hit.get("catalog_id")
+    if db_id is None or catalog_id is None:
+        return None
+    return {
+        "result_type": "meeting",
+        "catalog_id": int(catalog_id),
+        "db_id": int(db_id),
+        "event_id": hit.get("event_id"),
+        "city": str(hit.get("city") or "").lower(),
+        "meeting_category": hit.get("meeting_category") or "Other",
+        "organization": hit.get("organization") or "City Council",
+        "date": hit.get("date"),
+        "source_type": "lexical_fallback",
+    }
+
+
+def _agenda_candidate_metadata(hit: Mapping[str, Any]) -> dict[str, Any] | None:
+    db_id = _candidate_db_id(hit, prefix="item_")
+    if db_id is None:
+        return None
+    return {
+        "result_type": "agenda_item",
+        "catalog_id": hit.get("catalog_id"),
+        "db_id": int(db_id),
+        "event_id": hit.get("event_id"),
+        "city": str(hit.get("city") or "").lower(),
+        "meeting_category": hit.get("meeting_category") or "Other",
+        "organization": hit.get("organization") or "City Council",
+        "date": hit.get("date"),
+        "source_type": "lexical_fallback",
+    }
+
+
+def _candidate_db_id(hit: Mapping[str, Any], *, prefix: str) -> int | None:
+    db_id = hit.get("db_id")
+    if db_id is not None:
+        return int(db_id)
+    raw_id = str(hit.get("id") or "")
+    if not raw_id.startswith(prefix):
+        return None
+    try:
+        return int(raw_id.split("_", 1)[1])
+    except (IndexError, ValueError):
+        return None

--- a/semantic_service/filters.py
+++ b/semantic_service/filters.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from fastapi import HTTPException
+
+from api.search.query_builder import build_meili_filter_clauses, normalize_filters
+
+
+def validate_date_format(date_str: str) -> None:
+    if not re.match(r"^\d{4}-\d{2}-\d{2}$", date_str):
+        raise HTTPException(status_code=400, detail="Invalid date format. Use YYYY-MM-DD.")
+
+
+def build_filter_values(
+    city: str | None,
+    meeting_type: str | None,
+    org: str | None,
+    date_from: str | None,
+    date_to: str | None,
+    include_agenda_items: bool,
+) -> dict[str, Any]:
+    try:
+        filters = normalize_filters(
+            city=city,
+            meeting_type=meeting_type,
+            org=org,
+            date_from=date_from,
+            date_to=date_to,
+            include_agenda_items=include_agenda_items,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return {
+        "city": filters.city,
+        "meeting_type": filters.meeting_type,
+        "org": filters.org,
+        "date_from": filters.date_from,
+        "date_to": filters.date_to,
+        "include_agenda_items": filters.include_agenda_items,
+    }
+
+
+def build_meilisearch_filter_clauses(
+    city: str | None,
+    meeting_type: str | None,
+    org: str | None,
+    date_from: str | None,
+    date_to: str | None,
+    include_agenda_items: bool,
+) -> list[str]:
+    try:
+        return build_meili_filter_clauses(
+            normalize_filters(
+                city=city,
+                meeting_type=meeting_type,
+                org=org,
+                date_from=date_from,
+                date_to=date_to,
+                include_agenda_items=include_agenda_items,
+            )
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/semantic_service/main.py
+++ b/semantic_service/main.py
@@ -1,8 +1,6 @@
 import logging
 import os
-import re
 import time
-from dataclasses import dataclass
 from typing import Optional, Any
 
 import meilisearch
@@ -10,7 +8,6 @@ from fastapi import FastAPI, HTTPException, Query, Depends
 from sqlalchemy import text
 from sqlalchemy.orm import Session as SQLAlchemySession, sessionmaker
 
-from api.search.query_builder import normalize_filters, build_meili_filter_clauses
 from pipeline.config import (
     SEMANTIC_ENABLED,
     SEMANTIC_BACKEND,
@@ -24,6 +21,17 @@ from pipeline.semantic_index import (
     get_semantic_backend,
     SemanticConfigError,
     PgvectorSemanticBackend,
+)
+from semantic_service.candidates import (
+    dedupe_semantic_candidates as _dedupe_semantic_candidates,
+    lexical_hit_to_candidate as _lexical_hit_to_candidate,
+    semantic_candidate_key as _semantic_candidate_key,
+    semantic_candidate_matches_filters as _semantic_candidate_matches_filters,
+)
+from semantic_service.filters import (
+    build_filter_values as _build_filter_values,
+    build_meilisearch_filter_clauses as _build_meilisearch_filter_clauses,
+    validate_date_format,
 )
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
@@ -84,175 +92,6 @@ def _semantic_backend_engine_for_diagnostics(backend: Any) -> str | None:
         logger.warning("semantic backend health diagnostic returned unhealthy status: %s", backend_health)
         return None
     return _public_semantic_backend_engine(backend_health.get("engine"))
-
-
-def validate_date_format(date_str: str):
-    if not re.match(r"^\d{4}-\d{2}-\d{2}$", date_str):
-        raise HTTPException(status_code=400, detail="Invalid date format. Use YYYY-MM-DD.")
-
-
-def _build_filter_values(
-    city: Optional[str],
-    meeting_type: Optional[str],
-    org: Optional[str],
-    date_from: Optional[str],
-    date_to: Optional[str],
-    include_agenda_items: bool,
-) -> dict[str, Any]:
-    try:
-        filters = normalize_filters(
-            city=city,
-            meeting_type=meeting_type,
-            org=org,
-            date_from=date_from,
-            date_to=date_to,
-            include_agenda_items=include_agenda_items,
-        )
-    except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
-    return {
-        "city": filters.city,
-        "meeting_type": filters.meeting_type,
-        "org": filters.org,
-        "date_from": filters.date_from,
-        "date_to": filters.date_to,
-        "include_agenda_items": filters.include_agenda_items,
-    }
-
-
-def _build_meilisearch_filter_clauses(
-    city: Optional[str],
-    meeting_type: Optional[str],
-    org: Optional[str],
-    date_from: Optional[str],
-    date_to: Optional[str],
-    include_agenda_items: bool,
-) -> list[str]:
-    try:
-        return build_meili_filter_clauses(
-            normalize_filters(
-                city=city,
-                meeting_type=meeting_type,
-                org=org,
-                date_from=date_from,
-                date_to=date_to,
-                include_agenda_items=include_agenda_items,
-            )
-        )
-    except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
-
-
-@dataclass
-class _FallbackCandidate:
-    row_id: int
-    score: float
-    metadata: dict[str, Any]
-
-
-def _semantic_candidate_matches_filters(meta: dict, filters: dict) -> bool:
-    result_type = str(meta.get("result_type") or "")
-    if not filters.get("include_agenda_items") and result_type != "meeting":
-        return False
-    city = filters.get("city")
-    if city and str(meta.get("city") or "").lower() != str(city).lower():
-        return False
-    meeting_type = filters.get("meeting_type")
-    if meeting_type and str(meta.get("meeting_category") or "").lower() != str(meeting_type).lower():
-        return False
-    org = filters.get("org")
-    if org and str(meta.get("organization") or "").lower() != str(org).lower():
-        return False
-    date_val = str(meta.get("date") or "")
-    date_from = filters.get("date_from")
-    date_to = filters.get("date_to")
-    if date_from and (not date_val or date_val < date_from):
-        return False
-    if date_to and (not date_val or date_val > date_to):
-        return False
-    return True
-
-
-def _dedupe_semantic_candidates(candidates):
-    best_by_key = {}
-    for cand in candidates:
-        meta = cand.metadata
-        result_type = str(meta.get("result_type") or "meeting")
-        if result_type == "meeting":
-            key = ("meeting", int(meta.get("catalog_id") or 0))
-        else:
-            key = ("agenda_item", int(meta.get("db_id") or 0))
-        existing = best_by_key.get(key)
-        if existing is None or cand.score > existing.score:
-            best_by_key[key] = cand
-    deduped = list(best_by_key.values())
-    deduped.sort(key=lambda c: c.score, reverse=True)
-    return deduped
-
-
-def _semantic_candidate_key(candidate) -> tuple[str, int]:
-    meta = candidate.metadata
-    result_type = str(meta.get("result_type") or "meeting")
-    if result_type == "meeting":
-        return ("meeting", int(meta.get("catalog_id") or 0))
-    return ("agenda_item", int(meta.get("db_id") or 0))
-
-
-def _lexical_hit_to_candidate(hit: dict, order_idx: int):
-    result_type = str(hit.get("result_type") or "meeting")
-    if result_type == "meeting":
-        db_id = hit.get("db_id")
-        if db_id is None:
-            raw_id = str(hit.get("id") or "")
-            if raw_id.startswith("doc_"):
-                try:
-                    db_id = int(raw_id.split("_", 1)[1])
-                except (IndexError, ValueError):
-                    db_id = None
-        catalog_id = hit.get("catalog_id")
-        if db_id is None or catalog_id is None:
-            return None
-        metadata = {
-            "result_type": "meeting",
-            "catalog_id": int(catalog_id),
-            "db_id": int(db_id),
-            "event_id": hit.get("event_id"),
-            "city": str(hit.get("city") or "").lower(),
-            "meeting_category": hit.get("meeting_category") or "Other",
-            "organization": hit.get("organization") or "City Council",
-            "date": hit.get("date"),
-            "source_type": "lexical_fallback",
-        }
-    elif result_type == "agenda_item":
-        db_id = hit.get("db_id")
-        if db_id is None:
-            raw_id = str(hit.get("id") or "")
-            if raw_id.startswith("item_"):
-                try:
-                    db_id = int(raw_id.split("_", 1)[1])
-                except (IndexError, ValueError):
-                    db_id = None
-        if db_id is None:
-            return None
-        metadata = {
-            "result_type": "agenda_item",
-            "catalog_id": hit.get("catalog_id"),
-            "db_id": int(db_id),
-            "event_id": hit.get("event_id"),
-            "city": str(hit.get("city") or "").lower(),
-            "meeting_category": hit.get("meeting_category") or "Other",
-            "organization": hit.get("organization") or "City Council",
-            "date": hit.get("date"),
-            "source_type": "lexical_fallback",
-        }
-    else:
-        return None
-
-    return _FallbackCandidate(
-        row_id=order_idx,
-        score=-float(order_idx + 1),
-        metadata=metadata,
-    )
 
 
 def _merge_semantic_with_lexical_fallback(semantic_candidates, lexical_hits: list[dict], filters: dict):

--- a/tests/test_semantic_service_contract_helpers.py
+++ b/tests/test_semantic_service_contract_helpers.py
@@ -1,0 +1,87 @@
+from pipeline.semantic_index import SemanticCandidate
+from semantic_service import candidates
+from semantic_service.main import _lexical_hit_to_candidate as facade_lexical_hit_to_candidate
+
+
+def test_semantic_main_keeps_lexical_candidate_compatibility_seam():
+    assert facade_lexical_hit_to_candidate is candidates.lexical_hit_to_candidate
+
+
+def test_semantic_lexical_meeting_candidate_rejects_malformed_doc_id():
+    candidate = candidates.lexical_hit_to_candidate(
+        {"id": "doc_not-an-int", "catalog_id": 12, "result_type": "meeting"},
+        0,
+    )
+
+    assert candidate is None
+
+
+def test_semantic_lexical_agenda_candidate_rejects_malformed_item_id():
+    candidate = candidates.lexical_hit_to_candidate({"id": "item_bad", "result_type": "agenda_item"}, 0)
+
+    assert candidate is None
+
+
+def test_semantic_lexical_candidate_preserves_meeting_metadata_defaults():
+    candidate = candidates.lexical_hit_to_candidate({"id": "doc_7", "catalog_id": 12, "result_type": "meeting"}, 2)
+
+    assert candidate is not None
+    assert candidate.row_id == 2
+    assert candidate.score == -3.0
+    assert candidate.metadata == {
+        "result_type": "meeting",
+        "catalog_id": 12,
+        "db_id": 7,
+        "event_id": None,
+        "city": "",
+        "meeting_category": "Other",
+        "organization": "City Council",
+        "date": None,
+        "source_type": "lexical_fallback",
+    }
+
+
+def test_semantic_filter_matching_preserves_case_insensitive_boundaries():
+    filters = {
+        "include_agenda_items": True,
+        "city": "Cupertino",
+        "meeting_type": "Regular",
+        "org": "City Council",
+        "date_from": "2026-01-01",
+        "date_to": "2026-01-31",
+    }
+    metadata = {
+        "result_type": "agenda_item",
+        "city": "cupertino",
+        "meeting_category": "regular",
+        "organization": "city council",
+        "date": "2026-01-31",
+    }
+
+    assert candidates.semantic_candidate_matches_filters(metadata, filters)
+
+
+def test_semantic_filter_matching_excludes_agenda_items_by_default():
+    assert not candidates.semantic_candidate_matches_filters(
+        {"result_type": "agenda_item", "date": "2026-01-10"},
+        {"include_agenda_items": False},
+    )
+
+
+def test_semantic_filter_matching_rejects_out_of_range_dates():
+    assert not candidates.semantic_candidate_matches_filters(
+        {"result_type": "meeting", "date": "2025-12-31"},
+        {"include_agenda_items": False, "date_from": "2026-01-01"},
+    )
+
+
+def test_semantic_dedupe_keeps_highest_score_per_result_key():
+    semantic_candidates = [
+        SemanticCandidate(row_id=1, score=0.2, metadata={"result_type": "meeting", "catalog_id": 10, "db_id": 1}),
+        SemanticCandidate(row_id=2, score=0.9, metadata={"result_type": "meeting", "catalog_id": 10, "db_id": 2}),
+        SemanticCandidate(row_id=3, score=0.8, metadata={"result_type": "agenda_item", "db_id": 5}),
+    ]
+
+    deduped = candidates.dedupe_semantic_candidates(semantic_candidates)
+
+    assert [candidate.row_id for candidate in deduped] == [2, 3]


### PR DESCRIPTION
## What changed
- Moved semantic candidate parsing, candidate keys, dedupe, and metadata filter matching into `semantic_service/candidates.py`.
- Moved semantic date/filter wrapper helpers into `semantic_service/filters.py`.
- Kept compatibility names imported through `semantic_service.main` so existing tests and monkeypatch seams keep working.
- Added helper contract tests for malformed lexical IDs, agenda exclusion, date/filter boundaries, dedupe score selection, and one facade seam.

## Why
`semantic_service/main.py` is the remaining god module and worst Radon hotspot. This is Batch G lane 1: extract pure contract/helper logic before retrieval and hydration orchestration move in later PRs.

## Risk / compatibility
Low. Route functions, DB session ownership, backend selection, Meilisearch calls, `/health`, `/search/semantic`, response shape, diagnostics, and error status/detail stay unchanged.

## Verification
- PASS `./.venv/bin/ruff check semantic_service tests/test_semantic_service_contract_helpers.py`
- PASS `PYTHONPATH=. .venv/bin/pytest -q tests/test_semantic_service_contract_helpers.py tests/test_semantic_dedup_catalog.py`
- PASS `./.venv/bin/ruff check api pipeline scripts tests`
- PASS `PYTHONPATH=. .venv/bin/pytest -q tests/test_repository_guardrails.py`
- PASS `PYTHONPATH=. .venv/bin/pytest -q tests/test_semantic_service_api.py`
- PASS `PYTHONPATH=. .venv/bin/pytest -q tests/test_search_pgvector_hybrid_rerank.py tests/test_semantic_recall_filters.py`
- PASS `PYTHONPATH=. .venv/bin/pytest -q tests/test_semantic_search_feature_flag.py tests/test_semantic_search_api.py tests/test_semantic_backend_selection.py`
- PASS `PYTHONPATH=. .venv/bin/pytest -q tests/test_api.py tests/test_query_builder_filters.py tests/test_query_builder_parity_search_vs_trends.py`
- PASS `./.venv/bin/python -m radon cc semantic_service -s -n C` ran; remaining `main.py` hotspots are expected lane 2/3 work.
- PASS `git diff --check`

## Review
Independent code review found no Critical issues. Important git-hygiene finding and Minor helper-test/import findings were fixed before commit.

## Remaining deficits
Batch G lane 2 still needs retrieval orchestration extraction. Batch G lane 3 still needs hydration/response assembly extraction. Docs/guardrails remain deferred to the separate Batch G follow-up PR.