### PR TITLE
Hide semantic health exception details

### DIFF
--- a/pipeline/semantic_faiss_backend.py
+++ b/pipeline/semantic_faiss_backend.py
@@ -174,4 +174,4 @@ class FaissSemanticBackend(SemanticBackend):
                 },
             }
         except (FileNotFoundError, json.JSONDecodeError, OSError, RuntimeError, ValueError) as exc:
-            return {"status": "error", "error": exc.__class__.__name__, "detail": str(exc)}
+            return {"status": "error", "error": exc.__class__.__name__}

--- a/tests/test_semantic_require_faiss.py
+++ b/tests/test_semantic_require_faiss.py
@@ -13,3 +13,14 @@ def test_semantic_require_faiss_raises_when_faiss_missing(monkeypatch):
     monkeypatch.setattr(semantic_index, "SEMANTIC_ALLOW_MULTIPROCESS", True)
     with pytest.raises(SemanticConfigError):
         backend._guard_runtime()
+
+
+def test_faiss_health_hides_exception_detail(monkeypatch):
+    semantic_index.FaissSemanticBackend._instance = None
+    backend = FaissSemanticBackend()
+    monkeypatch.setattr(backend, "_guard_runtime", lambda: None)
+    monkeypatch.setattr(backend, "_load_artifacts", lambda: (_ for _ in ()).throw(FileNotFoundError("/secret/index.faiss")))
+
+    health = backend.health()
+
+    assert health == {"status": "error", "error": "FileNotFoundError"}


### PR DESCRIPTION
## What changed
- Removed raw exception text from FAISS semantic backend health error payloads.
- Added regression coverage proving health errors expose only safe error metadata.

## Why
CodeQL alert 10 (`py/stack-trace-exposure`) reported exception details flowing toward a public health response. Exception strings can include local paths or other implementation details.

## Risk / compatibility
- No route, schema, dependency, or runtime default changes.
- Health error payload still includes `status=error` and exception class name for operator triage.
- Detailed exception text was already unsafe for public response payloads.

## Verification
PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_semantic_require_faiss.py tests/test_semantic_service_api.py tests/test_semantic_search_api.py`

PASS: `./.venv/bin/ruff check api pipeline scripts tests`

PASS: `./.venv/bin/mypy`

PASS: `git diff --check`

## Remaining notes
CodeQL closure will be confirmed by GitHub after this branch is scanned.
