### PR TITLE
Extract semantic service retrieval flow

### DIFF
--- a/semantic_service/main.py
+++ b/semantic_service/main.py
@@ -1,10 +1,10 @@
 import logging
 import os
 import time
-from typing import Optional, Any
+from typing import Any, Optional
 
 import meilisearch
-from fastapi import FastAPI, HTTPException, Query, Depends
+from fastapi import Depends, FastAPI, HTTPException, Query
 from sqlalchemy import text
 from sqlalchemy.orm import Session as SQLAlchemySession, sessionmaker
 
@@ -32,6 +32,11 @@ from semantic_service.filters import (
     build_filter_values as _build_filter_values,
     build_meilisearch_filter_clauses as _build_meilisearch_filter_clauses,
     validate_date_format,
+)
+from semantic_service.retrieval import (
+    SemanticRetrievalSettings,
+    SemanticSearchFilters,
+    retrieve_semantic_candidates,
 )
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
@@ -267,95 +272,38 @@ def search_documents_semantic(
         include_agenda_items=include_agenda_items,
     )
     target = offset + limit
-    k = max(SEMANTIC_BASE_TOP_K, target * SEMANTIC_FILTER_EXPANSION_FACTOR)
-    k = min(k, SEMANTIC_MAX_TOP_K)
-    expansion_steps = 0
     t0 = time.perf_counter()
     backend = get_semantic_backend()
 
     try:
-        deduped = []
-        raw_count = 0
-        filtered_count = 0
-        diagnostics_extra = {
-            "retrieval_mode": "vector_direct",
-            "result_scope": "full_semantic",
-            "hybrid_rerank_applied": False,
-            "degraded_to_lexical": False,
-            "skipped_reason": None,
-            "lexical_candidates": 0,
-            "eligible_meeting_candidates": 0,
-            "candidate_limit_applied": 0,
-            "fresh_embeddings": 0,
-            "missing_embeddings": 0,
-            "stale_embeddings": 0,
-            "lexical_fallback_candidates": 0,
-        }
-
-        if isinstance(backend, PgvectorSemanticBackend) or (SEMANTIC_BACKEND == "pgvector"):
-            index = client.index("documents")
-            lexical_limit = min(
-                SEMANTIC_MAX_TOP_K,
-                max(target * SEMANTIC_FILTER_EXPANSION_FACTOR, SEMANTIC_RERANK_CANDIDATE_LIMIT),
-            )
-            lexical_params = {
-                "limit": lexical_limit,
-                "offset": 0,
-                "attributesToRetrieve": [
-                    "id",
-                    "db_id",
-                    "event_id",
-                    "catalog_id",
-                    "result_type",
-                    "city",
-                    "meeting_category",
-                    "organization",
-                    "date",
-                ],
-                "filter": _build_meilisearch_filter_clauses(
-                    city=city,
-                    meeting_type=meeting_type,
-                    org=org,
-                    date_from=date_from,
-                    date_to=date_to,
-                    include_agenda_items=include_agenda_items,
-                ),
-            }
-            if not lexical_params["filter"]:
-                del lexical_params["filter"]
-            lexical_results = index.search(q, lexical_params)
-            lexical_hits = lexical_results.get("hits", []) or []
-            raw_count = len(lexical_hits)
-            rerank_with_diagnostics = getattr(backend, "rerank_candidates_with_diagnostics", None)
-            if callable(rerank_with_diagnostics):
-                rerank_result = rerank_with_diagnostics(db, q, lexical_hits, top_k=k)
-                candidates = rerank_result.candidates
-                diagnostics_extra.update(rerank_result.diagnostics)
-            else:
-                candidates = backend.rerank_candidates(db, q, lexical_hits, top_k=k)
-            filtered = [c for c in candidates if _semantic_candidate_matches_filters(c.metadata, filters)]
-            filtered_count = len(filtered)
-            deduped = _dedupe_semantic_candidates(filtered)
-            if diagnostics_extra.get("degraded_to_lexical") or len(deduped) < target:
-                deduped, fallback_added = _merge_semantic_with_lexical_fallback(deduped, lexical_hits, filters)
-                diagnostics_extra["degraded_to_lexical"] = True
-                diagnostics_extra["lexical_fallback_candidates"] = fallback_added
-                if fallback_added and diagnostics_extra.get("skipped_reason") is None:
-                    diagnostics_extra["skipped_reason"] = "partial_embedding_coverage"
-        else:
-            while True:
-                candidates = backend.query(q, k)
-                raw_count = len(candidates)
-                filtered = [c for c in candidates if _semantic_candidate_matches_filters(c.metadata, filters)]
-                filtered_count = len(filtered)
-                deduped = _dedupe_semantic_candidates(filtered)
-                if len(deduped) >= target or k >= SEMANTIC_MAX_TOP_K:
-                    break
-                next_k = min(SEMANTIC_MAX_TOP_K, max(k + 1, k * 2))
-                if next_k == k:
-                    break
-                k = next_k
-                expansion_steps += 1
+        retrieval_result = retrieve_semantic_candidates(
+            backend=backend,
+            db=db,
+            query_text=q,
+            target=target,
+            filters=filters,
+            search_filters=SemanticSearchFilters(
+                city=city,
+                meeting_type=meeting_type,
+                org=org,
+                date_from=date_from,
+                date_to=date_to,
+                include_agenda_items=include_agenda_items,
+            ),
+            settings=SemanticRetrievalSettings(
+                backend_name=SEMANTIC_BACKEND,
+                base_top_k=SEMANTIC_BASE_TOP_K,
+                filter_expansion_factor=SEMANTIC_FILTER_EXPANSION_FACTOR,
+                max_top_k=SEMANTIC_MAX_TOP_K,
+                rerank_candidate_limit=SEMANTIC_RERANK_CANDIDATE_LIMIT,
+            ),
+            meili_client=client,
+            is_pgvector_backend=isinstance(backend, PgvectorSemanticBackend),
+            build_filter_clauses=_build_meilisearch_filter_clauses,
+            filter_matcher=_semantic_candidate_matches_filters,
+            dedupe_candidates=_dedupe_semantic_candidates,
+            merge_lexical_fallback=_merge_semantic_with_lexical_fallback,
+        )
     except FileNotFoundError as exc:
         raise HTTPException(
             status_code=503,
@@ -371,6 +319,7 @@ def search_documents_semantic(
         logger.error("semantic search failed: %s", exc)
         raise HTTPException(status_code=500, detail="Internal semantic search error") from exc
 
+    deduped = retrieval_result.deduped
     page_candidates = deduped[offset : offset + limit]
     meeting_candidates = [c for c in page_candidates if str(c.metadata.get("result_type") or "meeting") == "meeting"]
     agenda_candidates = [c for c in page_candidates if str(c.metadata.get("result_type")) == "agenda_item"]
@@ -393,13 +342,13 @@ def search_documents_semantic(
         "limit": limit,
         "offset": offset,
         "semantic_diagnostics": {
-            "raw_candidates": raw_count,
-            "filtered_candidates": filtered_count,
+            "raw_candidates": retrieval_result.raw_count,
+            "filtered_candidates": retrieval_result.filtered_count,
             "dedup_candidates": len(deduped),
-            "k_used": k,
-            "expansion_steps": expansion_steps,
+            "k_used": retrieval_result.k_used,
+            "expansion_steps": retrieval_result.expansion_steps,
             "latency_ms": elapsed_ms,
             "engine": engine,
-            **diagnostics_extra,
+            **retrieval_result.diagnostics_extra,
         },
     }

--- a/semantic_service/retrieval.py
+++ b/semantic_service/retrieval.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Protocol
+
+
+SEMANTIC_DIAGNOSTIC_DEFAULTS: dict[str, object] = {
+    "retrieval_mode": "vector_direct",
+    "result_scope": "full_semantic",
+    "hybrid_rerank_applied": False,
+    "degraded_to_lexical": False,
+    "skipped_reason": None,
+    "lexical_candidates": 0,
+    "eligible_meeting_candidates": 0,
+    "candidate_limit_applied": 0,
+    "fresh_embeddings": 0,
+    "missing_embeddings": 0,
+    "stale_embeddings": 0,
+    "lexical_fallback_candidates": 0,
+}
+LEXICAL_ATTRIBUTES_TO_RETRIEVE = [
+    "id",
+    "db_id",
+    "event_id",
+    "catalog_id",
+    "result_type",
+    "city",
+    "meeting_category",
+    "organization",
+    "date",
+]
+
+
+class SemanticCandidateLike(Protocol):
+    score: float
+    metadata: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class SemanticRetrievalSettings:
+    backend_name: str
+    base_top_k: int
+    filter_expansion_factor: int
+    max_top_k: int
+    rerank_candidate_limit: int
+
+
+@dataclass(frozen=True)
+class SemanticSearchFilters:
+    city: str | None
+    meeting_type: str | None
+    org: str | None
+    date_from: str | None
+    date_to: str | None
+    include_agenda_items: bool
+
+
+@dataclass
+class SemanticRetrievalResult:
+    deduped: list[SemanticCandidateLike]
+    raw_count: int
+    filtered_count: int
+    k_used: int
+    expansion_steps: int
+    diagnostics_extra: dict[str, Any]
+
+
+FilterMatcher = Callable[[dict[str, Any], dict[str, Any]], bool]
+DedupeCandidates = Callable[[list[SemanticCandidateLike]], list[SemanticCandidateLike]]
+MergeLexicalFallback = Callable[[list[SemanticCandidateLike], list[dict[str, Any]], dict[str, Any]], tuple[list[Any], int]]
+BuildFilterClauses = Callable[..., list[str]]
+
+
+def initial_top_k(target: int, settings: SemanticRetrievalSettings) -> int:
+    return min(settings.max_top_k, max(settings.base_top_k, target * settings.filter_expansion_factor))
+
+
+def lexical_candidate_limit(target: int, settings: SemanticRetrievalSettings) -> int:
+    return min(settings.max_top_k, max(target * settings.filter_expansion_factor, settings.rerank_candidate_limit))
+
+
+def build_lexical_search_params(
+    search_filters: SemanticSearchFilters,
+    *,
+    target: int,
+    settings: SemanticRetrievalSettings,
+    build_filter_clauses: BuildFilterClauses,
+) -> dict[str, Any]:
+    lexical_params: dict[str, Any] = {
+        "limit": lexical_candidate_limit(target, settings),
+        "offset": 0,
+        "attributesToRetrieve": LEXICAL_ATTRIBUTES_TO_RETRIEVE,
+        "filter": build_filter_clauses(
+            city=search_filters.city,
+            meeting_type=search_filters.meeting_type,
+            org=search_filters.org,
+            date_from=search_filters.date_from,
+            date_to=search_filters.date_to,
+            include_agenda_items=search_filters.include_agenda_items,
+        ),
+    }
+    if not lexical_params["filter"]:
+        del lexical_params["filter"]
+    return lexical_params
+
+
+def retrieve_semantic_candidates(
+    *,
+    backend: Any,
+    db: Any,
+    query_text: str,
+    target: int,
+    filters: dict[str, Any],
+    search_filters: SemanticSearchFilters,
+    settings: SemanticRetrievalSettings,
+    meili_client: Any,
+    is_pgvector_backend: bool,
+    build_filter_clauses: BuildFilterClauses,
+    filter_matcher: FilterMatcher,
+    dedupe_candidates: DedupeCandidates,
+    merge_lexical_fallback: MergeLexicalFallback,
+) -> SemanticRetrievalResult:
+    k = initial_top_k(target, settings)
+    if is_pgvector_backend or settings.backend_name == "pgvector":
+        return _retrieve_pgvector_candidates(
+            backend=backend,
+            db=db,
+            query_text=query_text,
+            target=target,
+            filters=filters,
+            search_filters=search_filters,
+            settings=settings,
+            meili_client=meili_client,
+            k=k,
+            build_filter_clauses=build_filter_clauses,
+            filter_matcher=filter_matcher,
+            dedupe_candidates=dedupe_candidates,
+            merge_lexical_fallback=merge_lexical_fallback,
+        )
+    return _retrieve_direct_vector_candidates(
+        backend=backend,
+        query_text=query_text,
+        target=target,
+        filters=filters,
+        settings=settings,
+        k=k,
+        filter_matcher=filter_matcher,
+        dedupe_candidates=dedupe_candidates,
+    )
+
+
+def _retrieve_pgvector_candidates(
+    *,
+    backend: Any,
+    db: Any,
+    query_text: str,
+    target: int,
+    filters: dict[str, Any],
+    search_filters: SemanticSearchFilters,
+    settings: SemanticRetrievalSettings,
+    meili_client: Any,
+    k: int,
+    build_filter_clauses: BuildFilterClauses,
+    filter_matcher: FilterMatcher,
+    dedupe_candidates: DedupeCandidates,
+    merge_lexical_fallback: MergeLexicalFallback,
+) -> SemanticRetrievalResult:
+    diagnostics_extra: dict[str, Any] = dict(SEMANTIC_DIAGNOSTIC_DEFAULTS)
+    lexical_params = build_lexical_search_params(
+        search_filters,
+        target=target,
+        settings=settings,
+        build_filter_clauses=build_filter_clauses,
+    )
+    lexical_results = meili_client.index("documents").search(query_text, lexical_params)
+    lexical_hits = lexical_results.get("hits", []) or []
+    candidates = _rerank_pgvector_candidates(backend, db, query_text, lexical_hits, k, diagnostics_extra)
+    filtered = [candidate for candidate in candidates if filter_matcher(candidate.metadata, filters)]
+    deduped = dedupe_candidates(filtered)
+    if diagnostics_extra.get("degraded_to_lexical") or len(deduped) < target:
+        deduped, fallback_added = merge_lexical_fallback(deduped, lexical_hits, filters)
+        diagnostics_extra["degraded_to_lexical"] = True
+        diagnostics_extra["lexical_fallback_candidates"] = fallback_added
+        if fallback_added and diagnostics_extra.get("skipped_reason") is None:
+            diagnostics_extra["skipped_reason"] = "partial_embedding_coverage"
+    return SemanticRetrievalResult(
+        deduped=deduped,
+        raw_count=len(lexical_hits),
+        filtered_count=len(filtered),
+        k_used=k,
+        expansion_steps=0,
+        diagnostics_extra=diagnostics_extra,
+    )
+
+
+def _rerank_pgvector_candidates(
+    backend: Any,
+    db: Any,
+    query_text: str,
+    lexical_hits: list[dict[str, Any]],
+    k: int,
+    diagnostics_extra: dict[str, Any],
+) -> list[SemanticCandidateLike]:
+    rerank_with_diagnostics = getattr(backend, "rerank_candidates_with_diagnostics", None)
+    if callable(rerank_with_diagnostics):
+        rerank_result = rerank_with_diagnostics(db, query_text, lexical_hits, top_k=k)
+        diagnostics_extra.update(rerank_result.diagnostics)
+        return rerank_result.candidates
+    return backend.rerank_candidates(db, query_text, lexical_hits, top_k=k)
+
+
+def _retrieve_direct_vector_candidates(
+    *,
+    backend: Any,
+    query_text: str,
+    target: int,
+    filters: dict[str, Any],
+    settings: SemanticRetrievalSettings,
+    k: int,
+    filter_matcher: FilterMatcher,
+    dedupe_candidates: DedupeCandidates,
+) -> SemanticRetrievalResult:
+    diagnostics_extra: dict[str, Any] = dict(SEMANTIC_DIAGNOSTIC_DEFAULTS)
+    expansion_steps = 0
+    while True:
+        candidates = backend.query(query_text, k)
+        filtered = [candidate for candidate in candidates if filter_matcher(candidate.metadata, filters)]
+        deduped = dedupe_candidates(filtered)
+        if len(deduped) >= target or k >= settings.max_top_k:
+            break
+        next_k = min(settings.max_top_k, max(k + 1, k * 2))
+        if next_k == k:
+            break
+        k = next_k
+        expansion_steps += 1
+    return SemanticRetrievalResult(
+        deduped=deduped,
+        raw_count=len(candidates),
+        filtered_count=len(filtered),
+        k_used=k,
+        expansion_steps=expansion_steps,
+        diagnostics_extra=diagnostics_extra,
+    )

--- a/tests/test_search_pgvector_hybrid_rerank.py
+++ b/tests/test_search_pgvector_hybrid_rerank.py
@@ -86,7 +86,7 @@ def test_semantic_search_pgvector_hybrid_rerank_path(mocker):
 
     client = TestClient(app)
     try:
-        resp = client.get("/search/semantic?q=zoning&limit=20", headers={"X-API-Key": VALID_KEY})
+        resp = client.get("/search/semantic?q=zoning&include_agenda_items=true&limit=20", headers={"X-API-Key": VALID_KEY})
         assert resp.status_code == 200
         payload = resp.json()
         assert payload["hits"][0]["id"] == "doc_10"
@@ -95,6 +95,24 @@ def test_semantic_search_pgvector_hybrid_rerank_path(mocker):
         assert payload["semantic_diagnostics"]["retrieval_mode"] == "hybrid_pgvector"
         assert payload["semantic_diagnostics"]["result_scope"] == "meeting_hybrid"
         assert payload["semantic_diagnostics"]["hybrid_rerank_applied"] is True
+        meili_index.search.assert_called_once_with(
+            "zoning",
+            {
+                "limit": 200,
+                "offset": 0,
+                "attributesToRetrieve": [
+                    "id",
+                    "db_id",
+                    "event_id",
+                    "catalog_id",
+                    "result_type",
+                    "city",
+                    "meeting_category",
+                    "organization",
+                    "date",
+                ],
+            },
+        )
     finally:
         del app.dependency_overrides[get_db]
 

--- a/tests/test_semantic_recall_filters.py
+++ b/tests/test_semantic_recall_filters.py
@@ -52,6 +52,32 @@ class _AdaptiveBackend:
         return rows
 
 
+class _MaxCapBackend:
+    def __init__(self):
+        self.calls = []
+
+    def health(self):
+        return {"status": "ok", "engine": "faiss"}
+
+    def query(self, _q, k):
+        self.calls.append(k)
+        return [
+            SemanticCandidate(
+                row_id=1,
+                score=0.9,
+                metadata={
+                    "result_type": "meeting",
+                    "db_id": 100,
+                    "catalog_id": 100,
+                    "city": "ca_berkeley",
+                    "meeting_category": "Regular",
+                    "organization": "City Council",
+                    "date": "2025-01-01",
+                },
+            )
+        ]
+
+
 def test_semantic_search_expands_top_k_until_filtered_results_exist(mocker):
     db = MagicMock()
     app.dependency_overrides[get_db] = lambda: db
@@ -75,5 +101,29 @@ def test_semantic_search_expands_top_k_until_filtered_results_exist(mocker):
         payload = resp.json()
         assert payload["semantic_diagnostics"]["expansion_steps"] >= 1
         assert len(payload["hits"]) > 0
+    finally:
+        del app.dependency_overrides[get_db]
+
+
+def test_semantic_search_stops_expansion_at_max_top_k(mocker):
+    db = MagicMock()
+    app.dependency_overrides[get_db] = lambda: db
+    backend = _MaxCapBackend()
+    mocker.patch("semantic_service.main.SEMANTIC_ENABLED", True)
+    mocker.patch("semantic_service.main.SEMANTIC_BASE_TOP_K", 2)
+    mocker.patch("semantic_service.main.SEMANTIC_MAX_TOP_K", 4)
+    mocker.patch("semantic_service.main.SEMANTIC_FILTER_EXPANSION_FACTOR", 1)
+    mocker.patch("semantic_service.main.get_semantic_backend", return_value=backend)
+    mocker.patch("semantic_service.main._hydrate_meeting_hits", return_value=[])
+    mocker.patch("semantic_service.main._hydrate_agenda_hits", return_value=[])
+    client = TestClient(app)
+    try:
+        resp = client.get("/search/semantic?q=zoning&city=cupertino&limit=10", headers={"X-API-Key": VALID_KEY})
+        assert resp.status_code == 200
+        payload = resp.json()
+        assert backend.calls == [4]
+        assert payload["semantic_diagnostics"]["k_used"] == 4
+        assert payload["semantic_diagnostics"]["expansion_steps"] == 0
+        assert payload["semantic_diagnostics"]["filtered_candidates"] == 0
     finally:
         del app.dependency_overrides[get_db]


### PR DESCRIPTION
## What changed
- Moved pgvector lexical recall/rerank and direct vector expansion into `semantic_service/retrieval.py`.
- Kept `semantic_service.main` as the route facade and late-bound patch surface.
- Passed config constants, Meilisearch client, backend identity, filter matching, dedupe, and fallback helpers into retrieval explicitly.
- Added tests for Meilisearch params/filter omission and FAISS max-top-k stop behavior.

## Why
This is Batch G lane 2. It reduces `search_documents_semantic` complexity while preserving route behavior, diagnostics, fallback semantics, and monkeypatch seams.

## Risk / compatibility
Low. `/search/semantic`, `/health`, DB session ownership, response shape, status codes, diagnostics, backend selection, and Meilisearch call count stay unchanged. Lane 3 will handle hydration/response assembly separately.

## Verification
- PASS `./.venv/bin/ruff check api pipeline scripts tests`
- PASS `PYTHONPATH=. .venv/bin/pytest -q tests/test_repository_guardrails.py`
- PASS `PYTHONPATH=. .venv/bin/pytest -q tests/test_semantic_service_api.py tests/test_search_pgvector_hybrid_rerank.py tests/test_semantic_recall_filters.py tests/test_semantic_search_feature_flag.py tests/test_semantic_search_api.py tests/test_semantic_dedup_catalog.py tests/test_semantic_backend_selection.py`
- PASS `PYTHONPATH=. .venv/bin/pytest -q tests/test_api.py tests/test_query_builder_filters.py tests/test_query_builder_parity_search_vs_trends.py`
- PASS `./.venv/bin/python -m radon cc semantic_service -s -n C`
- PASS `git diff --check`

## Review
Independent code review found no Critical issues. Important finding was git hygiene only: stage the new `semantic_service/retrieval.py` helper with the commit. Fixed before commit.

## Remaining deficits
Batch G lane 3 still needs hydration/response assembly extraction. Docs/guardrails remain deferred to the separate Batch G follow-up PR.