### PR TITLE
Fix Sunnyvale crawl and summary backfill

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Town Council Architecture (2026)
 
-Last updated: 2026-05-12
+Last updated: 2026-05-16
 
 ## 1) System Overview
 
@@ -437,7 +437,7 @@ Owners:
 | `catalog.content_hash` | Canonical hash for extracted text used to detect staleness | `pipeline/content_hash.py`, `pipeline/extraction_service.py`, `pipeline/tasks.py` |
 | `catalog.entities_source_hash` | Hash of source text used to generate current entities | `pipeline/backfill_entities.py`, `pipeline/nlp_worker.py` facade plus focused `pipeline/nlp_entity_*` modules |
 | `catalog.agenda_items_hash` | Hash of the normalized structured agenda payload used for agenda-summary freshness | `pipeline/agenda_service.py`, `pipeline/summary_freshness.py`, `pipeline/tasks.py` |
-| `catalog.summary_source_hash` | Hash of the governing summary input; `content_hash` for non-agenda summaries and `agenda_items_hash` for agenda summaries | `pipeline/tasks.py`, `api/main.py`, `api/task_routes.py`, `api/catalog_routes.py`, `pipeline/summary_freshness.py` |
+| `catalog.summary_source_hash` | Hash of the governing summary input; `content_hash` for non-agenda summaries, `agenda_items_hash` for agenda summaries, and `content_hash` for deterministic summaries of agendas whose segmentation status is `empty` | `pipeline/tasks.py`, `api/main.py`, `api/task_routes.py`, `api/catalog_routes.py`, `pipeline/summary_freshness.py` |
 | `catalog.topics_source_hash` | Hash of source text used to generate current topics | `pipeline/topic_generation.py` facade plus focused `pipeline/topic_generation_*` modules, `pipeline/enrichment_tasks.py`, `pipeline/topic_worker.py`, `api/task_routes.py`, `api/catalog_routes.py` |
 | `agenda_item.result` | Normalized outcome field for agenda/vote interpretation | `pipeline/models.py` facade plus focused `pipeline/model_*` modules, `pipeline/tasks.py` |
 | `agenda_item.votes` | Structured vote payload with extraction metadata | `pipeline/models.py` facade plus focused `pipeline/model_*` modules, `pipeline/tasks.py` |

--- a/api/catalog_routes.py
+++ b/api/catalog_routes.py
@@ -170,6 +170,7 @@ def build_catalog_router(
             summary_source_hash=catalog.summary_source_hash,
             content_hash=content_hash,
             agenda_items_hash=agenda_items_hash,
+            agenda_segmentation_status=getattr(catalog, "agenda_segmentation_status", None),
         )
         topics_is_stale = bool(
             catalog.topics is not None and (not content_hash or catalog.topics_source_hash != content_hash)

--- a/api/task_route_summary.py
+++ b/api/task_route_summary.py
@@ -35,6 +35,7 @@ def summarize_document_request(
         summary_source_hash=catalog.summary_source_hash,
         content_hash=content_hash,
         agenda_items_hash=agenda_items_hash,
+        agenda_segmentation_status=getattr(catalog, "agenda_segmentation_status", None),
     )
 
     if (not force) and is_fresh:

--- a/api/task_route_summary.py
+++ b/api/task_route_summary.py
@@ -1,6 +1,69 @@
+from dataclasses import dataclass
 from typing import Any, Callable
 
 from fastapi import HTTPException
+
+from pipeline.agenda_summary_empty import EMPTY_AGENDA_SEGMENTATION_STATUS
+
+AGENDA_DOC_KIND = "agenda"
+GENERATE_SUMMARY_TASK_KEY = "generate_summary_task"
+
+
+@dataclass(frozen=True, slots=True)
+class SummaryFreshnessContext:
+    force: bool
+    catalog: Any  # Existing route facade accepts SQLAlchemy rows and test doubles.
+    doc_kind: str
+    content_hash: str | None
+    agenda_items_hash: str | None
+    agenda_segmentation_status: str | None
+
+
+def _is_empty_agenda_summary_candidate(
+    *,
+    doc_kind: str,
+    agenda_segmentation_status: str | None,
+    agenda_items_hash: str | None,
+) -> bool:
+    return (
+        doc_kind == AGENDA_DOC_KIND
+        and agenda_segmentation_status == EMPTY_AGENDA_SEGMENTATION_STATUS
+        and agenda_items_hash is None
+    )
+
+
+def _summary_freshness_payload(
+    *,
+    freshness_context: SummaryFreshnessContext,
+    is_summary_fresh: Callable[..., bool],
+) -> dict[str, Any] | None:
+    is_fresh = is_summary_fresh(
+        freshness_context.doc_kind,
+        summary=freshness_context.catalog.summary,
+        summary_source_hash=freshness_context.catalog.summary_source_hash,
+        content_hash=freshness_context.content_hash,
+        agenda_items_hash=freshness_context.agenda_items_hash,
+        agenda_segmentation_status=freshness_context.agenda_segmentation_status,
+    )
+    if (not freshness_context.force) and is_fresh:
+        return {"summary": freshness_context.catalog.summary, "status": "cached"}
+    if (not freshness_context.force) and freshness_context.catalog.summary and not is_fresh:
+        return {"summary": freshness_context.catalog.summary, "status": "stale"}
+    return None
+
+
+def _enqueue_summary_task(*, task_facade: Any, catalog_id: int, force: bool) -> dict[str, Any]:
+    task_id = task_facade._enqueue_task(
+        GENERATE_SUMMARY_TASK_KEY,
+        task_facade.generate_summary_task,
+        catalog_id,
+        force=force,
+    )
+    return {
+        "status": "processing",
+        "task_id": task_id,
+        "poll_url": f"/tasks/{task_id}",
+    }
 
 
 def summarize_document_request(
@@ -21,6 +84,28 @@ def summarize_document_request(
     if not catalog.content:
         raise HTTPException(status_code=400, detail="Document has no text to summarize")
 
+    doc_kind, content_hash, agenda_items_hash = task_facade._summary_doc_kind_and_hashes(db, catalog_id, catalog)
+    agenda_segmentation_status = getattr(catalog, "agenda_segmentation_status", None)
+    freshness_context = SummaryFreshnessContext(
+        force=force,
+        catalog=catalog,
+        doc_kind=doc_kind,
+        content_hash=content_hash,
+        agenda_items_hash=agenda_items_hash,
+        agenda_segmentation_status=agenda_segmentation_status,
+    )
+
+    if _is_empty_agenda_summary_candidate(
+        doc_kind=doc_kind,
+        agenda_segmentation_status=agenda_segmentation_status,
+        agenda_items_hash=agenda_items_hash,
+    ):
+        freshness_payload = _summary_freshness_payload(
+            freshness_context=freshness_context,
+            is_summary_fresh=is_summary_fresh,
+        )
+        return freshness_payload or _enqueue_summary_task(task_facade=task_facade, catalog_id=catalog_id, force=force)
+
     quality = analyze_source_text(catalog.content)
     if not is_source_summarizable(quality):
         return {
@@ -28,29 +113,8 @@ def summarize_document_request(
             "reason": build_low_signal_message(quality),
         }
 
-    doc_kind, content_hash, agenda_items_hash = task_facade._summary_doc_kind_and_hashes(db, catalog_id, catalog)
-    is_fresh = is_summary_fresh(
-        doc_kind,
-        summary=catalog.summary,
-        summary_source_hash=catalog.summary_source_hash,
-        content_hash=content_hash,
-        agenda_items_hash=agenda_items_hash,
-        agenda_segmentation_status=getattr(catalog, "agenda_segmentation_status", None),
+    freshness_payload = _summary_freshness_payload(
+        freshness_context=freshness_context,
+        is_summary_fresh=is_summary_fresh,
     )
-
-    if (not force) and is_fresh:
-        return {"summary": catalog.summary, "status": "cached"}
-    if (not force) and catalog.summary and not is_fresh:
-        return {"summary": catalog.summary, "status": "stale"}
-
-    task_id = task_facade._enqueue_task(
-        "generate_summary_task",
-        task_facade.generate_summary_task,
-        catalog_id,
-        force=force,
-    )
-    return {
-        "status": "processing",
-        "task_id": task_id,
-        "poll_url": f"/tasks/{task_id}",
-    }
+    return freshness_payload or _enqueue_summary_task(task_facade=task_facade, catalog_id=catalog_id, force=force)

--- a/council_crawler/council_crawler/spiders/ca_sunnyvale.py
+++ b/council_crawler/council_crawler/spiders/ca_sunnyvale.py
@@ -1,15 +1,29 @@
-from templates.legistar_cms import LegistarCms
+from templates.legistar_api import LegistarApi
 
-class Sunnyvale(LegistarCms):
+
+class Sunnyvale(LegistarApi):
     """
-    Spider for Sunnyvale, CA using the Legistar CMS template.
+    Spider for Sunnyvale, CA using the Legistar Web API.
     """
     name = 'sunnyvale'
 
     def __init__(self, *args, **kwargs):
         super().__init__(
-            legistar_url='https://sunnyvaleca.legistar.com/Calendar.aspx',
+            client='sunnyvaleca',
             city='sunnyvale',
             state='ca',
-            *args, **kwargs
+            *args,
+            **kwargs,
         )
+
+    def create_event_item(self, meeting_date, meeting_name, source_url, documents, meeting_type=None):
+        event = super().create_event_item(
+            meeting_date=meeting_date,
+            meeting_name=meeting_name,
+            source_url=source_url,
+            documents=documents,
+            meeting_type=meeting_type,
+        )
+        body_name = (meeting_type or meeting_name).removesuffix(" Meeting").strip()
+        event["name"] = f"Sunnyvale, CA City Council {body_name}"
+        return event

--- a/council_crawler/council_crawler/spiders/ca_sunnyvale.py
+++ b/council_crawler/council_crawler/spiders/ca_sunnyvale.py
@@ -25,5 +25,5 @@ class Sunnyvale(LegistarApi):
             meeting_type=meeting_type,
         )
         body_name = (meeting_type or meeting_name).removesuffix(" Meeting").strip()
-        event["name"] = f"Sunnyvale, CA City Council {body_name}"
+        event["name"] = f"Sunnyvale, CA {body_name}"
         return event

--- a/council_crawler/templates/legistar_api.py
+++ b/council_crawler/templates/legistar_api.py
@@ -118,6 +118,20 @@ class LegistarApi(BaseCitySpider):
             documents=api_documents + fallback_documents,
         )
 
+    def parse_meeting_detail_error(self, failure):
+        request = failure.request
+        self.logger.warning(
+            "Failed to fetch Legistar meeting detail %s: %s",
+            request.url,
+            failure.value,
+        )
+        yield self._build_event_item(
+            item=request.cb_kwargs["item"],
+            record_date=request.cb_kwargs["record_date"],
+            body_name=request.cb_kwargs["body_name"],
+            documents=request.cb_kwargs["api_documents"],
+        )
+
     def _next_events_request(self, response, data, skip):
         if len(data) < self.page_size:
             return None
@@ -186,6 +200,7 @@ class LegistarApi(BaseCitySpider):
                 yield scrapy.Request(
                     url=source_url,
                     callback=self.parse_meeting_detail,
+                    errback=self.parse_meeting_detail_error,
                     cb_kwargs={
                         "item": item,
                         "record_date": record_date,

--- a/council_crawler/templates/legistar_api.py
+++ b/council_crawler/templates/legistar_api.py
@@ -130,6 +130,9 @@ class LegistarApi(BaseCitySpider):
             dont_filter=True,
         )
 
+    def _should_fetch_meeting_detail(self, *, source_url, agenda_url, minutes_url):
+        return bool(source_url and (not agenda_url or not minutes_url))
+
     def parse(self, response, *, skip=0):
         # Legistar should return JSON, but in practice we sometimes see:
         # - a UTF-8 BOM prefix
@@ -149,6 +152,7 @@ class LegistarApi(BaseCitySpider):
 
         self.logger.info(f"Received {len(data)} events from Legistar API skip={skip}")
 
+        reached_delta_boundary = False
         for item in data:
             # 1. Parse Date
             raw_date = item.get('EventDate')
@@ -160,7 +164,8 @@ class LegistarApi(BaseCitySpider):
 
             # Use the BaseCitySpider to check if we should skip this meeting
             if self.should_skip_meeting(record_date):
-                continue
+                reached_delta_boundary = True
+                break
 
             # 2. Extract Metadata
             body_name = item.get('EventBodyName', 'City Council')
@@ -173,7 +178,11 @@ class LegistarApi(BaseCitySpider):
 
             # Some Legistar tenants omit file URLs from the API payload even when
             # the meeting detail page still publishes the agenda/minutes links.
-            if not documents and source_url:
+            if self._should_fetch_meeting_detail(
+                source_url=source_url,
+                agenda_url=agenda_url,
+                minutes_url=minutes_url,
+            ):
                 yield scrapy.Request(
                     url=source_url,
                     callback=self.parse_meeting_detail,
@@ -194,6 +203,8 @@ class LegistarApi(BaseCitySpider):
                 documents=documents,
             )
 
+        if reached_delta_boundary:
+            return
         next_request = self._next_events_request(response, data, skip)
         if next_request is not None:
             yield next_request

--- a/council_crawler/templates/legistar_api.py
+++ b/council_crawler/templates/legistar_api.py
@@ -1,7 +1,7 @@
 import datetime
 import html
 import json
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, urlencode, urlparse
 
 import scrapy
 
@@ -17,6 +17,7 @@ class LegistarApi(BaseCitySpider):
     """
     name = 'legistar_api'
     client_name = '' # e.g. 'cupertino'
+    page_size = 1000
     
     def __init__(self, client='', city='', state='', *args, **kwargs):
         # Use canonical slug identity for storage while keeping the API client
@@ -30,17 +31,32 @@ class LegistarApi(BaseCitySpider):
         
         super().__init__(*args, **kwargs)
 
-    def start_requests(self):
-        # We fetch the last 1000 events from the Legistar API.
-        #
+    def _initial_events_request(self):
         # Important: Legistar's Web API can respond with XML unless we ask for JSON.
         # Scrapy's default Accept header prefers HTML/XML, so we override it here.
-        url = f'https://webapi.legistar.com/v1/{self.client_name}/events?$top=1000&$orderby=EventDate%20desc'
-        yield scrapy.Request(
+        url = self._build_events_url(skip=0)
+        return scrapy.Request(
             url=url,
             callback=self.parse,
+            cb_kwargs={"skip": 0},
             headers={"Accept": "application/json"},
         )
+
+    async def start(self):
+        yield self._initial_events_request()
+
+    def start_requests(self):
+        yield self._initial_events_request()
+
+    def _build_events_url(self, *, skip):
+        query = urlencode(
+            {
+                "$top": str(self.page_size),
+                "$skip": str(skip),
+                "$orderby": "EventDate desc",
+            }
+        )
+        return f"https://webapi.legistar.com/v1/{self.client_name}/events?{query}"
 
     def _build_documents(self, *, agenda_url=None, minutes_url=None):
         documents = []
@@ -102,7 +118,19 @@ class LegistarApi(BaseCitySpider):
             documents=api_documents + fallback_documents,
         )
 
-    def parse(self, response):
+    def _next_events_request(self, response, data, skip):
+        if len(data) < self.page_size:
+            return None
+        next_skip = skip + self.page_size
+        return response.follow(
+            self._build_events_url(skip=next_skip),
+            callback=self.parse,
+            cb_kwargs={"skip": next_skip},
+            headers={"Accept": "application/json"},
+            dont_filter=True,
+        )
+
+    def parse(self, response, *, skip=0):
         # Legistar should return JSON, but in practice we sometimes see:
         # - a UTF-8 BOM prefix
         # - a non-JSON HTML/body when a proxy/WAF returns an error page
@@ -119,7 +147,7 @@ class LegistarApi(BaseCitySpider):
             )
             return
 
-        self.logger.info(f"Received {len(data)} events from Legistar API")
+        self.logger.info(f"Received {len(data)} events from Legistar API skip={skip}")
 
         for item in data:
             # 1. Parse Date
@@ -165,3 +193,7 @@ class LegistarApi(BaseCitySpider):
                 body_name=body_name,
                 documents=documents,
             )
+
+        next_request = self._next_events_request(response, data, skip)
+        if next_request is not None:
+            yield next_request

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,6 +1,6 @@
 # Operations Runbook
 
-Last updated: 2026-05-12
+Last updated: 2026-05-16
 
 ## Core workflow
 
@@ -144,7 +144,7 @@ Batch runtime notes:
 - entity backfill now reports `ner_processed`, `ner_skipped_low_signal`, `freshness_advanced`, and `candidate_slice_fallback_prefix`
 - default people linking is now driven by the entity delta from the same batch run rather than rescanning every entity-bearing catalog
 - people linking now reports `catalogs_with_people`, `catalogs_changed`, `exact_matches`, `fuzzy_matches`, and `cities_loaded`
-- agenda summaries now use structured-input freshness: deterministic agenda summaries store `summary_source_hash = agenda_items_hash`, while non-agenda summaries still key freshness to `content_hash`
+- agenda summaries now use structured-input freshness: deterministic agenda summaries store `summary_source_hash = agenda_items_hash`, while empty-segmented agenda summaries and non-agenda summaries key freshness to `content_hash`
 - `agenda_items_hash` is maintained when agenda rows are persisted and lets summary hydration skip already-fresh agenda summaries instead of rebuilding them every run
 - default `run_batch_enrichment.py` now snapshots eligible topic/table work before invoking heavy steps
 - topic modeling only hydrates catalogs whose topics are missing or stale relative to `content_hash`
@@ -1409,10 +1409,10 @@ Summary format:
 
 Agenda summary contract:
 - For `Document.category == "agenda"`, summaries are derived from segmented agenda items (Structured Agenda) to avoid drift.
-- Agenda summary freshness is keyed to `agenda_items_hash`; non-agenda summary freshness stays keyed to `content_hash`.
+- Agenda summary freshness is keyed to `agenda_items_hash`; agendas with `agenda_segmentation_status=empty` use deterministic empty-agenda summaries keyed to `content_hash`; non-agenda summary freshness also stays keyed to `content_hash`.
 - Agenda summary input uses structured fields (`title`, `description`, `classification`, `result`, `page_number`) and is hard-capped for context safety.
 - If input is truncated for context budget, summary output discloses partial coverage (`first N of M agenda items`) in `Unknowns`.
-- If an agenda has not been segmented yet, summary generation returns `not_generated_yet` and prompts you to segment first.
+- If an agenda has not been segmented yet, summary generation returns `not_generated_yet` and prompts you to segment first; if segmentation completed with `empty`, summary generation stores the deterministic empty-agenda summary.
 - If model output is too short/noncompliant/ungrounded, the system falls back to deterministic decision-brief output.
 - Existing catalogs do not update retroactively. Re-run both steps after tuning:
   - `POST /segment/{catalog_id}?force=true`

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1,6 +1,6 @@
 # Performance
 
-Last updated: 2026-05-11
+Last updated: 2026-05-16
 
 This page describes how to interpret and reproduce performance evidence for local Docker runs.
 For operational troubleshooting and sorting diagnostics, use `docs/OPERATIONS.md`.
@@ -177,7 +177,7 @@ Interpretation rule:
   - `people_linking` `0.969s`
 - The next summary-freshness pass made agenda summary hydration stale-aware via structured-input hashing:
   - `Catalog.agenda_items_hash` now fingerprints the normalized `AgendaItem` payload that deterministic agenda summaries actually depend on
-  - deterministic agenda summaries now store `summary_source_hash = agenda_items_hash` instead of `content_hash`
+  - deterministic agenda summaries now store `summary_source_hash = agenda_items_hash` instead of `content_hash`, except empty-segmented agendas whose deterministic fallback summary stays keyed to `content_hash`
   - the profiling harness now runs `pipeline/backfill_catalog_hashes.py` before baseline preconditioning so legacy agenda summaries are measured in steady state instead of one-time migration churn
 - On the same `baseline_representative_v1` manifest, the rollout-skewed first run (`pipeline_profile_baseline_20260403_003945`) selected `21` agenda summaries because old rows were missing the new agenda hash metadata, but the steady-state baseline after backfill (`pipeline_profile_baseline_20260403_004122`) returned to `selected=12`.
 - In the steady-state run, `summary_hydration_backfill` reported `selected=12 complete=12 changed_catalogs=12 agenda_deterministic_complete=12 llm_complete=0 deterministic_fallback_complete=0 reindexed=12 reindex_failed=0 embed_enqueued=12 embed_dispatch_failed=0`.

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -1,6 +1,6 @@
 # Town Council Pipeline Guide
 
-Last updated: 2026-05-10
+Last updated: 2026-05-16
 
 ## 1) Purpose and Boundaries
 
@@ -266,6 +266,7 @@ Agenda summaries are derived from segmented agenda items, not arbitrary raw text
 Freshness contract:
 - non-agenda summaries use `content_hash`
 - agenda summaries use `agenda_items_hash`
+- agendas with `agenda_segmentation_status=empty` use `content_hash` for their deterministic empty-agenda summaries
 - `summary_source_hash` stores whichever governing input hash applies to that catalog
 
 Why this exists:

--- a/pipeline/agenda_summary_batch.py
+++ b/pipeline/agenda_summary_batch.py
@@ -107,6 +107,7 @@ def persist_agenda_summary(
     prior_summary = catalog.summary
     prior_summary_source_hash = catalog.summary_source_hash
     prior_agenda_items_hash = catalog.agenda_items_hash
+    prior_content_hash = catalog.content_hash
     summary_source_hash = compute_summary_source_hash(
         "agenda",
         content_hash=content_hash,
@@ -124,6 +125,7 @@ def persist_agenda_summary(
         prior_summary != summary
         or prior_summary_source_hash != summary_source_hash
         or prior_agenda_items_hash != agenda_items_hash
+        or (content_hash is not None and prior_content_hash != content_hash)
     )
     return {"status": "complete", "summary": summary, "changed": changed}
 

--- a/pipeline/agenda_summary_batch.py
+++ b/pipeline/agenda_summary_batch.py
@@ -17,8 +17,15 @@ from pipeline.agenda_summary_contracts import (
     empty_agenda_summary_timings,
     rounded_agenda_summary_timings,
 )
+from pipeline.agenda_summary_empty import (
+    EMPTY_AGENDA_COMPLETION_MODE,
+    EMPTY_AGENDA_SEGMENTATION_STATUS,
+    build_empty_agenda_summary_text,
+    is_empty_agenda_without_items,
+)
 from pipeline.agenda_summary_inputs import build_agenda_summary_input_bundle
 from pipeline.config import AGENDA_SUMMARY_MAX_INPUT_CHARS, AGENDA_SUMMARY_MIN_RESERVED_OUTPUT_CHARS
+from pipeline.content_hash import compute_content_hash
 from pipeline.db_session import db_session
 from pipeline.laserfiche_error_pages import classify_catalog_bad_content
 from pipeline.models import AgendaItem, Catalog, Document
@@ -95,6 +102,7 @@ def persist_agenda_summary(
     summary: str,
     content_hash: str | None,
     agenda_items_hash: str | None,
+    agenda_segmentation_status: str | None = None,
 ) -> AgendaSummaryPayload:
     prior_summary = catalog.summary
     prior_summary_source_hash = catalog.summary_source_hash
@@ -103,6 +111,7 @@ def persist_agenda_summary(
         "agenda",
         content_hash=content_hash,
         agenda_items_hash=agenda_items_hash,
+        agenda_segmentation_status=agenda_segmentation_status,
     )
     catalog.summary = summary
     if content_hash:
@@ -211,11 +220,23 @@ def _build_catalog_result(
     if classification:
         return {"status": "error", "error": classification.reason}
 
+    agenda_items = agenda_items_by_catalog_id.get(catalog_id, [])
+    if is_empty_agenda_without_items(catalog, agenda_items):
+        content_hash = compute_content_hash(catalog.content) if (catalog.content or "") else None
+        persisted_result = persist_agenda_summary(
+            catalog=catalog,
+            summary=build_empty_agenda_summary_text(),
+            content_hash=content_hash,
+            agenda_items_hash=None,
+            agenda_segmentation_status=EMPTY_AGENDA_SEGMENTATION_STATUS,
+        )
+        return {**persisted_result, "completion_mode": EMPTY_AGENDA_COMPLETION_MODE}
+
     summary_bundle = _time_agenda_summary_bundle_build(
         agenda_summary_timings,
         catalog=catalog,
         document=documents_by_catalog_id.get(catalog_id),
-        agenda_items=agenda_items_by_catalog_id.get(catalog_id, []),
+        agenda_items=agenda_items,
         max_input_chars=max_input_chars,
         min_reserved_output_chars=min_reserved_output_chars,
     )

--- a/pipeline/agenda_summary_empty.py
+++ b/pipeline/agenda_summary_empty.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from pipeline.models import AgendaItem, Catalog
+
+EMPTY_AGENDA_SEGMENTATION_STATUS = "empty"
+EMPTY_AGENDA_COMPLETION_MODE = "agenda_empty_deterministic"
+EMPTY_AGENDA_SUMMARY_TEXT = (
+    "Agenda segmentation completed, but no substantive agenda items were detected in the extracted text."
+)
+
+
+def is_empty_agenda_without_items(catalog: Catalog, agenda_items: list[AgendaItem]) -> bool:
+    return (
+        getattr(catalog, "agenda_segmentation_status", None) == EMPTY_AGENDA_SEGMENTATION_STATUS
+        and not agenda_items
+    )
+
+
+def build_empty_agenda_summary_text() -> str:
+    return EMPTY_AGENDA_SUMMARY_TEXT

--- a/pipeline/backfill_catalog_hashes.py
+++ b/pipeline/backfill_catalog_hashes.py
@@ -56,6 +56,7 @@ def backfill(limit: int | None = None) -> dict:
                 doc_kind,
                 content_hash=content_hash,
                 agenda_items_hash=agenda_items_hash,
+                agenda_segmentation_status=getattr(c, "agenda_segmentation_status", None),
             )
 
             if c.summary and not c.summary_source_hash and summary_source_hash:

--- a/pipeline/backlog_maintenance.py
+++ b/pipeline/backlog_maintenance.py
@@ -80,12 +80,14 @@ def persist_agenda_summary(
     summary: str,
     content_hash: str | None,
     agenda_items_hash: str | None,
+    agenda_segmentation_status: str | None = None,
 ) -> dict[str, Any]:
     return agenda_summary_maintenance_mod.persist_agenda_summary(
         catalog=catalog,
         summary=summary,
         content_hash=content_hash,
         agenda_items_hash=agenda_items_hash,
+        agenda_segmentation_status=agenda_segmentation_status,
     )
 
 

--- a/pipeline/http_inference_payloads.py
+++ b/pipeline/http_inference_payloads.py
@@ -14,15 +14,19 @@ def build_request_payload(
     model_name: str,
     max_tokens: int,
     temperature: float,
+    context_window: int | None = None,
 ) -> dict[str, object]:
+    options: dict[str, object] = {
+        "num_predict": int(max_tokens),
+        "temperature": float(temperature),
+    }
+    if context_window is not None and context_window > 0:
+        options["num_ctx"] = int(context_window)
     return {
         "model": model_name,
         "prompt": prompt,
         "stream": False,
-        "options": {
-            "num_predict": int(max_tokens),
-            "temperature": float(temperature),
-        },
+        "options": options,
     }
 
 

--- a/pipeline/http_inference_provider.py
+++ b/pipeline/http_inference_provider.py
@@ -47,6 +47,7 @@ class HttpInferenceProvider:
         self.timeout_topics_seconds = max(MINIMUM_HTTP_TIMEOUT_SECONDS, facade.LOCAL_AI_HTTP_TIMEOUT_TOPICS_SECONDS)
         self.max_retries = max(0, facade.LOCAL_AI_HTTP_MAX_RETRIES)
         self.model_name = facade.LOCAL_AI_HTTP_MODEL
+        self.context_window = max(0, facade.LLM_CONTEXT_WINDOW)
 
     def health_check(self) -> bool:
         try:
@@ -75,7 +76,13 @@ class HttpInferenceProvider:
         )
 
     def _build_request_payload(self, prompt: str, *, max_tokens: int, temperature: float) -> dict[str, object]:
-        return build_request_payload(prompt, model_name=self.model_name, max_tokens=max_tokens, temperature=temperature)
+        return build_request_payload(
+            prompt,
+            model_name=self.model_name,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            context_window=self.context_window,
+        )
 
     def _post_generate_request(self, payload: dict[str, object], *, timeout_seconds: int) -> requests.Response:
         return _provider_facade().requests.post(

--- a/pipeline/indexer_documents.py
+++ b/pipeline/indexer_documents.py
@@ -115,6 +115,7 @@ def _build_meeting_search_doc(
             summary_source_hash=catalog.summary_source_hash,
             content_hash=catalog.content_hash,
             agenda_items_hash=getattr(catalog, "agenda_items_hash", None),
+            agenda_segmentation_status=getattr(catalog, "agenda_segmentation_status", None),
         ),
         "topics_is_stale": bool(
             catalog.topics is not None

--- a/pipeline/llm_provider.py
+++ b/pipeline/llm_provider.py
@@ -11,6 +11,7 @@ from pipeline.config import (
     LOCAL_AI_HTTP_TIMEOUT_SEGMENT_SECONDS,
     LOCAL_AI_HTTP_TIMEOUT_SUMMARY_SECONDS,
     LOCAL_AI_HTTP_TIMEOUT_TOPICS_SECONDS,
+    LLM_CONTEXT_WINDOW,
 )
 from pipeline.http_inference_provider import HttpInferenceProvider
 from pipeline.inference_provider_contract import (
@@ -57,6 +58,7 @@ __all__ = [
     "LOCAL_AI_HTTP_TIMEOUT_SEGMENT_SECONDS",
     "LOCAL_AI_HTTP_TIMEOUT_SUMMARY_SECONDS",
     "LOCAL_AI_HTTP_TIMEOUT_TOPICS_SECONDS",
+    "LLM_CONTEXT_WINDOW",
     "OPERATION_EXTRACT_AGENDA",
     "OPERATION_GENERATE_JSON",
     "OPERATION_GENERATE_TOPICS",

--- a/pipeline/summary_backfill_queries.py
+++ b/pipeline/summary_backfill_queries.py
@@ -44,6 +44,16 @@ def select_catalog_ids_for_summary_hydration(
     """
     doc_kind = summary_doc_kind_subquery(db)
     agenda_items_exist = db.query(AgendaItem.id).filter(AgendaItem.catalog_id == Catalog.id).exists()
+    empty_agenda_needs_summary = and_(
+        Catalog.agenda_segmentation_status == "empty",
+        ~agenda_items_exist,
+        or_(
+            Catalog.summary.is_(None),
+            Catalog.summary_source_hash.is_(None),
+            Catalog.content_hash.is_(None),
+            Catalog.summary_source_hash != Catalog.content_hash,
+        ),
+    )
     query = (
         db.query(Catalog.id)
         .join(doc_kind, doc_kind.c.catalog_id == Catalog.id)
@@ -64,12 +74,17 @@ def select_catalog_ids_for_summary_hydration(
                 ),
                 and_(
                     doc_kind.c.doc_kind == "agenda",
-                    agenda_items_exist,
                     or_(
-                        Catalog.summary.is_(None),
-                        Catalog.summary_source_hash.is_(None),
-                        Catalog.agenda_items_hash.is_(None),
-                        Catalog.summary_source_hash != Catalog.agenda_items_hash,
+                        and_(
+                            agenda_items_exist,
+                            or_(
+                                Catalog.summary.is_(None),
+                                Catalog.summary_source_hash.is_(None),
+                                Catalog.agenda_items_hash.is_(None),
+                                Catalog.summary_source_hash != Catalog.agenda_items_hash,
+                            ),
+                        ),
+                        empty_agenda_needs_summary,
                     ),
                 ),
             ),

--- a/pipeline/summary_freshness.py
+++ b/pipeline/summary_freshness.py
@@ -53,9 +53,12 @@ def compute_summary_source_hash(
     *,
     content_hash: str | None,
     agenda_items_hash: str | None,
+    agenda_segmentation_status: str | None = None,
 ) -> str | None:
     normalized_kind = normalize_summary_doc_kind(doc_kind)
     if normalized_kind == "agenda":
+        if agenda_segmentation_status == "empty" and not agenda_items_hash:
+            return content_hash
         return agenda_items_hash
     return content_hash
 
@@ -67,11 +70,13 @@ def is_summary_fresh(
     summary_source_hash: str | None,
     content_hash: str | None,
     agenda_items_hash: str | None,
+    agenda_segmentation_status: str | None = None,
 ) -> bool:
     expected_source_hash = compute_summary_source_hash(
         doc_kind,
         content_hash=content_hash,
         agenda_items_hash=agenda_items_hash,
+        agenda_segmentation_status=agenda_segmentation_status,
     )
     return bool(summary and expected_source_hash and summary_source_hash == expected_source_hash)
 
@@ -83,6 +88,7 @@ def is_summary_stale(
     summary_source_hash: str | None,
     content_hash: str | None,
     agenda_items_hash: str | None,
+    agenda_segmentation_status: str | None = None,
 ) -> bool:
     return bool(
         summary
@@ -92,5 +98,6 @@ def is_summary_stale(
             summary_source_hash=summary_source_hash,
             content_hash=content_hash,
             agenda_items_hash=agenda_items_hash,
+            agenda_segmentation_status=agenda_segmentation_status,
         )
     )

--- a/pipeline/task_summary_empty_agenda.py
+++ b/pipeline/task_summary_empty_agenda.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Protocol
+
+from pipeline.agenda_summary_empty import (
+    EMPTY_AGENDA_SEGMENTATION_STATUS,
+    build_empty_agenda_summary_text,
+)
+from pipeline.models import Catalog
+
+AGENDA_DOC_KIND = "agenda"
+SUMMARY_CACHED_STATUS = "cached"
+SUMMARY_COMPLETE_STATUS = "complete"
+SUMMARY_STALE_STATUS = "stale"
+
+
+class EmptyAgendaSummaryServices(Protocol):
+    is_summary_fresh: Callable[..., bool]
+    persist_agenda_summary: Callable[..., dict[str, object]]
+
+
+@dataclass(frozen=True)
+class EmptyAgendaGenerationContext:
+    db: object
+    catalog_id: int
+    force: bool
+    catalog: Catalog
+    content_hash: str | None
+    services: EmptyAgendaSummaryServices
+    side_effects_runner: Callable[[int], dict[str, int]]
+
+
+def run_empty_agenda_generation(context: EmptyAgendaGenerationContext) -> dict[str, object]:
+    summary = build_empty_agenda_summary_text()
+    is_fresh = context.services.is_summary_fresh(
+        AGENDA_DOC_KIND,
+        summary=context.catalog.summary,
+        summary_source_hash=context.catalog.summary_source_hash,
+        content_hash=context.content_hash,
+        agenda_items_hash=None,
+        agenda_segmentation_status=EMPTY_AGENDA_SEGMENTATION_STATUS,
+    )
+    if (not context.force) and is_fresh:
+        return {"status": SUMMARY_CACHED_STATUS, "summary": context.catalog.summary, "changed": False}
+    if (not context.force) and context.catalog.summary and not is_fresh:
+        return {"status": SUMMARY_STALE_STATUS, "summary": context.catalog.summary, "changed": False}
+
+    persisted_summary = context.services.persist_agenda_summary(
+        catalog=context.catalog,
+        summary=summary,
+        content_hash=context.content_hash,
+        agenda_items_hash=None,
+        agenda_segmentation_status=EMPTY_AGENDA_SEGMENTATION_STATUS,
+    )
+    context.db.commit()
+    side_effects = context.side_effects_runner(context.catalog_id)
+    return {
+        "status": SUMMARY_COMPLETE_STATUS,
+        "summary": summary,
+        "changed": bool(persisted_summary["changed"]),
+        **side_effects,
+    }

--- a/pipeline/task_summary_generation.py
+++ b/pipeline/task_summary_generation.py
@@ -1,268 +1,29 @@
-from collections.abc import Callable
-from dataclasses import dataclass
-from typing import Any
+from __future__ import annotations
 
-from pipeline.llm import LocalAI
-from pipeline.models import AgendaItem, Catalog, Document
+from pipeline.task_summary_generation_contracts import (
+    AGENDA_DOC_KIND,
+    SUMMARY_BLOCKED_LOW_SIGNAL_STATUS,
+    SUMMARY_BLOCKED_UNGROUNDED_STATUS,
+    SUMMARY_CACHED_STATUS,
+    SUMMARY_COMPLETE_STATUS,
+    SUMMARY_ERROR_STATUS,
+    SUMMARY_NONE_RETRY_ERROR,
+    SUMMARY_STALE_STATUS,
+    SummaryGenerationTaskServices,
+)
+from pipeline.task_summary_generation_flow import run_generate_summary_task_family
 from pipeline.task_summary_side_effects import run_summary_generation_side_effects
 
-
-AGENDA_DOC_KIND = "agenda"
-SUMMARY_COMPLETE_STATUS = "complete"
-SUMMARY_CACHED_STATUS = "cached"
-SUMMARY_STALE_STATUS = "stale"
-SUMMARY_ERROR_STATUS = "error"
-SUMMARY_BLOCKED_LOW_SIGNAL_STATUS = "blocked_low_signal"
-SUMMARY_BLOCKED_UNGROUNDED_STATUS = "blocked_ungrounded"
-SUMMARY_NONE_RETRY_ERROR = "AI Summarization returned None (Model missing or error)"
-
-
-@dataclass(frozen=True)
-class SummaryGenerationTaskServices:
-    local_ai_factory: Callable[[], LocalAI]
-    classify_catalog_bad_content: Callable[..., object]
-    compute_content_hash: Callable[[str | None], str | None]
-    normalize_summary_doc_kind: Callable[[str], str]
-    analyze_source_text: Callable[[str], object]
-    is_source_summarizable: Callable[[object], bool]
-    build_low_signal_message: Callable[[object], str]
-    build_agenda_summary_input_bundle: Callable[..., dict[str, Any]]
-    is_summary_fresh: Callable[..., bool]
-    compute_summary_source_hash: Callable[..., str | None]
-    postprocess_extracted_text: Callable[[str | None], str]
-    is_summary_grounded: Callable[[str, str], object]
-    persist_agenda_summary: Callable[..., dict[str, Any]]
-    reindex_catalog: Callable[[int], object]
-    embed_catalog: Callable[[int], object]
-
-def _source_text_quality_payload(catalog: Catalog, services: SummaryGenerationTaskServices) -> dict[str, Any] | None:
-    if not catalog.content:
-        return {"error": "No content to summarize"}
-
-    quality = services.analyze_source_text(catalog.content)
-    if services.is_source_summarizable(quality):
-        return None
-
-    # We do not run Gemma on low-signal content because it tends to hallucinate.
-    return {
-        "status": SUMMARY_BLOCKED_LOW_SIGNAL_STATUS,
-        "reason": services.build_low_signal_message(quality),
-        "summary": None,
-    }
-
-
-def _agenda_summary_bundle(
-    db,
-    *,
-    catalog: Catalog,
-    document: Document | None,
-    catalog_id: int,
-    services: SummaryGenerationTaskServices,
-) -> dict[str, Any]:
-    return services.build_agenda_summary_input_bundle(
-        catalog=catalog,
-        document=document,
-        agenda_items=(
-            db.query(AgendaItem)
-            .filter_by(catalog_id=catalog_id)
-            .order_by(AgendaItem.order)
-            .all()
-        ),
-        include_meeting_context=True,
-    )
-
-
-def _stale_or_cached_summary_payload(
-    *,
-    force: bool,
-    is_fresh: bool,
-    summary: str | None,
-) -> dict[str, Any] | None:
-    if (not force) and is_fresh:
-        return {"status": SUMMARY_CACHED_STATUS, "summary": summary, "changed": False}
-    if (not force) and summary and not is_fresh:
-        # Keep the old summary visible, but mark it as out-of-date.
-        return {"status": SUMMARY_STALE_STATUS, "summary": summary, "changed": False}
-    return None
-
-
-def _generated_summary(
-    *,
-    local_ai: LocalAI,
-    doc_kind: str,
-    catalog: Catalog,
-    agenda_summary_bundle: dict[str, Any] | None,
-    services: SummaryGenerationTaskServices,
-) -> tuple[str | None, bool]:
-    if doc_kind == AGENDA_DOC_KIND:
-        if agenda_summary_bundle is None:
-            raise RuntimeError("Agenda summary bundle is required for agenda summaries")
-        summary = local_ai.summarize_agenda_items(
-            meeting_title=agenda_summary_bundle["meeting_title"],
-            meeting_date=agenda_summary_bundle["meeting_date"],
-            items=agenda_summary_bundle["summary_items"],
-            truncation_meta=agenda_summary_bundle["truncation_meta"],
-        )
-        # Agenda summaries are derived from structured titles, not raw text.
-        return summary, False
-
-    return local_ai.summarize(
-        services.postprocess_extracted_text(catalog.content),
-        doc_kind=doc_kind,
-    ), True
-
-
-def _ungrounded_summary_payload(
-    *,
-    summary: str,
-    catalog: Catalog,
-    services: SummaryGenerationTaskServices,
-) -> dict[str, Any] | None:
-    grounding = services.is_summary_grounded(summary, services.postprocess_extracted_text(catalog.content))
-    if grounding.is_grounded:
-        return None
-
-    reason = (
-        "Generated summary appears unsupported by extracted text. "
-        f"(coverage={grounding.coverage:.2f})"
-    )
-    return {
-        "status": SUMMARY_BLOCKED_UNGROUNDED_STATUS,
-        "reason": reason,
-        "unsupported_claims": grounding.unsupported_claims[:3],
-        "summary": None,
-    }
-
-
-def _persist_non_agenda_summary(
-    *,
-    catalog: Catalog,
-    summary: str,
-    doc_kind: str,
-    content_hash: str | None,
-    agenda_items_hash: str | None,
-    services: SummaryGenerationTaskServices,
-) -> dict[str, Any]:
-    prior_summary = catalog.summary
-    prior_summary_source_hash = catalog.summary_source_hash
-    summary_source_hash = services.compute_summary_source_hash(
-        doc_kind,
-        content_hash=content_hash,
-        agenda_items_hash=agenda_items_hash,
-    )
-    catalog.summary = summary
-    if content_hash:
-        catalog.content_hash = content_hash
-    if summary_source_hash:
-        catalog.summary_source_hash = summary_source_hash
-    return {
-        "status": SUMMARY_COMPLETE_STATUS,
-        "summary": summary,
-        "changed": bool(prior_summary != summary or prior_summary_source_hash != summary_source_hash),
-    }
-
-
-def run_generate_summary_task_family(
-    db,
-    catalog_id: int,
-    *,
-    force: bool,
-    services: SummaryGenerationTaskServices,
-) -> dict[str, Any]:
-    """
-    Run summary generation for one catalog while leaving retry and session ownership to the task.
-    """
-    catalog = db.get(Catalog, catalog_id)
-
-    doc = db.query(Document).filter_by(catalog_id=catalog_id).first()
-    doc_kind = services.normalize_summary_doc_kind(doc.category if doc else "unknown")
-
-    if not catalog:
-        return {"error": "Catalog not found"}
-    classification = services.classify_catalog_bad_content(catalog)
-    if classification:
-        return {"status": SUMMARY_ERROR_STATUS, "error": classification.reason}
-    local_ai = services.local_ai_factory()
-
-    content_hash = services.compute_content_hash(catalog.content) if (catalog.content or "") else None
-    if content_hash:
-        catalog.content_hash = content_hash
-
-    if doc_kind != AGENDA_DOC_KIND:
-        quality_payload = _source_text_quality_payload(catalog, services)
-        if quality_payload is not None:
-            return quality_payload
-
-    agenda_items_hash = catalog.agenda_items_hash
-    agenda_summary_bundle = None
-    if doc_kind == AGENDA_DOC_KIND:
-        agenda_summary_bundle = _agenda_summary_bundle(
-            db,
-            catalog=catalog,
-            document=doc,
-            catalog_id=catalog_id,
-            services=services,
-        )
-        if agenda_summary_bundle.get("status") != "ready":
-            return agenda_summary_bundle
-        agenda_items_hash = agenda_summary_bundle["agenda_items_hash"]
-        if agenda_items_hash != catalog.agenda_items_hash:
-            catalog.agenda_items_hash = agenda_items_hash
-
-    is_fresh = services.is_summary_fresh(
-        doc_kind,
-        summary=catalog.summary,
-        summary_source_hash=catalog.summary_source_hash,
-        content_hash=content_hash,
-        agenda_items_hash=agenda_items_hash,
-    )
-    cached_payload = _stale_or_cached_summary_payload(
-        force=force,
-        is_fresh=is_fresh,
-        summary=catalog.summary,
-    )
-    if cached_payload is not None:
-        return cached_payload
-
-    summary, do_grounding_check = _generated_summary(
-        local_ai=local_ai,
-        doc_kind=doc_kind,
-        catalog=catalog,
-        agenda_summary_bundle=agenda_summary_bundle,
-        services=services,
-    )
-    if summary is None:
-        raise RuntimeError(SUMMARY_NONE_RETRY_ERROR)
-
-    if do_grounding_check:
-        grounding_payload = _ungrounded_summary_payload(summary=summary, catalog=catalog, services=services)
-        if grounding_payload is not None:
-            return grounding_payload
-
-    if doc_kind == AGENDA_DOC_KIND:
-        if agenda_summary_bundle is None:
-            raise RuntimeError("Agenda summary bundle is required for agenda summary persistence")
-        persisted_summary = services.persist_agenda_summary(
-            catalog=catalog,
-            summary=summary,
-            content_hash=agenda_summary_bundle["content_hash"],
-            agenda_items_hash=agenda_summary_bundle["agenda_items_hash"],
-        )
-    else:
-        persisted_summary = _persist_non_agenda_summary(
-            catalog=catalog,
-            summary=summary,
-            doc_kind=doc_kind,
-            content_hash=content_hash,
-            agenda_items_hash=agenda_items_hash,
-            services=services,
-        )
-    db.commit()
-
-    side_effects = run_summary_generation_side_effects(catalog_id, services=services)
-    return {
-        "status": SUMMARY_COMPLETE_STATUS,
-        "summary": summary,
-        "changed": bool(persisted_summary["changed"]),
-        **side_effects,
-    }
+__all__ = [
+    "AGENDA_DOC_KIND",
+    "SUMMARY_BLOCKED_LOW_SIGNAL_STATUS",
+    "SUMMARY_BLOCKED_UNGROUNDED_STATUS",
+    "SUMMARY_CACHED_STATUS",
+    "SUMMARY_COMPLETE_STATUS",
+    "SUMMARY_ERROR_STATUS",
+    "SUMMARY_NONE_RETRY_ERROR",
+    "SUMMARY_STALE_STATUS",
+    "SummaryGenerationTaskServices",
+    "run_generate_summary_task_family",
+    "run_summary_generation_side_effects",
+]

--- a/pipeline/task_summary_generation_contracts.py
+++ b/pipeline/task_summary_generation_contracts.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from pipeline.llm import LocalAI
+from pipeline.models import Catalog, Document
+
+AGENDA_DOC_KIND = "agenda"
+SUMMARY_COMPLETE_STATUS = "complete"
+SUMMARY_CACHED_STATUS = "cached"
+SUMMARY_STALE_STATUS = "stale"
+SUMMARY_ERROR_STATUS = "error"
+SUMMARY_BLOCKED_LOW_SIGNAL_STATUS = "blocked_low_signal"
+SUMMARY_BLOCKED_UNGROUNDED_STATUS = "blocked_ungrounded"
+SUMMARY_NONE_RETRY_ERROR = "AI Summarization returned None (Model missing or error)"
+
+
+@dataclass(frozen=True)
+class SummaryGenerationTaskServices:
+    local_ai_factory: Callable[[], LocalAI]
+    classify_catalog_bad_content: Callable[..., object]
+    compute_content_hash: Callable[[str | None], str | None]
+    normalize_summary_doc_kind: Callable[[str], str]
+    analyze_source_text: Callable[[str], object]
+    is_source_summarizable: Callable[[object], bool]
+    build_low_signal_message: Callable[[object], str]
+    build_agenda_summary_input_bundle: Callable[..., dict[str, Any]]
+    is_summary_fresh: Callable[..., bool]
+    compute_summary_source_hash: Callable[..., str | None]
+    postprocess_extracted_text: Callable[[str | None], str]
+    is_summary_grounded: Callable[[str, str], object]
+    persist_agenda_summary: Callable[..., dict[str, Any]]
+    reindex_catalog: Callable[[int], object]
+    embed_catalog: Callable[[int], object]
+
+
+@dataclass(frozen=True)
+class SummaryTaskContext:
+    db: Any
+    catalog_id: int
+    force: bool
+    services: SummaryGenerationTaskServices
+
+
+@dataclass(frozen=True)
+class SummaryRecordContext:
+    catalog: Catalog
+    document: Document | None
+    doc_kind: str
+    content_hash: str | None
+
+
+@dataclass(frozen=True)
+class PreparedSummaryInput:
+    agenda_items_hash: str | None
+    agenda_summary_bundle: dict[str, Any] | None

--- a/pipeline/task_summary_generation_flow.py
+++ b/pipeline/task_summary_generation_flow.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pipeline.agenda_summary_empty import is_empty_agenda_without_items
+from pipeline.models import AgendaItem, Catalog, Document
+from pipeline.task_summary_empty_agenda import EmptyAgendaGenerationContext, run_empty_agenda_generation
+from pipeline.task_summary_generation_contracts import (
+    AGENDA_DOC_KIND,
+    SUMMARY_BLOCKED_LOW_SIGNAL_STATUS,
+    SUMMARY_CACHED_STATUS,
+    SUMMARY_ERROR_STATUS,
+    SUMMARY_STALE_STATUS,
+    PreparedSummaryInput,
+    SummaryGenerationTaskServices,
+    SummaryRecordContext,
+    SummaryTaskContext,
+)
+from pipeline.task_summary_generation_persistence import generate_and_persist_summary
+from pipeline.task_summary_side_effects import run_summary_generation_side_effects
+
+
+def _source_text_quality_payload(catalog: Catalog, services: SummaryGenerationTaskServices) -> dict[str, Any] | None:
+    if not catalog.content:
+        return {"error": "No content to summarize"}
+
+    quality = services.analyze_source_text(catalog.content)
+    if services.is_source_summarizable(quality):
+        return None
+
+    # We do not run Gemma on low-signal content because it tends to hallucinate.
+    return {
+        "status": SUMMARY_BLOCKED_LOW_SIGNAL_STATUS,
+        "reason": services.build_low_signal_message(quality),
+        "summary": None,
+    }
+
+
+def _agenda_summary_bundle(
+    *,
+    catalog: Catalog,
+    document: Document | None,
+    agenda_items: list[AgendaItem],
+    services: SummaryGenerationTaskServices,
+) -> dict[str, Any]:
+    return services.build_agenda_summary_input_bundle(
+        catalog=catalog,
+        document=document,
+        agenda_items=agenda_items,
+        include_meeting_context=True,
+    )
+
+
+def _agenda_items_for_catalog(db: Any, catalog_id: int) -> list[AgendaItem]:
+    return (
+        db.query(AgendaItem)
+        .filter_by(catalog_id=catalog_id)
+        .order_by(AgendaItem.order)
+        .all()
+    )
+
+
+def _stale_or_cached_summary_payload(
+    *,
+    force: bool,
+    is_fresh: bool,
+    summary: str | None,
+) -> dict[str, Any] | None:
+    if (not force) and is_fresh:
+        return {"status": SUMMARY_CACHED_STATUS, "summary": summary, "changed": False}
+    if (not force) and summary and not is_fresh:
+        # Keep the old summary visible, but mark it as out-of-date.
+        return {"status": SUMMARY_STALE_STATUS, "summary": summary, "changed": False}
+    return None
+
+
+def _load_summary_record(context: SummaryTaskContext) -> SummaryRecordContext | dict[str, Any]:
+    catalog = context.db.get(Catalog, context.catalog_id)
+    document = context.db.query(Document).filter_by(catalog_id=context.catalog_id).first()
+    doc_kind = context.services.normalize_summary_doc_kind(document.category if document else "unknown")
+    if not catalog:
+        return {"error": "Catalog not found"}
+
+    classification = context.services.classify_catalog_bad_content(catalog)
+    if classification:
+        return {"status": SUMMARY_ERROR_STATUS, "error": classification.reason}
+
+    content_hash = context.services.compute_content_hash(catalog.content) if (catalog.content or "") else None
+    if content_hash:
+        catalog.content_hash = content_hash
+    return SummaryRecordContext(catalog, document, doc_kind, content_hash)
+
+
+def _prepare_agenda_summary_input(
+    context: SummaryTaskContext,
+    record: SummaryRecordContext,
+) -> PreparedSummaryInput | dict[str, Any]:
+    agenda_items = _agenda_items_for_catalog(context.db, context.catalog_id)
+    if is_empty_agenda_without_items(record.catalog, agenda_items):
+        return run_empty_agenda_generation(
+            EmptyAgendaGenerationContext(
+                db=context.db,
+                catalog_id=context.catalog_id,
+                force=context.force,
+                catalog=record.catalog,
+                content_hash=record.content_hash,
+                services=context.services,
+                side_effects_runner=lambda selected_catalog_id: run_summary_generation_side_effects(
+                    selected_catalog_id,
+                    services=context.services,
+                ),
+            )
+        )
+
+    agenda_summary_bundle = _agenda_summary_bundle(
+        catalog=record.catalog,
+        document=record.document,
+        agenda_items=agenda_items,
+        services=context.services,
+    )
+    if agenda_summary_bundle.get("status") != "ready":
+        return agenda_summary_bundle
+
+    agenda_items_hash = agenda_summary_bundle["agenda_items_hash"]
+    if agenda_items_hash != record.catalog.agenda_items_hash:
+        record.catalog.agenda_items_hash = agenda_items_hash
+    return PreparedSummaryInput(agenda_items_hash, agenda_summary_bundle)
+
+
+def _prepare_summary_input(
+    context: SummaryTaskContext,
+    record: SummaryRecordContext,
+) -> PreparedSummaryInput | dict[str, Any]:
+    if record.doc_kind != AGENDA_DOC_KIND:
+        quality_payload = _source_text_quality_payload(record.catalog, context.services)
+        if quality_payload is not None:
+            return quality_payload
+        return PreparedSummaryInput(record.catalog.agenda_items_hash, None)
+    return _prepare_agenda_summary_input(context, record)
+
+
+def _cached_summary_payload(
+    context: SummaryTaskContext,
+    record: SummaryRecordContext,
+    prepared: PreparedSummaryInput,
+) -> dict[str, Any] | None:
+    is_fresh = context.services.is_summary_fresh(
+        record.doc_kind,
+        summary=record.catalog.summary,
+        summary_source_hash=record.catalog.summary_source_hash,
+        content_hash=record.content_hash,
+        agenda_items_hash=prepared.agenda_items_hash,
+        agenda_segmentation_status=getattr(record.catalog, "agenda_segmentation_status", None),
+    )
+    return _stale_or_cached_summary_payload(
+        force=context.force,
+        is_fresh=is_fresh,
+        summary=record.catalog.summary,
+    )
+
+
+def run_generate_summary_task_family(
+    db: Any,
+    catalog_id: int,
+    *,
+    force: bool,
+    services: SummaryGenerationTaskServices,
+) -> dict[str, Any]:
+    context = SummaryTaskContext(db, catalog_id, force, services)
+    record = _load_summary_record(context)
+    if isinstance(record, dict):
+        return record
+
+    prepared = _prepare_summary_input(context, record)
+    if isinstance(prepared, dict):
+        return prepared
+
+    cached_payload = _cached_summary_payload(context, record, prepared)
+    if cached_payload is not None:
+        return cached_payload
+
+    return generate_and_persist_summary(context, record, prepared)

--- a/pipeline/task_summary_generation_persistence.py
+++ b/pipeline/task_summary_generation_persistence.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pipeline.llm import LocalAI
+from pipeline.models import Catalog
+from pipeline.task_summary_generation_contracts import (
+    AGENDA_DOC_KIND,
+    SUMMARY_BLOCKED_UNGROUNDED_STATUS,
+    SUMMARY_COMPLETE_STATUS,
+    SUMMARY_NONE_RETRY_ERROR,
+    PreparedSummaryInput,
+    SummaryGenerationTaskServices,
+    SummaryRecordContext,
+    SummaryTaskContext,
+)
+from pipeline.task_summary_side_effects import run_summary_generation_side_effects
+
+
+def _generated_summary(
+    *,
+    local_ai: LocalAI,
+    doc_kind: str,
+    catalog: Catalog,
+    agenda_summary_bundle: dict[str, Any] | None,
+    services: SummaryGenerationTaskServices,
+) -> tuple[str | None, bool]:
+    if doc_kind == AGENDA_DOC_KIND:
+        if agenda_summary_bundle is None:
+            raise RuntimeError("Agenda summary bundle is required for agenda summaries")
+        summary = local_ai.summarize_agenda_items(
+            meeting_title=agenda_summary_bundle["meeting_title"],
+            meeting_date=agenda_summary_bundle["meeting_date"],
+            items=agenda_summary_bundle["summary_items"],
+            truncation_meta=agenda_summary_bundle["truncation_meta"],
+        )
+        # Agenda summaries are derived from structured titles, not raw text.
+        return summary, False
+
+    return local_ai.summarize(
+        services.postprocess_extracted_text(catalog.content),
+        doc_kind=doc_kind,
+    ), True
+
+
+def _ungrounded_summary_payload(
+    *,
+    summary: str,
+    catalog: Catalog,
+    services: SummaryGenerationTaskServices,
+) -> dict[str, Any] | None:
+    grounding = services.is_summary_grounded(summary, services.postprocess_extracted_text(catalog.content))
+    if grounding.is_grounded:
+        return None
+
+    reason = (
+        "Generated summary appears unsupported by extracted text. "
+        f"(coverage={grounding.coverage:.2f})"
+    )
+    return {
+        "status": SUMMARY_BLOCKED_UNGROUNDED_STATUS,
+        "reason": reason,
+        "unsupported_claims": grounding.unsupported_claims[:3],
+        "summary": None,
+    }
+
+
+def _persist_non_agenda_summary(
+    *,
+    catalog: Catalog,
+    summary: str,
+    doc_kind: str,
+    content_hash: str | None,
+    agenda_items_hash: str | None,
+    services: SummaryGenerationTaskServices,
+) -> dict[str, Any]:
+    prior_summary = catalog.summary
+    prior_summary_source_hash = catalog.summary_source_hash
+    summary_source_hash = services.compute_summary_source_hash(
+        doc_kind,
+        content_hash=content_hash,
+        agenda_items_hash=agenda_items_hash,
+    )
+    catalog.summary = summary
+    if content_hash:
+        catalog.content_hash = content_hash
+    if summary_source_hash:
+        catalog.summary_source_hash = summary_source_hash
+    return {
+        "status": SUMMARY_COMPLETE_STATUS,
+        "summary": summary,
+        "changed": bool(prior_summary != summary or prior_summary_source_hash != summary_source_hash),
+    }
+
+
+def _persist_generated_summary(
+    context: SummaryTaskContext,
+    record: SummaryRecordContext,
+    prepared: PreparedSummaryInput,
+    summary: str,
+) -> dict[str, Any]:
+    if record.doc_kind == AGENDA_DOC_KIND:
+        if prepared.agenda_summary_bundle is None:
+            raise RuntimeError("Agenda summary bundle is required for agenda summary persistence")
+        return context.services.persist_agenda_summary(
+            catalog=record.catalog,
+            summary=summary,
+            content_hash=prepared.agenda_summary_bundle["content_hash"],
+            agenda_items_hash=prepared.agenda_summary_bundle["agenda_items_hash"],
+            agenda_segmentation_status=getattr(record.catalog, "agenda_segmentation_status", None),
+        )
+    return _persist_non_agenda_summary(
+        catalog=record.catalog,
+        summary=summary,
+        doc_kind=record.doc_kind,
+        content_hash=record.content_hash,
+        agenda_items_hash=prepared.agenda_items_hash,
+        services=context.services,
+    )
+
+
+def generate_and_persist_summary(
+    context: SummaryTaskContext,
+    record: SummaryRecordContext,
+    prepared: PreparedSummaryInput,
+) -> dict[str, Any]:
+    local_ai = context.services.local_ai_factory()
+    summary, do_grounding_check = _generated_summary(
+        local_ai=local_ai,
+        doc_kind=record.doc_kind,
+        catalog=record.catalog,
+        agenda_summary_bundle=prepared.agenda_summary_bundle,
+        services=context.services,
+    )
+    if summary is None:
+        raise RuntimeError(SUMMARY_NONE_RETRY_ERROR)
+    if do_grounding_check:
+        grounding_payload = _ungrounded_summary_payload(summary=summary, catalog=record.catalog, services=context.services)
+        if grounding_payload is not None:
+            return grounding_payload
+
+    persisted_summary = _persist_generated_summary(context, record, prepared, summary)
+    context.db.commit()
+    side_effects = run_summary_generation_side_effects(context.catalog_id, services=context.services)
+    return {
+        "status": SUMMARY_COMPLETE_STATUS,
+        "summary": summary,
+        "changed": bool(persisted_summary["changed"]),
+        **side_effects,
+    }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -802,3 +802,49 @@ def test_derived_status_marks_agenda_summary_stale_from_structured_items():
         assert payload["summary_is_stale"] is True
     finally:
         del app.dependency_overrides[get_db]
+
+
+def test_derived_status_marks_empty_agenda_fallback_summary_fresh():
+    from api.main import get_db
+    from pipeline.models import AgendaItem, Document
+
+    catalog = MagicMock(
+        id=913,
+        content="Extracted agenda text with no substantive agenda items.",
+        content_hash="content-hash",
+        agenda_items_hash=None,
+        summary="Agenda segmentation completed, but no substantive agenda items were detected in the extracted text.",
+        summary_source_hash="content-hash",
+        topics=[],
+        topics_source_hash=None,
+        agenda_segmentation_status="empty",
+        agenda_segmentation_item_count=0,
+        agenda_segmentation_attempted_at=None,
+        agenda_segmentation_error=None,
+    )
+    db = MagicMock()
+    db.get.return_value = catalog
+
+    def _query_side_effect(model):
+        query = MagicMock()
+        if model is Document:
+            query.filter_by.return_value.first.return_value = MagicMock(category="agenda")
+        elif model is AgendaItem:
+            query.filter_by.return_value.order_by.return_value.all.return_value = []
+        return query
+
+    db.query.side_effect = _query_side_effect
+
+    def _mock_get_db():
+        yield db
+
+    app.dependency_overrides[get_db] = _mock_get_db
+    try:
+        resp = client.get("/catalog/913/derived_status", headers={"X-API-Key": VALID_KEY})
+        assert resp.status_code == 200
+        payload = resp.json()
+        assert payload["summary_is_stale"] is False
+        assert payload["summary_not_generated_yet"] is False
+        assert payload["agenda_is_empty"] is True
+    finally:
+        del app.dependency_overrides[get_db]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -528,6 +528,39 @@ def test_summarize_returns_blocked_low_signal_without_queueing(mocker):
         del app.dependency_overrides[get_db]
 
 
+def test_summarize_empty_agenda_bypasses_low_signal_gate(mocker):
+    from api.main import get_db
+
+    catalog = MagicMock(
+        id=910,
+        content="Agenda",
+        summary=None,
+        content_hash="h1",
+        summary_source_hash=None,
+        agenda_segmentation_status="empty",
+    )
+    db = MagicMock()
+    db.get.return_value = catalog
+
+    def _mock_get_db():
+        yield db
+
+    app.dependency_overrides[get_db] = _mock_get_db
+    mock_task = MagicMock()
+    mock_task.id = "task_summary_empty_agenda"
+    delay = mocker.patch("api.main.generate_summary_task.delay", return_value=mock_task)
+    mocker.patch("api.main._summary_doc_kind_and_hashes", return_value=("agenda", "h1", None))
+    try:
+        resp = client.post("/summarize/910", headers={"X-API-Key": VALID_KEY})
+        assert resp.status_code == 200
+        payload = resp.json()
+        assert payload["status"] == "processing"
+        assert payload["task_id"] == "task_summary_empty_agenda"
+        delay.assert_called_once()
+    finally:
+        del app.dependency_overrides[get_db]
+
+
 def test_topics_returns_blocked_low_signal_without_queueing(mocker):
     from api.main import get_db
 

--- a/tests/test_inference_provider_protocol_contract.py
+++ b/tests/test_inference_provider_protocol_contract.py
@@ -93,6 +93,17 @@ def test_inprocess_provider_satisfies_protocol():
     assert provider.summarize_text("x", temperature=0.0, max_tokens=8) == "ok"
 
 
+def test_http_provider_payload_includes_configured_context_window(monkeypatch):
+    monkeypatch.setattr(llm_provider, "LLM_CONTEXT_WINDOW", 8192)
+    provider = DirectHttpInferenceProvider()
+
+    payload = provider._build_request_payload("summarize this", max_tokens=128, temperature=0.2)
+
+    assert payload["options"]["num_ctx"] == 8192
+    assert payload["options"]["num_predict"] == 128
+    assert payload["options"]["temperature"] == 0.2
+
+
 def test_inprocess_provider_preserves_response_format_fallback():
     owner = _DummyOwner()
     owner.llm = _FormatRejectingLlama()

--- a/tests/test_legistar_api_spider_contract.py
+++ b/tests/test_legistar_api_spider_contract.py
@@ -215,6 +215,35 @@ def test_legistar_api_spider_fetches_detail_when_one_api_document_is_missing(moc
     ]
 
 
+def test_legistar_api_spider_keeps_api_documents_when_detail_fetch_fails(mocker):
+    mocker.patch.object(LegistarApi, "_get_last_meeting_date", return_value=None)
+    spider = LegistarApi(client="cupertino", city="cupertino", state="ca")
+    response = TextResponse(
+        url="https://webapi.legistar.com/v1/cupertino/events",
+        body=json.dumps(
+            [
+                {
+                    "EventBodyName": "City Council",
+                    "EventDate": "2026-02-10T00:00:00",
+                    "EventAgendaFile": "https://cupertino.legistar.com/api-agenda.pdf",
+                    "EventMinutesFile": None,
+                    "EventInSiteURL": "https://cupertino.legistar.com/MeetingDetail.aspx?ID=456",
+                }
+            ]
+        ),
+        encoding="utf-8",
+        request=Request(url="https://webapi.legistar.com/v1/cupertino/events"),
+    )
+
+    [request] = list(spider.parse(response))
+    failure = type("DetailFailure", (), {"request": request, "value": RuntimeError("detail failed")})()
+
+    [event] = list(request.errback(failure))
+
+    assert [doc["category"] for doc in event["documents"]] == ["agenda"]
+    assert event["documents"][0]["url"] == "https://cupertino.legistar.com/api-agenda.pdf"
+
+
 def test_legistar_api_spider_prefers_api_documents_without_duplicate_fallback(mocker):
     mocker.patch.object(LegistarApi, "_get_last_meeting_date", return_value=None)
     spider = LegistarApi(client="cupertino", city="cupertino", state="ca")

--- a/tests/test_legistar_api_spider_contract.py
+++ b/tests/test_legistar_api_spider_contract.py
@@ -1,6 +1,7 @@
 import json
 import os
 import sys
+from urllib.parse import parse_qs, urlparse
 
 from scrapy.http import TextResponse, Request
 
@@ -9,6 +10,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", "council_crawler"))
 
 from templates.legistar_api import LegistarApi
+from council_crawler.spiders.ca_sunnyvale import Sunnyvale
 
 
 def test_legistar_api_spider_maps_event_fields_and_documents(mocker):
@@ -52,6 +54,48 @@ def test_legistar_api_spider_maps_event_fields_and_documents(mocker):
     assert [d["category"] for d in docs] == ["agenda", "minutes"]
     assert all(d["url"].startswith("https://") for d in docs)
     assert all(len(d["url_hash"]) == 32 for d in docs)  # md5 hex
+
+
+def test_sunnyvale_spider_uses_legistar_api_client(mocker):
+    mocker.patch.object(Sunnyvale, "_get_last_meeting_date", return_value=None)
+    spider = Sunnyvale()
+
+    [request] = list(spider.start_requests())
+
+    assert spider.name == "sunnyvale"
+    assert spider.client_name == "sunnyvaleca"
+    assert spider.ocd_division_id == "ocd-division/country:us/state:ca/place:sunnyvale"
+    assert request.url.startswith("https://webapi.legistar.com/v1/sunnyvaleca/events?")
+
+
+def test_sunnyvale_api_spider_preserves_existing_event_names(mocker):
+    mocker.patch.object(Sunnyvale, "_get_last_meeting_date", return_value=None)
+    spider = Sunnyvale()
+
+    response = TextResponse(
+        url="https://webapi.legistar.com/v1/sunnyvaleca/events",
+        body=json.dumps(
+            [
+                {
+                    "EventBodyName": "Planning Commission",
+                    "EventDate": "2026-02-10T00:00:00",
+                    "EventAgendaFile": "https://sunnyvaleca.legistar.com/agenda.pdf",
+                    "EventMinutesFile": "https://sunnyvaleca.legistar.com/minutes.pdf",
+                    "EventInSiteURL": "https://sunnyvaleca.legistar.com/MeetingDetail.aspx?ID=123",
+                }
+            ]
+        ),
+        encoding="utf-8",
+        request=Request(url="https://webapi.legistar.com/v1/sunnyvaleca/events"),
+    )
+
+    [event] = list(spider.parse(response))
+
+    assert event["name"] == "Sunnyvale, CA City Council Planning Commission"
+    assert [doc["url"] for doc in event["documents"]] == [
+        "https://sunnyvaleca.legistar.com/agenda.pdf",
+        "https://sunnyvaleca.legistar.com/minutes.pdf",
+    ]
 
 
 def test_legistar_api_spider_emits_no_documents_when_urls_missing(mocker):
@@ -157,3 +201,32 @@ def test_legistar_api_spider_prefers_api_documents_without_duplicate_fallback(mo
         "https://cupertino.legistar.com/agenda.pdf",
         "https://cupertino.legistar.com/minutes.pdf",
     ]
+
+
+def test_legistar_api_spider_paginates_full_event_history(mocker):
+    mocker.patch.object(LegistarApi, "_get_last_meeting_date", return_value=None)
+    spider = LegistarApi(client="cupertino", city="cupertino", state="ca")
+    event_rows = [
+        {
+            "EventBodyName": "City Council",
+            "EventDate": "2026-02-10T00:00:00",
+            "EventAgendaFile": None,
+            "EventMinutesFile": None,
+            "EventInSiteURL": "",
+        }
+        for _ in range(spider.page_size)
+    ]
+    response = TextResponse(
+        url=spider._build_events_url(skip=0),
+        body=json.dumps(event_rows),
+        encoding="utf-8",
+        request=Request(url=spider._build_events_url(skip=0)),
+    )
+
+    results = list(spider.parse(response, skip=0))
+
+    next_request = results[-1]
+    query = parse_qs(urlparse(next_request.url).query)
+    assert isinstance(next_request, Request)
+    assert query["$skip"] == ["1000"]
+    assert next_request.cb_kwargs == {"skip": 1000}

--- a/tests/test_legistar_api_spider_contract.py
+++ b/tests/test_legistar_api_spider_contract.py
@@ -69,7 +69,7 @@ def test_sunnyvale_spider_uses_legistar_api_client(mocker):
     assert request.url.startswith("https://webapi.legistar.com/v1/sunnyvaleca/events?")
 
 
-def test_sunnyvale_api_spider_preserves_existing_event_names(mocker):
+def test_sunnyvale_api_spider_preserves_body_event_names(mocker):
     mocker.patch.object(Sunnyvale, "_get_last_meeting_date", return_value=None)
     spider = Sunnyvale()
 
@@ -92,11 +92,43 @@ def test_sunnyvale_api_spider_preserves_existing_event_names(mocker):
 
     [event] = list(spider.parse(response))
 
-    assert event["name"] == "Sunnyvale, CA City Council Planning Commission"
+    assert event["name"] == "Sunnyvale, CA Planning Commission"
     assert [doc["url"] for doc in event["documents"]] == [
         "https://sunnyvaleca.legistar.com/agenda.pdf",
         "https://sunnyvaleca.legistar.com/minutes.pdf",
     ]
+
+
+def test_sunnyvale_api_spider_does_not_duplicate_city_council_name(mocker):
+    mocker.patch.object(Sunnyvale, "_get_last_meeting_date", return_value=None)
+    spider = Sunnyvale()
+    response = TextResponse(
+        url="https://webapi.legistar.com/v1/sunnyvaleca/events",
+        body=json.dumps(
+            [
+                {
+                    "EventBodyName": "City Council",
+                    "EventDate": "2026-02-10T00:00:00",
+                    "EventAgendaFile": "https://sunnyvaleca.legistar.com/agenda.pdf",
+                    "EventMinutesFile": None,
+                    "EventInSiteURL": "https://sunnyvaleca.legistar.com/MeetingDetail.aspx?ID=123",
+                }
+            ]
+        ),
+        encoding="utf-8",
+        request=Request(url="https://webapi.legistar.com/v1/sunnyvaleca/events"),
+    )
+
+    [request] = list(spider.parse(response))
+    detail_response = TextResponse(
+        url=request.url,
+        body="",
+        encoding="utf-8",
+        request=Request(url=request.url),
+    )
+    [event] = list(request.callback(detail_response, **request.cb_kwargs))
+
+    assert event["name"] == "Sunnyvale, CA City Council"
 
 
 def test_legistar_api_spider_emits_no_documents_when_urls_missing(mocker):

--- a/tests/test_legistar_api_spider_contract.py
+++ b/tests/test_legistar_api_spider_contract.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import os
 import sys
@@ -173,6 +174,47 @@ def test_legistar_api_spider_falls_back_to_meeting_detail_documents(mocker):
     assert docs[1]["url"] == "https://cupertino.legistar.com/View.ashx?M=M&ID=123"
 
 
+def test_legistar_api_spider_fetches_detail_when_one_api_document_is_missing(mocker):
+    mocker.patch.object(LegistarApi, "_get_last_meeting_date", return_value=None)
+    spider = LegistarApi(client="cupertino", city="cupertino", state="ca")
+    response = TextResponse(
+        url="https://webapi.legistar.com/v1/cupertino/events",
+        body=json.dumps(
+            [
+                {
+                    "EventBodyName": "City Council",
+                    "EventDate": "2026-02-10T00:00:00",
+                    "EventAgendaFile": "https://cupertino.legistar.com/api-agenda.pdf",
+                    "EventMinutesFile": None,
+                    "EventInSiteURL": "https://cupertino.legistar.com/MeetingDetail.aspx?ID=456",
+                }
+            ]
+        ),
+        encoding="utf-8",
+        request=Request(url="https://webapi.legistar.com/v1/cupertino/events"),
+    )
+
+    [request] = list(spider.parse(response))
+    detail_response = TextResponse(
+        url=request.url,
+        body="""
+        <html><body>
+          <a href="https://cupertino.legistar.com/api-agenda.pdf">Agenda</a>
+          <a href="View.ashx?M=M&amp;ID=456">Minutes</a>
+        </body></html>
+        """,
+        encoding="utf-8",
+        request=Request(url=request.url),
+    )
+
+    [event] = list(request.callback(detail_response, **request.cb_kwargs))
+    assert [doc["category"] for doc in event["documents"]] == ["agenda", "minutes"]
+    assert [doc["url"] for doc in event["documents"]] == [
+        "https://cupertino.legistar.com/api-agenda.pdf",
+        "https://cupertino.legistar.com/View.ashx?M=M&ID=456",
+    ]
+
+
 def test_legistar_api_spider_prefers_api_documents_without_duplicate_fallback(mocker):
     mocker.patch.object(LegistarApi, "_get_last_meeting_date", return_value=None)
     spider = LegistarApi(client="cupertino", city="cupertino", state="ca")
@@ -230,3 +272,37 @@ def test_legistar_api_spider_paginates_full_event_history(mocker):
     assert isinstance(next_request, Request)
     assert query["$skip"] == ["1000"]
     assert next_request.cb_kwargs == {"skip": 1000}
+
+
+def test_legistar_api_spider_stops_delta_pagination_after_old_meeting(mocker):
+    mocker.patch.object(LegistarApi, "_get_last_meeting_date", return_value=datetime.date(2026, 2, 1))
+    spider = LegistarApi(client="cupertino", city="cupertino", state="ca")
+    spider.page_size = 2
+    event_rows = [
+        {
+            "EventBodyName": "City Council",
+            "EventDate": "2026-02-10T00:00:00",
+            "EventAgendaFile": "https://cupertino.legistar.com/new-agenda.pdf",
+            "EventMinutesFile": None,
+            "EventInSiteURL": "",
+        },
+        {
+            "EventBodyName": "City Council",
+            "EventDate": "2026-01-10T00:00:00",
+            "EventAgendaFile": "https://cupertino.legistar.com/old-agenda.pdf",
+            "EventMinutesFile": None,
+            "EventInSiteURL": "",
+        },
+    ]
+    response = TextResponse(
+        url=spider._build_events_url(skip=0),
+        body=json.dumps(event_rows),
+        encoding="utf-8",
+        request=Request(url=spider._build_events_url(skip=0)),
+    )
+
+    results = list(spider.parse(response, skip=0))
+
+    assert len(results) == 1
+    assert not isinstance(results[0], Request)
+    assert results[0]["source_url"] == ""

--- a/tests/test_pipeline_batching.py
+++ b/tests/test_pipeline_batching.py
@@ -1,3 +1,5 @@
+from contextlib import nullcontext
+
 import pytest
 from unittest.mock import MagicMock
 import sys
@@ -12,6 +14,8 @@ from sqlalchemy.orm import sessionmaker
 from pipeline.run_pipeline import process_document_chunk
 from pipeline.agenda_service import persist_agenda_items
 from pipeline.tasks import select_catalog_ids_for_summary_hydration, run_summary_hydration_backfill
+from pipeline.agenda_summary_batch import build_deterministic_agenda_summary_payloads
+from pipeline.agenda_summary_empty import EMPTY_AGENDA_SUMMARY_TEXT
 from pipeline.agenda_worker import select_catalog_ids_for_agenda_segmentation
 from pipeline.table_worker import select_catalog_ids_for_table_extraction
 from pipeline.models import Base, Catalog, Document, AgendaItem, Event, Place
@@ -321,6 +325,37 @@ def test_select_catalog_ids_for_summary_hydration_filters_agenda_without_items(b
     assert summarized_catalog.id not in selected
 
 
+def test_select_catalog_ids_for_summary_hydration_includes_empty_agenda_without_items(batching_db):
+    db, event, place = batching_db
+    empty_agenda = _add_catalog(
+        db,
+        event,
+        place,
+        category="agenda",
+        content="agenda text",
+        content_hash="empty-content-hash",
+        summary=None,
+        segmentation_status="empty",
+    )
+    fresh_empty_agenda = _add_catalog(
+        db,
+        event,
+        place,
+        category="agenda",
+        content="agenda text",
+        content_hash="fresh-content-hash",
+        summary=EMPTY_AGENDA_SUMMARY_TEXT,
+        summary_source_hash="fresh-content-hash",
+        segmentation_status="empty",
+    )
+    db.commit()
+
+    selected = select_catalog_ids_for_summary_hydration(db)
+
+    assert empty_agenda.id in selected
+    assert fresh_empty_agenda.id not in selected
+
+
 def test_select_catalog_ids_for_summary_hydration_treats_agenda_html_like_agenda(batching_db):
     db, event, place = batching_db
     agenda_html_with_items = _add_catalog(
@@ -404,6 +439,86 @@ def test_select_catalog_ids_for_summary_hydration_includes_stale_agenda_but_skip
 
     assert fresh_agenda.id not in selected
     assert stale_agenda.id in selected
+
+
+def test_select_catalog_ids_for_summary_hydration_reselects_empty_agenda_after_items_exist(batching_db):
+    db, event, place = batching_db
+    empty_agenda_with_items = _add_catalog(
+        db,
+        event,
+        place,
+        category="agenda",
+        content="agenda text",
+        content_hash="content-hash",
+        summary=EMPTY_AGENDA_SUMMARY_TEXT,
+        summary_source_hash="content-hash",
+        segmentation_status="empty",
+    )
+    items = [
+        {
+            "order": 1,
+            "title": "New Item",
+            "description": "Desc",
+            "classification": "Agenda",
+            "result": "",
+            "page_number": 1,
+        }
+    ]
+    persist_agenda_items(db, empty_agenda_with_items.id, event.id, items)
+    db.commit()
+
+    selected = select_catalog_ids_for_summary_hydration(db)
+
+    assert empty_agenda_with_items.id in selected
+
+
+def test_deterministic_agenda_summary_payloads_persist_empty_agenda_fallback(batching_db):
+    db, event, place = batching_db
+    empty_agenda = _add_catalog(
+        db,
+        event,
+        place,
+        category="agenda",
+        content="agenda text",
+        content_hash=None,
+        summary=None,
+        summary_source_hash=None,
+        segmentation_status="empty",
+    )
+    db.commit()
+
+    batch = build_deterministic_agenda_summary_payloads(
+        [empty_agenda.id],
+        session_factory=lambda: nullcontext(db),
+    )
+
+    refreshed = db.get(Catalog, empty_agenda.id)
+    assert batch["results"][empty_agenda.id]["status"] == "complete"
+    assert batch["results"][empty_agenda.id]["completion_mode"] == "agenda_empty_deterministic"
+    assert refreshed.summary == EMPTY_AGENDA_SUMMARY_TEXT
+    assert refreshed.summary_source_hash == refreshed.content_hash
+
+
+def test_deterministic_agenda_summary_payloads_do_not_fallback_for_failed_agenda(batching_db):
+    db, event, place = batching_db
+    failed_agenda = _add_catalog(
+        db,
+        event,
+        place,
+        category="agenda",
+        content="agenda text",
+        summary=None,
+        segmentation_status="failed",
+    )
+    db.commit()
+
+    batch = build_deterministic_agenda_summary_payloads(
+        [failed_agenda.id],
+        session_factory=lambda: nullcontext(db),
+    )
+
+    assert batch["results"][failed_agenda.id]["status"] == "not_generated_yet"
+    assert db.get(Catalog, failed_agenda.id).summary is None
 
 
 def test_persist_agenda_items_updates_catalog_agenda_items_hash(batching_db):

--- a/tests/test_pipeline_batching.py
+++ b/tests/test_pipeline_batching.py
@@ -20,6 +20,7 @@ from pipeline.agenda_worker import select_catalog_ids_for_agenda_segmentation
 from pipeline.table_worker import select_catalog_ids_for_table_extraction
 from pipeline.models import Base, Catalog, Document, AgendaItem, Event, Place
 from pipeline.city_scope import ordered_hydration_cities, source_aliases_for_city
+from pipeline.content_hash import compute_content_hash
 from pipeline.summary_freshness import compute_agenda_items_hash
 
 
@@ -115,7 +116,6 @@ def test_run_entity_backfill_uses_in_process_fast_path_for_small_snapshots(mocke
 
 def test_process_entity_chunk_marks_low_signal_docs_fresh_without_spacy(db_session, mocker):
     from pipeline.backfill_entities import process_entity_chunk
-    from pipeline.content_hash import compute_content_hash
     from pipeline.models import Catalog, Document, Event, Place
 
     place = Place(
@@ -167,7 +167,6 @@ def test_process_entity_chunk_marks_low_signal_docs_fresh_without_spacy(db_sessi
 
 def test_process_entity_chunk_backfills_missing_entities_source_hash_without_rerunning_ner(db_session, mocker):
     from pipeline.backfill_entities import process_entity_chunk
-    from pipeline.content_hash import compute_content_hash
     from pipeline.models import Catalog, Document, Event, Place
 
     place = Place(
@@ -497,6 +496,52 @@ def test_deterministic_agenda_summary_payloads_persist_empty_agenda_fallback(bat
     assert batch["results"][empty_agenda.id]["completion_mode"] == "agenda_empty_deterministic"
     assert refreshed.summary == EMPTY_AGENDA_SUMMARY_TEXT
     assert refreshed.summary_source_hash == refreshed.content_hash
+
+
+def test_empty_agenda_content_hash_backfill_marks_catalog_changed(batching_db):
+    db, event, place = batching_db
+    content = "agenda text"
+    expected_content_hash = compute_content_hash(content)
+    empty_agenda = _add_catalog(
+        db,
+        event,
+        place,
+        category="agenda",
+        content=content,
+        content_hash=None,
+        summary=EMPTY_AGENDA_SUMMARY_TEXT,
+        summary_source_hash=expected_content_hash,
+        segmentation_status="empty",
+    )
+    db.commit()
+    reindexed_catalog_ids: list[int] = []
+    embedded_catalog_ids: list[int] = []
+
+    batch = build_deterministic_agenda_summary_payloads(
+        [empty_agenda.id],
+        session_factory=lambda: nullcontext(db),
+        reindex_callback=lambda catalog_ids: reindexed_catalog_ids.extend(catalog_ids)
+        or {
+            "catalogs_considered": len(catalog_ids),
+            "catalogs_reindexed": len(catalog_ids),
+            "catalogs_failed": 0,
+            "failed_catalog_ids": [],
+        },
+        embed_callback=lambda catalog_ids: embedded_catalog_ids.extend(catalog_ids)
+        or {
+            "catalogs_considered": len(catalog_ids),
+            "embed_enqueued": len(catalog_ids),
+            "embed_dispatch_failed": 0,
+            "failed_catalog_ids": [],
+        },
+    )
+
+    refreshed = db.get(Catalog, empty_agenda.id)
+    assert batch["results"][empty_agenda.id]["changed"] is True
+    assert batch["changed_catalog_ids"] == [empty_agenda.id]
+    assert reindexed_catalog_ids == [empty_agenda.id]
+    assert embedded_catalog_ids == [empty_agenda.id]
+    assert refreshed.content_hash == expected_content_hash
 
 
 def test_deterministic_agenda_summary_payloads_do_not_fallback_for_failed_agenda(batching_db):

--- a/tests/test_summary_staleness.py
+++ b/tests/test_summary_staleness.py
@@ -7,7 +7,7 @@ from fastapi.testclient import TestClient
 sys.modules["llama_cpp"] = MagicMock()
 
 from api.main import app
-from pipeline.summary_freshness import compute_agenda_items_hash
+from pipeline.summary_freshness import compute_agenda_items_hash, is_summary_fresh
 
 
 client = TestClient(app)
@@ -213,3 +213,25 @@ def test_summarize_returns_stale_for_agenda_when_agenda_items_hash_is_missing(mo
         delay.assert_not_called()
     finally:
         del app.dependency_overrides[get_db]
+
+
+def test_empty_agenda_summary_freshness_uses_content_hash():
+    assert is_summary_fresh(
+        "agenda",
+        summary="No items were detected.",
+        summary_source_hash="content-hash",
+        content_hash="content-hash",
+        agenda_items_hash=None,
+        agenda_segmentation_status="empty",
+    )
+
+
+def test_empty_agenda_with_rows_uses_agenda_items_hash():
+    assert not is_summary_fresh(
+        "agenda",
+        summary="Old empty agenda fallback.",
+        summary_source_hash="content-hash",
+        content_hash="content-hash",
+        agenda_items_hash="items-hash",
+        agenda_segmentation_status="empty",
+    )


### PR DESCRIPTION
## What changed
- Switched the Sunnyvale crawler to the Legistar Web API path with paginated event retrieval and deterministic meeting names.
- Passed `LLM_CONTEXT_WINDOW` through to Ollama as `options.num_ctx` so local inference can use the configured context window.
- Added deterministic summary handling for agendas with `agenda_segmentation_status='empty'`, including status-aware freshness and derived-status behavior.
- Split summary task generation into focused helper modules to keep the task facade small while preserving behavior.

## Why
Sunnyvale backfill had two completion blockers: the crawler source needed the API path for complete event coverage, and empty-segmented agendas had no deliberate summary path. The Ollama context setting was also parsed but not included in requests, causing large-summary retries to run against the default context.

## Risk / compatibility
- No API route, response-shape, schema, dependency, or runtime-default changes.
- Existing task/API facades remain in place.
- Empty-agenda fallback only applies to `agenda_segmentation_status='empty'`; `null` and `failed` remain blocked/not generated.
- Local Docker/Desktop memory changes used for manual model testing are not committed.

## Verification
PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_legistar_api_spider_contract.py tests/test_inference_provider_protocol_contract.py tests/test_pipeline_batching.py tests/test_summary_staleness.py tests/test_api.py`

PASS: `./.venv/bin/ruff check api pipeline scripts tests`

PASS: `./.venv/bin/mypy`

PASS: `git diff --check`

Previously completed during implementation:
- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_provider_error_mapping_retry_vs_fallback.py tests/test_llm_backend_parity_*.py tests/test_runtime_profiles_defaults.py`
- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_run_pipeline_orchestration.py tests/test_task_metrics.py tests/test_tasks_agenda_summary_format.py tests/test_summary_hydration_diagnostics.py tests/test_not_generated_status.py`
- PASS: Docker empty-agenda backfill selected 16 Sunnyvale empty agendas and completed 16 with 0 errors.
- PASS: `gemma4:e2b` Ollama smoke after increasing local Docker memory: model loaded and `/api/generate` returned HTTP 200.

## Remaining notes
- The remaining Sunnyvale minutes still need an operational retry with the larger model after this code lands.
- Docs/runbook updates were intentionally not mixed into this code PR.
