### PR TITLE
T-CI-1A: Require Python guardrails before merging

### DIFF
--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,8 +1,9 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 1.6
+version: 1.7
 generated: 2026-07-22
-changelog: v1.6 expands T-CI-1 ownership so the complete-suite workflow,
+changelog: v1.7 adds T-CI-1A to make the green `python-guardrails` check
+mandatory through an active default-branch repository ruleset. v1.6 expands T-CI-1 ownership so the complete-suite workflow,
 contract tests, runbook, and implementation plan land together. It also adds
 the crawler and Python 3.14-compatible topic dependencies, preserves the local
 `.venv/bin/python` subprocess contract, and removes event path filters so the
@@ -157,8 +158,33 @@ other ownership of those files.
   `PYTHONPATH=. .venv/bin/python -m pytest -q tests/`, `git diff --check`, and
   the PR's Python Guardrails run with the pinned CI dependencies.
 
+### T-CI-1A: Require Python Guardrails before default-branch updates
+- priority: P0
+- depends_on: T-CI-1
+- status: complete and verified 2026-07-22
+- external_state: active repository ruleset 19594795
+- files_owned: docs/plans/T_CI_1_REQUIRED_CHECK_POLICY_PLAN.md,
+  docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+- external_state_owned: repository ruleset `Require Python Guardrails`
+- decision: Approved by the operator on 2026-07-22 using the exact active
+  ruleset payload in `docs/plans/T_CI_1_REQUIRED_CHECK_POLICY_PLAN.md`.
+- do: Maintain the active default-branch ruleset with no bypass actors. Its
+  sole required context is GitHub Actions `python-guardrails` from integration
+  15368, evaluated against the latest default-branch code.
+- accept: GitHub reports the ruleset active; its only required status context
+  is `python-guardrails`; the target is the default branch; no actor can bypass
+  it; branch creation remains exempt; T-CI-1's complete-suite check is
+  mandatory before the ref can update.
+- forbidden: Requiring approvals, CodeQL, deployments, signed commits, linear
+  history, or any check other than `python-guardrails`; adding bypass actors;
+  changing workflow code or repository files outside `files_owned`.
+- verify: Read the ruleset back through GitHub's REST API and compare target,
+  enforcement, conditions, bypass actors, context, integration, strict policy,
+  and effective rules on `master` with the expected contract.
+
 ### T-CI-2: Give the frontend a test runner and CI job
 - priority: P0
+- depends_on: T-CI-1A
 - files_owned: frontend/package.json, frontend/jest.config.js (new),
   .github/workflows/frontend-tests.yml (new)
 - do: Add jest (or vitest — pick whichever the 4 existing tests under

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -3,7 +3,8 @@
 version: 1.7
 generated: 2026-07-22
 changelog: v1.7 adds T-CI-1A to make the green `python-guardrails` check
-mandatory through an active default-branch repository ruleset. v1.6 expands T-CI-1 ownership so the complete-suite workflow,
+mandatory through an active default-branch repository ruleset and schedules
+T-CI-2A to add the universal frontend check only after T-CI-2 is green. v1.6 expands T-CI-1 ownership so the complete-suite workflow,
 contract tests, runbook, and implementation plan land together. It also adds
 the crawler and Python 3.14-compatible topic dependencies, preserves the local
 `.venv/bin/python` subprocess contract, and removes event path filters so the
@@ -176,8 +177,9 @@ other ownership of those files.
   it; branch creation remains exempt; T-CI-1's complete-suite check is
   mandatory before the ref can update.
 - forbidden: Requiring approvals, CodeQL, deployments, signed commits, linear
-  history, or any check other than `python-guardrails`; adding bypass actors;
-  changing workflow code or repository files outside `files_owned`.
+  history, or any check other than `python-guardrails` before T-CI-2A is
+  approved and T-CI-2 is green; adding bypass actors; changing workflow code
+  or repository files outside `files_owned`.
 - verify: Read the ruleset back through GitHub's REST API and compare target,
   enforcement, conditions, bypass actors, context, integration, strict policy,
   and effective rules on `master` with the expected contract.
@@ -186,14 +188,51 @@ other ownership of those files.
 - priority: P0
 - depends_on: T-CI-1A
 - files_owned: frontend/package.json, frontend/jest.config.js (new),
-  .github/workflows/frontend-tests.yml (new)
+  .github/workflows/frontend-tests.yml (new),
+  tests/test_repository_guardrails.py
 - do: Add jest (or vitest — pick whichever the 4 existing tests under
   frontend/components/__tests__/ run under with least modification), a
-  `"test"` script, and a workflow running `npm ci && npm test` on PRs
-  touching frontend/**.
-- accept: All 4 existing test files execute and pass in CI.
-- forbidden: Rewriting the tests' assertions; adding new tests.
-- verify: `cd frontend && npm test` exit 0.
+  `"test"` script, and a workflow running `npm ci && npm test` on every pull
+  request and master push so the `frontend-tests` context always exists before
+  T-CI-2A makes it required.
+- accept: All 4 existing test files execute and pass in CI; frontend-only and
+  non-frontend pull requests both receive a terminal `frontend-tests` check;
+  a repository guardrail test enforces the exact job name and unconditional
+  pull-request and master-push triggers.
+- forbidden: Rewriting the existing frontend assertions; adding new frontend
+  component tests; path-filtering the workflow so an otherwise mergeable pull
+  request lacks the check.
+- verify: `cd frontend && npm test` and
+  `PYTHONPATH=. .venv/bin/pytest -q tests/test_repository_guardrails.py` exit 0.
+
+### T-CI-2A: Require the universal frontend test check
+- priority: P0
+- depends_on: T-CI-2
+- files_owned: docs/plans/T_CI_2_REQUIRED_CHECK_POLICY_PLAN.md (new),
+  docs/plans/T_CI_1_REQUIRED_CHECK_POLICY_PLAN.md,
+  docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md, AGENTS.md (verification-matrix
+  transition marker only)
+- external_state_owned: repository ruleset `Require Python Guardrails`
+- decision_required: Operator approval of an exact update to ruleset 19594795
+  that adds GitHub Actions context `frontend-tests` from integration 15368
+  while preserving every T-CI-1A field.
+- do: After T-CI-2 is green on frontend and non-frontend pull requests, update
+  ruleset 19594795 so its required status checks are exactly
+  `python-guardrails` and `frontend-tests`. Remove the AGENTS.md transition
+  marker only after the live readback proves both checks are mandatory.
+- accept: Every pull request receives both contexts; the default branch cannot
+  update unless both pass; strict policy, branch-creation exemption, empty
+  bypass list, target, and all other T-CI-1A fields remain unchanged.
+- forbidden: Adding the check while the workflow is path-filtered or unproven;
+  adding any third check or rule; changing the existing Python gate; assuming
+  approval from T-CI-1A.
+- verify: Demonstrate `frontend-tests` on one frontend and one non-frontend PR,
+  update the ruleset once, and assert exact ruleset and effective-`master`
+  readback through the pinned GitHub REST API.
+- rollback: Restore ruleset 19594795 to the exact T-CI-1A Python-only contract;
+  never delete the ruleset or remove `python-guardrails` while rolling back the
+  frontend requirement. Replace T-CI-1A's original creation-time rollback in
+  its owned plan with this restoration procedure.
 
 ### T-CI-3: Enforce coverage threshold
 - priority: P2

--- a/docs/plans/T_CI_1_REQUIRED_CHECK_POLICY_PLAN.md
+++ b/docs/plans/T_CI_1_REQUIRED_CHECK_POLICY_PLAN.md
@@ -1,0 +1,262 @@
+# T-CI-1A: Require Python Guardrails Before Default-Branch Updates
+
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+execution: code
+task: T-CI-1A
+lane: CI
+implementation_status: complete
+external_state_status: active
+external_ruleset_id: 19594795
+activated: 2026-07-22
+
+## 1. Context & Alignment
+
+**a) Driver.** Before T-CI-1A, T-CI-1 ran the complete Python suite on every
+pull request and master push, but GitHub had no branch protection or repository
+ruleset. PR #111 remained mergeable while its first `python-guardrails` run was
+red and was later merged by an owner. Ruleset 19594795 now closes that gap by
+making the check mandatory.
+
+**b) Canonical documents.** `AGENTS.md` defines the complete Python suite as
+the authoritative merge gate and requires exact evidence for policy changes.
+`docs/ENGINEERING_GUARDRAILS.md` names the complete suite as the Python gate.
+`docs/TESTING.MD` preserves fast-fail diagnostics beneath the authoritative
+suite. The remediation plan orders safety-net work before Phase 2.
+
+**c) Remediation alignment.** Register T-CI-1A in the CI lane. It owns only
+this plan, `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`, and the external
+repository ruleset named `Require Python Guardrails`. No workflow or runtime
+file changes.
+
+**d) Decision gates.** No G1-G5 decision applies. The operator approved the
+exact active ruleset payload in 2e on 2026-07-22, including strict status
+checks, no bypass actors, and the branch-creation exemption. No policy field
+may be added or altered without a new decision.
+
+## 2. Design
+
+**e) Approach.**
+
+1. Record the historical precondition: default branch `master`, no branch
+   protection, and no repository rulesets.
+2. Resolve the successful `python-guardrails` check on T-CI-1 commit
+   `07d0d99cc3184769a0b89a27a653758d10e3f220` and confirm it is produced by
+   GitHub Actions integration ID 15368.
+3. Confirm `.github/workflows/python-guardrails.yml` is the only workflow with
+   a `python-guardrails` job ID.
+4. Record the exact one-time creation request:
+
+   ```json
+   {
+     "name": "Require Python Guardrails",
+     "target": "branch",
+     "enforcement": "active",
+     "bypass_actors": [],
+     "conditions": {
+       "ref_name": {
+         "include": ["~DEFAULT_BRANCH"],
+         "exclude": []
+       }
+     },
+     "rules": [
+       {
+         "type": "required_status_checks",
+         "parameters": {
+           "required_status_checks": [
+             {
+               "context": "python-guardrails",
+               "integration_id": 15368
+             }
+           ],
+           "strict_required_status_checks_policy": true,
+           "do_not_enforce_on_create": true
+         }
+       }
+     ]
+   }
+   ```
+
+5. On 2026-07-22, post the request once to
+   `POST /repos/manumissio/town-council/rulesets`, creating ruleset 19594795
+   with:
+   - target `branch`;
+   - default-branch condition `~DEFAULT_BRANCH`;
+   - no bypass actors;
+   - one `required_status_checks` rule;
+   - context `python-guardrails`, integration ID 15368;
+   - strict latest-default-branch policy enabled;
+   - branch-creation exemption enabled.
+   This creation operation is complete and must not be rerun.
+6. Read ruleset 19594795 back and compare every policy field with the
+   request contract.
+7. Read effective rules for `master` and prove this ruleset supplies the only
+   required-status-check rule.
+8. Confirm no second ruleset or legacy branch-protection policy was created.
+
+No new function or module is added. The GitHub REST API remains the sole owner
+of external repository policy.
+
+**f) Reuse audit.** Reuse the existing GitHub Actions check identity and the
+repository ruleset API. Do not add a workflow, script, policy registry, or
+duplicate check.
+
+**g) Data contracts.** The only contract is the recorded JSON request accepted
+by GitHub's ruleset endpoint. It documents live repository policy, not an
+application payload or a repeatable creation command.
+
+**h) Schema and migrations.** None.
+
+## 3. Security & Data Governance
+
+**i) Security boundary.** This changes repository write policy, not an
+application trust boundary. An update to the default branch loses the ability
+to proceed without the named GitHub Actions check passing on current code.
+
+**j) Secrets.** No new token or credential. `gh` uses the operator's existing
+authenticated session; request and response output contain no secret.
+
+**k) Person data.** None.
+
+**l) Untrusted input.** GitHub API responses are external input. Verification
+uses `jq` to select and compare named fields; no response text is executed.
+
+## 4. Code Health
+
+**m) Conformance.** No Python, error handler, timestamp, environment default,
+or runtime logic changes. The temporary JSON uses named policy fields and an
+exact check identity.
+
+**n) Antipattern scan, plan pass.** A1/H1 are resolved through GitHub REST API
+documentation and live check metadata. No new setting has a silent default.
+No wrapper, compatibility path, duplicate workflow, weakened test, ignored
+failure, broad edit, or import-time work is introduced. The ruleset is one
+source of enforcement rather than a second implementation of CI.
+
+**o) Ratchets.** Old value: zero default-branch protection rules and zero
+required checks. New value: one active default-branch ruleset requiring only
+`python-guardrails`. Ruff, Mypy, coverage, formatter, and runtime policy remain
+unchanged.
+
+**p) Dead code and duplication.** None. No existing protection policy is
+superseded because none exists. Expected tracked line delta is documentation
+only.
+
+## 5. Testing
+
+**q) Failure scenarios.**
+
+1. Wrong ref target could protect an unrelated branch.
+2. Wrong context or integration could leave the intended check optional.
+3. A bypass actor could let owners merge red code.
+4. Non-strict policy could test against stale default-branch code.
+5. Extra rules could introduce unapproved review or commit requirements.
+6. Duplicate rulesets could make rollback ambiguous.
+7. API authorization failure must leave repository policy unchanged.
+
+**r) Verification mapping.** Ruleset readback assertions cover scenarios 1-5.
+Effective-rule readback covers scenarios 1, 2, 5, and 6. Capture the POST
+status and list rulesets after any failure for scenario 7. Static workflow
+search proves one check producer. Docs-link tests cover both tracked files.
+
+**s) Fakes and mocks.** None. GitHub's authenticated REST API is the actual
+operator boundary.
+
+**t) Verification rows.** Apply the docs-only row. External acceptance requires
+the live ruleset readback; local tests cannot prove repository enforcement.
+
+## 6. Execution, Rollback, Docs
+
+**u) Commands.**
+
+```bash
+gh api -H "X-GitHub-Api-Version: 2026-03-10" \
+  repos/manumissio/town-council/commits/07d0d99cc3184769a0b89a27a653758d10e3f220/check-runs \
+  --jq '.check_runs[] | select(.name=="python-guardrails") | {name, app_id:.app.id}'
+test "$(rg -l '^  python-guardrails:' .github/workflows/*.yml | wc -l | tr -d ' ')" = "1"
+
+gh api -H "X-GitHub-Api-Version: 2026-03-10" \
+  repos/manumissio/town-council/rulesets/19594795 \
+  > /tmp/t-ci-1-required-check-readback.json
+jq -e '
+  .id == 19594795 and
+  .name == "Require Python Guardrails" and
+  .target == "branch" and
+  .enforcement == "active" and
+  .bypass_actors == [] and
+  .conditions.ref_name.include == ["~DEFAULT_BRANCH"] and
+  .conditions.ref_name.exclude == [] and
+  (.rules | length) == 1 and
+  .rules[0].type == "required_status_checks" and
+  .rules[0].parameters.required_status_checks ==
+    [{"context":"python-guardrails","integration_id":15368}] and
+  .rules[0].parameters.strict_required_status_checks_policy == true and
+  .rules[0].parameters.do_not_enforce_on_create == true
+' /tmp/t-ci-1-required-check-readback.json
+
+gh api -H "X-GitHub-Api-Version: 2026-03-10" \
+  repos/manumissio/town-council/rules/branches/master \
+  > /tmp/t-ci-1-effective-master-rules.json
+jq -e --argjson ruleset_id 19594795 '
+  ([.[] | select(.type == "required_status_checks")] | length) == 1 and
+  any(.[];
+    .ruleset_id == $ruleset_id and
+    .type == "required_status_checks" and
+    .parameters.strict_required_status_checks_policy == true and
+    .parameters.do_not_enforce_on_create == true and
+    .parameters.required_status_checks ==
+      [{"context":"python-guardrails","integration_id":15368}]
+  )
+' /tmp/t-ci-1-effective-master-rules.json
+test "$(gh api -H 'X-GitHub-Api-Version: 2026-03-10' \
+  repos/manumissio/town-council/rulesets --jq 'length')" = "1"
+! gh api -H "X-GitHub-Api-Version: 2026-03-10" \
+  repos/manumissio/town-council/branches/master/protection
+PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py
+git diff --check
+```
+
+The POST that created ruleset 19594795 is historical and non-repeatable.
+
+**v) Rollback.**
+
+```bash
+gh api -H "X-GitHub-Api-Version: 2026-03-10" --method DELETE \
+  repos/manumissio/town-council/rulesets/19594795
+! gh api -H "X-GitHub-Api-Version: 2026-03-10" \
+  repos/manumissio/town-council/rulesets/19594795
+gh api -H "X-GitHub-Api-Version: 2026-03-10" \
+  repos/manumissio/town-council/rulesets \
+  | jq -e --argjson ruleset_id 19594795 'all(.[]; .id != $ruleset_id)'
+T_CI_1A_DOCS_COMMIT=$(git log --diff-filter=A -1 --format=%H -- \
+  docs/plans/T_CI_1_REQUIRED_CHECK_POLICY_PLAN.md)
+test -n "$T_CI_1A_DOCS_COMMIT"
+git revert "$T_CI_1A_DOCS_COMMIT"
+PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py
+git diff --check
+```
+
+Rollback is complete only when the named ruleset is absent and the committed
+documents no longer declare it active. No code, migration, data, package, or
+runtime rollback exists.
+
+**w) Docs synchronization.** Update this implementation plan and remediation
+registry only. Existing guardrail policy text becomes accurate when the live
+ruleset is active; do not duplicate the ruleset JSON into other docs.
+
+## 7. Delivery Self-Audit
+
+**x) Diff scan.** Reject any workflow edit, extra rule, bypass actor, extra
+required check, external policy outside the default branch, or tracked file
+outside the two-file ownership set.
+
+**y) Evidence.** Ruleset 19594795 is active and exact REST readback confirms
+the approved target, enforcement, conditions, bypass list, sole required
+check, strict policy, and branch-creation exemption. Effective rules on
+`master` contain that sole rule; legacy branch protection remains absent.
+Report docs-link result, diff check, and rollback command. Mark GitHub UI
+behavior not directly exercised as `NOT VERIFIED` rather than inferring it.
+
+**z) Deviations.** Expected result is none. Any API field change, additional
+ruleset, bypass, unverified readback, or tracked path outside ownership blocks
+completion.

--- a/docs/plans/T_CI_1_REQUIRED_CHECK_POLICY_PLAN.md
+++ b/docs/plans/T_CI_1_REQUIRED_CHECK_POLICY_PLAN.md
@@ -93,6 +93,10 @@ may be added or altered without a new decision.
 7. Read effective rules for `master` and prove this ruleset supplies the only
    required-status-check rule.
 8. Confirm no second ruleset or legacy branch-protection policy was created.
+9. Keep `python-guardrails` as the sole required check until T-CI-2 runs a
+   stable `frontend-tests` context on every pull request. T-CI-2A then requires
+   a separate operator-approved update to this ruleset; this task does not
+   pre-authorize that future gate change.
 
 No new function or module is added. The GitHub REST API remains the sole owner
 of external repository policy.
@@ -135,8 +139,10 @@ source of enforcement rather than a second implementation of CI.
 
 **o) Ratchets.** Old value: zero default-branch protection rules and zero
 required checks. New value: one active default-branch ruleset requiring only
-`python-guardrails`. Ruff, Mypy, coverage, formatter, and runtime policy remain
-unchanged.
+`python-guardrails`. Remaining deficit: `frontend-tests` cannot become required
+until T-CI-2 emits that context on every pull request and T-CI-2A receives
+separate operator approval. Ruff, Mypy, coverage, formatter, and runtime policy
+remain unchanged.
 
 **p) Dead code and duplication.** None. No existing protection policy is
 superseded because none exists. Expected tracked line delta is documentation
@@ -220,6 +226,12 @@ The POST that created ruleset 19594795 is historical and non-repeatable.
 
 **v) Rollback.**
 
+This creation-time rollback applies only while ruleset 19594795 still has the
+Python-only contract verified by this plan. After T-CI-2A adds
+`frontend-tests`, its plan owns this section and must replace deletion with a
+PATCH that restores the exact Python-only contract below. Deleting the ruleset
+after T-CI-2A would also remove the established Python merge gate.
+
 ```bash
 gh api -H "X-GitHub-Api-Version: 2026-03-10" --method DELETE \
   repos/manumissio/town-council/rulesets/19594795
@@ -247,8 +259,8 @@ ruleset is active; do not duplicate the ruleset JSON into other docs.
 ## 7. Delivery Self-Audit
 
 **x) Diff scan.** Reject any workflow edit, extra rule, bypass actor, extra
-required check, external policy outside the default branch, or tracked file
-outside the two-file ownership set.
+required check before T-CI-2A, external policy outside the default branch, or
+tracked file outside the two-file ownership set.
 
 **y) Evidence.** Ruleset 19594795 is active and exact REST readback confirms
 the approved target, enforcement, conditions, bypass list, sole required

--- a/docs/plans/T_CI_1_REQUIRED_CHECK_POLICY_PLAN.md
+++ b/docs/plans/T_CI_1_REQUIRED_CHECK_POLICY_PLAN.md
@@ -163,13 +163,16 @@ only.
 **r) Verification mapping.** Ruleset readback assertions cover scenarios 1-5.
 Effective-rule readback covers scenarios 1, 2, 5, and 6. Capture the POST
 status and list rulesets after any failure for scenario 7. Static workflow
-search proves one check producer. Docs-link tests cover both tracked files.
+search proves one check producer. The docs-link test covers the canonical map;
+manual semantic diff review covers both tracked plan files.
 
 **s) Fakes and mocks.** None. GitHub's authenticated REST API is the actual
 operator boundary.
 
-**t) Verification rows.** Apply the docs-only row. External acceptance requires
-the live ruleset readback; local tests cannot prove repository enforcement.
+**t) Verification rows.** Apply the docs-only row. That test validates the
+canonical documentation map; it does not inspect internal references in these
+two plan files. External acceptance requires the live ruleset readback, and a
+manual semantic diff review covers the changed plan text.
 
 ## 6. Execution, Rollback, Docs
 
@@ -216,8 +219,18 @@ jq -e --argjson ruleset_id 19594795 '
 ' /tmp/t-ci-1-effective-master-rules.json
 test "$(gh api -H 'X-GitHub-Api-Version: 2026-03-10' \
   repos/manumissio/town-council/rulesets --jq 'length')" = "1"
-! gh api -H "X-GitHub-Api-Version: 2026-03-10" \
-  repos/manumissio/town-council/branches/master/protection
+if gh api --include -H "X-GitHub-Api-Version: 2026-03-10" \
+  repos/manumissio/town-council/branches/master/protection \
+  > /tmp/t-ci-1-legacy-protection-response.txt 2>&1; then
+  echo "Expected legacy branch protection to be absent" >&2
+  exit 1
+fi
+legacy_protection_status=$(awk 'index($0, "HTTP/") == 1 { status=$2 } END { print status }' \
+  /tmp/t-ci-1-legacy-protection-response.txt)
+if [ "$legacy_protection_status" != "404" ]; then
+  echo "Expected HTTP 404, received ${legacy_protection_status:-no status}" >&2
+  exit 1
+fi
 PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py
 git diff --check
 ```
@@ -235,8 +248,18 @@ after T-CI-2A would also remove the established Python merge gate.
 ```bash
 gh api -H "X-GitHub-Api-Version: 2026-03-10" --method DELETE \
   repos/manumissio/town-council/rulesets/19594795
-! gh api -H "X-GitHub-Api-Version: 2026-03-10" \
-  repos/manumissio/town-council/rulesets/19594795
+if gh api --include -H "X-GitHub-Api-Version: 2026-03-10" \
+  repos/manumissio/town-council/rulesets/19594795 \
+  > /tmp/t-ci-1-deleted-ruleset-response.txt 2>&1; then
+  echo "Expected deleted ruleset to return 404" >&2
+  exit 1
+fi
+deleted_ruleset_status=$(awk 'index($0, "HTTP/") == 1 { status=$2 } END { print status }' \
+  /tmp/t-ci-1-deleted-ruleset-response.txt)
+if [ "$deleted_ruleset_status" != "404" ]; then
+  echo "Expected HTTP 404, received ${deleted_ruleset_status:-no status}" >&2
+  exit 1
+fi
 gh api -H "X-GitHub-Api-Version: 2026-03-10" \
   repos/manumissio/town-council/rulesets \
   | jq -e --argjson ruleset_id 19594795 'all(.[]; .id != $ruleset_id)'
@@ -266,8 +289,9 @@ tracked file outside the two-file ownership set.
 the approved target, enforcement, conditions, bypass list, sole required
 check, strict policy, and branch-creation exemption. Effective rules on
 `master` contain that sole rule; legacy branch protection remains absent.
-Report docs-link result, diff check, and rollback command. Mark GitHub UI
-behavior not directly exercised as `NOT VERIFIED` rather than inferring it.
+Report the docs-link result as canonical-map coverage only, plus the manual
+plan diff review, diff check, and rollback command. Mark GitHub UI behavior not
+directly exercised as `NOT VERIFIED` rather than inferring it.
 
 **z) Deviations.** Expected result is none. Any API field change, additional
 ruleset, bypass, unverified readback, or tracked path outside ownership blocks


### PR DESCRIPTION
## What changed

- Records T-CI-1A in the remediation plan.
- Documents active repository ruleset `19594795` and its exact required-check contract.
- Provides executable verification and rollback steps.

## Why

The complete Python suite was running in GitHub Actions but remained advisory because `master` had no required-check policy. The approved ruleset now requires `python-guardrails` before the default branch can update.

## Risk and compatibility

- No runtime, workflow, API, schema, dependency, or application behavior changes.
- Repository policy now blocks default-branch updates until the current `python-guardrails` check succeeds.
- No bypass actors or additional required checks were added.

## Verification

- PASS: exact REST readback for ruleset `19594795`.
- PASS: effective rules for `master` contain only the approved required-status-check rule.
- PASS: one repository ruleset exists and legacy branch protection remains absent.
- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py` (`2 passed`).
- PASS: `git diff --check`.
- PASS: independent pre-commit review after fixes (`no remaining P1/P2`).

## Remaining work

T-CI-4 will rebase after this PR and use remediation-plan version 1.8.
