### PR TITLE
Add minutes fallback for empty summary responses

### DIFF
--- a/pipeline/agenda_segmentation_maintenance.py
+++ b/pipeline/agenda_segmentation_maintenance.py
@@ -103,13 +103,18 @@ def capture_summary_fallback_events() -> dict[str, int]:
     class _CaptureHandler(logging.Handler):
         def emit(self, record: logging.LogRecord) -> None:
             message = record.getMessage()
-            if "AI Agenda Items Summarization failed" not in message:
+            if (
+                "AI Agenda Items Summarization failed" not in message
+                and "AI Summarization failed" not in message
+            ):
                 return
             lowered = message.lower()
             if "timed out" in lowered:
                 counts["timeout"] += 1
             if "unavailable" in lowered or "connection" in lowered:
                 counts["unavailable"] += 1
+            if "empty response payload" in lowered:
+                counts["empty_response"] += 1
 
     handler = _CaptureHandler()
     local_ai_logger.addHandler(handler)

--- a/pipeline/agenda_summary_fallback.py
+++ b/pipeline/agenda_summary_fallback.py
@@ -8,7 +8,11 @@ from pipeline.db_session import db_session
 from pipeline.document_kinds import normalize_summary_doc_kind
 from pipeline.models import Document
 
-_PROVIDER_FAILURE_TOKENS = ("timed out", "timeout", "unavailable", "connection", "empty response payload")
+_PROVIDER_FAILURE_REASONS = (
+    ("empty_response", ("empty response payload",)),
+    ("timeout", ("timed out", "timeout")),
+    ("unavailable", ("unavailable", "connection")),
+)
 
 
 def summarize_catalog_with_optional_fallback(
@@ -16,7 +20,7 @@ def summarize_catalog_with_optional_fallback(
     *,
     summary_fallback_mode: str = "none",
     generate_summary_callable: Callable[[int], dict[str, Any] | None],
-    deterministic_summary_callable: Callable[[int], dict[str, Any]],
+    deterministic_summary_callable: Callable[..., dict[str, Any]],
     capture_summary_fallback_events_factory: Callable[[], Any] | None = None,
 ) -> AgendaSummaryPayload:
     fallback_context = (
@@ -31,12 +35,9 @@ def summarize_catalog_with_optional_fallback(
             result = {"status": "error", "error": str(error)}
 
     status = str(result.get("status") or "other")
-    if (
-        summary_fallback_mode == "deterministic"
-        and status == "error"
-        and _provider_failure_detected(result, fallback_events)
-    ):
-        fallback_result = deterministic_summary_callable(catalog_id)
+    fallback_reason = _provider_failure_reason(result, fallback_events)
+    if summary_fallback_mode == "deterministic" and status == "error" and fallback_reason:
+        fallback_result = deterministic_summary_callable(catalog_id, fallback_reason=fallback_reason)
         fallback_result["provider_failure"] = dict(fallback_events)
         return fallback_result
     if status == "complete":
@@ -49,7 +50,7 @@ def summarize_catalog_with_maintenance_mode(
     *,
     summary_fallback_mode: str = "none",
     generate_summary_callable: Callable[[int], dict[str, Any] | None],
-    deterministic_summary_callable: Callable[[int], dict[str, Any]],
+    deterministic_summary_callable: Callable[..., dict[str, Any]],
     session_factory: Callable[[], Any] = db_session,
     capture_summary_fallback_events_factory: Callable[[], Any] | None = None,
     optional_fallback_callable: Callable[..., AgendaSummaryPayload] = summarize_catalog_with_optional_fallback,
@@ -76,12 +77,12 @@ def summarize_catalog_with_maintenance_mode(
     )
 
 
-def _provider_failure_detected(result: dict[str, Any], fallback_events: dict[str, int]) -> bool:
-    if (
-        fallback_events.get("timeout", 0)
-        or fallback_events.get("unavailable", 0)
-        or fallback_events.get("empty_response", 0)
-    ):
-        return True
+def _provider_failure_reason(result: dict[str, Any], fallback_events: dict[str, int]) -> str | None:
+    for reason, _tokens in _PROVIDER_FAILURE_REASONS:
+        if fallback_events.get(reason, 0):
+            return reason
     lowered_error = str(result.get("error") or "").lower()
-    return any(token in lowered_error for token in _PROVIDER_FAILURE_TOKENS)
+    for reason, tokens in _PROVIDER_FAILURE_REASONS:
+        if any(token in lowered_error for token in tokens):
+            return reason
+    return None

--- a/pipeline/agenda_summary_fallback.py
+++ b/pipeline/agenda_summary_fallback.py
@@ -8,7 +8,7 @@ from pipeline.db_session import db_session
 from pipeline.document_kinds import normalize_summary_doc_kind
 from pipeline.models import Document
 
-_PROVIDER_FAILURE_TOKENS = ("timed out", "timeout", "unavailable", "connection")
+_PROVIDER_FAILURE_TOKENS = ("timed out", "timeout", "unavailable", "connection", "empty response payload")
 
 
 def summarize_catalog_with_optional_fallback(
@@ -77,7 +77,11 @@ def summarize_catalog_with_maintenance_mode(
 
 
 def _provider_failure_detected(result: dict[str, Any], fallback_events: dict[str, int]) -> bool:
-    if fallback_events.get("timeout", 0) or fallback_events.get("unavailable", 0):
+    if (
+        fallback_events.get("timeout", 0)
+        or fallback_events.get("unavailable", 0)
+        or fallback_events.get("empty_response", 0)
+    ):
         return True
     lowered_error = str(result.get("error") or "").lower()
     return any(token in lowered_error for token in _PROVIDER_FAILURE_TOKENS)

--- a/pipeline/backlog_maintenance.py
+++ b/pipeline/backlog_maintenance.py
@@ -129,12 +129,14 @@ def build_deterministic_non_agenda_summary_payload(
     *,
     reindex_callback: Callable[[int], Any] | None = None,
     embed_callback: Callable[[int], Any] | None = None,
+    fallback_reason: str = "empty_response",
 ) -> dict[str, Any]:
     return _build_deterministic_non_agenda_summary_payload(
         catalog_id,
         reindex_callback=reindex_callback,
         embed_callback=embed_callback,
         session_factory=db_session,
+        fallback_reason=fallback_reason,
     )
 
 

--- a/pipeline/backlog_maintenance.py
+++ b/pipeline/backlog_maintenance.py
@@ -9,6 +9,9 @@ from pipeline.agenda_resolver import has_viable_structured_agenda_source
 from pipeline.config import AGENDA_SUMMARY_MAX_INPUT_CHARS, AGENDA_SUMMARY_MIN_RESERVED_OUTPUT_CHARS
 from pipeline.db_session import db_session
 from pipeline.models import Document
+from pipeline.non_agenda_summary_fallback import (
+    build_deterministic_non_agenda_summary_payload as _build_deterministic_non_agenda_summary_payload,
+)
 
 AGENDA_SUMMARY_READY_STATUS = agenda_summary_maintenance_mod.AGENDA_SUMMARY_READY_STATUS
 AGENDA_SUMMARY_SEGMENTATION_REQUIRED_REASON = (
@@ -118,6 +121,20 @@ def build_deterministic_agenda_summary_payload(
         reindex_callback=reindex_callback,
         embed_callback=embed_callback,
         build_payloads_callable=build_deterministic_agenda_summary_payloads,
+    )
+
+
+def build_deterministic_non_agenda_summary_payload(
+    catalog_id: int,
+    *,
+    reindex_callback: Callable[[int], Any] | None = None,
+    embed_callback: Callable[[int], Any] | None = None,
+) -> dict[str, Any]:
+    return _build_deterministic_non_agenda_summary_payload(
+        catalog_id,
+        reindex_callback=reindex_callback,
+        embed_callback=embed_callback,
+        session_factory=db_session,
     )
 
 

--- a/pipeline/non_agenda_summary_fallback.py
+++ b/pipeline/non_agenda_summary_fallback.py
@@ -24,11 +24,16 @@ from pipeline.task_summary_generation_contracts import (
 logger = logging.getLogger(__name__)
 
 NON_AGENDA_FALLBACK_COMPLETION_MODE = "deterministic_fallback"
-NON_AGENDA_FALLBACK_NOTE = (
-    "Generation note: Deterministic fallback used because the local AI provider "
-    "returned an empty summary response."
+NON_AGENDA_FALLBACK_NOTE_PREFIX = (
+    "Generation note: Deterministic fallback used because the local AI provider"
 )
+NON_AGENDA_FALLBACK_NOTE = f"{NON_AGENDA_FALLBACK_NOTE_PREFIX} returned an empty summary response."
 NON_AGENDA_FALLBACK_REASON = "empty_response"
+_FALLBACK_REASON_NOTES = {
+    "empty_response": "returned an empty summary response.",
+    "timeout": "timed out while generating the summary.",
+    "unavailable": "was unavailable while generating the summary.",
+}
 _CATALOG_NOT_FOUND_ERROR = "Catalog not found"
 _DOCUMENT_NOT_FOUND_ERROR = "Document not found"
 _NO_CONTENT_ERROR = "No content to summarize"
@@ -46,13 +51,26 @@ class NonAgendaFallbackPersistence:
 def build_non_agenda_fallback_summary_text(*, document: Document | None, content: str | None) -> str:
     doc_label = _document_label(document)
     excerpt = _fallback_excerpt(content)
+    return _format_non_agenda_fallback_summary(
+        doc_label=doc_label,
+        excerpt=excerpt,
+        fallback_reason=NON_AGENDA_FALLBACK_REASON,
+    )
+
+
+def _format_non_agenda_fallback_summary(
+    *,
+    doc_label: str,
+    excerpt: str,
+    fallback_reason: str,
+) -> str:
+    provider_note = _provider_note(fallback_reason)
     return (
-        f"BLUF: {doc_label} text is available, but the local AI provider returned "
-        "an empty response before it could generate a model summary.\n"
+        f"BLUF: {doc_label} text is available, but the local AI provider {provider_note}\n"
         f"- Source excerpt: {excerpt}\n"
         "- Review the extracted minutes for the authoritative meeting details.\n"
         "- Regenerate this summary after the local provider/runtime issue is resolved.\n"
-        f"{NON_AGENDA_FALLBACK_NOTE}"
+        f"{NON_AGENDA_FALLBACK_NOTE_PREFIX} {provider_note}"
     )
 
 
@@ -62,9 +80,14 @@ def build_deterministic_non_agenda_summary_payload(
     reindex_callback: Callable[[int], Any] | None = None,
     embed_callback: Callable[[int], Any] | None = None,
     session_factory: Callable[[], Any] = db_session,
+    fallback_reason: str = NON_AGENDA_FALLBACK_REASON,
 ) -> dict[str, Any]:
     with session_factory() as session:
-        persistence = _build_and_persist_non_agenda_fallback(session, catalog_id)
+        persistence = _build_and_persist_non_agenda_fallback(
+            session,
+            catalog_id,
+            fallback_reason=fallback_reason,
+        )
         if isinstance(persistence, dict):
             return persistence
 
@@ -72,7 +95,7 @@ def build_deterministic_non_agenda_summary_payload(
         "non_agenda_summary_fallback.used catalog_id=%s doc_kind=%s fallback_reason=%s summary_fallback_mode=%s",
         catalog_id,
         persistence.doc_kind,
-        NON_AGENDA_FALLBACK_REASON,
+        fallback_reason,
         "deterministic",
     )
     side_effects = _run_fallback_side_effects(
@@ -92,6 +115,8 @@ def build_deterministic_non_agenda_summary_payload(
 def _build_and_persist_non_agenda_fallback(
     session: Any,
     catalog_id: int,
+    *,
+    fallback_reason: str,
 ) -> NonAgendaFallbackPersistence | dict[str, Any]:
     catalog = session.get(Catalog, catalog_id)
     document = session.query(Document).filter_by(catalog_id=catalog_id).first()
@@ -102,7 +127,11 @@ def _build_and_persist_non_agenda_fallback(
     if catalog is None or document is None:
         return {"status": SUMMARY_ERROR_STATUS, "error": _CATALOG_NOT_FOUND_ERROR}
     doc_kind = normalize_summary_doc_kind(document.category)
-    fallback_summary = build_non_agenda_fallback_summary_text(document=document, content=catalog.content)
+    fallback_summary = _format_non_agenda_fallback_summary(
+        doc_label=_document_label(document),
+        excerpt=_fallback_excerpt(catalog.content),
+        fallback_reason=fallback_reason,
+    )
     persisted_summary = _persist_non_agenda_fallback_summary(
         catalog=catalog,
         summary=fallback_summary,
@@ -122,6 +151,10 @@ def _document_label(document: Document | None) -> str:
         return "Non-agenda document"
     doc_kind = normalize_summary_doc_kind(document.category)
     return f"{doc_kind.title()} document"
+
+
+def _provider_note(fallback_reason: str) -> str:
+    return _FALLBACK_REASON_NOTES.get(fallback_reason, _FALLBACK_REASON_NOTES[NON_AGENDA_FALLBACK_REASON])
 
 
 def _fallback_excerpt(content: str | None) -> str:

--- a/pipeline/non_agenda_summary_fallback.py
+++ b/pipeline/non_agenda_summary_fallback.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from pipeline.agenda_summary_contracts import AGENDA_SUMMARY_EMBED_DISPATCH_ERRORS
+from pipeline.content_hash import compute_content_hash
+from pipeline.db_session import db_session
+from pipeline.document_kinds import normalize_summary_doc_kind
+from pipeline.laserfiche_error_pages import classify_catalog_bad_content
+from pipeline.models import Catalog, Document
+from pipeline.summary_freshness import compute_summary_source_hash
+from pipeline.summary_quality import analyze_source_text, build_low_signal_message, is_source_summarizable
+from pipeline.task_side_effects import REINDEX_FAILURE_EXCEPTIONS
+from pipeline.task_summary_generation_contracts import (
+    SUMMARY_BLOCKED_LOW_SIGNAL_STATUS,
+    SUMMARY_COMPLETE_STATUS,
+    SUMMARY_ERROR_STATUS,
+)
+
+logger = logging.getLogger(__name__)
+
+NON_AGENDA_FALLBACK_COMPLETION_MODE = "deterministic_fallback"
+NON_AGENDA_FALLBACK_NOTE = (
+    "Generation note: Deterministic fallback used because the local AI provider "
+    "returned an empty summary response."
+)
+NON_AGENDA_FALLBACK_REASON = "empty_response"
+_CATALOG_NOT_FOUND_ERROR = "Catalog not found"
+_DOCUMENT_NOT_FOUND_ERROR = "Document not found"
+_NO_CONTENT_ERROR = "No content to summarize"
+_UNSUPPORTED_DOC_KIND_ERROR = "Non-agenda fallback only supports minutes documents"
+_MAX_EXCERPT_CHARS = 240
+
+
+@dataclass(frozen=True)
+class NonAgendaFallbackPersistence:
+    summary: str
+    doc_kind: str
+    changed: bool
+
+
+def build_non_agenda_fallback_summary_text(*, document: Document | None, content: str | None) -> str:
+    doc_label = _document_label(document)
+    excerpt = _fallback_excerpt(content)
+    return (
+        f"BLUF: {doc_label} text is available, but the local AI provider returned "
+        "an empty response before it could generate a model summary.\n"
+        f"- Source excerpt: {excerpt}\n"
+        "- Review the extracted minutes for the authoritative meeting details.\n"
+        "- Regenerate this summary after the local provider/runtime issue is resolved.\n"
+        f"{NON_AGENDA_FALLBACK_NOTE}"
+    )
+
+
+def build_deterministic_non_agenda_summary_payload(
+    catalog_id: int,
+    *,
+    reindex_callback: Callable[[int], Any] | None = None,
+    embed_callback: Callable[[int], Any] | None = None,
+    session_factory: Callable[[], Any] = db_session,
+) -> dict[str, Any]:
+    with session_factory() as session:
+        persistence = _build_and_persist_non_agenda_fallback(session, catalog_id)
+        if isinstance(persistence, dict):
+            return persistence
+
+    logger.warning(
+        "non_agenda_summary_fallback.used catalog_id=%s doc_kind=%s fallback_reason=%s summary_fallback_mode=%s",
+        catalog_id,
+        persistence.doc_kind,
+        NON_AGENDA_FALLBACK_REASON,
+        "deterministic",
+    )
+    side_effects = _run_fallback_side_effects(
+        catalog_id,
+        reindex_callback=reindex_callback,
+        embed_callback=embed_callback,
+    )
+    return {
+        "status": SUMMARY_COMPLETE_STATUS,
+        "summary": persistence.summary,
+        "completion_mode": NON_AGENDA_FALLBACK_COMPLETION_MODE,
+        "changed": persistence.changed,
+        **side_effects,
+    }
+
+
+def _build_and_persist_non_agenda_fallback(
+    session: Any,
+    catalog_id: int,
+) -> NonAgendaFallbackPersistence | dict[str, Any]:
+    catalog = session.get(Catalog, catalog_id)
+    document = session.query(Document).filter_by(catalog_id=catalog_id).first()
+    validation_payload = _non_agenda_fallback_validation_payload(catalog, document)
+    if validation_payload is not None:
+        return validation_payload
+
+    if catalog is None or document is None:
+        return {"status": SUMMARY_ERROR_STATUS, "error": _CATALOG_NOT_FOUND_ERROR}
+    doc_kind = normalize_summary_doc_kind(document.category)
+    fallback_summary = build_non_agenda_fallback_summary_text(document=document, content=catalog.content)
+    persisted_summary = _persist_non_agenda_fallback_summary(
+        catalog=catalog,
+        summary=fallback_summary,
+        doc_kind=doc_kind,
+        content_hash=compute_content_hash(catalog.content),
+    )
+    session.commit()
+    return NonAgendaFallbackPersistence(
+        summary=fallback_summary,
+        doc_kind=doc_kind,
+        changed=bool(persisted_summary["changed"]),
+    )
+
+
+def _document_label(document: Document | None) -> str:
+    if document is None:
+        return "Non-agenda document"
+    doc_kind = normalize_summary_doc_kind(document.category)
+    return f"{doc_kind.title()} document"
+
+
+def _fallback_excerpt(content: str | None) -> str:
+    normalized = re.sub(r"\s+", " ", content or "").strip()
+    if not normalized:
+        return "No extracted text was available."
+    if len(normalized) <= _MAX_EXCERPT_CHARS:
+        return normalized
+    return f"{normalized[:_MAX_EXCERPT_CHARS].rstrip()}..."
+
+
+def _non_agenda_fallback_validation_payload(
+    catalog: Catalog | None,
+    document: Document | None,
+) -> dict[str, Any] | None:
+    if catalog is None:
+        return {"status": SUMMARY_ERROR_STATUS, "error": _CATALOG_NOT_FOUND_ERROR}
+    if document is None:
+        return {"status": SUMMARY_ERROR_STATUS, "error": _DOCUMENT_NOT_FOUND_ERROR}
+    if normalize_summary_doc_kind(document.category) != "minutes":
+        return {"status": SUMMARY_ERROR_STATUS, "error": _UNSUPPORTED_DOC_KIND_ERROR}
+    if not catalog.content:
+        return {"error": _NO_CONTENT_ERROR}
+    classification = classify_catalog_bad_content(catalog)
+    if classification:
+        return {"status": SUMMARY_ERROR_STATUS, "error": classification.reason}
+    quality = analyze_source_text(catalog.content)
+    if not is_source_summarizable(quality):
+        return {
+            "status": SUMMARY_BLOCKED_LOW_SIGNAL_STATUS,
+            "reason": build_low_signal_message(quality),
+            "summary": None,
+        }
+    return None
+
+
+def _persist_non_agenda_fallback_summary(
+    *,
+    catalog: Catalog,
+    summary: str,
+    doc_kind: str,
+    content_hash: str | None,
+) -> dict[str, Any]:
+    prior_summary = catalog.summary
+    prior_summary_source_hash = catalog.summary_source_hash
+    summary_source_hash = compute_summary_source_hash(
+        doc_kind,
+        content_hash=content_hash,
+        agenda_items_hash=None,
+    )
+    catalog.summary = summary
+    if content_hash:
+        catalog.content_hash = content_hash
+    if summary_source_hash:
+        catalog.summary_source_hash = summary_source_hash
+    return {
+        "status": SUMMARY_COMPLETE_STATUS,
+        "summary": summary,
+        "changed": bool(prior_summary != summary or prior_summary_source_hash != summary_source_hash),
+    }
+
+
+def _run_fallback_side_effects(
+    catalog_id: int,
+    *,
+    reindex_callback: Callable[[int], Any] | None,
+    embed_callback: Callable[[int], Any] | None,
+) -> dict[str, int]:
+    reindexed, reindex_failed = _run_reindex_callback(reindex_callback, catalog_id)
+    embed_enqueued, embed_dispatch_failed = _run_embed_callback(embed_callback, catalog_id)
+    return {
+        "reindexed": reindexed,
+        "reindex_failed": reindex_failed,
+        "embed_enqueued": embed_enqueued,
+        "embed_dispatch_failed": embed_dispatch_failed,
+    }
+
+
+def _run_reindex_callback(callback: Callable[[int], Any] | None, catalog_id: int) -> tuple[int, int]:
+    if callback is None:
+        return 0, 0
+    try:
+        callback(catalog_id)
+        return 1, 0
+    except REINDEX_FAILURE_EXCEPTIONS as reindex_error:
+        logger.warning("non_agenda_summary_fallback.reindex_failed catalog_id=%s error=%s", catalog_id, reindex_error)
+        return 0, 1
+
+
+def _run_embed_callback(callback: Callable[[int], Any] | None, catalog_id: int) -> tuple[int, int]:
+    if callback is None:
+        return 0, 0
+    try:
+        callback(catalog_id)
+        return 1, 0
+    except AGENDA_SUMMARY_EMBED_DISPATCH_ERRORS as dispatch_error:
+        logger.warning(
+            "non_agenda_summary_fallback.embed_dispatch_failed catalog_id=%s error=%s",
+            catalog_id,
+            dispatch_error,
+        )
+        return 0, 1

--- a/pipeline/summary_backfill.py
+++ b/pipeline/summary_backfill.py
@@ -24,6 +24,7 @@ def run_summary_hydration_backfill(
     select_catalog_ids_callable: Callable[[Any, int | None, str | None], list[int]] | None = None,
     summary_doc_kind_map_callable: Callable[[Any, list[int]], dict[int, str]] | None = None,
     agenda_summary_batch_builder: Callable[..., dict[str, Any]] | None = None,
+    non_agenda_summary_builder: Callable[..., dict[str, Any]] | None = None,
     summarize_catalog_callable: Callable[..., dict[str, Any]] | None = None,
 ) -> dict[str, int]:
     # Resolve embed dispatch through this facade so existing monkeypatch seams stay live.
@@ -51,6 +52,11 @@ def run_summary_hydration_backfill(
         **(
             {"agenda_summary_batch_builder": agenda_summary_batch_builder}
             if agenda_summary_batch_builder is not None
+            else {}
+        ),
+        **(
+            {"non_agenda_summary_builder": non_agenda_summary_builder}
+            if non_agenda_summary_builder is not None
             else {}
         ),
         **(

--- a/pipeline/summary_backfill_runner.py
+++ b/pipeline/summary_backfill_runner.py
@@ -163,10 +163,11 @@ def _run_backfill_loop(
                     cid,
                     summary_fallback_mode=summary_fallback_mode,
                     generate_summary_callable=lambda catalog_id: generate_summary_callable(catalog_id),
-                    deterministic_summary_callable=lambda catalog_id: non_agenda_summary_builder(
+                    deterministic_summary_callable=lambda catalog_id, fallback_reason="empty_response": non_agenda_summary_builder(
                         catalog_id,
                         reindex_callback=reindex_catalog,
                         embed_callback=lambda target_catalog_id: embed_catalog_task.delay(target_catalog_id),
+                        fallback_reason=fallback_reason,
                     ),
                 )
             record_summary_result_counts(counts, result)

--- a/pipeline/summary_backfill_runner.py
+++ b/pipeline/summary_backfill_runner.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from typing import Any, Callable
 
 from pipeline.backlog_maintenance import (
-    build_deterministic_agenda_summary_payload,
     build_deterministic_agenda_summary_payloads,
+    build_deterministic_non_agenda_summary_payload,
     summarize_catalog_with_maintenance_mode,
     summary_timeout_override,
 )
@@ -44,6 +44,7 @@ def run_summary_hydration_backfill(
     ] = select_catalog_ids_for_summary_hydration,
     summary_doc_kind_map_callable: Callable[[Any, list[int]], dict[int, str]] = summary_doc_kind_map,
     agenda_summary_batch_builder: Callable[..., dict[str, Any]] = build_deterministic_agenda_summary_payloads,
+    non_agenda_summary_builder: Callable[..., dict[str, Any]] = build_deterministic_non_agenda_summary_payload,
     summarize_catalog_callable: Callable[..., dict[str, Any]] = summarize_catalog_with_maintenance_mode,
 ) -> dict[str, int]:
     """
@@ -82,6 +83,7 @@ def run_summary_hydration_backfill(
         progress_callback=progress_callback,
         progress_every=progress_every,
         generate_summary_callable=generate_summary_callable,
+        non_agenda_summary_builder=non_agenda_summary_builder,
         summarize_catalog_callable=summarize_catalog_callable,
     )
     log_backfill_counts(counts)
@@ -149,6 +151,7 @@ def _run_backfill_loop(
     progress_callback: Callable[[dict[str, Any]], None] | None,
     progress_every: int,
     generate_summary_callable: Callable[[int], dict[str, Any]],
+    non_agenda_summary_builder: Callable[..., dict[str, Any]],
     summarize_catalog_callable: Callable[..., dict[str, Any]],
 ) -> None:
     with summary_timeout_override(summary_timeout_seconds):
@@ -160,7 +163,7 @@ def _run_backfill_loop(
                     cid,
                     summary_fallback_mode=summary_fallback_mode,
                     generate_summary_callable=lambda catalog_id: generate_summary_callable(catalog_id),
-                    deterministic_summary_callable=lambda catalog_id: build_deterministic_agenda_summary_payload(
+                    deterministic_summary_callable=lambda catalog_id: non_agenda_summary_builder(
                         catalog_id,
                         reindex_callback=reindex_catalog,
                         embed_callback=lambda target_catalog_id: embed_catalog_task.delay(target_catalog_id),

--- a/pipeline/task_facade_helpers.py
+++ b/pipeline/task_facade_helpers.py
@@ -64,6 +64,7 @@ def run_summary_hydration_backfill(
         select_catalog_ids_callable=facade["select_catalog_ids_for_summary_hydration"],
         summary_doc_kind_map_callable=facade["_summary_doc_kind_map"],
         agenda_summary_batch_builder=facade["build_deterministic_agenda_summary_payloads"],
+        non_agenda_summary_builder=facade["build_deterministic_non_agenda_summary_payload"],
         summarize_catalog_callable=facade["summarize_catalog_with_maintenance_mode"],
     )
 

--- a/pipeline/tasks.py
+++ b/pipeline/tasks.py
@@ -10,6 +10,7 @@ from pipeline.agenda_resolver import has_viable_structured_agenda_source, resolv
 from pipeline.backlog_maintenance import (
     build_agenda_summary_input_bundle,
     build_deterministic_agenda_summary_payloads,
+    build_deterministic_non_agenda_summary_payload,
     persist_agenda_summary,
     summarize_catalog_with_maintenance_mode,
 )
@@ -44,7 +45,8 @@ from pipeline.text_cleaning import postprocess_extracted_text
 from pipeline.vote_extractor import run_vote_extraction_for_catalog
 
 _TASK_FACADE_DEPENDENCIES = (
-    build_agenda_summary_input_bundle, build_deterministic_agenda_summary_payloads, persist_agenda_summary,
+    build_agenda_summary_input_bundle, build_deterministic_agenda_summary_payloads,
+    build_deterministic_non_agenda_summary_payload, persist_agenda_summary,
     summarize_catalog_with_maintenance_mode, classify_catalog_bad_content, persist_agenda_items,
     has_viable_structured_agenda_source, resolve_agenda_items, TIKA_MIN_EXTRACTED_CHARS_FOR_NO_OCR,
     ENABLE_VOTE_EXTRACTION, reextract_catalog_content, reindex_catalog, compute_content_hash,

--- a/tests/test_pipeline_batching.py
+++ b/tests/test_pipeline_batching.py
@@ -16,6 +16,11 @@ from pipeline.agenda_service import persist_agenda_items
 from pipeline.tasks import select_catalog_ids_for_summary_hydration, run_summary_hydration_backfill
 from pipeline.agenda_summary_batch import build_deterministic_agenda_summary_payloads
 from pipeline.agenda_summary_empty import EMPTY_AGENDA_SUMMARY_TEXT
+from pipeline.non_agenda_summary_fallback import (
+    NON_AGENDA_FALLBACK_COMPLETION_MODE,
+    NON_AGENDA_FALLBACK_NOTE,
+    build_deterministic_non_agenda_summary_payload,
+)
 from pipeline.agenda_worker import select_catalog_ids_for_agenda_segmentation
 from pipeline.table_worker import select_catalog_ids_for_table_extraction
 from pipeline.models import Base, Catalog, Document, AgendaItem, Event, Place
@@ -713,6 +718,123 @@ def test_run_summary_hydration_backfill_counts_outcomes(mocker):
     assert counts["agenda_summary_embed_dispatch_ms"] == 55
     batch_spy.assert_called_once()
     summarize_spy.assert_called_once()
+
+
+def test_run_summary_hydration_backfill_uses_non_agenda_fallback_builder(mocker):
+    mock_db = MagicMock()
+    mock_db.close.return_value = None
+    mocker.patch("pipeline.tasks.SessionLocal", return_value=mock_db)
+    mocker.patch("pipeline.tasks.select_catalog_ids_for_summary_hydration", return_value=[3])
+    mocker.patch("pipeline.tasks._summary_doc_kind_map", return_value={3: "minutes"})
+    agenda_builder_spy = mocker.patch("pipeline.tasks.build_deterministic_agenda_summary_payloads")
+    non_agenda_builder_spy = mocker.patch(
+        "pipeline.tasks.build_deterministic_non_agenda_summary_payload",
+        return_value={
+            "status": "complete",
+            "completion_mode": NON_AGENDA_FALLBACK_COMPLETION_MODE,
+            "changed": True,
+        },
+    )
+
+    def _summarize_with_fallback(catalog_id, *, deterministic_summary_callable, **kwargs):
+        _ = kwargs
+        return deterministic_summary_callable(catalog_id)
+
+    mocker.patch(
+        "pipeline.tasks.summarize_catalog_with_maintenance_mode",
+        side_effect=_summarize_with_fallback,
+    )
+
+    counts = run_summary_hydration_backfill(summary_fallback_mode="deterministic")
+
+    assert counts["selected"] == 1
+    assert counts["complete"] == 1
+    assert counts["deterministic_fallback_complete"] == 1
+    agenda_builder_spy.assert_not_called()
+    non_agenda_builder_spy.assert_called_once()
+
+
+def test_non_agenda_fallback_persists_content_hash_and_side_effects(batching_db):
+    db, event, place = batching_db
+    minutes_content = (
+        "The council approved the consent calendar and reviewed transportation funding. "
+        "Members discussed budget updates, public comments, and next steps for staff reports."
+    )
+    minutes_catalog = _add_catalog(
+        db,
+        event,
+        place,
+        category="minutes",
+        content=minutes_content,
+    )
+    db.commit()
+
+    reindexed_catalog_ids = []
+    embedded_catalog_ids = []
+    fallback_result = build_deterministic_non_agenda_summary_payload(
+        minutes_catalog.id,
+        reindex_callback=reindexed_catalog_ids.append,
+        embed_callback=embedded_catalog_ids.append,
+        session_factory=lambda: nullcontext(db),
+    )
+
+    db.expire_all()
+    refreshed = db.get(Catalog, minutes_catalog.id)
+    assert fallback_result["status"] == "complete"
+    assert fallback_result["completion_mode"] == NON_AGENDA_FALLBACK_COMPLETION_MODE
+    assert fallback_result["changed"] is True
+    assert fallback_result["reindexed"] == 1
+    assert fallback_result["embed_enqueued"] == 1
+    assert refreshed.summary.startswith("BLUF:")
+    assert NON_AGENDA_FALLBACK_NOTE in refreshed.summary
+    assert refreshed.summary_source_hash == refreshed.content_hash
+    assert refreshed.content_hash == compute_content_hash(minutes_content)
+    assert reindexed_catalog_ids == [minutes_catalog.id]
+    assert embedded_catalog_ids == [minutes_catalog.id]
+
+
+def test_non_agenda_fallback_preserves_low_signal_block(batching_db):
+    db, event, place = batching_db
+    low_signal_catalog = _add_catalog(db, event, place, category="minutes", content="Minutes")
+    db.commit()
+
+    fallback_result = build_deterministic_non_agenda_summary_payload(
+        low_signal_catalog.id,
+        session_factory=lambda: nullcontext(db),
+    )
+
+    db.expire_all()
+    refreshed = db.get(Catalog, low_signal_catalog.id)
+    assert fallback_result["status"] == "blocked_low_signal"
+    assert refreshed.summary is None
+
+
+def test_non_agenda_fallback_rejects_unknown_document_kind(batching_db):
+    db, event, place = batching_db
+    unknown_catalog = _add_catalog(
+        db,
+        event,
+        place,
+        category="attachment",
+        content=(
+            "Attachment text includes enough substantive terms about council business, "
+            "budget updates, transportation planning, public comments, and staff reports."
+        ),
+    )
+    db.commit()
+
+    fallback_result = build_deterministic_non_agenda_summary_payload(
+        unknown_catalog.id,
+        session_factory=lambda: nullcontext(db),
+    )
+
+    db.expire_all()
+    refreshed = db.get(Catalog, unknown_catalog.id)
+    assert fallback_result == {
+        "status": "error",
+        "error": "Non-agenda fallback only supports minutes documents",
+    }
+    assert refreshed.summary is None
 
 
 def test_summary_backfill_progress_helpers_preserve_counts_and_empty_payload():

--- a/tests/test_pipeline_batching.py
+++ b/tests/test_pipeline_batching.py
@@ -19,6 +19,7 @@ from pipeline.agenda_summary_empty import EMPTY_AGENDA_SUMMARY_TEXT
 from pipeline.non_agenda_summary_fallback import (
     NON_AGENDA_FALLBACK_COMPLETION_MODE,
     NON_AGENDA_FALLBACK_NOTE,
+    NON_AGENDA_FALLBACK_NOTE_PREFIX,
     build_deterministic_non_agenda_summary_payload,
 )
 from pipeline.agenda_worker import select_catalog_ids_for_agenda_segmentation
@@ -791,6 +792,33 @@ def test_non_agenda_fallback_persists_content_hash_and_side_effects(batching_db)
     assert refreshed.content_hash == compute_content_hash(minutes_content)
     assert reindexed_catalog_ids == [minutes_catalog.id]
     assert embedded_catalog_ids == [minutes_catalog.id]
+
+
+def test_non_agenda_fallback_records_timeout_reason(batching_db):
+    db, event, place = batching_db
+    minutes_catalog = _add_catalog(
+        db,
+        event,
+        place,
+        category="minutes",
+        content=(
+            "The council discussed housing, transportation, public comments, budget "
+            "updates, staff reports, and future meeting actions."
+        ),
+    )
+    db.commit()
+
+    fallback_result = build_deterministic_non_agenda_summary_payload(
+        minutes_catalog.id,
+        session_factory=lambda: nullcontext(db),
+        fallback_reason="timeout",
+    )
+
+    db.expire_all()
+    refreshed = db.get(Catalog, minutes_catalog.id)
+    assert fallback_result["status"] == "complete"
+    assert f"{NON_AGENDA_FALLBACK_NOTE_PREFIX} timed out" in refreshed.summary
+    assert "returned an empty summary response" not in refreshed.summary
 
 
 def test_non_agenda_fallback_preserves_low_signal_block(batching_db):

--- a/tests/test_tasks_agenda_summary_format.py
+++ b/tests/test_tasks_agenda_summary_format.py
@@ -282,7 +282,7 @@ def test_summarize_catalog_with_optional_fallback_uses_deterministic_on_runtime_
     assert fallback_summary_result["status"] == "complete"
     assert fallback_summary_result["summary"] == "fallback summary"
     assert fallback_summary_result["provider_failure"] == {}
-    deterministic_spy.assert_called_once_with(303)
+    deterministic_spy.assert_called_once_with(303, fallback_reason="timeout")
 
 
 def test_summarize_catalog_with_optional_fallback_uses_deterministic_on_empty_summary_response():
@@ -305,7 +305,7 @@ def test_summarize_catalog_with_optional_fallback_uses_deterministic_on_empty_su
 
     assert fallback_summary_result["status"] == "complete"
     assert fallback_summary_result["summary"] == "fallback summary"
-    deterministic_spy.assert_called_once_with(304)
+    deterministic_spy.assert_called_once_with(304, fallback_reason="empty_response")
 
 
 def test_summarize_catalog_with_optional_fallback_keeps_empty_summary_error_when_disabled():

--- a/tests/test_tasks_agenda_summary_format.py
+++ b/tests/test_tasks_agenda_summary_format.py
@@ -285,6 +285,69 @@ def test_summarize_catalog_with_optional_fallback_uses_deterministic_on_runtime_
     deterministic_spy.assert_called_once_with(303)
 
 
+def test_summarize_catalog_with_optional_fallback_uses_deterministic_on_empty_summary_response():
+    import logging
+
+    deterministic_spy = MagicMock(return_value={"status": "complete", "summary": "fallback summary"})
+    local_ai_logger = logging.getLogger("local-ai")
+
+    def _raise_empty_response_error(catalog_id):
+        _ = catalog_id
+        local_ai_logger.error("AI Summarization failed: Empty response payload")
+        raise RuntimeError("AI Summarization returned None (Model missing or error)")
+
+    fallback_summary_result = backlog_maintenance.summarize_catalog_with_optional_fallback(
+        304,
+        summary_fallback_mode="deterministic",
+        generate_summary_callable=_raise_empty_response_error,
+        deterministic_summary_callable=deterministic_spy,
+    )
+
+    assert fallback_summary_result["status"] == "complete"
+    assert fallback_summary_result["summary"] == "fallback summary"
+    deterministic_spy.assert_called_once_with(304)
+
+
+def test_summarize_catalog_with_optional_fallback_keeps_empty_summary_error_when_disabled():
+    deterministic_spy = MagicMock(return_value={"status": "complete", "summary": "fallback summary"})
+
+    fallback_summary_result = backlog_maintenance.summarize_catalog_with_optional_fallback(
+        305,
+        summary_fallback_mode="none",
+        generate_summary_callable=MagicMock(side_effect=RuntimeError("AI Summarization returned None (Model missing or error)")),
+        deterministic_summary_callable=deterministic_spy,
+    )
+
+    assert fallback_summary_result["status"] == "error"
+    assert "AI Summarization returned None" in fallback_summary_result["error"]
+    deterministic_spy.assert_not_called()
+
+
+def test_summarize_catalog_with_optional_fallback_does_not_override_low_signal():
+    deterministic_spy = MagicMock(return_value={"status": "complete", "summary": "fallback summary"})
+
+    fallback_summary_result = backlog_maintenance.summarize_catalog_with_optional_fallback(
+        306,
+        summary_fallback_mode="deterministic",
+        generate_summary_callable=MagicMock(return_value={"status": "blocked_low_signal", "summary": None}),
+        deterministic_summary_callable=deterministic_spy,
+    )
+
+    assert fallback_summary_result["status"] == "blocked_low_signal"
+    deterministic_spy.assert_not_called()
+
+
+def test_capture_summary_fallback_events_counts_non_agenda_empty_response():
+    import logging
+
+    local_ai_logger = logging.getLogger("local-ai")
+
+    with backlog_maintenance.capture_summary_fallback_events() as fallback_events:
+        local_ai_logger.error("AI Summarization failed: Empty response payload")
+
+    assert fallback_events["empty_response"] == 1
+
+
 def test_summarize_catalog_with_maintenance_mode_returns_error_when_agenda_deterministic_fails(mocker):
     mock_session = MagicMock()
     mock_session.__enter__.return_value = mock_session


### PR DESCRIPTION
## What changed
- Added a maintenance/backfill-only deterministic fallback for minutes when the local AI provider returns an empty summary response.
- Scoped fallback persistence to normalized `minutes` documents only.
- Captured non-agenda `AI Summarization failed: Empty response payload` events as fallback-eligible in deterministic mode.
- Preserved interactive summary task retry/error behavior and existing agenda fallback behavior.
- Added tests for fallback detection, disabled fallback, low-signal blocking, unsupported document kinds, persistence, side effects, and count reporting.

## Why
Final Sunnyvale minutes exposed a provider edge case where Ollama returned HTTP 200 with an empty response payload. Maintenance backfills need a deterministic, truthful completion path without changing model fallback policy or interactive task behavior.

## Risk / compatibility
- No API, schema, dependency, runtime default, or model policy changes.
- Fallback is explicit maintenance behavior under `summary_fallback_mode="deterministic"`.
- Unsupported non-agenda categories return an error instead of persisting fallback summaries.

## Verification
PASS:
```bash
./.venv/bin/ruff check api pipeline scripts tests
./.venv/bin/mypy
PYTHONPATH=. .venv/bin/pytest -q tests/test_tasks_agenda_summary_format.py tests/test_task_provider_retry_semantics.py tests/test_provider_error_mapping_retry_vs_fallback.py tests/test_pipeline_batching.py tests/test_summary_staleness.py tests/test_not_generated_status.py tests/test_run_pipeline_orchestration.py tests/test_task_metrics.py tests/test_docs_links.py
PYTHONPATH=. .venv/bin/pytest -q tests/test_pipeline_batching.py -k "non_agenda_fallback or summary_hydration_backfill"
PYTHONPATH=. .venv/bin/pytest -q tests/test_tasks_agenda_summary_format.py
git diff --check
```

Runtime check:
```text
agenda:2768:2768:0
minutes:1909:1909:0
```

## Remaining deficits
- The final Sunnyvale runtime run completed through the normal LLM path (`llm_complete=2`), so the fallback path is verified by tests rather than live production data in that run.
