### PR TITLE
Sync crawler and context docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ docker compose run --rm crawler scrapy crawl berkeley
 
 # Cupertino (Legistar API crawler)
 docker compose run --rm crawler scrapy crawl cupertino
+
+# Sunnyvale (Legistar API crawler)
+docker compose run --rm crawler scrapy crawl sunnyvale
 ```
 
 ### 4) Process + index

--- a/docs/CONTRIBUTING_CITIES.md
+++ b/docs/CONTRIBUTING_CITIES.md
@@ -22,6 +22,23 @@ Prefer existing templates/base classes when possible:
 - `BaseCitySpider`
 - Legistar templates in `council_crawler/templates/`
 
+Legistar source choice:
+- Use the Legistar Web API template (`LegistarApi`) when the city exposes
+  meeting rows through `webapi.legistar.com`.
+- Use the Legistar CMS template only when the public calendar page is the
+  reliable source of truth and the Web API is unavailable or incomplete.
+
+When using `LegistarApi`:
+- Pass the tenant slug as `client` (for example `sunnyvaleca`) and the local
+  city slug as `city` (for example `sunnyvale`). The API client slug controls
+  the upstream URL; the city slug controls normalized local identity.
+- The template requests JSON explicitly, orders events by descending
+  `EventDate`, and paginates with `$top` / `$skip`.
+- The template fetches the meeting detail page when either the agenda or minutes
+  URL is missing from the API row, then dedupes API and detail-page documents.
+  This prevents partial Legistar API rows from silently dropping one document
+  category.
+
 ### 3) Validate crawler output contract
 Ensure emitted items include:
 - meeting/event identity
@@ -51,6 +68,9 @@ Add/extend tests with invariant checks (not brittle exact output):
 - seed places includes city record
 - spider handles missing optional doc links cleanly
 - mapping from source payload -> internal fields remains valid
+- Legistar API spiders preserve API documents when detail fallback fails
+- Legistar API detail fallback recovers the missing agenda or minutes URL when
+  only one document category is present in the API row
 
 ## Related Docs
 - Crawler internals: `council_crawler/council_crawler_readme.md`

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -565,9 +565,14 @@ Task polling note:
 Default local model: Gemma 3 270M (trained for up to 32K context).
 
 We default to a smaller context window for Docker stability/performance. Tune via env vars (worker reads them):
-- `LLM_CONTEXT_WINDOW` (default `16384`, max for this model: `32768`)
-- `LLM_SUMMARY_MAX_TEXT` (default `30000`)
-- `LLM_SUMMARY_MAX_TOKENS` (default `512`)
+- `LLM_CONTEXT_WINDOW` (default `16384`, max for this model: `32768`): sent
+  to Ollama as `options.num_ctx`, which controls the model context window for
+  the request.
+- `LLM_SUMMARY_MAX_TEXT` (default `30000`): trims the source text before the
+  prompt is built; lowering this reduces prompt size but does not raise the
+  model context window.
+- `LLM_SUMMARY_MAX_TOKENS` (default `512`): sent to Ollama as `num_predict`,
+  which controls the output token budget.
 - `LLM_AGENDA_MAX_TEXT` (default `60000`)
 
 ### LocalAI process model guardrail
@@ -1410,6 +1415,7 @@ Summary format:
 Agenda summary contract:
 - For `Document.category == "agenda"`, summaries are derived from segmented agenda items (Structured Agenda) to avoid drift.
 - Agenda summary freshness is keyed to `agenda_items_hash`; agendas with `agenda_segmentation_status=empty` use deterministic empty-agenda summaries keyed to `content_hash`; non-agenda summary freshness also stays keyed to `content_hash`.
+- `POST /summarize/{catalog_id}` allows that deterministic empty-agenda summary path before the low-signal text gate when segmentation reached the terminal `empty` state.
 - Agenda summary input uses structured fields (`title`, `description`, `classification`, `result`, `page_number`) and is hard-capped for context safety.
 - If input is truncated for context budget, summary output discloses partial coverage (`first N of M agenda items`) in `Unknowns`.
 - If an agenda has not been segmented yet, summary generation returns `not_generated_yet` and prompts you to segment first; if segmentation completed with `empty`, summary generation stores the deterministic empty-agenda summary.


### PR DESCRIPTION
## What changed
- Documented when to use the Legistar Web API crawler template and how its client/city slugs, pagination, JSON requests, and detail fallback work.
- Added Sunnyvale to the README scrape examples as a Legistar API crawler.
- Clarified how `LLM_CONTEXT_WINDOW`, `LLM_SUMMARY_MAX_TEXT`, and `LLM_SUMMARY_MAX_TOKENS` affect Ollama summary requests.
- Documented the empty-agenda summary route behavior.

## Why
Recent crawler and summary backfill work changed operational behavior, and the docs needed to match the current source ownership and runtime semantics.

## Risk / compatibility
Docs-only. No runtime behavior, API contract, dependency, workflow, or config changes.

## Verification
- PASS `PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py`
- PASS `git diff --check`

## Remaining deficits
None.