### PR TITLE
Clarify performance baseline compare reports

### DIFF
--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -132,6 +132,13 @@ Interpretation rule:
   - stable counters from `commands.log` are compared exactly
   - reduced-confidence or non-baseline-valid runs are reported as non-comparable, not clean passes
 
+Baseline compare report:
+- `status=pass` means every comparable timing and stable-counter check stayed within the checked-in baseline contract.
+- `status=fail` means the report's `Failed Checks` section is the priority list; inspect the first failed reason, then compare expected, actual, delta, and tolerance values before changing code.
+- `status=non_comparable` means the run is diagnostic only. Fix the listed confidence or baseline-validity reason before using the run for regression or promotion decisions.
+- `Failed Checks` lists timing regressions, missing artifacts, and workload-shape drift separately enough for an engineer to reproduce the failing condition without reading the JSON payload.
+- The `Reproduce` command at the end of the report is the canonical rerun command for that manifest/baseline pair.
+
 ### Latest runtime optimization note
 
 - The default core pipeline and batch enrichment paths no longer shell into full `python indexer.py` rebuilds.

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -70,14 +70,14 @@ Use the profiling harness when the question is "what is actually slow on the cri
 
 Commands:
 ```bash
-python scripts/profile_pipeline.py --mode triage
-python scripts/build_profile_manifest.py --name <name>
-python scripts/build_profile_manifest.py --name <name> --write
-python scripts/profile_pipeline.py --mode baseline --manifest profiling/manifests/<name>.txt --dry-run-prepare
-python scripts/profile_pipeline.py --mode baseline --manifest profiling/manifests/<name>.txt
-python scripts/profile_pipeline.py --mode baseline --manifest profiling/manifests/<name>.txt --compare-to profiling/baselines/<name>.json
-python scripts/analyze_pipeline_profile.py --run-id <run_id>
-python scripts/analyze_pipeline_profile.py --run-id <run_id> --compare-to profiling/baselines/<name>.json
+PYTHONPATH=. .venv/bin/python scripts/profile_pipeline.py --mode triage
+PYTHONPATH=. .venv/bin/python scripts/build_profile_manifest.py --name <name>
+PYTHONPATH=. .venv/bin/python scripts/build_profile_manifest.py --name <name> --write
+PYTHONPATH=. .venv/bin/python scripts/profile_pipeline.py --mode baseline --manifest profiling/manifests/<name>.txt --dry-run-prepare
+PYTHONPATH=. .venv/bin/python scripts/profile_pipeline.py --mode baseline --manifest profiling/manifests/<name>.txt
+PYTHONPATH=. .venv/bin/python scripts/profile_pipeline.py --mode baseline --manifest profiling/manifests/<name>.txt --compare-to profiling/baselines/<name>.json
+PYTHONPATH=. .venv/bin/python scripts/analyze_pipeline_profile.py --run-id <run_id>
+PYTHONPATH=. .venv/bin/python scripts/analyze_pipeline_profile.py --run-id <run_id> --compare-to profiling/baselines/<name>.json
 ```
 
 Artifacts:

--- a/scripts/operator_profile_reports.py
+++ b/scripts/operator_profile_reports.py
@@ -19,6 +19,12 @@ AGENDA_SUMMARY_SUBPHASE_KEYS = (
     AGENDA_SUMMARY_REINDEX_MS,
     AGENDA_SUMMARY_EMBED_DISPATCH_MS,
 )
+BASELINE_MANIFEST_DIR = "profiling/manifests"
+BASELINE_PROFILE_COMMAND = "python scripts/profile_pipeline.py"
+NON_COMPARABLE_REASON_TEXT = {
+    "baseline_invalid": "Run is not baseline-valid, so timing and counter checks are diagnostic only.",
+    "confidence_reduced": "Run has reduced-confidence evidence, so timing and counter checks are diagnostic only.",
+}
 
 
 def load_expected_baseline(path: Path, load_json: Callable[[Path], dict[str, Any]]) -> dict[str, Any]:
@@ -121,21 +127,99 @@ def render_report(summary: dict[str, Any]) -> str:
 
 
 def render_compare_report(summary: dict[str, Any], comparison: dict[str, Any]) -> str:
+    checks = _checks_from_comparison(comparison)
     lines = [
         f"# Baseline Compare: {summary.get('run_id')}",
         "",
         f"- expected_baseline: `{comparison.get('expected_baseline')}`",
+        f"- manifest_name: `{comparison.get('manifest_name')}`",
         f"- status: `{comparison.get('status')}`",
         f"- reason: `{comparison.get('reason')}`",
         f"- comparable: `{comparison.get('comparable')}`",
         "",
-        "## Checks",
     ]
-    for check in comparison.get("checks") or []:
-        lines.append(
-            f"- `{check['metric']}`: `{check['status']}` expected=`{check.get('expected')}` actual=`{check.get('actual')}`"
-        )
+    lines.extend(_render_non_comparable_section(comparison))
+    lines.extend(_render_failed_checks(checks))
+    lines.extend(
+        [
+            "## Checks",
+            *_render_check_lines(checks),
+            "",
+            "## Reproduce",
+            "```bash",
+            _baseline_compare_command(comparison),
+            "```",
+        ]
+    )
     return "\n".join(lines) + "\n"
+
+
+def _checks_from_comparison(comparison: dict[str, Any]) -> list[dict[str, Any]]:
+    raw_checks = comparison.get("checks")
+    if not isinstance(raw_checks, list):
+        return []
+    return [check for check in raw_checks if isinstance(check, dict)]
+
+
+def _render_non_comparable_section(comparison: dict[str, Any]) -> list[str]:
+    if comparison.get("comparable") is not False:
+        return []
+    reason = str(comparison.get("reason") or "")
+    detail = NON_COMPARABLE_REASON_TEXT.get(reason, "Run is non-comparable; inspect run confidence before using it.")
+    return ["## Non-Comparable Run", "", f"- detail: {detail}", ""]
+
+
+def _render_failed_checks(checks: list[dict[str, Any]]) -> list[str]:
+    failed_checks = [check for check in checks if check.get("status") == "fail"]
+    if not failed_checks:
+        return []
+    return ["## Failed Checks", *(_render_check_line(check) for check in failed_checks), ""]
+
+
+def _render_check_lines(checks: list[dict[str, Any]]) -> list[str]:
+    if not checks:
+        return ["No checks were evaluated."]
+    return [_render_check_line(check) for check in checks]
+
+
+def _render_check_line(check: dict[str, Any]) -> str:
+    return (
+        f"- `{check.get('metric')}`: `{check.get('status')}` "
+        f"expected=`{check.get('expected')}` actual=`{check.get('actual')}` "
+        f"{_render_delta(check)}{_render_tolerance(check)}reason=`{check.get('reason')}`"
+    )
+
+
+def _render_delta(check: dict[str, Any]) -> str:
+    if "delta" not in check:
+        return ""
+    return f"delta=`{check.get('delta')}` "
+
+
+def _render_tolerance(check: dict[str, Any]) -> str:
+    tolerance_pct = check.get("tolerance_pct")
+    tolerance_abs = check.get("tolerance_abs")
+    if tolerance_pct is None and tolerance_abs is None:
+        return ""
+    return f"tolerance=`{tolerance_pct}% / {tolerance_abs}` "
+
+
+def _baseline_compare_command(comparison: dict[str, Any]) -> str:
+    return " ".join(
+        [
+            BASELINE_PROFILE_COMMAND,
+            "--mode baseline",
+            f"--manifest {_manifest_path_for_comparison(comparison)}",
+            f"--compare-to {comparison.get('expected_baseline') or '<baseline.json>'}",
+        ]
+    )
+
+
+def _manifest_path_for_comparison(comparison: dict[str, Any]) -> str:
+    manifest_name = str(comparison.get("manifest_name") or "").strip()
+    if not manifest_name:
+        return "<manifest.txt>"
+    return f"{BASELINE_MANIFEST_DIR}/{manifest_name}.txt"
 
 
 def render_pairwise_compare_report(comparison: dict[str, Any]) -> str:

--- a/scripts/operator_profile_reports.py
+++ b/scripts/operator_profile_reports.py
@@ -20,7 +20,7 @@ AGENDA_SUMMARY_SUBPHASE_KEYS = (
     AGENDA_SUMMARY_EMBED_DISPATCH_MS,
 )
 BASELINE_MANIFEST_DIR = "profiling/manifests"
-BASELINE_PROFILE_COMMAND = "python scripts/profile_pipeline.py"
+BASELINE_PROFILE_COMMAND = "PYTHONPATH=. .venv/bin/python scripts/profile_pipeline.py"
 NON_COMPARABLE_REASON_TEXT = {
     "baseline_invalid": "Run is not baseline-valid, so timing and counter checks are diagnostic only.",
     "confidence_reduced": "Run has reduced-confidence evidence, so timing and counter checks are diagnostic only.",

--- a/tests/test_pipeline_profile_report.py
+++ b/tests/test_pipeline_profile_report.py
@@ -348,7 +348,7 @@ def test_render_compare_report_explains_failed_elapsed_phase_and_counter_checks(
     assert "tolerance=`25.0% / 0.9`" in report
     assert "`summary_hydration_backfill.selected`" in report
     assert "reason=`workload_shape_drift`" in report
-    assert "scripts/profile_pipeline.py --mode baseline" in report
+    assert "PYTHONPATH=. .venv/bin/python scripts/profile_pipeline.py --mode baseline" in report
     assert "--compare-to profiling/baselines/baseline_representative_v1.json" in report
 
 

--- a/tests/test_pipeline_profile_report.py
+++ b/tests/test_pipeline_profile_report.py
@@ -298,6 +298,117 @@ def test_compare_against_expected_baseline_fails_for_counter_drift(tmp_path: Pat
     )
 
 
+def test_render_compare_report_explains_failed_elapsed_phase_and_counter_checks():
+    report = mod.render_compare_report(
+        {"run_id": "profile_run_slow"},
+        {
+            "expected_baseline": "profiling/baselines/baseline_representative_v1.json",
+            "manifest_name": "baseline_representative_v1",
+            "status": "fail",
+            "reason": "timing_regression",
+            "comparable": True,
+            "checks": [
+                {
+                    "metric": "elapsed_seconds",
+                    "expected": 9.473,
+                    "actual": 12.5,
+                    "delta": 3.027,
+                    "tolerance_pct": 20.0,
+                    "tolerance_abs": 1.895,
+                    "status": "fail",
+                    "reason": "timing_regression",
+                },
+                {
+                    "metric": "phase.summarize.duration_s",
+                    "expected": 3.601,
+                    "actual": 5.0,
+                    "delta": 1.399,
+                    "tolerance_pct": 25.0,
+                    "tolerance_abs": 0.9,
+                    "status": "fail",
+                    "reason": "timing_regression",
+                },
+                {
+                    "metric": "summary_hydration_backfill.selected",
+                    "expected": 12,
+                    "actual": 15,
+                    "status": "fail",
+                    "reason": "workload_shape_drift",
+                },
+            ],
+        },
+    )
+
+    assert "## Failed Checks" in report
+    assert "`elapsed_seconds`" in report
+    assert "expected=`9.473`" in report
+    assert "actual=`12.5`" in report
+    assert "tolerance=`20.0% / 1.895`" in report
+    assert "`phase.summarize.duration_s`" in report
+    assert "tolerance=`25.0% / 0.9`" in report
+    assert "`summary_hydration_backfill.selected`" in report
+    assert "reason=`workload_shape_drift`" in report
+    assert "scripts/profile_pipeline.py --mode baseline" in report
+    assert "--compare-to profiling/baselines/baseline_representative_v1.json" in report
+
+
+def test_render_compare_report_explains_non_comparable_confidence_reason():
+    report = mod.render_compare_report(
+        {"run_id": "profile_run_low_confidence"},
+        {
+            "expected_baseline": "profiling/baselines/baseline_representative_v1.json",
+            "manifest_name": "baseline_representative_v1",
+            "status": "non_comparable",
+            "reason": "confidence_reduced",
+            "comparable": False,
+            "checks": [],
+        },
+    )
+
+    assert "- status: `non_comparable`" in report
+    assert "- reason: `confidence_reduced`" in report
+    assert "- comparable: `False`" in report
+    assert "## Non-Comparable Run" in report
+    assert "reduced-confidence" in report
+    assert "## Failed Checks" not in report
+    assert "No checks were evaluated." in report
+
+
+def test_render_compare_report_handles_empty_checks_without_crashing():
+    report = mod.render_compare_report(
+        {"run_id": "profile_run_empty"},
+        {
+            "expected_baseline": "profiling/baselines/baseline_representative_v1.json",
+            "manifest_name": "baseline_representative_v1",
+            "status": "pass",
+            "reason": "matched",
+            "comparable": True,
+            "checks": [],
+        },
+    )
+
+    assert "- status: `pass`" in report
+    assert "No checks were evaluated." in report
+    assert "## Reproduce" in report
+
+
+def test_render_compare_report_handles_malformed_checks_without_crashing():
+    report = mod.render_compare_report(
+        {"run_id": "profile_run_malformed"},
+        {
+            "expected_baseline": "profiling/baselines/baseline_representative_v1.json",
+            "manifest_name": "baseline_representative_v1",
+            "status": "non_comparable",
+            "reason": "confidence_reduced",
+            "comparable": False,
+            "checks": 1,
+        },
+    )
+
+    assert "- status: `non_comparable`" in report
+    assert "No checks were evaluated." in report
+
+
 def test_compare_against_expected_baseline_marks_reduced_confidence_as_non_comparable(tmp_path: Path):
     run_dir = tmp_path / "profile_run_low_confidence"
     run_dir.mkdir()


### PR DESCRIPTION
## What changed
- Baseline compare reports now show failed checks separately, including expected values, actual values, deltas, tolerance values, and failure reasons.
- Non-comparable runs now include a dedicated explanation section while preserving existing `non_comparable` semantics.
- Reports now include a reproduce command for rerunning the baseline profile against the expected baseline.
- Malformed `checks` payloads no longer crash report rendering.
- Performance docs explain how to read pass/fail/non-comparable compare reports.

## Why
The performance profiler already had baseline comparison logic, but the Markdown report was too thin to act on quickly. This makes performance PR evidence easier to review without changing runtime behavior or comparison policy.

## Risk / compatibility
- Runtime behavior unchanged.
- Baseline thresholds unchanged: total elapsed remains 20%, phase duration remains 25%.
- Existing `baseline_invalid` and reduced-confidence runs remain non-comparable.
- No DB, API, config, dependency, or model-policy changes.

## Verification
- PASS: initial tests-first run failed as expected on new report assertions.
- PASS: `./.venv/bin/ruff check api pipeline scripts tests`
- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_pipeline_profile_report.py`
- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_profile_pipeline_cli.py`
- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_profile_manifest_builder.py`
- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_pipeline_profile_spans.py`
- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py`
- PASS: `./.venv/bin/mypy`
- PASS: `git diff --check`

## Review
- Independent review found one P2: malformed truthy `checks` payload crashed rendering.
- Fixed with regression coverage: `test_render_compare_report_handles_malformed_checks_without_crashing`.

## Remaining deficits
- Optional live Docker profile smoke was not run; this PR changes report rendering/tests/docs only.
