### PR TITLE
Fix localhost derived actions

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -115,13 +115,12 @@ flowchart LR
     API --> Meili
     API --> Semantic
     People -->|"people reads"| API
-    UI -->|"POST summarize/segment/topics/extract/votes"| API
+    UI -->|"proxied protected catalog reads/writes"| API
     API <--> Queue --> Worker --> LocalAI
     LocalAI --> InProc
     LocalAI --> HttpProv --> HttpSvc
     Worker --> Core
     UI -->|"GET /tasks/{id}"| API
-    UI -->|"GET /catalog/{id}/derived_status"| API
 
     API -. metrics .-> Prom
     Worker -. metrics .-> Prom
@@ -428,7 +427,7 @@ Owners:
 | Trends reads/export | `GET /trends/topics`, `GET /trends/compare`, `GET /trends/export` | none | no | `api/main.py`, `api/search_routes.py`, `api/trends_routes.py`, `api/search/query_builder.py` |
 | Protected generation writes | `POST /summarize/{catalog_id}`, `POST /segment/{catalog_id}`, `POST /topics/{catalog_id}`, `POST /extract/{catalog_id}`, `POST /votes/{catalog_id}` | `X-API-Key` | yes (task id returned) | `api/main.py`, `api/task_routes.py`, `pipeline/tasks.py` |
 | Task lifecycle | `GET /tasks/{task_id}` | none | n/a | `api/main.py`, `api/task_routes.py`, Celery task backend |
-| Derived status/readability | `GET /catalog/{catalog_id}/derived_status`, `GET /catalog/{catalog_id}/content` | `X-API-Key` | no | `api/main.py`, `api/catalog_routes.py` |
+| Derived status/readability | `GET /catalog/{catalog_id}/derived_status`, `GET /catalog/{catalog_id}/content`, `GET /catalog/{catalog_id}/agenda_items` | `X-API-Key` | no | `api/main.py`, `api/catalog_routes.py` |
 | Issue reporting | `POST /report-issue` | `X-API-Key` | no | `api/main.py`, `api/reporting_routes.py` |
 
 ### Data Contract

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Note on Full Text after restart:
 If `STARTUP_PURGE_DERIVED=true`, extracted text is cleared from the DB on startup.
 The checked-in base `docker-compose.yml` defaults this to `false`; `docker-compose.dev.yml` turns it on for dev convenience.
 (`pipeline/config.py` also defaults to `false` unless env is explicitly set.)
-The UI Full Text tab pulls canonical text from Postgres (`/catalog/{id}/content`), so it may show **Not extracted yet** until you click **Re-extract text** for that record.
+The UI Full Text tab pulls canonical text from Postgres through the same-origin frontend proxy for `GET /catalog/{id}/content`, so it may show **Not extracted yet** until you click **Re-extract text** for that record.
 
 ### 2.5) Verify containers are using the latest image
 This catches “stale image” problems early (for example, missing Python deps).

--- a/api/catalog_routes.py
+++ b/api/catalog_routes.py
@@ -19,9 +19,17 @@ BATCH_REQUEST_TOO_LARGE_DETAIL = "Batch request too large. Limit is 50 IDs."
 DOCUMENT_NOT_FOUND_DETAIL = "Document not found"
 PAGE_MARKER_PREFIX = "[PAGE "
 VALID_AGENDA_SEGMENTATION_STATUSES = {None, "complete", "empty", "failed"}
+AGENDA_ITEM_CANONICAL_SOURCE = "catalog_agenda_items"
+AGENDA_ITEM_SEGMENTATION_SOURCE = "llm"
 
 
-def _agenda_item_payload(item: AgendaItem) -> dict[str, Any]:
+def _agenda_item_source(catalog: Catalog) -> str:
+    if getattr(catalog, "agenda_segmentation_status", None) == "complete":
+        return AGENDA_ITEM_SEGMENTATION_SOURCE
+    return AGENDA_ITEM_CANONICAL_SOURCE
+
+
+def _agenda_item_payload(item: AgendaItem, *, source: str) -> dict[str, Any]:
     return {
         "id": item.id,
         "order": item.order,
@@ -31,7 +39,7 @@ def _agenda_item_payload(item: AgendaItem) -> dict[str, Any]:
         "result": item.result,
         "page_number": item.page_number,
         "votes": item.votes,
-        "source": "catalog_agenda_items",
+        "source": source,
     }
 
 
@@ -134,9 +142,10 @@ def build_catalog_router(
             .order_by(AgendaItem.order)
             .all()
         )
+        agenda_item_source = _agenda_item_source(catalog)
         return {
             "catalog_id": catalog_id,
-            "items": [_agenda_item_payload(item) for item in agenda_items],
+            "items": [_agenda_item_payload(item, source=agenda_item_source) for item in agenda_items],
         }
 
     @router.get("/catalog/{catalog_id}/derived_status", dependencies=[Depends(verify_api_key_dependency)])

--- a/api/catalog_routes.py
+++ b/api/catalog_routes.py
@@ -21,6 +21,20 @@ PAGE_MARKER_PREFIX = "[PAGE "
 VALID_AGENDA_SEGMENTATION_STATUSES = {None, "complete", "empty", "failed"}
 
 
+def _agenda_item_payload(item: AgendaItem) -> dict[str, Any]:
+    return {
+        "id": item.id,
+        "order": item.order,
+        "title": item.title,
+        "description": item.description,
+        "classification": item.classification,
+        "result": item.result,
+        "page_number": item.page_number,
+        "votes": item.votes,
+        "source": "catalog_agenda_items",
+    }
+
+
 def _summary_doc_kind_and_hashes(
     db: SQLAlchemySession,
     catalog_id: int,
@@ -103,6 +117,26 @@ def build_catalog_router(
             "chars": len(catalog.content),
             "has_page_markers": PAGE_MARKER_PREFIX in catalog.content,
             "content": catalog.content,
+        }
+
+    @router.get("/catalog/{catalog_id}/agenda_items", dependencies=[Depends(verify_api_key_dependency)])
+    def get_catalog_agenda_items(
+        catalog_id: int = Path(..., ge=1),
+        db: SQLAlchemySession = Depends(get_db_dependency),
+    ) -> dict[str, Any]:
+        catalog = db.get(Catalog, catalog_id)
+        if not catalog:
+            raise HTTPException(status_code=404, detail=DOCUMENT_NOT_FOUND_DETAIL)
+
+        agenda_items = (
+            db.query(AgendaItem)
+            .filter(AgendaItem.catalog_id == catalog_id)
+            .order_by(AgendaItem.order)
+            .all()
+        )
+        return {
+            "catalog_id": catalog_id,
+            "items": [_agenda_item_payload(item) for item in agenda_items],
         }
 
     @router.get("/catalog/{catalog_id}/derived_status", dependencies=[Depends(verify_api_key_dependency)])

--- a/docs/ADR.md
+++ b/docs/ADR.md
@@ -468,7 +468,7 @@ Use each entry to record:
   - Keeping `api.main` as the facade preserves current imports, dependency overrides, and Docker `main:app` behavior while narrowing implementation ownership.
 - Affected boundaries:
   - `api/main.py` remains the ASGI app and route-wiring boundary.
-  - `api/catalog_routes.py` owns `/catalog/batch`, `/catalog/{catalog_id}/content`, and `/catalog/{catalog_id}/derived_status`.
+  - `api/catalog_routes.py` owns `/catalog/batch`, `/catalog/{catalog_id}/content`, `/catalog/{catalog_id}/derived_status`, and `/catalog/{catalog_id}/agenda_items`.
   - `api/task_routes.py` keeps owning task dispatch while using the `api.main` facade for `_summary_doc_kind_and_hashes`.
 - Canonical references:
   - [ARCHITECTURE.md](../ARCHITECTURE.md)

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,6 +1,6 @@
 # Operations Runbook
 
-Last updated: 2026-05-11
+Last updated: 2026-05-12
 
 ## Core workflow
 
@@ -467,7 +467,7 @@ docker compose start api worker frontend monitor
   - `STARTUP_PURGE_DERIVED=false` by default for `api`, `worker`, and `pipeline`
   - the base API service no longer runs `uvicorn --reload`
   - dev-only convenience now lives in `docker-compose.dev.yml`
-- Frontend privileged actions now flow through same-origin Next route handlers instead of embedding `NEXT_PUBLIC_API_AUTH_KEY` in the browser bundle.
+- Frontend protected catalog reads and privileged actions now flow through same-origin Next route handlers instead of embedding `NEXT_PUBLIC_API_AUTH_KEY` in the browser bundle.
   - required frontend server-side env:
     - `INTERNAL_API_BASE_URL` for backend-to-backend calls, default `http://api:8000`
     - `API_AUTH_KEY` for forwarding privileged requests
@@ -539,8 +539,11 @@ npx serve out
 - Trigger: push to `master` or manual dispatch
 - Output: static export deployed to GitHub Pages
 
-## Protected write endpoints
+## Protected catalog and write endpoints
 These routes require `X-API-Key`:
+- `GET /catalog/{catalog_id}/content`
+- `GET /catalog/{catalog_id}/derived_status`
+- `GET /catalog/{catalog_id}/agenda_items`
 - `POST /summarize/{catalog_id}`
 - `POST /segment/{catalog_id}`
 - `POST /topics/{catalog_id}`

--- a/frontend/app/api/catalog/[catalogId]/agenda_items/route.js
+++ b/frontend/app/api/catalog/[catalogId]/agenda_items/route.js
@@ -4,6 +4,6 @@ export async function GET(_request, { params }) {
   const { catalogId } = await params;
   return proxyBackendJson({
     method: "GET",
-    path: `/catalog/${catalogId}/content`,
+    path: `/catalog/${catalogId}/agenda_items`,
   });
 }

--- a/frontend/app/api/catalog/[catalogId]/derived_status/route.js
+++ b/frontend/app/api/catalog/[catalogId]/derived_status/route.js
@@ -1,8 +1,9 @@
 import { proxyBackendJson } from "../../../_lib/backend";
 
 export async function GET(_request, { params }) {
+  const { catalogId } = await params;
   return proxyBackendJson({
     method: "GET",
-    path: `/catalog/${params.catalogId}/derived_status`,
+    path: `/catalog/${catalogId}/derived_status`,
   });
 }

--- a/frontend/app/api/extract/[catalogId]/route.js
+++ b/frontend/app/api/extract/[catalogId]/route.js
@@ -1,9 +1,10 @@
 import { proxyBackendJson } from "../../_lib/backend";
 
 export async function POST(request, { params }) {
+  const { catalogId } = await params;
   return proxyBackendJson({
     method: "POST",
-    path: `/extract/${params.catalogId}`,
+    path: `/extract/${catalogId}`,
     searchParams: request.nextUrl.searchParams,
   });
 }

--- a/frontend/app/api/segment/[catalogId]/route.js
+++ b/frontend/app/api/segment/[catalogId]/route.js
@@ -1,9 +1,10 @@
 import { proxyBackendJson } from "../../_lib/backend";
 
 export async function POST(request, { params }) {
+  const { catalogId } = await params;
   return proxyBackendJson({
     method: "POST",
-    path: `/segment/${params.catalogId}`,
+    path: `/segment/${catalogId}`,
     searchParams: request.nextUrl.searchParams,
   });
 }

--- a/frontend/app/api/summarize/[catalogId]/route.js
+++ b/frontend/app/api/summarize/[catalogId]/route.js
@@ -1,9 +1,10 @@
 import { proxyBackendJson } from "../../_lib/backend";
 
 export async function POST(request, { params }) {
+  const { catalogId } = await params;
   return proxyBackendJson({
     method: "POST",
-    path: `/summarize/${params.catalogId}`,
+    path: `/summarize/${catalogId}`,
     searchParams: request.nextUrl.searchParams,
   });
 }

--- a/frontend/app/api/topics/[catalogId]/route.js
+++ b/frontend/app/api/topics/[catalogId]/route.js
@@ -1,9 +1,10 @@
 import { proxyBackendJson } from "../../_lib/backend";
 
 export async function POST(request, { params }) {
+  const { catalogId } = await params;
   return proxyBackendJson({
     method: "POST",
-    path: `/topics/${params.catalogId}`,
+    path: `/topics/${catalogId}`,
     searchParams: request.nextUrl.searchParams,
   });
 }

--- a/frontend/components/ResultCard.js
+++ b/frontend/components/ResultCard.js
@@ -467,14 +467,14 @@ export default function ResultCard({ hit, onPersonClick, onTopicClick }) {
         setIsSegmenting(false);
         // Refresh derived status so "Not generated yet" clears immediately after segmentation.
         fetchDerivedStatus();
-        fetchAgendaItems();
+        if (data.items.length === 0) fetchAgendaItems();
       } else if (data.task_id) {
         addPollStop(pollTaskStatus(data.task_id, (result) => {
           setAgendaItems(result);
           setIsSegmenting(false);
           // Segmentation creates AgendaItem rows; update derived status so badges stay in sync.
           fetchDerivedStatus();
-          fetchAgendaItems();
+          if (result.length === 0) fetchAgendaItems();
         }, (error) => {
           setAgendaActionError(error ? `Agenda segmentation failed: ${error}` : "Agenda segmentation failed.");
           setIsSegmenting(false);

--- a/frontend/components/ResultCard.js
+++ b/frontend/components/ResultCard.js
@@ -7,7 +7,13 @@ import {
 } from "lucide-react";
 import DataTable from "./DataTable";
 import LineageTimeline from "./LineageTimeline";
-import { buildApiUrl, getApiHeaders, isDemoMode, TRENDS_DASHBOARD_ENABLED } from "../lib/api";
+import {
+  buildApiUrl,
+  buildProtectedCatalogApiUrl,
+  getApiHeaders,
+  isDemoMode,
+  TRENDS_DASHBOARD_ENABLED,
+} from "../lib/api";
 import textFormatter from "../lib/textFormatter";
 
 const { renderFormattedExtractedText } = textFormatter;
@@ -15,6 +21,29 @@ const AI_DISCLAIMER_TEXT = "AI-generated content may be incomplete or inaccurate
 const TASK_POLL_INITIAL_INTERVAL_MS = 1500;
 const TASK_POLL_MAX_INTERVAL_MS = 5000;
 const TASK_POLL_MAX_ATTEMPTS = 45;
+
+function extractErrorDetail(payload, fallback) {
+  if (payload && typeof payload.detail === "string") return payload.detail;
+  if (payload && typeof payload.error === "string") return payload.error;
+  if (payload && typeof payload.reason === "string") return payload.reason;
+  return fallback;
+}
+
+async function readJsonResponse(response, actionLabel) {
+  let payload = null;
+  try {
+    payload = await response.json();
+  } catch {
+    if (response.ok) return {};
+  }
+
+  if (!response.ok) {
+    const detail = extractErrorDetail(payload, response.statusText || "Request failed");
+    throw new Error(`${actionLabel} failed (HTTP ${response.status}): ${detail}`);
+  }
+
+  return payload || {};
+}
 
 // Poll background tasks until complete/failed.
 function pollTaskStatus(taskId, callback, onError, type = "summary") {
@@ -33,7 +62,7 @@ function pollTaskStatus(taskId, callback, onError, type = "summary") {
     if (!active) return true;
     try {
       const res = await fetch(buildApiUrl(`/tasks/${taskId}`));
-      const data = await res.json();
+      const data = await readJsonResponse(res, "Poll task");
 
       if (data.status === "complete") {
         if (type === "summary") callback(data.result || {});
@@ -97,19 +126,27 @@ export default function ResultCard({ hit, onPersonClick, onTopicClick }) {
   const [summaryBlockReason, setSummaryBlockReason] = useState(null);
   const [topicsBlockReason, setTopicsBlockReason] = useState(null);
   const [agendaItems, setAgendaItems] = useState(hit.agenda_items || null);
+  const [isLoadingAgendaItems, setIsLoadingAgendaItems] = useState(false);
+  const [agendaLoadError, setAgendaLoadError] = useState(null);
   const [relatedMeetings, setRelatedMeetings] = useState(null);
   const [isGenerating, setIsGenerating] = useState(false);
   const [isTaggingTopics, setIsTaggingTopics] = useState(false);
   const [isSegmenting, setIsSegmenting] = useState(false);
   const [isExtracting, setIsExtracting] = useState(false);
+  const [summaryActionError, setSummaryActionError] = useState(null);
+  const [topicsActionError, setTopicsActionError] = useState(null);
+  const [agendaActionError, setAgendaActionError] = useState(null);
+  const [extractActionError, setExtractActionError] = useState(null);
   const [extractedTextOverride, setExtractedTextOverride] = useState(null);
   const [isLoadingCanonicalText, setIsLoadingCanonicalText] = useState(false);
   const [canonicalTextLoadError, setCanonicalTextLoadError] = useState(null);
   const [canonicalTextFetchFailed, setCanonicalTextFetchFailed] = useState(false);
   const [derivedStatus, setDerivedStatus] = useState(null);
+  const [derivedStatusLoadError, setDerivedStatusLoadError] = useState(null);
   const [isLoadingRelated, setIsLoadingRelated] = useState(false);
   const [isReporting, setIsReporting] = useState(false);
   const [reportStatus, setReportStatus] = useState(null); // 'loading', 'success', 'error'
+  const [reportActionError, setReportActionError] = useState(null);
   const demoMode = isDemoMode();
   const canMutate = !demoMode;
 
@@ -167,6 +204,7 @@ export default function ResultCard({ hit, onPersonClick, onTopicClick }) {
   const handleReportIssue = async (issueType) => {
     if (!canMutate) return;
     setReportStatus('loading');
+    setReportActionError(null);
     try {
       const res = await fetch(`/api/report-issue`, {
         method: "POST",
@@ -177,6 +215,7 @@ export default function ResultCard({ hit, onPersonClick, onTopicClick }) {
           description: "Reported from web UI"
         })
       });
+      await readJsonResponse(res, "Report issue");
       if (res.ok) {
         setReportStatus('success');
         // Hide the form after 3 seconds of success
@@ -190,6 +229,7 @@ export default function ResultCard({ hit, onPersonClick, onTopicClick }) {
     } catch (err) {
       console.error("Reporting failed", err);
       setReportStatus('error');
+      setReportActionError(err instanceof Error ? err.message : "Report issue failed.");
     }
   };
 
@@ -215,6 +255,11 @@ export default function ResultCard({ hit, onPersonClick, onTopicClick }) {
   }, [isExpanded, hit.catalog_id]);
 
   useEffect(() => {
+    if (!isExpanded || viewMode !== "agenda" || !hit.catalog_id || demoMode || agendaItems !== null) return;
+    fetchAgendaItems();
+  }, [isExpanded, viewMode, hit.catalog_id, demoMode, agendaItems]);
+
+  useEffect(() => {
     return () => {
       for (const stop of activePollStopsRef.current) {
         try {
@@ -229,16 +274,16 @@ export default function ResultCard({ hit, onPersonClick, onTopicClick }) {
 
   const fetchDerivedStatus = async () => {
     if (!hit.catalog_id) return;
+    setDerivedStatusLoadError(null);
     try {
-      const res = await fetch(buildApiUrl(`/catalog/${hit.catalog_id}/derived_status`), {
+      const res = await fetch(buildProtectedCatalogApiUrl(`/catalog/${hit.catalog_id}/derived_status`), {
         headers: getApiHeaders(),
       });
-      if (!res.ok) return;
-      const data = await res.json();
+      const data = await readJsonResponse(res, "Load derived status");
       setDerivedStatus(data);
     } catch (err) {
-      // Best-effort only; staleness badges are helpful but not critical.
       console.error("Failed to fetch derived status", err);
+      setDerivedStatusLoadError(err instanceof Error ? err.message : "Failed to load derived status.");
     }
   };
 
@@ -247,25 +292,36 @@ export default function ResultCard({ hit, onPersonClick, onTopicClick }) {
     setIsLoadingCanonicalText(true);
     setCanonicalTextLoadError(null);
     try {
-      const res = await fetch(buildApiUrl(`/catalog/${hit.catalog_id}/content`), {
+      const res = await fetch(buildProtectedCatalogApiUrl(`/catalog/${hit.catalog_id}/content`), {
         headers: getApiHeaders(),
       });
-      if (!res.ok) {
-        setCanonicalTextFetchFailed(true);
-        setCanonicalTextLoadError(`Failed to load extracted text (HTTP ${res.status}).`);
-        setIsLoadingCanonicalText(false);
-        return;
-      }
-
-      const data = await res.json();
+      const data = await readJsonResponse(res, "Load extracted text");
       setExtractedTextOverride(typeof data.content === "string" ? data.content : "");
       setCanonicalTextFetchFailed(false);
-      setIsLoadingCanonicalText(false);
     } catch (err) {
       console.error("Failed to fetch canonical text", err);
       setCanonicalTextFetchFailed(true);
-      setCanonicalTextLoadError("Failed to load extracted text (network error).");
+      setCanonicalTextLoadError(err instanceof Error ? err.message : "Failed to load extracted text.");
+    } finally {
       setIsLoadingCanonicalText(false);
+    }
+  };
+
+  const fetchAgendaItems = async () => {
+    if (!hit.catalog_id || demoMode) return;
+    setIsLoadingAgendaItems(true);
+    setAgendaLoadError(null);
+    try {
+      const res = await fetch(buildProtectedCatalogApiUrl(`/catalog/${hit.catalog_id}/agenda_items`), {
+        headers: getApiHeaders(),
+      });
+      const data = await readJsonResponse(res, "Load agenda items");
+      setAgendaItems(Array.isArray(data.items) ? data.items : []);
+    } catch (err) {
+      console.error("Failed to fetch agenda items", err);
+      setAgendaLoadError(err instanceof Error ? err.message : "Failed to load agenda items.");
+    } finally {
+      setIsLoadingAgendaItems(false);
     }
   };
 
@@ -291,6 +347,7 @@ export default function ResultCard({ hit, onPersonClick, onTopicClick }) {
     if (!hit.catalog_id || demoMode) return;
     
     setIsGenerating(true);
+    setSummaryActionError(null);
     try {
       const url = new URL(`/api/summarize/${hit.catalog_id}`, window.location.origin);
       if (force) url.searchParams.set("force", "true");
@@ -299,7 +356,7 @@ export default function ResultCard({ hit, onPersonClick, onTopicClick }) {
         method: "POST",
         headers: getApiHeaders()
       });
-      const data = await res.json();
+      const data = await readJsonResponse(res, "Generate summary");
       
       if ((data.status === 'cached' || data.status === 'stale') && data.summary) {
         setSummary(data.summary);
@@ -322,12 +379,16 @@ export default function ResultCard({ hit, onPersonClick, onTopicClick }) {
           }
           setIsGenerating(false);
           fetchDerivedStatus();
-        }, () => setIsGenerating(false), 'summary'));
+        }, (error) => {
+          setSummaryActionError(error ? `Summary generation failed: ${error}` : "Summary generation failed.");
+          setIsGenerating(false);
+        }, 'summary'));
       } else {
         setIsGenerating(false);
       }
     } catch (err) {
       console.error("AI Generation failed", err);
+      setSummaryActionError(err instanceof Error ? err.message : "Summary generation failed.");
       setIsGenerating(false);
     }
   };
@@ -335,6 +396,7 @@ export default function ResultCard({ hit, onPersonClick, onTopicClick }) {
   const handleGenerateTopics = async ({ force = false } = {}) => {
     if (!hit.catalog_id || demoMode) return;
     setIsTaggingTopics(true);
+    setTopicsActionError(null);
     try {
       const url = new URL(`/api/topics/${hit.catalog_id}`, window.location.origin);
       if (force) url.searchParams.set("force", "true");
@@ -343,7 +405,7 @@ export default function ResultCard({ hit, onPersonClick, onTopicClick }) {
         method: "POST",
         headers: getApiHeaders(),
       });
-      const data = await res.json();
+      const data = await readJsonResponse(res, "Generate topics");
 
       if ((data.status === "cached" || data.status === "stale") && data.topics) {
         setTopics(data.topics || []);
@@ -369,7 +431,10 @@ export default function ResultCard({ hit, onPersonClick, onTopicClick }) {
             setIsTaggingTopics(false);
             fetchDerivedStatus();
           },
-          () => setIsTaggingTopics(false),
+          (error) => {
+            setTopicsActionError(error ? `Topic generation failed: ${error}` : "Topic generation failed.");
+            setIsTaggingTopics(false);
+          },
           "topics"
         ));
       } else {
@@ -377,6 +442,7 @@ export default function ResultCard({ hit, onPersonClick, onTopicClick }) {
       }
     } catch (err) {
       console.error("Topic generation failed", err);
+      setTopicsActionError(err instanceof Error ? err.message : "Topic generation failed.");
       setIsTaggingTopics(false);
     }
   };
@@ -385,6 +451,7 @@ export default function ResultCard({ hit, onPersonClick, onTopicClick }) {
     if (!hit.catalog_id || demoMode) return;
     
     setIsSegmenting(true);
+    setAgendaActionError(null);
     try {
       const url = new URL(`/api/segment/${hit.catalog_id}`, window.location.origin);
       if (force) url.searchParams.set("force", "true");
@@ -393,25 +460,31 @@ export default function ResultCard({ hit, onPersonClick, onTopicClick }) {
         method: "POST",
         headers: getApiHeaders()
       });
-      const data = await res.json();
+      const data = await readJsonResponse(res, "Segment agenda");
       
       if (data.status === 'cached' && data.items) {
         setAgendaItems(data.items);
         setIsSegmenting(false);
         // Refresh derived status so "Not generated yet" clears immediately after segmentation.
         fetchDerivedStatus();
+        fetchAgendaItems();
       } else if (data.task_id) {
         addPollStop(pollTaskStatus(data.task_id, (result) => {
           setAgendaItems(result);
           setIsSegmenting(false);
           // Segmentation creates AgendaItem rows; update derived status so badges stay in sync.
           fetchDerivedStatus();
-        }, () => setIsSegmenting(false), 'agenda'));
+          fetchAgendaItems();
+        }, (error) => {
+          setAgendaActionError(error ? `Agenda segmentation failed: ${error}` : "Agenda segmentation failed.");
+          setIsSegmenting(false);
+        }, 'agenda'));
       } else {
         setIsSegmenting(false);
       }
     } catch (err) {
       console.error("Agenda segmentation failed", err);
+      setAgendaActionError(err instanceof Error ? err.message : "Agenda segmentation failed.");
       setIsSegmenting(false);
     }
   };
@@ -419,6 +492,7 @@ export default function ResultCard({ hit, onPersonClick, onTopicClick }) {
   const handleReextractText = async ({ ocrFallback = true } = {}) => {
     if (!hit.catalog_id || demoMode) return;
     setIsExtracting(true);
+    setExtractActionError(null);
     try {
       const url = new URL(`/api/extract/${hit.catalog_id}`, window.location.origin);
       url.searchParams.set("force", "true");
@@ -428,7 +502,7 @@ export default function ResultCard({ hit, onPersonClick, onTopicClick }) {
         method: "POST",
         headers: getApiHeaders(),
       });
-      const data = await res.json();
+      const data = await readJsonResponse(res, "Re-extract text");
       if (data.status === "cached") {
         // Pull fresh text from the DB endpoint even when cached so the UI refreshes.
         await fetchCanonicalContent();
@@ -445,7 +519,10 @@ export default function ResultCard({ hit, onPersonClick, onTopicClick }) {
             setIsExtracting(false);
             fetchDerivedStatus();
           },
-          () => setIsExtracting(false),
+          (error) => {
+            setExtractActionError(error ? `Re-extraction failed: ${error}` : "Re-extraction failed.");
+            setIsExtracting(false);
+          },
           "extract"
         ));
         return;
@@ -454,6 +531,7 @@ export default function ResultCard({ hit, onPersonClick, onTopicClick }) {
       setIsExtracting(false);
     } catch (err) {
       console.error("Re-extraction failed", err);
+      setExtractActionError(err instanceof Error ? err.message : "Re-extraction failed.");
       setIsExtracting(false);
     }
   };
@@ -555,6 +633,11 @@ export default function ResultCard({ hit, onPersonClick, onTopicClick }) {
               </div>
             ) : (
               <div className="space-y-3">
+                {reportActionError && (
+                  <div className="rounded-xl border border-red-200 bg-red-50 px-3 py-2 text-[12px] text-red-700">
+                    {reportActionError}
+                  </div>
+                )}
                 <p className="text-xs text-red-600/70 mb-3">What seems to be the problem with this data?</p>
                 <div className="grid grid-cols-2 gap-2">
                   {[
@@ -667,6 +750,11 @@ export default function ResultCard({ hit, onPersonClick, onTopicClick }) {
                   </p>
                 </div>
               )}
+              {derivedStatusLoadError && (
+                <div className="mb-4 rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-[12px] text-amber-800">
+                  {derivedStatusLoadError}
+                </div>
+              )}
               {viewMode === "summary" ? (
                 <div className="p-8 bg-purple-50/30 border border-purple-100 rounded-3xl space-y-6">
                     <div className="space-y-3">
@@ -674,6 +762,11 @@ export default function ResultCard({ hit, onPersonClick, onTopicClick }) {
                         <Sparkles className="w-4 h-4" />
                         Executive Summary
                       </div>
+                      {summaryActionError && (
+                        <div className="rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-[12px] text-amber-800">
+                          {summaryActionError}
+                        </div>
+                      )}
                       {showAiDisclaimer && (
                         <div className="rounded-xl border border-slate-200 bg-slate-50 px-3 py-2">
                           <p className="text-[12px] text-slate-600 flex items-center gap-2">
@@ -799,7 +892,7 @@ export default function ResultCard({ hit, onPersonClick, onTopicClick }) {
                     )}
                   </div>
 
-                  {(hit.entities || (topics && topics.length > 0) || effectiveTopicsBlockReason || topicsNotGeneratedYet) && (
+                  {(hit.entities || (topics && topics.length > 0) || effectiveTopicsBlockReason || topicsActionError || topicsNotGeneratedYet) && (
                     <div className="grid md:grid-cols-2 gap-6 pt-6 border-t border-purple-100">
                       {hit.entities && (
                         <div className="space-y-3">
@@ -813,7 +906,7 @@ export default function ResultCard({ hit, onPersonClick, onTopicClick }) {
                           </div>
                         </div>
                       )}
-		                      {(topics && topics.length > 0) || effectiveTopicsBlockReason || topicsNotGeneratedYet ? (
+			                      {(topics && topics.length > 0) || effectiveTopicsBlockReason || topicsActionError || topicsNotGeneratedYet ? (
 		                        <div className="space-y-3">
 		                          <div className="flex items-center justify-between">
 		                            <div className="flex items-center gap-2">
@@ -844,6 +937,10 @@ export default function ResultCard({ hit, onPersonClick, onTopicClick }) {
                               {effectiveTopicsBlockReason ? (
                                 <div className="rounded-xl border border-amber-200 bg-amber-50 px-3 py-2">
                                   <p className="text-[12px] text-amber-700">Topics unavailable: {effectiveTopicsBlockReason}</p>
+                                </div>
+                              ) : topicsActionError ? (
+                                <div className="rounded-xl border border-amber-200 bg-amber-50 px-3 py-2">
+                                  <p className="text-[12px] text-amber-700">{topicsActionError}</p>
                                 </div>
                               ) : topicsNotGeneratedYet ? (
                                 <div className="rounded-xl border border-slate-200 bg-slate-50 px-3 py-2">
@@ -886,6 +983,17 @@ export default function ResultCard({ hit, onPersonClick, onTopicClick }) {
                         </span>
                       )}
                     </div>
+                    {(agendaLoadError || agendaActionError) && (
+                      <div className="rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-[12px] text-amber-800">
+                        {agendaLoadError || agendaActionError}
+                      </div>
+                    )}
+                    {isLoadingAgendaItems && (
+                      <div className="rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-[12px] text-slate-600 flex items-center gap-2">
+                        <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                        Loading structured agenda...
+                      </div>
+                    )}
                     {showAgendaAiDisclaimer && (
                       <div className="rounded-xl border border-slate-200 bg-slate-50 px-3 py-2">
                         <p className="text-[12px] text-slate-600 flex items-center gap-2">
@@ -980,6 +1088,11 @@ export default function ResultCard({ hit, onPersonClick, onTopicClick }) {
                           {canonicalTextFetchFailed && typeof hit.content === "string" && hit.content.length > 0
                             ? "Showing search snippet instead."
                             : null}
+                        </div>
+                      )}
+                      {extractActionError && (
+                        <div className="mb-4 text-[12px] text-amber-800 bg-amber-50 border border-amber-200 rounded-xl px-3 py-2">
+                          {extractActionError}
                         </div>
                       )}
                       {isLoadingCanonicalText && (

--- a/frontend/lib/api.js
+++ b/frontend/lib/api.js
@@ -37,6 +37,15 @@ export function buildApiUrl(path) {
   return `${API_BASE_URL}${path}`;
 }
 
+export function buildProtectedCatalogApiUrl(path) {
+  const cleanPath = path.startsWith("/") ? path : `/${path}`;
+  if (DEMO_MODE) {
+    const demoPath = getDemoPath(cleanPath);
+    if (demoPath) return `.${demoPath}`;
+  }
+  return `/api${cleanPath}`;
+}
+
 export function getApiHeaders({ useAuth = false, json = false } = {}) {
   const headers = {};
 

--- a/pipeline/topic_generation_batch.py
+++ b/pipeline/topic_generation_batch.py
@@ -58,7 +58,7 @@ def _assign_batch_topics(
             keywords = _keywords_for_document_vector(document_vector, feature_names)
             catalog.topics = [_normal_topic_title(keyword) for keyword in keywords]
             catalog.topics_source_hash = catalog.content_hash
-        except IndexError, ValueError:
+        except (IndexError, ValueError):
             catalog.topics_source_hash = catalog.content_hash
             continue
 

--- a/pipeline/topic_generation_batch.py
+++ b/pipeline/topic_generation_batch.py
@@ -58,7 +58,7 @@ def _assign_batch_topics(
             keywords = _keywords_for_document_vector(document_vector, feature_names)
             catalog.topics = [_normal_topic_title(keyword) for keyword in keywords]
             catalog.topics_source_hash = catalog.content_hash
-        except (IndexError, ValueError):
+        except (IndexError, ValueError) as _topic_error:
             catalog.topics_source_hash = catalog.content_hash
             continue
 

--- a/pipeline/topic_generation_text.py
+++ b/pipeline/topic_generation_text.py
@@ -113,7 +113,7 @@ def _place_tokens(db: Any, place_id: int | None, place_model: Any) -> set[str]:
         return set()
     try:
         place = db.get(place_model, place_id)
-    except SQLAlchemyError, RuntimeError, ValueError, AttributeError:
+    except (SQLAlchemyError, RuntimeError, ValueError, AttributeError):
         return set()
 
     display = (getattr(place, "display_name", "") or getattr(place, "name", "") or "").lower()

--- a/pipeline/topic_generation_text.py
+++ b/pipeline/topic_generation_text.py
@@ -113,7 +113,7 @@ def _place_tokens(db: Any, place_id: int | None, place_model: Any) -> set[str]:
         return set()
     try:
         place = db.get(place_model, place_id)
-    except (SQLAlchemyError, RuntimeError, ValueError, AttributeError):
+    except (SQLAlchemyError, RuntimeError, ValueError, AttributeError) as _place_error:
         return set()
 
     display = (getattr(place, "display_name", "") or getattr(place, "name", "") or "").lower()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -689,6 +689,35 @@ def test_catalog_agenda_items_returns_ordered_minimal_payload():
         del app.dependency_overrides[get_db]
 
 
+def test_catalog_agenda_items_preserves_segmentation_source_for_disclaimer():
+    from api.main import get_db
+
+    agenda_item = MagicMock(
+        id=12,
+        order=1,
+        title="Approve project contract",
+        description="Authorize amendment.",
+        classification="Action",
+        result="Passed",
+        page_number=3,
+        votes=None,
+    )
+    db = MagicMock()
+    db.get.return_value = MagicMock(id=909, agenda_segmentation_status="complete")
+    db.query.return_value.filter.return_value.order_by.return_value.all.return_value = [agenda_item]
+
+    def _mock_get_db():
+        yield db
+
+    app.dependency_overrides[get_db] = _mock_get_db
+    try:
+        resp = client.get("/catalog/909/agenda_items", headers={"X-API-Key": VALID_KEY})
+        assert resp.status_code == 200
+        assert resp.json()["items"][0]["source"] == "llm"
+    finally:
+        del app.dependency_overrides[get_db]
+
+
 def test_derived_status_exposes_not_generated_flags():
     from api.main import get_db
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -583,6 +583,112 @@ def test_derived_status_exposes_blocked_reasons_for_low_signal_content():
         del app.dependency_overrides[get_db]
 
 
+def test_catalog_agenda_items_requires_api_key():
+    resp = client.get("/catalog/909/agenda_items")
+    assert resp.status_code == 401
+
+
+def test_catalog_agenda_items_returns_404_for_missing_catalog():
+    from api.main import get_db
+
+    db = MagicMock()
+    db.get.return_value = None
+
+    def _mock_get_db():
+        yield db
+
+    app.dependency_overrides[get_db] = _mock_get_db
+    try:
+        resp = client.get("/catalog/909/agenda_items", headers={"X-API-Key": VALID_KEY})
+        assert resp.status_code == 404
+        assert resp.json()["detail"] == "Document not found"
+    finally:
+        del app.dependency_overrides[get_db]
+
+
+def test_catalog_agenda_items_returns_empty_list_for_catalog_without_items():
+    from api.main import get_db
+
+    db = MagicMock()
+    db.get.return_value = MagicMock(id=909)
+    db.query.return_value.filter.return_value.order_by.return_value.all.return_value = []
+
+    def _mock_get_db():
+        yield db
+
+    app.dependency_overrides[get_db] = _mock_get_db
+    try:
+        resp = client.get("/catalog/909/agenda_items", headers={"X-API-Key": VALID_KEY})
+        assert resp.status_code == 200
+        assert resp.json() == {"catalog_id": 909, "items": []}
+    finally:
+        del app.dependency_overrides[get_db]
+
+
+def test_catalog_agenda_items_returns_ordered_minimal_payload():
+    from api.main import get_db
+
+    first_item = MagicMock(
+        id=12,
+        order=1,
+        title="Approve project contract",
+        description="Authorize amendment.",
+        classification="Action",
+        result="Passed",
+        page_number=3,
+        votes=[{"member": "A", "vote": "yes"}],
+    )
+    second_item = MagicMock(
+        id=13,
+        order=2,
+        title="Receive report",
+        description=None,
+        classification=None,
+        result=None,
+        page_number=None,
+        votes=None,
+    )
+    db = MagicMock()
+    db.get.return_value = MagicMock(id=909)
+    db.query.return_value.filter.return_value.order_by.return_value.all.return_value = [first_item, second_item]
+
+    def _mock_get_db():
+        yield db
+
+    app.dependency_overrides[get_db] = _mock_get_db
+    try:
+        resp = client.get("/catalog/909/agenda_items", headers={"X-API-Key": VALID_KEY})
+        assert resp.status_code == 200
+        payload = resp.json()
+        assert payload["catalog_id"] == 909
+        assert payload["items"] == [
+            {
+                "id": 12,
+                "order": 1,
+                "title": "Approve project contract",
+                "description": "Authorize amendment.",
+                "classification": "Action",
+                "result": "Passed",
+                "page_number": 3,
+                "votes": [{"member": "A", "vote": "yes"}],
+                "source": "catalog_agenda_items",
+            },
+            {
+                "id": 13,
+                "order": 2,
+                "title": "Receive report",
+                "description": None,
+                "classification": None,
+                "result": None,
+                "page_number": None,
+                "votes": None,
+                "source": "catalog_agenda_items",
+            },
+        ]
+    finally:
+        del app.dependency_overrides[get_db]
+
+
 def test_derived_status_exposes_not_generated_flags():
     from api.main import get_db
 

--- a/tests/test_demo_mode_ui_guardrails.py
+++ b/tests/test_demo_mode_ui_guardrails.py
@@ -3,10 +3,15 @@ from pathlib import Path
 
 def test_result_card_uses_demo_mode_mutation_guard():
     source = Path("frontend/components/ResultCard.js").read_text(encoding="utf-8")
+    api_lib = Path("frontend/lib/api.js").read_text(encoding="utf-8")
     assert "const canMutate = !demoMode" in source
     assert "if (!hit.catalog_id || demoMode) return;" in source
-    assert 'fetch(buildApiUrl(`/catalog/${hit.catalog_id}/derived_status`)' in source
-    assert 'fetch(buildApiUrl(`/catalog/${hit.catalog_id}/content`)' in source
+    assert 'fetch(buildProtectedCatalogApiUrl(`/catalog/${hit.catalog_id}/derived_status`)' in source
+    assert 'fetch(buildProtectedCatalogApiUrl(`/catalog/${hit.catalog_id}/content`)' in source
+    assert "if (DEMO_MODE) {" in api_lib
+    assert "return `.${demoPath}`;" in api_lib
+    assert "/demo/catalog_${catalogStatusMatch[1]}_derived_status.json" in api_lib
+    assert "/demo/catalog_${catalogContentMatch[1]}_content.json" in api_lib
 
 
 def test_home_page_enables_demo_mode_banner_and_static_routing():

--- a/tests/test_frontend_pages_config.py
+++ b/tests/test_frontend_pages_config.py
@@ -23,6 +23,8 @@ def test_frontend_uses_proxy_csp_and_same_origin_mutation_routes():
 
     assert "NEXT_PUBLIC_API_AUTH_KEY" not in api_lib
     assert "NEXT_PUBLIC_API_AUTH_KEY" not in result_card
+    assert "buildProtectedCatalogApiUrl" in api_lib
+    assert "return `/api${cleanPath}`;" in api_lib
     assert "x-nonce" in proxy_source
     assert "script-src 'self' 'nonce-${nonce}' 'strict-dynamic'" in proxy_source
     assert "script-src 'self' 'unsafe-inline'" not in proxy_source
@@ -32,6 +34,24 @@ def test_frontend_uses_proxy_csp_and_same_origin_mutation_routes():
     assert 'new URL(`/api/segment/${hit.catalog_id}`' in result_card
     assert 'new URL(`/api/topics/${hit.catalog_id}`' in result_card
     assert 'new URL(`/api/extract/${hit.catalog_id}`' in result_card
+    assert "buildProtectedCatalogApiUrl(`/catalog/${hit.catalog_id}/content`)" in result_card
+    assert "buildProtectedCatalogApiUrl(`/catalog/${hit.catalog_id}/derived_status`)" in result_card
+    assert "buildProtectedCatalogApiUrl(`/catalog/${hit.catalog_id}/agenda_items`)" in result_card
+
+
+def test_catalog_proxy_routes_await_next_dynamic_params():
+    for route_path in (
+        Path("frontend/app/api/catalog/[catalogId]/content/route.js"),
+        Path("frontend/app/api/catalog/[catalogId]/derived_status/route.js"),
+        Path("frontend/app/api/catalog/[catalogId]/agenda_items/route.js"),
+        Path("frontend/app/api/summarize/[catalogId]/route.js"),
+        Path("frontend/app/api/topics/[catalogId]/route.js"),
+        Path("frontend/app/api/segment/[catalogId]/route.js"),
+        Path("frontend/app/api/extract/[catalogId]/route.js"),
+    ):
+        route_source = route_path.read_text(encoding="utf-8")
+        assert "const { catalogId } = await params;" in route_source
+        assert "params.catalogId" not in route_source
 
 
 def test_static_export_build_wrapper_restores_api_routes(tmp_path):

--- a/tests/test_resultcard_agenda_status_refresh.py
+++ b/tests/test_resultcard_agenda_status_refresh.py
@@ -12,3 +12,17 @@ def test_result_card_refreshes_derived_status_after_segmentation():
     assert "const handleGenerateAgenda" in source
     assert "fetchDerivedStatus();" in source
 
+
+def test_result_card_surfaces_agenda_item_load_errors():
+    source = Path("frontend/components/ResultCard.js").read_text(encoding="utf-8")
+
+    assert "agendaLoadError" in source
+    assert "Load agenda items" in source
+    assert "Failed to load agenda items." in source
+
+
+def test_result_card_surfaces_topic_action_errors_without_existing_topics():
+    source = Path("frontend/components/ResultCard.js").read_text(encoding="utf-8")
+
+    assert "(topics && topics.length > 0) || effectiveTopicsBlockReason || topicsActionError || topicsNotGeneratedYet" in source
+    assert "{topicsActionError}" in source

--- a/tests/test_resultcard_agenda_status_refresh.py
+++ b/tests/test_resultcard_agenda_status_refresh.py
@@ -26,3 +26,11 @@ def test_result_card_surfaces_topic_action_errors_without_existing_topics():
 
     assert "(topics && topics.length > 0) || effectiveTopicsBlockReason || topicsActionError || topicsNotGeneratedYet" in source
     assert "{topicsActionError}" in source
+
+
+def test_result_card_keeps_task_agenda_source_after_segmentation():
+    source = Path("frontend/components/ResultCard.js").read_text(encoding="utf-8")
+
+    assert "setAgendaItems(result);" in source
+    assert "if (result.length === 0) fetchAgendaItems();" in source
+    assert "if (data.items.length === 0) fetchAgendaItems();" in source

--- a/tests/test_resultcard_fetches_canonical_content.py
+++ b/tests/test_resultcard_fetches_canonical_content.py
@@ -3,13 +3,22 @@ from pathlib import Path
 
 def test_result_card_fetches_canonical_catalog_content_on_expand():
     """
-    Regression: Full Text should be fetched from the DB (/catalog/{id}/content),
-    not treated as equivalent to the Meilisearch content snippet.
+    Regression: Full Text should be fetched through the same-origin proxy so the
+    browser never calls the protected FastAPI endpoint without API auth.
     """
     source = Path("frontend/components/ResultCard.js").read_text(encoding="utf-8")
 
     assert "fetchCanonicalContent" in source
-    assert "buildApiUrl(`/catalog/${hit.catalog_id}/content`)" in source
+    assert "buildProtectedCatalogApiUrl(`/catalog/${hit.catalog_id}/content`)" in source
+    assert "buildApiUrl(`/catalog/${hit.catalog_id}/content`)" not in source
+
+
+def test_result_card_fetches_derived_status_through_proxy():
+    source = Path("frontend/components/ResultCard.js").read_text(encoding="utf-8")
+
+    assert "fetchDerivedStatus" in source
+    assert "buildProtectedCatalogApiUrl(`/catalog/${hit.catalog_id}/derived_status`)" in source
+    assert "buildApiUrl(`/catalog/${hit.catalog_id}/derived_status`)" not in source
 
 
 def test_result_card_uses_db_text_even_when_empty():
@@ -30,3 +39,12 @@ def test_result_card_shows_empty_state_for_empty_canonical_text_and_gates_snippe
     assert "typeof extractedTextOverride === \"string\"" in source
     assert "extractedTextOverride.trim() === \"\"" in source
     assert ") : canonicalTextFetchFailed ? (" in source
+
+
+def test_result_card_fetches_canonical_agenda_items_for_live_mode():
+    source = Path("frontend/components/ResultCard.js").read_text(encoding="utf-8")
+
+    assert "fetchAgendaItems" in source
+    assert "buildProtectedCatalogApiUrl(`/catalog/${hit.catalog_id}/agenda_items`)" in source
+    assert "viewMode !== \"agenda\"" in source
+    assert "demoMode || agendaItems !== null" in source


### PR DESCRIPTION
## What changed
- Route live catalog content, derived status, and agenda item reads through same-origin Next proxies.
- Add protected `GET /catalog/{catalog_id}/agenda_items` with ordered minimal agenda item payloads.
- Fix Next 16 async `params` handling for protected catalog/action proxy routes.
- Surface visible UI errors for protected reads and derived actions instead of failing silently.
- Fix Python 3 multi-exception syntax that prevented the enrichment topic worker from starting.
- Update docs/source maps for protected catalog reads and the agenda-items endpoint.

## Why
Localhost Docker UI was calling protected FastAPI catalog endpoints directly from the browser, so content/status reads returned `401`. Regeneration routes also hit `422` because proxy route params were read synchronously under Next 16. Topic regeneration had an additional worker startup blocker from invalid Python exception syntax.

## Risk / compatibility
- Browser still never receives `API_AUTH_KEY`; protected FastAPI endpoints remain protected.
- Demo mode keeps fixture-based reads.
- No Playwright dependency, config, or CI gate added.
- No DB migration or API auth model change.

## Verification
- PASS `./.venv/bin/ruff check api pipeline scripts tests`
- PASS `PYTHONPATH=. .venv/bin/pytest -q tests/test_api.py tests/test_extract_endpoint.py tests/test_not_generated_status.py`
- PASS `PYTHONPATH=. .venv/bin/pytest -q tests/test_frontend_pages_config.py tests/test_resultcard_agenda_status_refresh.py tests/test_search_sort_ui_guardrails.py tests/test_semantic_search_ui_guardrails.py tests/test_resultcard_fetches_canonical_content.py tests/test_demo_mode_ui_guardrails.py`
- PASS `PYTHONPATH=. .venv/bin/pytest -q tests/test_topics_blocking.py tests/test_topics_staleness.py tests/test_topics_tfidf_small_corpus.py tests/test_enrichment_task_routing.py tests/test_topic_generation_cleanup.py tests/test_task_provider_retry_semantics.py`
- PASS `PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py`
- PASS `cd frontend && npm run build`
- PASS `git diff --check`
- PASS Docker smoke: `api`, `frontend`, `meilisearch`, `inference`, `semantic`, `semantic-worker`, `worker`, and `enrichment-worker` healthy.
- PASS Playwright smoke: no `401` for `/api/catalog/3016/content`, `/derived_status`, or `/agenda_items`; Full Text loaded; Structured Agenda loaded canonical rows; summary/topics/extract actions returned `200`; segment proxy returned `200` by curl.

## Remaining deficits
- Full pytest suite was not run because `AGENTS.md` requires explicit confirmation.
- `npm run build` still emits the pre-existing Next/Turbopack multiple-lockfile warning.
