### PR TITLE
Extract semantic service hydration flow

### DIFF
--- a/semantic_service/hydration.py
+++ b/semantic_service/hydration.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Protocol
+
+from sqlalchemy.orm import Session as SQLAlchemySession
+
+from pipeline.models import AgendaItem, Catalog, Document, Event, Organization, Place
+from semantic_service.retrieval import SemanticRetrievalResult
+
+
+class SemanticCandidateLike(Protocol):
+    score: float
+    metadata: dict[str, Any]
+
+
+HydrateCandidates = Callable[[SQLAlchemySession, list[SemanticCandidateLike]], list[dict[str, Any]]]
+
+
+@dataclass(frozen=True)
+class SemanticResponseTiming:
+    elapsed_ms: float
+    engine: str | None
+
+
+def hydrate_meeting_hits(db: SQLAlchemySession, candidates: list[SemanticCandidateLike]) -> list[dict[str, Any]]:
+    doc_ids = _positive_candidate_db_ids(candidates)
+    if not doc_ids:
+        return []
+    by_doc_id = _meeting_hits_by_doc_id(db, doc_ids)
+    return _hydrate_candidates(candidates, by_doc_id)
+
+
+def hydrate_agenda_hits(db: SQLAlchemySession, candidates: list[SemanticCandidateLike]) -> list[dict[str, Any]]:
+    item_ids = _positive_candidate_db_ids(candidates)
+    if not item_ids:
+        return []
+    by_item_id = _agenda_hits_by_item_id(db, item_ids)
+    return _hydrate_candidates(candidates, by_item_id)
+
+
+def build_semantic_search_response(
+    *,
+    db: SQLAlchemySession,
+    retrieval_result: SemanticRetrievalResult,
+    limit: int,
+    offset: int,
+    timing: SemanticResponseTiming,
+    hydrate_meetings: HydrateCandidates,
+    hydrate_agenda_items: HydrateCandidates,
+) -> dict[str, Any]:
+    deduped = retrieval_result.deduped
+    page_candidates = deduped[offset : offset + limit]
+    meeting_candidates = _candidates_by_type(page_candidates, result_type="meeting")
+    agenda_candidates = _candidates_by_type(page_candidates, result_type="agenda_item")
+    meeting_hits = hydrate_meetings(db, meeting_candidates)
+    agenda_hits = hydrate_agenda_items(db, agenda_candidates)
+    hits = _ordered_hydrated_hits(page_candidates, meeting_hits, agenda_hits)
+    return {
+        "hits": hits,
+        "estimatedTotalHits": len(deduped),
+        "limit": limit,
+        "offset": offset,
+        "semantic_diagnostics": {
+            "raw_candidates": retrieval_result.raw_count,
+            "filtered_candidates": retrieval_result.filtered_count,
+            "dedup_candidates": len(deduped),
+            "k_used": retrieval_result.k_used,
+            "expansion_steps": retrieval_result.expansion_steps,
+            "latency_ms": timing.elapsed_ms,
+            "engine": timing.engine,
+            **retrieval_result.diagnostics_extra,
+        },
+    }
+
+
+def _positive_candidate_db_ids(candidates: list[SemanticCandidateLike]) -> list[int]:
+    return [int(candidate.metadata.get("db_id") or 0) for candidate in candidates if int(candidate.metadata.get("db_id") or 0) > 0]
+
+
+def _meeting_hits_by_doc_id(db: SQLAlchemySession, doc_ids: list[int]) -> dict[int, dict[str, Any]]:
+    rows = (
+        db.query(Document, Catalog, Event, Place, Organization)
+        .join(Catalog, Document.catalog_id == Catalog.id)
+        .join(Event, Document.event_id == Event.id)
+        .join(Place, Document.place_id == Place.id)
+        .outerjoin(Organization, Event.organization_id == Organization.id)
+        .filter(Document.id.in_(doc_ids))
+        .all()
+    )
+    return {_doc_id(doc): _meeting_hit(doc, catalog, event, place, organization) for doc, catalog, event, place, organization in rows}
+
+
+def _agenda_hits_by_item_id(db: SQLAlchemySession, item_ids: list[int]) -> dict[int, dict[str, Any]]:
+    rows = (
+        db.query(AgendaItem, Event, Place, Organization)
+        .join(Event, AgendaItem.event_id == Event.id)
+        .join(Place, Event.place_id == Place.id)
+        .outerjoin(Organization, Event.organization_id == Organization.id)
+        .filter(AgendaItem.id.in_(item_ids))
+        .all()
+    )
+    return {int(item.id): _agenda_hit(item, event, place, org) for item, event, place, org in rows}
+
+
+def _meeting_hit(doc: Document, catalog: Catalog, event: Event, place: Place, organization: Organization | None) -> dict[str, Any]:
+    return {
+        "id": f"doc_{doc.id}",
+        "db_id": doc.id,
+        "ocd_id": event.ocd_id,
+        "result_type": "meeting",
+        "catalog_id": catalog.id,
+        "filename": catalog.filename,
+        "url": catalog.url,
+        "content": (catalog.content or "")[:5000] if catalog.content else None,
+        "summary": catalog.summary,
+        "summary_extractive": catalog.summary_extractive,
+        "topics": catalog.topics,
+        "related_ids": catalog.related_ids,
+        "summary_is_stale": bool(
+            catalog.summary and (not catalog.content_hash or catalog.summary_source_hash != catalog.content_hash)
+        ),
+        "topics_is_stale": bool(
+            catalog.topics is not None and (not catalog.content_hash or catalog.topics_source_hash != catalog.content_hash)
+        ),
+        "people_metadata": [],
+        "event_name": event.name,
+        "meeting_category": event.meeting_type or "Other",
+        "organization": organization.name if organization else "City Council",
+        "date": event.record_date.isoformat() if event.record_date else None,
+        "city": place.display_name or place.name,
+        "state": place.state,
+    }
+
+
+def _agenda_hit(item: AgendaItem, event: Event, place: Place, org: Organization | None) -> dict[str, Any]:
+    return {
+        "id": f"item_{item.id}",
+        "db_id": item.id,
+        "ocd_id": item.ocd_id,
+        "result_type": "agenda_item",
+        "title": item.title,
+        "description": item.description,
+        "classification": item.classification,
+        "result": item.result,
+        "page_number": item.page_number,
+        "event_name": event.name,
+        "date": event.record_date.isoformat() if event.record_date else None,
+        "city": place.display_name or place.name,
+        "organization": org.name if org else "City Council",
+        "meeting_category": event.meeting_type or "Other",
+        "catalog_id": item.catalog_id,
+        "url": item.catalog.url if item.catalog else None,
+    }
+
+
+def _hydrate_candidates(candidates: list[SemanticCandidateLike], hits_by_db_id: dict[int, dict[str, Any]]) -> list[dict[str, Any]]:
+    hydrated = []
+    for candidate in candidates:
+        hit = hits_by_db_id.get(int(candidate.metadata.get("db_id") or 0))
+        if hit:
+            enriched = dict(hit)
+            enriched["semantic_score"] = round(float(candidate.score), 6)
+            hydrated.append(enriched)
+    return hydrated
+
+
+def _candidates_by_type(candidates: list[SemanticCandidateLike], *, result_type: str) -> list[SemanticCandidateLike]:
+    if result_type == "meeting":
+        return [candidate for candidate in candidates if str(candidate.metadata.get("result_type") or "meeting") == "meeting"]
+    return [candidate for candidate in candidates if str(candidate.metadata.get("result_type")) == result_type]
+
+
+def _ordered_hydrated_hits(
+    page_candidates: list[SemanticCandidateLike],
+    meeting_hits: list[dict[str, Any]],
+    agenda_hits: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    meeting_by_db = {hit["db_id"]: hit for hit in meeting_hits}
+    agenda_by_db = {hit["db_id"]: hit for hit in agenda_hits}
+    hits = []
+    for candidate in page_candidates:
+        result_type = str(candidate.metadata.get("result_type") or "meeting")
+        db_id = int(candidate.metadata.get("db_id") or 0)
+        hit = meeting_by_db.get(db_id) if result_type == "meeting" else agenda_by_db.get(db_id)
+        if hit:
+            hits.append(hit)
+    return hits
+
+
+def _doc_id(doc: Document) -> int:
+    return int(doc.id)

--- a/semantic_service/hydration.py
+++ b/semantic_service/hydration.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 from dataclasses import dataclass
 from typing import Any, Callable, Protocol
 
@@ -19,8 +20,9 @@ HydrateCandidates = Callable[[SQLAlchemySession, list[SemanticCandidateLike]], l
 
 @dataclass(frozen=True)
 class SemanticResponseTiming:
-    elapsed_ms: float
+    started_at: float
     engine: str | None
+    clock: Callable[[], float] = time.perf_counter
 
 
 def hydrate_meeting_hits(db: SQLAlchemySession, candidates: list[SemanticCandidateLike]) -> list[dict[str, Any]]:
@@ -56,6 +58,7 @@ def build_semantic_search_response(
     meeting_hits = hydrate_meetings(db, meeting_candidates)
     agenda_hits = hydrate_agenda_items(db, agenda_candidates)
     hits = _ordered_hydrated_hits(page_candidates, meeting_hits, agenda_hits)
+    elapsed_ms = round((timing.clock() - timing.started_at) * 1000.0, 2)
     return {
         "hits": hits,
         "estimatedTotalHits": len(deduped),
@@ -67,7 +70,7 @@ def build_semantic_search_response(
             "dedup_candidates": len(deduped),
             "k_used": retrieval_result.k_used,
             "expansion_steps": retrieval_result.expansion_steps,
-            "latency_ms": timing.elapsed_ms,
+            "latency_ms": elapsed_ms,
             "engine": timing.engine,
             **retrieval_result.diagnostics_extra,
         },

--- a/semantic_service/main.py
+++ b/semantic_service/main.py
@@ -234,14 +234,13 @@ def search_documents_semantic(
         logger.error("semantic search failed: %s", exc)
         raise HTTPException(status_code=500, detail="Internal semantic search error") from exc
 
-    elapsed_ms = round((time.perf_counter() - t0) * 1000.0, 2)
     engine = _semantic_backend_engine_for_diagnostics(backend)
     return build_semantic_search_response(
         db=db,
         retrieval_result=retrieval_result,
         limit=limit,
         offset=offset,
-        timing=SemanticResponseTiming(elapsed_ms=elapsed_ms, engine=engine),
+        timing=SemanticResponseTiming(started_at=t0, engine=engine),
         hydrate_meetings=_hydrate_meeting_hits,
         hydrate_agenda_items=_hydrate_agenda_hits,
     )

--- a/semantic_service/main.py
+++ b/semantic_service/main.py
@@ -16,7 +16,7 @@ from pipeline.config import (
     SEMANTIC_MAX_TOP_K,
     SEMANTIC_RERANK_CANDIDATE_LIMIT,
 )
-from pipeline.models import db_connect, Document, Event, Place, Catalog, AgendaItem, Organization
+from pipeline.models import db_connect
 from pipeline.semantic_index import (
     get_semantic_backend,
     SemanticConfigError,
@@ -32,6 +32,12 @@ from semantic_service.filters import (
     build_filter_values as _build_filter_values,
     build_meilisearch_filter_clauses as _build_meilisearch_filter_clauses,
     validate_date_format,
+)
+from semantic_service.hydration import (
+    SemanticResponseTiming,
+    build_semantic_search_response,
+    hydrate_agenda_hits,
+    hydrate_meeting_hits,
 )
 from semantic_service.retrieval import (
     SemanticRetrievalSettings,
@@ -119,102 +125,11 @@ def _merge_semantic_with_lexical_fallback(semantic_candidates, lexical_hits: lis
 
 
 def _hydrate_meeting_hits(db: SQLAlchemySession, candidates: list) -> list[dict]:
-    doc_ids = [int(c.metadata.get("db_id") or 0) for c in candidates if int(c.metadata.get("db_id") or 0) > 0]
-    if not doc_ids:
-        return []
-    rows = (
-        db.query(Document, Catalog, Event, Place, Organization)
-        .join(Catalog, Document.catalog_id == Catalog.id)
-        .join(Event, Document.event_id == Event.id)
-        .join(Place, Document.place_id == Place.id)
-        .outerjoin(Organization, Event.organization_id == Organization.id)
-        .filter(Document.id.in_(doc_ids))
-        .all()
-    )
-    by_doc_id = {}
-    for doc, catalog, event, place, organization in rows:
-        by_doc_id[doc.id] = {
-            "id": f"doc_{doc.id}",
-            "db_id": doc.id,
-            "ocd_id": event.ocd_id,
-            "result_type": "meeting",
-            "catalog_id": catalog.id,
-            "filename": catalog.filename,
-            "url": catalog.url,
-            "content": (catalog.content or "")[:5000] if catalog.content else None,
-            "summary": catalog.summary,
-            "summary_extractive": catalog.summary_extractive,
-            "topics": catalog.topics,
-            "related_ids": catalog.related_ids,
-            "summary_is_stale": bool(
-                catalog.summary and (not catalog.content_hash or catalog.summary_source_hash != catalog.content_hash)
-            ),
-            "topics_is_stale": bool(
-                catalog.topics is not None and (not catalog.content_hash or catalog.topics_source_hash != catalog.content_hash)
-            ),
-            "people_metadata": [],
-            "event_name": event.name,
-            "meeting_category": event.meeting_type or "Other",
-            "organization": organization.name if organization else "City Council",
-            "date": event.record_date.isoformat() if event.record_date else None,
-            "city": place.display_name or place.name,
-            "state": place.state,
-        }
-
-    hydrated = []
-    for cand in candidates:
-        doc_id = int(cand.metadata.get("db_id") or 0)
-        hit = by_doc_id.get(doc_id)
-        if not hit:
-            continue
-        enriched = dict(hit)
-        enriched["semantic_score"] = round(float(cand.score), 6)
-        hydrated.append(enriched)
-    return hydrated
+    return hydrate_meeting_hits(db, candidates)
 
 
 def _hydrate_agenda_hits(db: SQLAlchemySession, candidates: list) -> list[dict]:
-    item_ids = [int(c.metadata.get("db_id") or 0) for c in candidates if int(c.metadata.get("db_id") or 0) > 0]
-    if not item_ids:
-        return []
-    rows = (
-        db.query(AgendaItem, Event, Place, Organization)
-        .join(Event, AgendaItem.event_id == Event.id)
-        .join(Place, Event.place_id == Place.id)
-        .outerjoin(Organization, Event.organization_id == Organization.id)
-        .filter(AgendaItem.id.in_(item_ids))
-        .all()
-    )
-    by_item_id = {}
-    for item, event, place, org in rows:
-        by_item_id[item.id] = {
-            "id": f"item_{item.id}",
-            "db_id": item.id,
-            "ocd_id": item.ocd_id,
-            "result_type": "agenda_item",
-            "title": item.title,
-            "description": item.description,
-            "classification": item.classification,
-            "result": item.result,
-            "page_number": item.page_number,
-            "event_name": event.name,
-            "date": event.record_date.isoformat() if event.record_date else None,
-            "city": place.display_name or place.name,
-            "organization": org.name if org else "City Council",
-            "meeting_category": event.meeting_type or "Other",
-            "catalog_id": item.catalog_id,
-            "url": item.catalog.url if item.catalog else None,
-        }
-    hydrated = []
-    for cand in candidates:
-        item_id = int(cand.metadata.get("db_id") or 0)
-        hit = by_item_id.get(item_id)
-        if not hit:
-            continue
-        enriched = dict(hit)
-        enriched["semantic_score"] = round(float(cand.score), 6)
-        hydrated.append(enriched)
-    return hydrated
+    return hydrate_agenda_hits(db, candidates)
 
 
 @app.get("/health")
@@ -319,36 +234,14 @@ def search_documents_semantic(
         logger.error("semantic search failed: %s", exc)
         raise HTTPException(status_code=500, detail="Internal semantic search error") from exc
 
-    deduped = retrieval_result.deduped
-    page_candidates = deduped[offset : offset + limit]
-    meeting_candidates = [c for c in page_candidates if str(c.metadata.get("result_type") or "meeting") == "meeting"]
-    agenda_candidates = [c for c in page_candidates if str(c.metadata.get("result_type")) == "agenda_item"]
-    meeting_hits = _hydrate_meeting_hits(db, meeting_candidates)
-    agenda_hits = _hydrate_agenda_hits(db, agenda_candidates)
-    meeting_by_db = {hit["db_id"]: hit for hit in meeting_hits}
-    agenda_by_db = {hit["db_id"]: hit for hit in agenda_hits}
-    hits = []
-    for cand in page_candidates:
-        result_type = str(cand.metadata.get("result_type") or "meeting")
-        db_id = int(cand.metadata.get("db_id") or 0)
-        hit = meeting_by_db.get(db_id) if result_type == "meeting" else agenda_by_db.get(db_id)
-        if hit:
-            hits.append(hit)
     elapsed_ms = round((time.perf_counter() - t0) * 1000.0, 2)
     engine = _semantic_backend_engine_for_diagnostics(backend)
-    return {
-        "hits": hits,
-        "estimatedTotalHits": len(deduped),
-        "limit": limit,
-        "offset": offset,
-        "semantic_diagnostics": {
-            "raw_candidates": retrieval_result.raw_count,
-            "filtered_candidates": retrieval_result.filtered_count,
-            "dedup_candidates": len(deduped),
-            "k_used": retrieval_result.k_used,
-            "expansion_steps": retrieval_result.expansion_steps,
-            "latency_ms": elapsed_ms,
-            "engine": engine,
-            **retrieval_result.diagnostics_extra,
-        },
-    }
+    return build_semantic_search_response(
+        db=db,
+        retrieval_result=retrieval_result,
+        limit=limit,
+        offset=offset,
+        timing=SemanticResponseTiming(elapsed_ms=elapsed_ms, engine=engine),
+        hydrate_meetings=_hydrate_meeting_hits,
+        hydrate_agenda_items=_hydrate_agenda_hits,
+    )

--- a/tests/test_semantic_service_hydration.py
+++ b/tests/test_semantic_service_hydration.py
@@ -11,6 +11,7 @@ from semantic_service.retrieval import SemanticRetrievalResult
 
 
 def test_semantic_response_preserves_mixed_candidate_order_and_drops_missing_hits():
+    current_time = {"now": 1.0125}
     retrieval_result = SemanticRetrievalResult(
         deduped=[
             _candidate("meeting", 10, 100, 0.91),
@@ -29,7 +30,7 @@ def test_semantic_response_preserves_mixed_candidate_order_and_drops_missing_hit
         retrieval_result=retrieval_result,
         limit=3,
         offset=0,
-        timing=SemanticResponseTiming(elapsed_ms=12.5, engine="faiss"),
+        timing=SemanticResponseTiming(started_at=1.0, engine="faiss", clock=lambda: current_time["now"]),
         hydrate_meetings=lambda _db, _candidates: [
             {"db_id": 10, "id": "doc_10", "result_type": "meeting"},
             {"db_id": 30, "id": "doc_30", "result_type": "meeting"},
@@ -42,6 +43,34 @@ def test_semantic_response_preserves_mixed_candidate_order_and_drops_missing_hit
     assert response["semantic_diagnostics"]["dedup_candidates"] == 3
     assert response["semantic_diagnostics"]["latency_ms"] == 12.5
     assert response["semantic_diagnostics"]["engine"] == "faiss"
+
+
+def test_semantic_response_latency_includes_hydration_work():
+    current_time = {"now": 1.0}
+    retrieval_result = SemanticRetrievalResult(
+        deduped=[_candidate("meeting", 10, 100, 0.91)],
+        raw_count=1,
+        filtered_count=1,
+        k_used=200,
+        expansion_steps=0,
+        diagnostics_extra={},
+    )
+
+    def hydrate_after_db_work(_db, _candidates):
+        current_time["now"] = 1.025
+        return [{"db_id": 10, "id": "doc_10", "result_type": "meeting"}]
+
+    response = build_semantic_search_response(
+        db=MagicMock(),
+        retrieval_result=retrieval_result,
+        limit=1,
+        offset=0,
+        timing=SemanticResponseTiming(started_at=1.0, engine="faiss", clock=lambda: current_time["now"]),
+        hydrate_meetings=hydrate_after_db_work,
+        hydrate_agenda_items=lambda _db, _candidates: [],
+    )
+
+    assert response["semantic_diagnostics"]["latency_ms"] == 25.0
 
 
 def test_semantic_response_applies_offset_after_dedupe_before_hydration():
@@ -62,7 +91,7 @@ def test_semantic_response_applies_offset_after_dedupe_before_hydration():
         retrieval_result=retrieval_result,
         limit=1,
         offset=1,
-        timing=SemanticResponseTiming(elapsed_ms=1.0, engine=None),
+        timing=SemanticResponseTiming(started_at=1.0, engine=None, clock=lambda: 1.001),
         hydrate_meetings=lambda _db, candidates: [
             {"db_id": candidates[0].metadata["db_id"], "id": f"doc_{candidates[0].metadata['db_id']}"}
         ],

--- a/tests/test_semantic_service_hydration.py
+++ b/tests/test_semantic_service_hydration.py
@@ -1,0 +1,126 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from pipeline.semantic_index import SemanticCandidate
+from semantic_service.hydration import (
+    SemanticResponseTiming,
+    build_semantic_search_response,
+    hydrate_meeting_hits,
+)
+from semantic_service.retrieval import SemanticRetrievalResult
+
+
+def test_semantic_response_preserves_mixed_candidate_order_and_drops_missing_hits():
+    retrieval_result = SemanticRetrievalResult(
+        deduped=[
+            _candidate("meeting", 10, 100, 0.91),
+            _candidate("agenda_item", 20, 100, 0.82),
+            _candidate("meeting", 30, 300, 0.73),
+        ],
+        raw_count=4,
+        filtered_count=3,
+        k_used=200,
+        expansion_steps=1,
+        diagnostics_extra={"retrieval_mode": "vector_direct"},
+    )
+
+    response = build_semantic_search_response(
+        db=MagicMock(),
+        retrieval_result=retrieval_result,
+        limit=3,
+        offset=0,
+        timing=SemanticResponseTiming(elapsed_ms=12.5, engine="faiss"),
+        hydrate_meetings=lambda _db, _candidates: [
+            {"db_id": 10, "id": "doc_10", "result_type": "meeting"},
+            {"db_id": 30, "id": "doc_30", "result_type": "meeting"},
+        ],
+        hydrate_agenda_items=lambda _db, _candidates: [],
+    )
+
+    assert [hit["id"] for hit in response["hits"]] == ["doc_10", "doc_30"]
+    assert response["estimatedTotalHits"] == 3
+    assert response["semantic_diagnostics"]["dedup_candidates"] == 3
+    assert response["semantic_diagnostics"]["latency_ms"] == 12.5
+    assert response["semantic_diagnostics"]["engine"] == "faiss"
+
+
+def test_semantic_response_applies_offset_after_dedupe_before_hydration():
+    retrieval_result = SemanticRetrievalResult(
+        deduped=[
+            _candidate("meeting", 10, 100, 0.91),
+            _candidate("meeting", 20, 200, 0.82),
+        ],
+        raw_count=2,
+        filtered_count=2,
+        k_used=200,
+        expansion_steps=0,
+        diagnostics_extra={},
+    )
+
+    response = build_semantic_search_response(
+        db=MagicMock(),
+        retrieval_result=retrieval_result,
+        limit=1,
+        offset=1,
+        timing=SemanticResponseTiming(elapsed_ms=1.0, engine=None),
+        hydrate_meetings=lambda _db, candidates: [
+            {"db_id": candidates[0].metadata["db_id"], "id": f"doc_{candidates[0].metadata['db_id']}"}
+        ],
+        hydrate_agenda_items=lambda _db, _candidates: [],
+    )
+
+    assert [hit["id"] for hit in response["hits"]] == ["doc_20"]
+    assert response["estimatedTotalHits"] == 2
+    assert response["limit"] == 1
+    assert response["offset"] == 1
+
+
+def test_hydrate_meeting_hits_rounds_semantic_score_to_six_decimals():
+    db = MagicMock()
+    query = db.query.return_value
+    query.join.return_value = query
+    query.outerjoin.return_value = query
+    query.filter.return_value = query
+    query.all.return_value = [(_doc(), _catalog(), _event(), _place(), None)]
+
+    hits = hydrate_meeting_hits(db, [_candidate("meeting", 10, 100, 0.123456789)])
+
+    assert hits[0]["semantic_score"] == 0.123457
+    assert hits[0]["id"] == "doc_10"
+    assert hits[0]["organization"] == "City Council"
+
+
+def _candidate(result_type: str, db_id: int, catalog_id: int, score: float) -> SemanticCandidate:
+    return SemanticCandidate(
+        row_id=db_id,
+        score=score,
+        metadata={"result_type": result_type, "db_id": db_id, "catalog_id": catalog_id},
+    )
+
+
+def _doc() -> SimpleNamespace:
+    return SimpleNamespace(id=10, catalog_id=100, event_id=1, place_id=1)
+
+
+def _catalog() -> SimpleNamespace:
+    return SimpleNamespace(
+        id=100,
+        filename="agenda.pdf",
+        url="https://example.test/agenda.pdf",
+        content="Meeting content",
+        summary="Summary",
+        summary_extractive=None,
+        topics=["housing"],
+        related_ids=[],
+        content_hash="abc",
+        summary_source_hash="abc",
+        topics_source_hash="abc",
+    )
+
+
+def _event() -> SimpleNamespace:
+    return SimpleNamespace(ocd_id="ocd-1", name="Council Meeting", meeting_type=None, record_date=None)
+
+
+def _place() -> SimpleNamespace:
+    return SimpleNamespace(display_name="Cupertino", name="cupertino", state="CA")


### PR DESCRIPTION
## What changed
- Moved semantic meeting and agenda hydration into `semantic_service/hydration.py`.
- Moved final semantic search response assembly into the hydration helper.
- Kept `semantic_service.main` as the route facade, DB session owner, and monkeypatch surface through `_hydrate_meeting_hits` and `_hydrate_agenda_hits` wrappers.
- Added behavior locks for mixed result ordering, pagination after dedupe, hydration misses, and semantic score rounding.

## Why
This is Batch G lane 3. It reduces `semantic_service/main.py` size and complexity while preserving the `/search/semantic` response contract and existing test patch seams.

## Risk / compatibility impact
- No API route, response key, status code, DB ownership, runtime config, or backend-selection change.
- Hydration helpers receive the existing FastAPI-owned DB session; they do not create, close, commit, or roll back sessions.
- Existing facade patch seams remain in `semantic_service.main`.

## Verification
- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_semantic_service_hydration.py`
- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_semantic_service_api.py tests/test_search_pgvector_hybrid_rerank.py tests/test_semantic_recall_filters.py`
- PASS: `./.venv/bin/ruff check semantic_service tests/test_semantic_service_hydration.py`
- PASS: `./.venv/bin/python -m radon cc semantic_service -s -n C`
- PASS: `./.venv/bin/ruff check api pipeline scripts tests`
- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_repository_guardrails.py`
- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_semantic_service_api.py tests/test_search_pgvector_hybrid_rerank.py tests/test_semantic_recall_filters.py tests/test_semantic_search_feature_flag.py tests/test_semantic_search_api.py tests/test_semantic_dedup_catalog.py tests/test_semantic_backend_selection.py tests/test_semantic_service_hydration.py`
- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_api.py tests/test_query_builder_filters.py tests/test_query_builder_parity_search_vs_trends.py`
- PASS: `git diff --check`

## Review
- PASS: independent code review found no Critical, Important, or Minor issues.

## Remaining deficits
- Batch G docs/guardrails follow-up remains separate after this code lane merges.
