### PR TITLE
Track Batch G semantic service cleanup

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Town Council Architecture (2026)
 
-Last updated: 2026-05-11
+Last updated: 2026-05-12
 
 ## 1) System Overview
 
@@ -313,6 +313,7 @@ Primary owners:
 - Update semantic retrieval behavior:
   - `api/main.py` (FastAPI app facade and compatibility surface)
   - `api/search_routes.py` (`/search` and `/search/semantic` paths)
+  - `semantic_service/main.py` route facade plus focused `semantic_service/candidates.py`, `semantic_service/filters.py`, `semantic_service/retrieval.py`, and `semantic_service/hydration.py` helpers
   - `pipeline/semantic_index.py`
   - `pipeline/db_migrate.py` facade plus focused `pipeline/db_migration_*` helpers
   - `pipeline/migrate_v8.py` compatibility wrapper and `pipeline/migration_pgvector_semantic_embeddings.py`
@@ -324,7 +325,7 @@ Primary owners:
 - Async orchestration and writes: `pipeline/tasks.py` facade plus focused `pipeline/task_*` helpers, vote extraction through `pipeline/vote_extractor.py` plus focused `pipeline/vote_extraction_*` helpers
 - Inference abstraction and provider telemetry: `pipeline/llm.py` facade plus focused `pipeline/local_ai_*` helpers, `pipeline/agenda_extraction.py`, `pipeline/llm_provider.py`, `pipeline/http_inference_provider.py` facade plus focused `pipeline/http_inference_*` helpers, `pipeline/inprocess_inference_provider.py`, `pipeline/provider_telemetry.py`, `pipeline/metrics.py`, `pipeline/metrics_provider_recorders.py`, `pipeline/metrics_redis_backend.py`
 - API surface and auth: `api/main.py`, `api/app_setup.py`, `api/search_routes.py`, `api/search_read_routes.py` facade plus focused `api/search_read_*` helpers, `api/task_routes.py` facade plus focused `api/task_*` helpers, `api/search_support.py` facade plus focused `api/search/*_support.py` helpers, `api/search/query_builder.py`, `api/metrics.py`
-- Semantic retrieval and embeddings: `pipeline/semantic_index.py`, `pipeline/semantic_faiss_backend.py`, `pipeline/semantic_pgvector_backend.py`, focused semantic backend helpers, `pipeline/models.py` facade plus focused `pipeline/model_*` modules
+- Semantic retrieval and embeddings: `semantic_service/main.py` route facade plus focused `semantic_service/*` helpers, `pipeline/semantic_index.py`, `pipeline/semantic_faiss_backend.py`, `pipeline/semantic_pgvector_backend.py`, focused semantic backend helpers, `pipeline/models.py` facade plus focused `pipeline/model_*` modules
 - Frontend query/task UX: `frontend/app/page.js`, `frontend/state/search-state.js`, `frontend/components/ResultCard.js`
 - Data model and persistence: `pipeline/models.py` facade plus focused `pipeline/model_*` modules, `pipeline/db_migrate.py` facade plus focused `pipeline/db_migration_*` helpers, `pipeline/migrate_v8.py` and `pipeline/migrate_v9.py` compatibility wrappers, descriptive `pipeline/migration_*` modules
 - Onboarding orchestration and evaluation: `scripts/onboard_city_wave.sh`, `scripts/check_city_crawl_evidence.py`, `scripts/evaluate_city_onboarding.py` facade plus focused `pipeline/city_onboarding_*` helpers

--- a/docs/ADR.md
+++ b/docs/ADR.md
@@ -8,6 +8,26 @@ Use each entry to record:
 - the affected boundary or contract
 - links to the canonical docs that carry the ongoing operational or architecture detail
 
+## 2026-05-12: Track Batch G semantic service cleanup helpers
+
+- Status: Accepted
+- Decision:
+  - Batch G keeps semantic service complexity cleanup behind the stable `semantic_service/main.py` route facade.
+  - `semantic_service/candidates.py` owns candidate parsing, metadata filter matching, and dedupe helpers.
+  - `semantic_service/filters.py` owns semantic filter validation and Meilisearch filter wrapping.
+  - `semantic_service/retrieval.py` owns semantic retrieval orchestration, lexical recall, fallback diagnostics, and vector expansion.
+  - `semantic_service/hydration.py` owns DB hydration and final semantic response assembly.
+- Why:
+  - Batch G reduced the last semantic service god-module and Radon hotspot without changing `/search/semantic`, `/health`, diagnostics, backend selection, DB session ownership, or monkeypatch seams.
+  - Keeping docs and guardrails in one follow-up PR avoids source-map conflicts across the staged semantic service code PRs.
+- Affected boundaries:
+  - `semantic_service/main.py` remains the ASGI app, route facade, runtime env owner, DB dependency owner, and compatibility patch surface.
+  - Helper modules receive dependencies explicitly and do not import `semantic_service.main`.
+  - Radon and Vulture remain advisory local audits, not CI gates.
+- Canonical references:
+  - [ARCHITECTURE.md](../ARCHITECTURE.md)
+  - [docs/ENGINEERING_GUARDRAILS.md](ENGINEERING_GUARDRAILS.md)
+
 ## 2026-05-11: Track Batch F complexity cleanup helpers
 
 - Status: Accepted

--- a/docs/ENGINEERING_GUARDRAILS.md
+++ b/docs/ENGINEERING_GUARDRAILS.md
@@ -44,7 +44,11 @@ cd <REPO_ROOT>
 - no raw `print(...)` in non-CLI pipeline modules
 - no silent broad exception handlers or broad exception allowlist drift
 - existing Town Council policy tests for fail-fast runtime behavior, freshness contracts, and profile comparability
-- cleanup module families for downloader, NLP entities, segment-city CLI, hydration CLIs, models, DB migrations, LocalAI, indexing, semantic backends, summary text and backfill, vote extraction, provider/person utilities, reporting/profile scripts, shared helper utilities, agenda QA, task/API/search helpers, onboarding/repair scripts, and prior facade splits stay under the 300-line target
+- cleanup module families for downloader, NLP entities, segment-city CLI, hydration CLIs, models, DB migrations, LocalAI, indexing, semantic backends and service helpers, summary text and backfill, vote extraction, provider/person utilities, reporting/profile scripts, shared helper utilities, agenda QA, task/API/search helpers, onboarding/repair scripts, and prior facade splits stay under the 300-line target
+
+Batch G cleanup coverage includes:
+- semantic service facade and helpers: `semantic_service/main.py`, `semantic_service/candidates.py`, `semantic_service/filters.py`, `semantic_service/retrieval.py`, `semantic_service/hydration.py`
+- semantic service helpers must not import `semantic_service.main`; dependencies flow from the route facade into helpers
 
 Batch F cleanup coverage includes:
 - search-read facade and helpers: `api/search_read_routes.py`, `api/search_read_meilisearch.py`, `api/search_read_params.py`, `api/search_read_results.py`

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -429,6 +429,13 @@ SEMANTIC_BACKEND_CLEANUP_MODULES = (
     "pipeline/semantic_pgvector_rows.py",
     "pipeline/semantic_pgvector_rerank.py",
 )
+SEMANTIC_SERVICE_CLEANUP_MODULES = (
+    "semantic_service/main.py",
+    "semantic_service/candidates.py",
+    "semantic_service/filters.py",
+    "semantic_service/retrieval.py",
+    "semantic_service/hydration.py",
+)
 SUMMARY_TEXT_CLEANUP_MODULES = (
     "pipeline/text_generation.py",
     "pipeline/summary_text_formatting.py",
@@ -1175,6 +1182,29 @@ def test_semantic_backend_cleanup_modules_stay_under_size_target():
     ]
 
     assert oversized_modules == []
+
+
+def test_semantic_service_cleanup_modules_stay_under_size_target():
+    oversized_modules = [
+        module_path
+        for module_path in SEMANTIC_SERVICE_CLEANUP_MODULES
+        if len((ROOT / module_path).read_text(encoding="utf-8").splitlines()) > 300
+    ]
+
+    assert oversized_modules == []
+
+
+def test_batch_g_semantic_service_helpers_do_not_import_facade():
+    forbidden_imports: list[str] = []
+    for module_path in (
+        ROOT / "semantic_service" / "candidates.py",
+        ROOT / "semantic_service" / "filters.py",
+        ROOT / "semantic_service" / "retrieval.py",
+        ROOT / "semantic_service" / "hydration.py",
+    ):
+        forbidden_imports.extend(_forbidden_imports(module_path, {"semantic_service.main"}))
+
+    assert forbidden_imports == []
 
 
 def test_summary_text_cleanup_modules_stay_under_size_target():

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -18,6 +18,7 @@ TEXT_FILE_SUFFIXES = {
     ".yml",
 }
 GUARDRAIL_SCAN_PREFIXES = {"api", "pipeline", "scripts", "tests", "docs", "ops", "experiments"}
+FACADE_IMPORT_PACKAGE_ROOTS = ("api", "pipeline", "scripts", "semantic_service", "tests")
 PERSONAL_PATH_PATTERNS = (
     re.compile(r"/Users/[^/\s]+/"),
     re.compile(r"/home/[^/\s]+/"),
@@ -562,7 +563,7 @@ def _mypy_enrolled_paths() -> tuple[str, ...]:
 
 def _module_name_for_path(module_path: Path) -> str:
     module_parts = module_path.with_suffix("").parts
-    for package_name in ("api", "pipeline", "scripts", "tests"):
+    for package_name in FACADE_IMPORT_PACKAGE_ROOTS:
         if package_name in module_parts:
             package_index = module_parts.index(package_name)
             return ".".join(module_parts[package_index:])
@@ -608,13 +609,11 @@ def _forbidden_imports(module_path: Path, forbidden_modules: set[str]) -> list[s
             )
             if node.level == 0 and node.module in forbidden_modules:
                 found_imports.append(node.module)
-            if node.level == 0 and node.module == "pipeline":
+            if node.level == 0 and node.module:
                 found_imports.extend(
-                    f"pipeline.{alias.name}" for alias in node.names if f"pipeline.{alias.name}" in forbidden_modules
-                )
-            if node.level == 0 and node.module == "scripts":
-                found_imports.extend(
-                    f"scripts.{alias.name}" for alias in node.names if f"scripts.{alias.name}" in forbidden_modules
+                    f"{node.module}.{alias.name}"
+                    for alias in node.names
+                    if f"{node.module}.{alias.name}" in forbidden_modules
                 )
             if node.level == 0 and node.module:
                 for forbidden_module in forbidden_modules:
@@ -720,12 +719,23 @@ def test_facade_import_guardrail_detects_relative_imports(tmp_path: Path):
     script_helper = tmp_path / "scripts" / "helper.py"
     script_helper.parent.mkdir(parents=True)
     script_helper.write_text("from .profile_pipeline import main\n", encoding="utf-8")
+    semantic_helper = tmp_path / "semantic_service" / "helper.py"
+    semantic_helper.parent.mkdir(parents=True)
+    semantic_helper.write_text(
+        "from . import main\nfrom .main import app\nfrom semantic_service import main as semantic_main\n",
+        encoding="utf-8",
+    )
 
     assert _forbidden_imports(
         pipeline_helper,
         {"pipeline.vote_extractor", "pipeline.vote_extraction_runner"},
     ) == ["pipeline.vote_extractor", "pipeline.vote_extraction_runner"]
     assert _forbidden_imports(script_helper, {"scripts.profile_pipeline"}) == ["scripts.profile_pipeline"]
+    assert _forbidden_imports(semantic_helper, {"semantic_service.main"}) == [
+        "semantic_service.main",
+        "semantic_service.main",
+        "semantic_service.main",
+    ]
 
 
 def test_broad_exception_allowlist_stays_explicit():


### PR DESCRIPTION
## What changed
- Added Batch G semantic service source ownership to `ARCHITECTURE.md`.
- Added an ADR entry for the semantic service facade-preserving cleanup.
- Added Batch G semantic service helper coverage to `docs/ENGINEERING_GUARDRAILS.md`.
- Enrolled `semantic_service/main.py` and its focused helpers in repository guardrails.
- Added a guardrail that semantic service helpers do not import the `semantic_service.main` facade.

## Why
Batch G code PRs split semantic service candidates, filters, retrieval, and hydration behind the stable route facade. This follow-up keeps source maps and guardrails aligned after the code lanes merged.

## Risk / compatibility impact
- No runtime behavior change.
- No API, CLI, DB, dependency, workflow, formatter-scope, or mypy-scope change.
- Guardrail scope only adds Batch G semantic service cleanup-family coverage.

## Verification
- PASS: `./.venv/bin/ruff check api pipeline scripts tests`
- PASS: `./.venv/bin/mypy`
- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_repository_guardrails.py`
- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py`
- PASS: `git diff --check`

## Advisory audit snapshot
- PASS: `./.venv/bin/python -m radon cc api pipeline scripts council_crawler semantic_service -s -n D`
- NON-GATING FAIL: `./.venv/bin/python -m vulture api pipeline scripts council_crawler semantic_service tests --min-confidence 80`
  - Existing findings: unused `bind` fixture args in `tests/test_startup_purge_gating.py` and `tests/test_startup_purge_locking.py`.
  - Not changed here because this PR is docs/guardrails only and Vulture remains advisory.

## Remaining deficits
- The advisory Vulture findings above remain outside this PR scope.
