### PR TITLE
T-CI-2A: Prepare the required frontend check policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,12 +194,12 @@ If the impact is unclear, invoke the objection protocol rather than guessing.
 
 <verification_matrix>
 Scope: the matrix is a fast local pre-check for iterating on a change. The
-authoritative merge gate is the full test suite run by CI on every pull
-request (`python-guardrails` for Python, `frontend-tests` for the frontend).
+authoritative CI verification is the full test suite run by both jobs on every
+pull request (`python-guardrails` for Python, `frontend-tests` for the frontend).
 A passing matrix row is necessary for proceeding, not sufficient for merge.
-[transition: the CI full-suite and frontend jobs are delivered by remediation
-tasks T-CI-1 and T-CI-2; until both merge, run the full sweep locally before
-handoff on any non-trivial change.]
+[transition: both jobs run on every pull request, but only
+`python-guardrails` is mandatory until T-CI-2A adds `frontend-tests` to the
+required-check ruleset.]
 
 All commands in applicable row(s) are mandatory, not advisory.
 If no row applies, run `PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py` at minimum.
@@ -247,7 +247,7 @@ Frontend contract changes (`frontend/**` affecting API/task/search behavior):
 
 Frontend component/behavior changes (`frontend/**` JS/JSX):
 - `cd frontend && npm test`
-  [transition: effective when the frontend test runner lands (T-CI-2)]
+  [transition: the runner is live; T-CI-2A makes its CI context mandatory]
 
 Broad cross-cutting changes:
 - Required: run all applicable rows above.

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,8 +1,10 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 2.0
+version: 2.1
 generated: 2026-07-23
-changelog: v2.0 records T-CI-2 completion and adds the implementation-ready
+changelog: v2.1 adds the direct development-only PyYAML contract required to
+validate workflow check identities semantically instead of approximating YAML
+with regular expressions. v2.0 records T-CI-2 completion and adds the implementation-ready
 T-CI-2A plan for the separately approval-gated frontend required-check policy.
 v1.9 corrects T-CI-2 to use the existing Node 20 test runner,
 permits the stale CSP contract to follow its current proxy owner, expands
@@ -232,6 +234,9 @@ contract test only; later GOV work retains all other ownership.
   docs/plans/T_CI_1_REQUIRED_CHECK_POLICY_PLAN.md,
   docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md, AGENTS.md (verification-matrix
   CI-status paragraph and transition markers only),
+  pipeline/requirements-dev.txt,
+  tests/test_docker_build_contracts.py
+  (development-only workflow parser dependency contract only),
   tests/test_repository_guardrails.py
   (canonical frontend required-check job identity only)
 - external_state_owned: repository ruleset `Require Python Guardrails`

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,8 +1,10 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 1.9
+version: 2.0
 generated: 2026-07-23
-changelog: v1.9 corrects T-CI-2 to use the existing Node 20 test runner,
+changelog: v2.0 records T-CI-2 completion and adds the implementation-ready
+T-CI-2A plan for the separately approval-gated frontend required-check policy.
+v1.9 corrects T-CI-2 to use the existing Node 20 test runner,
 permits the stale CSP contract to follow its current proxy owner, expands
 planning and testing-policy ownership, and records completed Phase 0 work.
 v1.8 expands T-CI-4 ownership and records the dedicated
@@ -196,6 +198,7 @@ contract test only; later GOV work retains all other ownership.
 ### T-CI-2: Give the frontend a test runner and CI job
 - priority: P0
 - depends_on: T-CI-1A
+- status: complete and verified 2026-07-23 (PR #115)
 - files_owned: docs/plans/T_CI_2_FRONTEND_TESTS_PLAN.md,
   docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md, docs/TESTING.MD (frontend
   transition sentence only), frontend/package.json,
@@ -224,18 +227,24 @@ contract test only; later GOV work retains all other ownership.
 ### T-CI-2A: Require the universal frontend test check
 - priority: P0
 - depends_on: T-CI-2
+- status: planning complete; live policy update awaits operator approval
 - files_owned: docs/plans/T_CI_2_REQUIRED_CHECK_POLICY_PLAN.md (new),
   docs/plans/T_CI_1_REQUIRED_CHECK_POLICY_PLAN.md,
   docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md, AGENTS.md (verification-matrix
-  transition marker only)
+  CI-status paragraph and transition markers only),
+  tests/test_repository_guardrails.py
+  (canonical frontend required-check job identity only)
 - external_state_owned: repository ruleset `Require Python Guardrails`
 - decision_required: Operator approval of an exact update to ruleset 19594795
   that adds GitHub Actions context `frontend-tests` from integration 15368
   while preserving every T-CI-1A field.
+- implementation_plan: `docs/plans/T_CI_2_REQUIRED_CHECK_POLICY_PLAN.md`
 - do: After T-CI-2 is green on frontend and non-frontend pull requests, update
   ruleset 19594795 so its required status checks are exactly
-  `python-guardrails` and `frontend-tests`. Remove the AGENTS.md transition
-  marker only after the live readback proves both checks are mandatory.
+  `python-guardrails` and `frontend-tests`. Replace stale landed-task
+  transition text with accurate T-CI-2A-pending text in the planning PR, then
+  remove both temporary markers only after live readback proves both checks
+  are mandatory.
 - accept: Every pull request receives both contexts; the default branch cannot
   update unless both pass; strict policy, branch-creation exemption, empty
   bypass list, target, and all other T-CI-1A fields remain unchanged.

--- a/docs/plans/T_CI_1_REQUIRED_CHECK_POLICY_PLAN.md
+++ b/docs/plans/T_CI_1_REQUIRED_CHECK_POLICY_PLAN.md
@@ -239,41 +239,22 @@ The POST that created ruleset 19594795 is historical and non-repeatable.
 
 **v) Rollback.**
 
-This creation-time rollback applies only while ruleset 19594795 still has the
-Python-only contract verified by this plan. After T-CI-2A adds
-`frontend-tests`, its plan owns this section and must replace deletion with a
-PATCH that restores the exact Python-only contract below. Deleting the ruleset
-after T-CI-2A would also remove the established Python merge gate.
+Ruleset 19594795 is now an established merge gate and must never be deleted as
+a rollback action. Reverting this historical plan alone does not authorize
+removing `python-guardrails` or disabling the ruleset.
 
-```bash
-gh api -H "X-GitHub-Api-Version: 2026-03-10" --method DELETE \
-  repos/manumissio/town-council/rulesets/19594795
-if gh api --include -H "X-GitHub-Api-Version: 2026-03-10" \
-  repos/manumissio/town-council/rulesets/19594795 \
-  > /tmp/t-ci-1-deleted-ruleset-response.txt 2>&1; then
-  echo "Expected deleted ruleset to return 404" >&2
-  exit 1
-fi
-deleted_ruleset_status=$(awk 'index($0, "HTTP/") == 1 { status=$2 } END { print status }' \
-  /tmp/t-ci-1-deleted-ruleset-response.txt)
-if [ "$deleted_ruleset_status" != "404" ]; then
-  echo "Expected HTTP 404, received ${deleted_ruleset_status:-no status}" >&2
-  exit 1
-fi
-gh api -H "X-GitHub-Api-Version: 2026-03-10" \
-  repos/manumissio/town-council/rulesets \
-  | jq -e --argjson ruleset_id 19594795 'all(.[]; .id != $ruleset_id)'
-T_CI_1A_DOCS_COMMIT=$(git log --diff-filter=A -1 --format=%H -- \
-  docs/plans/T_CI_1_REQUIRED_CHECK_POLICY_PLAN.md)
-test -n "$T_CI_1A_DOCS_COMMIT"
-git revert "$T_CI_1A_DOCS_COMMIT"
-PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py
-git diff --check
-```
+If T-CI-2A adds another required check and must be rolled back, follow
+`docs/plans/T_CI_2_REQUIRED_CHECK_POLICY_PLAN.md` to restore the exact
+Python-only contract with `PUT`. Rollback is complete only after direct
+ruleset and effective-`master` readbacks prove that:
 
-Rollback is complete only when the named ruleset is absent and the committed
-documents no longer declare it active. No code, migration, data, package, or
-runtime rollback exists.
+- ruleset 19594795 remains active;
+- `python-guardrails` from integration 15368 remains required;
+- strict latest-default-branch policy remains enabled;
+- branch creation remains exempt;
+- no bypass actor or extra rule exists.
+
+No code, migration, data, package, or runtime rollback exists.
 
 **w) Docs synchronization.** Update this implementation plan and remediation
 registry only. Existing guardrail policy text becomes accurate when the live

--- a/docs/plans/T_CI_2_REQUIRED_CHECK_POLICY_PLAN.md
+++ b/docs/plans/T_CI_2_REQUIRED_CHECK_POLICY_PLAN.md
@@ -42,11 +42,14 @@ one frontend and one non-frontend pull request prove the context is universal.
 - `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`
 - `AGENTS.md`, verification-matrix CI-status paragraph and transition markers
   only
+- `pipeline/requirements-dev.txt`, direct development-only YAML parser pin
+- `tests/test_docker_build_contracts.py`, development-only dependency boundary
+  assertion
 - `tests/test_repository_guardrails.py`, canonical frontend required-check job
   identity only
 - repository ruleset `Require Python Guardrails`, ID `19594795`
 
-No workflow, package, runtime, or application file may change.
+No workflow, runtime package, runtime behavior, or application file may change.
 
 **d) Decision-gate check.** No G1-G5 gate applies. T-CI-2A has its own explicit
 operator decision. Repository planning work may proceed, but the ruleset
@@ -62,9 +65,12 @@ recorded below. G3 remains open and continues to block Phase 2.
 2. Confirm PR #114 supplies the post-T-CI-2 frontend-change proof:
    `frontend-tests` completed successfully from GitHub Actions integration
    `15368`.
-3. Add a repository guardrail test proving `.github/workflows/frontend-tests.yml`
-   contains the only literal `frontend-tests` occurrence across workflow files,
-   as the canonical job ID `frontend-tests:` with no name override.
+3. Pin PyYAML in development requirements and use `yaml.safe_load` to prove
+   `.github/workflows/frontend-tests.yml` contains the only workflow job whose
+   effective check name is `frontend-tests`, as canonical job ID
+   `frontend-tests` with no display-name override. Semantic parsing must cover
+   comments, quoted keys, folded scalars, and command blocks without treating
+   their text as workflow jobs.
 4. Add this Full plan, update the remediation registry, replace T-CI-1A's
    obsolete deletion rollback with a non-destructive restoration policy, and
    replace the stale AGENTS transition annotations with accurate T-CI-2A
@@ -112,14 +118,21 @@ recorded below. G3 remains open and continues to block Phase 2.
     post-merge ruleset and effective-`master` readbacks pass. Merge it after
     both required checks pass, then repeat the policy readback.
 
-No function, module, workflow, helper script, parser, compatibility path, or
-new configuration surface is added.
+No production function, module, workflow, helper script, compatibility path,
+or new configuration surface is added. The guardrail test uses the direct
+development-only PyYAML dependency rather than maintaining a partial YAML
+parser.
 
 **f) Reuse audit.** Reuse the existing universal frontend workflow, its
 GitHub Actions check identity, ruleset `19594795`, T-CI-1A readback
-assertions, GitHub CLI authentication, and `jq`. A second ruleset, legacy
-branch protection, custom policy script, or workflow duplication is rejected
-because each would create another enforcement owner.
+assertions, GitHub CLI authentication, `jq`, and PyYAML's safe loader. A second
+ruleset, legacy branch protection, custom policy script, or workflow
+duplication is rejected because each would create another enforcement owner.
+
+**Dependencies.** Add `PyYAML==6.0.3` to
+`pipeline/requirements-dev.txt`. It is already present locally as a transitive
+dependency of pre-commit, but the workflow contract test must not depend on
+that accidental relationship. It remains absent from runtime requirements.
 
 **g) Data contracts.**
 
@@ -205,6 +218,8 @@ exposed. G4 is unaffected.
 
 **l) Untrusted input.** GitHub API responses are external input. Verification
 selects and compares named JSON fields with `jq`; no response text is executed.
+Tracked workflow YAML is parsed with `yaml.safe_load`, which does not construct
+arbitrary Python objects.
 
 ## 4. Code Health
 
@@ -220,13 +235,14 @@ The external mutation is fail-fast and preceded by exact drift detection.
   field appears in the approved contract.
 - A3 corrected: repository, PR, and effective-rule claims require fresh API
   readback.
-- B1/F1 corrected: no wrapper, registry, parser, duplicate workflow, or
-  second ruleset.
+- B1/F1 corrected: no wrapper, registry, hand-written parser, duplicate
+  workflow, or second ruleset. The established PyYAML parser is pinned
+  directly for the contract test.
 - B2/C1 corrected: T-CI-1A's obsolete deletion rollback is replaced in the
   planning PR before any live policy change; no destructive fallback survives.
 - D1-D3 corrected: no test is weakened or mocked; live policy equality is the
   observable contract.
-- E1-E3 corrected: only the five tracked owned files and one owned external
+- E1-E3 corrected: only the seven tracked owned files and one owned external
   ruleset may change.
 - A4, B3, C2, F2, H2-H4: no planned violations.
 
@@ -265,6 +281,12 @@ and readback commands. Runtime-code delta is zero.
 12. The request or observed pre-state bytes change after operator approval.
 13. Another operator changes the ruleset between the final pre-state read and
     the full `PUT`; the API has no documented atomic write precondition.
+14. Comments, step names, command bodies, quoted YAML, or folded scalars cause
+    a text scanner to misclassify the effective workflow job name.
+15. The workflow parser is present only transitively or leaks into runtime
+    requirements.
+16. A dynamic top-level job name resolves to `frontend-tests` only at runtime,
+    preventing static proof that the required-check producer is unique.
 
 **r) Verification mapping.**
 
@@ -282,6 +304,9 @@ and readback commands. Runtime-code delta is zero.
 | Canonical frontend job-identity guardrail | 11 |
 | Approved request and pre-state SHA-256 assertions | 12 |
 | Exclusive change window, immediate pre-state check, and exact readback | 13 |
+| Semantic workflow-parser regression cases | 14 |
+| Development/runtime dependency boundary contract | 15 |
+| Fail-closed dynamic job-name regression case | 16 |
 
 No fixed test count or inferred UI behavior is used as acceptance evidence.
 
@@ -870,6 +895,7 @@ Repository verification:
 ./.venv/bin/ruff check .
 ./.venv/bin/mypy
 PYTHONPATH=. .venv/bin/pytest -q tests/test_repository_guardrails.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_docker_build_contracts.py
 PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py
 PYTHONPATH=. .venv/bin/pytest -q
 git diff --check
@@ -1170,8 +1196,10 @@ rollback guidance in T-CI-1A.
 - `AGENTS.md` first replaces stale landed-task annotations with accurate
   T-CI-2A-pending text, then removes that temporary text after live readback.
 - `tests/test_repository_guardrails.py` enforces one canonical repository-wide
-  `frontend-tests` workflow job ID with no alternate occurrence or name
-  override.
+  `frontend-tests` workflow job ID and no alternate effective job-name
+  producer, using semantic YAML parsing.
+- `pipeline/requirements-dev.txt` and `tests/test_docker_build_contracts.py`
+  make the parser a direct development-only dependency.
 - README, architecture review, ADR, operations, security, data governance,
   application contracts, and workflows: no changes.
 
@@ -1191,6 +1219,6 @@ count, CI state, merge, and post-merge policy readback. Anything unrun is
 `NOT VERIFIED`.
 
 **z) Deviations.** The expected deviation report is none. Any changed tracked
-path outside the five owned files, any external policy field outside the
+path outside the seven owned files, any external policy field outside the
 approved request, missing frontend/non-frontend proof, skipped review,
 unresolved P1/P2, or unrun required check is a blocker.

--- a/docs/plans/T_CI_2_REQUIRED_CHECK_POLICY_PLAN.md
+++ b/docs/plans/T_CI_2_REQUIRED_CHECK_POLICY_PLAN.md
@@ -1,0 +1,1196 @@
+# T-CI-2A: Require the Universal Frontend Test Check
+
+`artifact_contract: ce-unified-plan/v1`
+`artifact_readiness: implementation-ready`
+`execution: code`
+`task: T-CI-2A`
+`lane: CI`
+
+## 1. Context & Alignment
+
+**a) Driver.** T-CI-2 is merged and now emits `frontend-tests` on every pull
+request and every push to `master`. The active default-branch ruleset still
+requires only `python-guardrails`, so a frontend regression can remain
+mergeable even when the frontend test job fails. T-CI-2A closes that gap after
+one frontend and one non-frontend pull request prove the context is universal.
+
+**b) Canonical documents consulted.**
+
+- `AGENTS.md` `<hard_invariants>`, `<workflow_contract>`,
+  `<verification_matrix>`, and `<status_reporting_contract>` require an
+  operator decision for gate changes, exact evidence, and current merge-gate
+  guidance.
+- `docs/TESTING.MD` defines the frontend test command and complete Python suite
+  as independent authoritative gates.
+- `docs/ENGINEERING_GUARDRAILS.md` assigns frontend CI orchestration to
+  `.github/workflows/frontend-tests.yml`.
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md` requires T-CI-2A after T-CI-2
+  and grants ownership of the live ruleset.
+- `docs/plans/T_CI_1_REQUIRED_CHECK_POLICY_PLAN.md` records every field in the
+  current Python-only ruleset and requires T-CI-2A to replace its obsolete
+  deletion rollback.
+- `docs/plans/T_CI_2_FRONTEND_TESTS_PLAN.md` records the universal workflow,
+  its exact job context, and the required frontend/non-frontend proof.
+- `docs/reviews/architecture-review-2026-07-19.html` historically identified
+  missing merge gates; current completion status comes from the remediation
+  registry and live repository policy.
+
+**c) Remediation alignment.** T-CI-2A remains in the CI lane and owns exactly:
+
+- `docs/plans/T_CI_2_REQUIRED_CHECK_POLICY_PLAN.md`
+- `docs/plans/T_CI_1_REQUIRED_CHECK_POLICY_PLAN.md`
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`
+- `AGENTS.md`, verification-matrix CI-status paragraph and transition markers
+  only
+- `tests/test_repository_guardrails.py`, canonical frontend required-check job
+  identity only
+- repository ruleset `Require Python Guardrails`, ID `19594795`
+
+No workflow, package, runtime, or application file may change.
+
+**d) Decision-gate check.** No G1-G5 gate applies. T-CI-2A has its own explicit
+operator decision. Repository planning work may proceed, but the ruleset
+`PUT` must not run until the operator approves the exact old and new contracts
+recorded below. G3 remains open and continues to block Phase 2.
+
+## 2. Design
+
+**e) Step-by-step approach.**
+
+1. Record the current ruleset and effective `master` rules. Fail unless they
+   exactly match the T-CI-1A Python-only contract.
+2. Confirm PR #114 supplies the post-T-CI-2 frontend-change proof:
+   `frontend-tests` completed successfully from GitHub Actions integration
+   `15368`.
+3. Add a repository guardrail test proving `.github/workflows/frontend-tests.yml`
+   contains the only literal `frontend-tests` occurrence across workflow files,
+   as the canonical job ID `frontend-tests:` with no name override.
+4. Add this Full plan, update the remediation registry, replace T-CI-1A's
+   obsolete deletion rollback with a non-destructive restoration policy, and
+   replace the stale AGENTS transition annotations with accurate T-CI-2A
+   pending text.
+5. Run repository verification and obtain a fresh subagent pre-commit review.
+   Apply every eligible P1/P2 finding and repeat affected checks.
+6. Commit, push, and open a non-frontend policy PR without changing live
+   policy. Wait for that PR's `frontend-tests` and `python-guardrails` contexts to
+   complete successfully. Confirm `frontend-tests` also comes from integration
+   `15368`. This supplies the non-frontend proof.
+7. Merge the planning PR and verify that the live ruleset remains Python-only.
+8. Generate the exact request and canonical observed pre-state in untracked
+   temporary files. Present both complete JSON documents and SHA-256 digests
+   for operator approval. The pre-state includes the ruleset `updated_at`
+   value:
+   - old required checks:
+     `python-guardrails` from integration `15368`;
+   - new required checks, in order:
+     `python-guardrails` and `frontend-tests`, both from integration `15368`;
+   - all other ruleset fields unchanged.
+9. Stop unless the operator explicitly approves both exact JSON documents and
+   digests and establishes an exclusive ruleset change window through the
+   post-update readback. Any byte change or concurrent policy operation
+   invalidates approval.
+10. In one fail-closed shell block, verify both approved digests, repeat the
+    full direct and effective Python-only preflight, prove the canonical direct
+    pre-state still matches approval, prepare the exact rollback request,
+    send one `PUT`, and perform complete direct and effective readback. GitHub
+    does not expose a documented atomic compare-and-swap for this full ruleset
+    `PUT`; the exclusive change window, immediate pre-state check, and exact
+    readback reduce but do not eliminate that non-atomic interval.
+11. Only after successful live readback, create a completion documentation
+    branch and:
+    - mark T-CI-2A `live policy active; merge verification pending`;
+    - update T-CI-1A's current-state wording without erasing its historical
+      decision;
+    - remove the two T-CI-2A-pending transition annotations from
+      `AGENTS.md`.
+12. Run documentation verification and obtain a fresh subagent pre-commit
+    review. Apply every eligible P1/P2 finding and repeat affected checks.
+13. Commit and push the completion policy record, open a second PR, wait for
+    all checks, request review, merge, and verify the ruleset again after the
+    default branch advances.
+14. Open a final closure PR that records T-CI-2A complete only after the
+    post-merge ruleset and effective-`master` readbacks pass. Merge it after
+    both required checks pass, then repeat the policy readback.
+
+No function, module, workflow, helper script, parser, compatibility path, or
+new configuration surface is added.
+
+**f) Reuse audit.** Reuse the existing universal frontend workflow, its
+GitHub Actions check identity, ruleset `19594795`, T-CI-1A readback
+assertions, GitHub CLI authentication, and `jq`. A second ruleset, legacy
+branch protection, custom policy script, or workflow duplication is rejected
+because each would create another enforcement owner.
+
+**g) Data contracts.**
+
+Current contract:
+
+```json
+{
+  "name": "Require Python Guardrails",
+  "target": "branch",
+  "enforcement": "active",
+  "bypass_actors": [],
+  "conditions": {
+    "ref_name": {
+      "include": ["~DEFAULT_BRANCH"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "required_status_checks": [
+          {"context": "python-guardrails", "integration_id": 15368}
+        ],
+        "strict_required_status_checks_policy": true,
+        "do_not_enforce_on_create": true
+      }
+    }
+  ]
+}
+```
+
+Proposed contract:
+
+```json
+{
+  "name": "Require Python Guardrails",
+  "target": "branch",
+  "enforcement": "active",
+  "bypass_actors": [],
+  "conditions": {
+    "ref_name": {
+      "include": ["~DEFAULT_BRANCH"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "required_status_checks": [
+          {"context": "python-guardrails", "integration_id": 15368},
+          {"context": "frontend-tests", "integration_id": 15368}
+        ],
+        "strict_required_status_checks_policy": true,
+        "do_not_enforce_on_create": true
+      }
+    }
+  ]
+}
+```
+
+GitHub REST API documentation verifies `PUT` as the update method and requires
+the ruleset name, target, and enforcement fields. The OpenAPI contract
+verifies each status-check context, optional integration identity, required
+strict policy, and creation-exemption parameter.
+
+**h) Schema and migration impact.** None.
+
+## 3. Security & Data Governance
+
+**i) Security boundary.** This changes repository write policy, not an
+application trust boundary. Default-branch updates lose the ability to proceed
+unless both authoritative test contexts pass against current default-branch
+code. No actor gains bypass capability; the bypass list stays empty.
+
+**j) Secrets.** No credential or secret is added. `gh` uses the operator's
+existing authenticated session. Request and readback artifacts contain policy
+metadata only.
+
+**k) Person data.** No person-level data is created, linked, aggregated, or
+exposed. G4 is unaffected.
+
+**l) Untrusted input.** GitHub API responses are external input. Verification
+selects and compares named JSON fields with `jq`; no response text is executed.
+
+## 4. Code Health
+
+**m) GED conformance sweep.** No Python, JavaScript, error handler, timestamp,
+environment read, runtime default, soak gate, or inference policy changes.
+The external mutation is fail-fast and preceded by exact drift detection.
+
+**n) Antipattern scan, plan pass.**
+
+- A1/H1 corrected: current GitHub REST and OpenAPI documentation verify the
+  ruleset update method and required-status-check fields.
+- A2 corrected: no new setting or hidden default is introduced; every changed
+  field appears in the approved contract.
+- A3 corrected: repository, PR, and effective-rule claims require fresh API
+  readback.
+- B1/F1 corrected: no wrapper, registry, parser, duplicate workflow, or
+  second ruleset.
+- B2/C1 corrected: T-CI-1A's obsolete deletion rollback is replaced in the
+  planning PR before any live policy change; no destructive fallback survives.
+- D1-D3 corrected: no test is weakened or mocked; live policy equality is the
+  observable contract.
+- E1-E3 corrected: only the five tracked owned files and one owned external
+  ruleset may change.
+- A4, B3, C2, F2, H2-H4: no planned violations.
+
+**o) Ratchet interaction.**
+
+- Required checks: 1 to 2.
+- Added check: `frontend-tests`, integration `15368`.
+- Strict latest-default-branch policy: unchanged at `true`.
+- Branch-creation exemption: unchanged at `true`.
+- Bypass actors: unchanged at none.
+- Other rules and rulesets: unchanged.
+- Ruff, formatter, Mypy, coverage, runtime, and soak policy: unchanged.
+
+**p) Dead code and duplication audit.** Replace two obsolete transition
+annotations with accurate pending text, then remove that text after activation.
+Remove the obsolete ruleset-deletion rollback. Reuse all existing CI producers
+and readback commands. Runtime-code delta is zero.
+
+## 5. Testing
+
+**q) Edge and failure scenarios.**
+
+1. The current ruleset drifts before mutation.
+2. The frontend context is absent or non-terminal on a non-frontend PR.
+3. A check context comes from the wrong GitHub integration.
+4. The request omits an existing policy field.
+5. The request adds an extra check, rule, bypass actor, or ref target.
+6. GitHub rejects or partially applies the update.
+7. Effective `master` rules differ from the direct ruleset readback.
+8. The policy update succeeds but documentation still describes the
+   transition.
+9. The PR fails after live policy changes.
+10. A default-branch update after merge changes or removes the policy.
+11. Another workflow occurrence or job-name override can alter or duplicate the
+    `frontend-tests` check identity.
+12. The request or observed pre-state bytes change after operator approval.
+13. Another operator changes the ruleset between the final pre-state read and
+    the full `PUT`; the API has no documented atomic write precondition.
+
+**r) Verification mapping.**
+
+| Evidence | Scenarios |
+|---|---|
+| Pre-mutation exact ruleset assertion | 1, 4, 5 |
+| PR #114 check-run readback | 2, 3 |
+| T-CI-2A PR check-run readback | 2, 3 |
+| Approved request-file equality assertion | 4, 5 |
+| Direct post-update ruleset assertion | 4-6 |
+| Effective `master` rules assertion | 6, 7 |
+| Documentation search and docs-link test | 8 |
+| Python-only rollback `PUT` | 9 |
+| Post-merge ruleset and effective-rule readback | 10 |
+| Canonical frontend job-identity guardrail | 11 |
+| Approved request and pre-state SHA-256 assertions | 12 |
+| Exclusive change window, immediate pre-state check, and exact readback | 13 |
+
+No fixed test count or inferred UI behavior is used as acceptance evidence.
+
+**s) Fakes and mocks.** None. GitHub's authenticated REST API is the real
+operator boundary. Tracked documentation is verified through the filesystem.
+
+**t) Verification rows.** Apply the guardrail/tooling and docs-only rows, then
+run the complete Python suite because a repository-wide CI identity contract
+changes. External acceptance also requires the frontend and non-frontend PR
+check evidence, direct ruleset readback, effective-`master` readback, and
+post-merge recheck.
+
+## 6. Execution, Rollback, Docs
+
+**u) Exact commands.**
+
+Repository setup:
+
+```bash
+git fetch origin --prune
+git switch master
+git merge --ff-only origin/master
+git switch -c codex/t-ci-2a-required-frontend-check
+```
+
+Precondition and tests-first policy evidence:
+
+```bash
+set -euo pipefail
+API_VERSION=2026-03-10
+RULESET_ENDPOINT=repos/manumissio/town-council/rulesets/19594795
+EFFECTIVE_ENDPOINT=repos/manumissio/town-council/rules/branches/master
+WORK_DIR=$(mktemp -d)
+
+gh api -H "X-GitHub-Api-Version: 2026-03-10" \
+  "$RULESET_ENDPOINT" > "$WORK_DIR/ruleset-before.json"
+gh api -H "X-GitHub-Api-Version: 2026-03-10" \
+  "$EFFECTIVE_ENDPOINT" > "$WORK_DIR/effective-before.json"
+
+jq -e '
+  .id == 19594795 and
+  .source == "manumissio/town-council" and
+  .source_type == "Repository" and
+  .name == "Require Python Guardrails" and
+  .target == "branch" and
+  .enforcement == "active" and
+  .bypass_actors == [] and
+  .conditions.ref_name.include == ["~DEFAULT_BRANCH"] and
+  .conditions.ref_name.exclude == [] and
+  (.rules | length) == 1 and
+  .rules[0].type == "required_status_checks" and
+  .rules[0].parameters.required_status_checks ==
+    [{"context":"python-guardrails","integration_id":15368}] and
+  .rules[0].parameters.strict_required_status_checks_policy == true and
+  .rules[0].parameters.do_not_enforce_on_create == true
+' "$WORK_DIR/ruleset-before.json"
+
+jq -e '
+  length == 1 and
+  .[0].ruleset_id == 19594795 and
+  .[0].ruleset_source == "manumissio/town-council" and
+  .[0].ruleset_source_type == "Repository" and
+  .[0].type == "required_status_checks" and
+  .[0].parameters.required_status_checks ==
+    [{"context":"python-guardrails","integration_id":15368}] and
+  .[0].parameters.strict_required_status_checks_policy == true and
+  .[0].parameters.do_not_enforce_on_create == true
+' "$WORK_DIR/effective-before.json"
+
+if ! RULESET_COUNT=$(gh api -H "X-GitHub-Api-Version: $API_VERSION" \
+  "repos/manumissio/town-council/rulesets?includes_parents=false" \
+  --jq 'length'); then
+  echo "Ruleset-count readback failed; external state is unknown" >&2
+  exit 1
+fi
+if [ "$RULESET_COUNT" != "1" ]; then
+  echo "Expected exactly one repository ruleset" >&2
+  exit 1
+fi
+
+if gh api --include -H "X-GitHub-Api-Version: $API_VERSION" \
+  repos/manumissio/town-council/branches/master/protection \
+  > "$WORK_DIR/legacy-protection.txt" 2>&1; then
+  echo "Expected legacy branch protection to be absent" >&2
+  exit 1
+fi
+LEGACY_STATUS=$(awk '
+  index($0, "HTTP/") == 1 { status=$2 }
+  END { print status }
+' "$WORK_DIR/legacy-protection.txt")
+test "$LEGACY_STATUS" = "404"
+
+if jq -e '
+  (.rules[0].parameters.required_status_checks | sort_by(.context)) ==
+    [
+      {"context":"frontend-tests","integration_id":15368},
+      {"context":"python-guardrails","integration_id":15368}
+    ]
+' "$WORK_DIR/ruleset-before.json"; then
+  echo "Expected frontend-tests to be optional before T-CI-2A" >&2
+  exit 1
+fi
+```
+
+Frontend and non-frontend proof:
+
+```bash
+set -euo pipefail
+API_VERSION=2026-03-10
+WORK_DIR=$(mktemp -d)
+T_CI_2A_PR=$(gh pr view --json number --jq .number)
+
+assert_ci_contexts() {
+  PR_NUMBER=$1
+  PR_HEAD=$(gh pr view "$PR_NUMBER" --json headRefOid --jq .headRefOid)
+  gh api -H "X-GitHub-Api-Version: $API_VERSION" \
+    "repos/manumissio/town-council/commits/$PR_HEAD/check-runs" \
+    > "$WORK_DIR/pr-$PR_NUMBER-checks.json"
+  jq -e --arg head "$PR_HEAD" '
+    [
+      .check_runs[]
+      | select(.name == "frontend-tests" or .name == "python-guardrails")
+    ]
+    | group_by(.name)
+    | map(max_by(.id))
+    | map({
+        name,
+        status,
+        conclusion,
+        integration_id: .app.id,
+        head_sha
+      })
+    | sort_by(.name)
+    ==
+      [
+        {
+          name: "frontend-tests",
+          status: "completed",
+          conclusion: "success",
+          integration_id: 15368,
+          head_sha: $head
+        },
+        {
+          name: "python-guardrails",
+          status: "completed",
+          conclusion: "success",
+          integration_id: 15368,
+          head_sha: $head
+        }
+      ]
+  ' "$WORK_DIR/pr-$PR_NUMBER-checks.json"
+}
+
+gh pr view 114 --json files |
+jq -e '
+  (.files | length) > 0 and
+  all(.files[]; .path | startswith("frontend/"))
+'
+
+gh pr view "$T_CI_2A_PR" --json files |
+jq -e '
+  (.files | length) > 0 and
+  all(.files[]; (.path | startswith("frontend/") | not))
+'
+
+assert_ci_contexts 114
+assert_ci_contexts "$T_CI_2A_PR"
+
+test "$(rg -l '^  frontend-tests:' .github/workflows \
+  -g '*.yml' -g '*.yaml' | wc -l | tr -d ' ')" = "1"
+test "$(rg -l '^  python-guardrails:' .github/workflows \
+  -g '*.yml' -g '*.yaml' | wc -l | tr -d ' ')" = "1"
+```
+
+Generate the immutable approval artifact before requesting approval:
+
+```bash
+set -euo pipefail
+API_VERSION=2026-03-10
+RULESET_ENDPOINT=repos/manumissio/town-council/rulesets/19594795
+RULESET_REQUEST=/tmp/t-ci-2a-ruleset-request.json
+RULESET_PRESTATE=/tmp/t-ci-2a-ruleset-prestate.json
+RULESET_PRESTATE_RAW=$(mktemp)
+
+gh api -H "X-GitHub-Api-Version: $API_VERSION" \
+  "$RULESET_ENDPOINT" > "$RULESET_PRESTATE_RAW"
+jq -S '{
+  id,
+  source,
+  source_type,
+  updated_at,
+  name,
+  target,
+  enforcement,
+  bypass_actors,
+  conditions,
+  rules
+}' "$RULESET_PRESTATE_RAW" > "$RULESET_PRESTATE"
+
+jq -n -S '
+  {
+    name: "Require Python Guardrails",
+    target: "branch",
+    enforcement: "active",
+    bypass_actors: [],
+    conditions: {
+      ref_name: {
+        include: ["~DEFAULT_BRANCH"],
+        exclude: []
+      }
+    },
+    rules: [
+      {
+        type: "required_status_checks",
+        parameters: {
+          required_status_checks: [
+            {context: "python-guardrails", integration_id: 15368},
+            {context: "frontend-tests", integration_id: 15368}
+          ],
+          strict_required_status_checks_policy: true,
+          do_not_enforce_on_create: true
+        }
+      }
+    ]
+  }
+' > "$RULESET_REQUEST"
+
+jq -e '
+  .name == "Require Python Guardrails" and
+  .target == "branch" and
+  .enforcement == "active" and
+  .bypass_actors == [] and
+  .conditions.ref_name.include == ["~DEFAULT_BRANCH"] and
+  .conditions.ref_name.exclude == [] and
+  (.rules | length) == 1 and
+  .rules[0].type == "required_status_checks" and
+  (.rules[0].parameters.required_status_checks | sort_by(.context)) ==
+    [
+      {"context":"frontend-tests","integration_id":15368},
+      {"context":"python-guardrails","integration_id":15368}
+    ] and
+  .rules[0].parameters.strict_required_status_checks_policy == true and
+  .rules[0].parameters.do_not_enforce_on_create == true
+' "$RULESET_REQUEST"
+
+jq -e '
+  .id == 19594795 and
+  .source == "manumissio/town-council" and
+  .source_type == "Repository" and
+  (.updated_at | type) == "string" and
+  (.updated_at | length) > 0 and
+  .name == "Require Python Guardrails" and
+  .target == "branch" and
+  .enforcement == "active" and
+  .bypass_actors == [] and
+  .conditions.ref_name.include == ["~DEFAULT_BRANCH"] and
+  .conditions.ref_name.exclude == [] and
+  (.rules | length) == 1 and
+  .rules[0].type == "required_status_checks" and
+  .rules[0].parameters.required_status_checks ==
+    [{"context":"python-guardrails","integration_id":15368}] and
+  .rules[0].parameters.strict_required_status_checks_policy == true and
+  .rules[0].parameters.do_not_enforce_on_create == true
+' "$RULESET_PRESTATE"
+
+jq . "$RULESET_PRESTATE"
+shasum -a 256 "$RULESET_PRESTATE"
+jq . "$RULESET_REQUEST"
+shasum -a 256 "$RULESET_REQUEST"
+```
+
+After approval of both displayed JSON documents and digests, establish the
+exclusive ruleset change window, export `APPROVED_PRESTATE_SHA256` and
+`APPROVED_REQUEST_SHA256` with those exact digests, and run one fail-closed
+mutation block:
+
+```bash
+set -euo pipefail
+API_VERSION=2026-03-10
+RULESET_ENDPOINT=repos/manumissio/town-council/rulesets/19594795
+EFFECTIVE_ENDPOINT=repos/manumissio/town-council/rules/branches/master
+RULESET_REQUEST=/tmp/t-ci-2a-ruleset-request.json
+: "${APPROVED_PRESTATE_SHA256:?Set the exact operator-approved pre-state SHA-256 digest}"
+: "${APPROVED_REQUEST_SHA256:?Set the exact operator-approved SHA-256 digest}"
+EXPECTED_PRESTATE_SHA256=$APPROVED_PRESTATE_SHA256
+EXPECTED_REQUEST_SHA256=$APPROVED_REQUEST_SHA256
+WORK_DIR=$(mktemp -d)
+SUBMITTED_REQUEST="$WORK_DIR/approved-request.json"
+
+cp "$RULESET_REQUEST" "$SUBMITTED_REQUEST"
+ACTUAL_REQUEST_SHA256=$(shasum -a 256 "$SUBMITTED_REQUEST" | awk '{print $1}')
+test "$ACTUAL_REQUEST_SHA256" = "$EXPECTED_REQUEST_SHA256"
+
+gh api -H "X-GitHub-Api-Version: $API_VERSION" \
+  "$RULESET_ENDPOINT" > "$WORK_DIR/ruleset-before.json"
+gh api -H "X-GitHub-Api-Version: $API_VERSION" \
+  "$EFFECTIVE_ENDPOINT" > "$WORK_DIR/effective-before.json"
+jq -S '{
+  id,
+  source,
+  source_type,
+  updated_at,
+  name,
+  target,
+  enforcement,
+  bypass_actors,
+  conditions,
+  rules
+}' "$WORK_DIR/ruleset-before.json" > "$WORK_DIR/prestate-before.json"
+ACTUAL_PRESTATE_SHA256=$(shasum -a 256 "$WORK_DIR/prestate-before.json" | awk '{print $1}')
+test "$ACTUAL_PRESTATE_SHA256" = "$EXPECTED_PRESTATE_SHA256"
+
+jq -e '
+  .id == 19594795 and
+  .source == "manumissio/town-council" and
+  .source_type == "Repository" and
+  .name == "Require Python Guardrails" and
+  .target == "branch" and
+  .enforcement == "active" and
+  .bypass_actors == [] and
+  .conditions.ref_name.include == ["~DEFAULT_BRANCH"] and
+  .conditions.ref_name.exclude == [] and
+  (.rules | length) == 1 and
+  .rules[0].type == "required_status_checks" and
+  .rules[0].parameters.required_status_checks ==
+    [{"context":"python-guardrails","integration_id":15368}] and
+  .rules[0].parameters.strict_required_status_checks_policy == true and
+  .rules[0].parameters.do_not_enforce_on_create == true
+' "$WORK_DIR/ruleset-before.json"
+
+jq -e '
+  length == 1 and
+  .[0].ruleset_id == 19594795 and
+  .[0].ruleset_source == "manumissio/town-council" and
+  .[0].ruleset_source_type == "Repository" and
+  .[0].type == "required_status_checks" and
+  .[0].parameters.required_status_checks ==
+    [{"context":"python-guardrails","integration_id":15368}] and
+  .[0].parameters.strict_required_status_checks_policy == true and
+  .[0].parameters.do_not_enforce_on_create == true
+' "$WORK_DIR/effective-before.json"
+
+if ! RULESET_COUNT=$(gh api -H "X-GitHub-Api-Version: $API_VERSION" \
+  "repos/manumissio/town-council/rulesets?includes_parents=false" \
+  --jq 'length'); then
+  echo "Ruleset-count readback failed; external state is unknown" >&2
+  exit 1
+fi
+if [ "$RULESET_COUNT" != "1" ]; then
+  echo "Expected exactly one repository ruleset" >&2
+  exit 1
+fi
+
+if gh api --include -H "X-GitHub-Api-Version: $API_VERSION" \
+  repos/manumissio/town-council/branches/master/protection \
+  > "$WORK_DIR/legacy-protection.txt" 2>&1; then
+  echo "Expected legacy branch protection to be absent" >&2
+  exit 1
+fi
+LEGACY_STATUS=$(awk '
+  index($0, "HTTP/") == 1 { status=$2 }
+  END { print status }
+' "$WORK_DIR/legacy-protection.txt")
+test "$LEGACY_STATUS" = "404"
+
+jq '{
+  name,
+  target,
+  enforcement,
+  bypass_actors,
+  conditions,
+  rules
+}' "$WORK_DIR/ruleset-before.json" > "$WORK_DIR/rollback.json"
+jq -e '
+  .name == "Require Python Guardrails" and
+  .target == "branch" and
+  .enforcement == "active" and
+  .bypass_actors == [] and
+  .conditions.ref_name.include == ["~DEFAULT_BRANCH"] and
+  .conditions.ref_name.exclude == [] and
+  (.rules | length) == 1 and
+  .rules[0].type == "required_status_checks" and
+  .rules[0].parameters.required_status_checks ==
+    [{"context":"python-guardrails","integration_id":15368}] and
+  .rules[0].parameters.strict_required_status_checks_policy == true and
+  .rules[0].parameters.do_not_enforce_on_create == true
+' "$WORK_DIR/rollback.json" >/dev/null
+ROLLBACK_REQUEST_SHA256=$(shasum -a 256 "$WORK_DIR/rollback.json" | awk '{print $1}')
+
+is_python_ruleset() {
+  jq -e '
+    .id == 19594795 and
+    .source == "manumissio/town-council" and
+    .source_type == "Repository" and
+    .name == "Require Python Guardrails" and
+    .target == "branch" and
+    .enforcement == "active" and
+    .bypass_actors == [] and
+    .conditions.ref_name.include == ["~DEFAULT_BRANCH"] and
+    .conditions.ref_name.exclude == [] and
+    (.rules | length) == 1 and
+    .rules[0].type == "required_status_checks" and
+    .rules[0].parameters.required_status_checks ==
+      [{"context":"python-guardrails","integration_id":15368}] and
+    .rules[0].parameters.strict_required_status_checks_policy == true and
+    .rules[0].parameters.do_not_enforce_on_create == true
+  ' "$1" >/dev/null
+}
+
+is_two_check_ruleset() {
+  jq -e '
+    .id == 19594795 and
+    .source == "manumissio/town-council" and
+    .source_type == "Repository" and
+    .name == "Require Python Guardrails" and
+    .target == "branch" and
+    .enforcement == "active" and
+    .bypass_actors == [] and
+    .conditions.ref_name.include == ["~DEFAULT_BRANCH"] and
+    .conditions.ref_name.exclude == [] and
+    (.rules | length) == 1 and
+    .rules[0].type == "required_status_checks" and
+    (.rules[0].parameters.required_status_checks | sort_by(.context)) ==
+      [
+        {"context":"frontend-tests","integration_id":15368},
+        {"context":"python-guardrails","integration_id":15368}
+      ] and
+    .rules[0].parameters.strict_required_status_checks_policy == true and
+    .rules[0].parameters.do_not_enforce_on_create == true
+  ' "$1" >/dev/null
+}
+
+is_python_effective() {
+  jq -e '
+    length == 1 and
+    .[0].ruleset_id == 19594795 and
+    .[0].ruleset_source == "manumissio/town-council" and
+    .[0].ruleset_source_type == "Repository" and
+    .[0].type == "required_status_checks" and
+    .[0].parameters.required_status_checks ==
+      [{"context":"python-guardrails","integration_id":15368}] and
+    .[0].parameters.strict_required_status_checks_policy == true and
+    .[0].parameters.do_not_enforce_on_create == true
+  ' "$1" >/dev/null
+}
+
+is_two_check_effective() {
+  jq -e '
+    length == 1 and
+    .[0].ruleset_id == 19594795 and
+    .[0].ruleset_source == "manumissio/town-council" and
+    .[0].ruleset_source_type == "Repository" and
+    .[0].type == "required_status_checks" and
+    (.[0].parameters.required_status_checks | sort_by(.context)) ==
+      [
+        {"context":"frontend-tests","integration_id":15368},
+        {"context":"python-guardrails","integration_id":15368}
+      ] and
+    .[0].parameters.strict_required_status_checks_policy == true and
+    .[0].parameters.do_not_enforce_on_create == true
+  ' "$1" >/dev/null
+}
+
+has_one_repository_ruleset() {
+  test "$(gh api -H "X-GitHub-Api-Version: $API_VERSION" \
+    "repos/manumissio/town-council/rulesets?includes_parents=false" \
+    --jq 'length')" = "1"
+}
+
+has_no_legacy_protection() {
+  local readback_path=$1
+  if gh api --include -H "X-GitHub-Api-Version: $API_VERSION" \
+    repos/manumissio/town-council/branches/master/protection \
+    > "$readback_path" 2>&1; then
+    return 1
+  fi
+  local legacy_status
+  legacy_status=$(awk '
+    index($0, "HTTP/") == 1 { status=$2 }
+    END { print status }
+  ' "$readback_path")
+  test "$legacy_status" = "404"
+}
+
+PUT_OK=1
+test "$(shasum -a 256 "$SUBMITTED_REQUEST" | awk '{print $1}')" = \
+  "$EXPECTED_REQUEST_SHA256"
+if ! gh api -H "X-GitHub-Api-Version: $API_VERSION" \
+  --method PUT \
+  "$RULESET_ENDPOINT" \
+  --input "$SUBMITTED_REQUEST" \
+  > "$WORK_DIR/update-response.json"; then
+  PUT_OK=0
+fi
+
+POST_READBACK_OK=1
+if ! gh api -H "X-GitHub-Api-Version: $API_VERSION" \
+  "$RULESET_ENDPOINT" > "$WORK_DIR/ruleset-after.json"; then
+  POST_READBACK_OK=0
+fi
+if ! gh api -H "X-GitHub-Api-Version: $API_VERSION" \
+  "$EFFECTIVE_ENDPOINT" > "$WORK_DIR/effective-after.json"; then
+  POST_READBACK_OK=0
+fi
+
+if [ "$PUT_OK" -eq 1 ] &&
+  [ "$POST_READBACK_OK" -eq 1 ] &&
+  is_two_check_ruleset "$WORK_DIR/ruleset-after.json" &&
+  is_two_check_effective "$WORK_DIR/effective-after.json" &&
+  has_one_repository_ruleset &&
+  has_no_legacy_protection "$WORK_DIR/legacy-protection-after.txt"; then
+  printf '%s\n' "$WORK_DIR"
+else
+  RECOVERY_READBACK_OK=1
+  if ! gh api -H "X-GitHub-Api-Version: $API_VERSION" \
+    "$RULESET_ENDPOINT" > "$WORK_DIR/ruleset-recovery.json"; then
+    RECOVERY_READBACK_OK=0
+  fi
+  if ! gh api -H "X-GitHub-Api-Version: $API_VERSION" \
+    "$EFFECTIVE_ENDPOINT" > "$WORK_DIR/effective-recovery.json"; then
+    RECOVERY_READBACK_OK=0
+  fi
+  if [ "$RECOVERY_READBACK_OK" -ne 1 ]; then
+    echo "Ruleset update failed and live state could not be read; external state is unknown" >&2
+    echo "Recovery artifacts: $WORK_DIR" >&2
+    exit 1
+  fi
+  if is_python_ruleset "$WORK_DIR/ruleset-recovery.json" &&
+    is_python_effective "$WORK_DIR/effective-recovery.json" &&
+    has_one_repository_ruleset &&
+    has_no_legacy_protection "$WORK_DIR/legacy-protection-recovery.txt"; then
+    echo "Ruleset update failed; the Python-only contract remains active" >&2
+    exit 1
+  fi
+  if ! is_two_check_ruleset "$WORK_DIR/ruleset-recovery.json" ||
+    ! is_two_check_effective "$WORK_DIR/effective-recovery.json"; then
+    echo "Ruleset update failed with unrecognized concurrent policy drift; rollback not attempted" >&2
+    exit 1
+  fi
+
+  if ! gh api -H "X-GitHub-Api-Version: $API_VERSION" \
+    "$RULESET_ENDPOINT" > "$WORK_DIR/ruleset-rollback-preflight.json" ||
+    ! gh api -H "X-GitHub-Api-Version: $API_VERSION" \
+      "$EFFECTIVE_ENDPOINT" > "$WORK_DIR/effective-rollback-preflight.json" ||
+    ! is_two_check_ruleset "$WORK_DIR/ruleset-rollback-preflight.json" ||
+    ! is_two_check_effective "$WORK_DIR/effective-rollback-preflight.json" ||
+    ! has_one_repository_ruleset ||
+    ! has_no_legacy_protection "$WORK_DIR/legacy-protection-rollback-preflight.txt"; then
+    echo "Rollback preflight could not prove the approved two-check state; external state is unknown" >&2
+    echo "Recovery artifacts: $WORK_DIR" >&2
+    exit 1
+  fi
+
+  test "$(shasum -a 256 "$WORK_DIR/rollback.json" | awk '{print $1}')" = \
+    "$ROLLBACK_REQUEST_SHA256"
+  if ! gh api -H "X-GitHub-Api-Version: $API_VERSION" \
+    --method PUT \
+    "$RULESET_ENDPOINT" \
+    --input "$WORK_DIR/rollback.json" \
+    > "$WORK_DIR/rollback-response.json"; then
+    echo "Rollback request failed; external state is unknown" >&2
+    echo "Recovery artifacts: $WORK_DIR" >&2
+    exit 1
+  fi
+
+  if ! gh api -H "X-GitHub-Api-Version: $API_VERSION" \
+    "$RULESET_ENDPOINT" > "$WORK_DIR/ruleset-rollback.json" ||
+    ! gh api -H "X-GitHub-Api-Version: $API_VERSION" \
+      "$EFFECTIVE_ENDPOINT" > "$WORK_DIR/effective-rollback.json" ||
+    ! is_python_ruleset "$WORK_DIR/ruleset-rollback.json" ||
+    ! is_python_effective "$WORK_DIR/effective-rollback.json" ||
+    ! has_one_repository_ruleset ||
+    ! has_no_legacy_protection "$WORK_DIR/legacy-protection-rollback.txt"; then
+    echo "Rollback completed without a complete Python-only readback; external state is unknown" >&2
+    echo "Recovery artifacts: $WORK_DIR" >&2
+    exit 1
+  fi
+  echo "Two-check readback failed; restored the Python-only ruleset" >&2
+  exit 1
+fi
+```
+
+Repository verification:
+
+```bash
+./.venv/bin/ruff check .
+./.venv/bin/mypy
+PYTHONPATH=. .venv/bin/pytest -q tests/test_repository_guardrails.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py
+PYTHONPATH=. .venv/bin/pytest -q
+git diff --check
+git status --short
+
+FENCE_DIR=$(mktemp -d)
+awk -v fence_dir="$FENCE_DIR" '
+  /^```bash$/ {
+    in_bash=1
+    file=sprintf("%s/fence-%02d.sh", fence_dir, ++count)
+    next
+  }
+  /^```$/ && in_bash {
+    close(file)
+    in_bash=0
+    next
+  }
+  in_bash { print > file }
+' docs/plans/T_CI_2_REQUIRED_CHECK_POLICY_PLAN.md
+for fence in "$FENCE_DIR"/*.sh; do
+  bash -n "$fence"
+done
+```
+
+**v) Rollback.** If the live update succeeds but completion cannot proceed,
+establish the same exclusive ruleset change window, then restore and verify the
+Python-only policy with this fail-closed block:
+
+```bash
+set -euo pipefail
+API_VERSION=2026-03-10
+RULESET_ENDPOINT=repos/manumissio/town-council/rulesets/19594795
+EFFECTIVE_ENDPOINT=repos/manumissio/town-council/rules/branches/master
+ROLLBACK_REQUEST=/tmp/t-ci-2a-python-only-rollback.json
+WORK_DIR=$(mktemp -d)
+
+gh api -H "X-GitHub-Api-Version: $API_VERSION" \
+  "$RULESET_ENDPOINT" > "$WORK_DIR/ruleset-before-rollback.json"
+gh api -H "X-GitHub-Api-Version: $API_VERSION" \
+  "$EFFECTIVE_ENDPOINT" > "$WORK_DIR/effective-before-rollback.json"
+
+jq -e '
+  .id == 19594795 and
+  .source == "manumissio/town-council" and
+  .source_type == "Repository" and
+  .name == "Require Python Guardrails" and
+  .target == "branch" and
+  .enforcement == "active" and
+  .bypass_actors == [] and
+  .conditions.ref_name.include == ["~DEFAULT_BRANCH"] and
+  .conditions.ref_name.exclude == [] and
+  (.rules | length) == 1 and
+  .rules[0].type == "required_status_checks" and
+  (.rules[0].parameters.required_status_checks | sort_by(.context)) ==
+    [
+      {"context":"frontend-tests","integration_id":15368},
+      {"context":"python-guardrails","integration_id":15368}
+    ] and
+  .rules[0].parameters.strict_required_status_checks_policy == true and
+  .rules[0].parameters.do_not_enforce_on_create == true
+' "$WORK_DIR/ruleset-before-rollback.json"
+
+jq -e '
+  length == 1 and
+  .[0].ruleset_id == 19594795 and
+  .[0].ruleset_source == "manumissio/town-council" and
+  .[0].ruleset_source_type == "Repository" and
+  .[0].type == "required_status_checks" and
+  (.[0].parameters.required_status_checks | sort_by(.context)) ==
+    [
+      {"context":"frontend-tests","integration_id":15368},
+      {"context":"python-guardrails","integration_id":15368}
+    ] and
+  .[0].parameters.strict_required_status_checks_policy == true and
+  .[0].parameters.do_not_enforce_on_create == true
+' "$WORK_DIR/effective-before-rollback.json"
+
+test "$(gh api -H "X-GitHub-Api-Version: $API_VERSION" \
+  "repos/manumissio/town-council/rulesets?includes_parents=false" \
+  --jq 'length')" = "1"
+
+if gh api --include -H "X-GitHub-Api-Version: $API_VERSION" \
+  repos/manumissio/town-council/branches/master/protection \
+  > "$WORK_DIR/legacy-protection-before-rollback.txt" 2>&1; then
+  echo "Expected legacy branch protection to be absent" >&2
+  exit 1
+fi
+LEGACY_STATUS=$(awk '
+  index($0, "HTTP/") == 1 { status=$2 }
+  END { print status }
+' "$WORK_DIR/legacy-protection-before-rollback.txt")
+test "$LEGACY_STATUS" = "404"
+
+jq -n -S '
+  {
+    name: "Require Python Guardrails",
+    target: "branch",
+    enforcement: "active",
+    bypass_actors: [],
+    conditions: {
+      ref_name: {
+        include: ["~DEFAULT_BRANCH"],
+        exclude: []
+      }
+    },
+    rules: [
+      {
+        type: "required_status_checks",
+        parameters: {
+          required_status_checks: [
+            {context: "python-guardrails", integration_id: 15368}
+          ],
+          strict_required_status_checks_policy: true,
+          do_not_enforce_on_create: true
+        }
+      }
+    ]
+  }
+' > "$ROLLBACK_REQUEST"
+
+jq -e '
+  .name == "Require Python Guardrails" and
+  .target == "branch" and
+  .enforcement == "active" and
+  .bypass_actors == [] and
+  .conditions.ref_name.include == ["~DEFAULT_BRANCH"] and
+  .conditions.ref_name.exclude == [] and
+  (.rules | length) == 1 and
+  .rules[0].type == "required_status_checks" and
+  .rules[0].parameters.required_status_checks ==
+    [{"context":"python-guardrails","integration_id":15368}] and
+  .rules[0].parameters.strict_required_status_checks_policy == true and
+  .rules[0].parameters.do_not_enforce_on_create == true
+' "$ROLLBACK_REQUEST" >/dev/null
+ROLLBACK_REQUEST_SHA256=$(shasum -a 256 "$ROLLBACK_REQUEST" | awk '{print $1}')
+
+if ! gh api -H "X-GitHub-Api-Version: $API_VERSION" \
+  "$RULESET_ENDPOINT" > "$WORK_DIR/ruleset-rollback-preflight.json" ||
+  ! gh api -H "X-GitHub-Api-Version: $API_VERSION" \
+    "$EFFECTIVE_ENDPOINT" > "$WORK_DIR/effective-rollback-preflight.json"; then
+  echo "Rollback preflight readback failed; external state is unknown" >&2
+  echo "Recovery artifacts: $WORK_DIR" >&2
+  exit 1
+fi
+
+if ! jq -e '
+  .id == 19594795 and
+  .source == "manumissio/town-council" and
+  .source_type == "Repository" and
+  .name == "Require Python Guardrails" and
+  .target == "branch" and
+  .enforcement == "active" and
+  .bypass_actors == [] and
+  .conditions.ref_name.include == ["~DEFAULT_BRANCH"] and
+  .conditions.ref_name.exclude == [] and
+  (.rules | length) == 1 and
+  .rules[0].type == "required_status_checks" and
+  (.rules[0].parameters.required_status_checks | sort_by(.context)) ==
+    [
+      {"context":"frontend-tests","integration_id":15368},
+      {"context":"python-guardrails","integration_id":15368}
+    ] and
+  .rules[0].parameters.strict_required_status_checks_policy == true and
+  .rules[0].parameters.do_not_enforce_on_create == true
+' "$WORK_DIR/ruleset-rollback-preflight.json" >/dev/null ||
+  ! jq -e '
+  length == 1 and
+  .[0].ruleset_id == 19594795 and
+  .[0].ruleset_source == "manumissio/town-council" and
+  .[0].ruleset_source_type == "Repository" and
+  .[0].type == "required_status_checks" and
+  (.[0].parameters.required_status_checks | sort_by(.context)) ==
+    [
+      {"context":"frontend-tests","integration_id":15368},
+      {"context":"python-guardrails","integration_id":15368}
+    ] and
+  .[0].parameters.strict_required_status_checks_policy == true and
+  .[0].parameters.do_not_enforce_on_create == true
+' "$WORK_DIR/effective-rollback-preflight.json" >/dev/null; then
+  echo "Rollback preflight found unrecognized policy drift; rollback not attempted" >&2
+  exit 1
+fi
+
+test "$(gh api -H "X-GitHub-Api-Version: $API_VERSION" \
+  "repos/manumissio/town-council/rulesets?includes_parents=false" \
+  --jq 'length')" = "1"
+
+if gh api --include -H "X-GitHub-Api-Version: $API_VERSION" \
+  repos/manumissio/town-council/branches/master/protection \
+  > "$WORK_DIR/legacy-protection-rollback-preflight.txt" 2>&1; then
+  echo "Expected legacy branch protection to remain absent" >&2
+  exit 1
+fi
+ROLLBACK_PREFLIGHT_LEGACY_STATUS=$(awk '
+  index($0, "HTTP/") == 1 { status=$2 }
+  END { print status }
+' "$WORK_DIR/legacy-protection-rollback-preflight.txt")
+if [ "$ROLLBACK_PREFLIGHT_LEGACY_STATUS" != "404" ]; then
+  echo "Rollback preflight could not prove legacy branch protection is absent" >&2
+  exit 1
+fi
+
+test "$(shasum -a 256 "$ROLLBACK_REQUEST" | awk '{print $1}')" = \
+  "$ROLLBACK_REQUEST_SHA256"
+if ! gh api -H "X-GitHub-Api-Version: $API_VERSION" \
+  --method PUT \
+  "$RULESET_ENDPOINT" \
+  --input "$ROLLBACK_REQUEST" \
+  > "$WORK_DIR/rollback-response.json"; then
+  echo "Rollback request failed; external state is unknown" >&2
+  echo "Recovery artifacts: $WORK_DIR" >&2
+  exit 1
+fi
+if ! gh api -H "X-GitHub-Api-Version: $API_VERSION" \
+  "$RULESET_ENDPOINT" > "$WORK_DIR/ruleset-rollback.json" ||
+  ! gh api -H "X-GitHub-Api-Version: $API_VERSION" \
+    "$EFFECTIVE_ENDPOINT" > "$WORK_DIR/effective-rollback.json"; then
+  echo "Rollback completed without a complete readback; external state is unknown" >&2
+  echo "Recovery artifacts: $WORK_DIR" >&2
+  exit 1
+fi
+
+if ! jq -e '
+  .id == 19594795 and
+  .source == "manumissio/town-council" and
+  .source_type == "Repository" and
+  .name == "Require Python Guardrails" and
+  .target == "branch" and
+  .enforcement == "active" and
+  .bypass_actors == [] and
+  .conditions.ref_name.include == ["~DEFAULT_BRANCH"] and
+  .conditions.ref_name.exclude == [] and
+  (.rules | length) == 1 and
+  .rules[0].type == "required_status_checks" and
+  .rules[0].parameters.required_status_checks ==
+    [{"context":"python-guardrails","integration_id":15368}] and
+  .rules[0].parameters.strict_required_status_checks_policy == true and
+  .rules[0].parameters.do_not_enforce_on_create == true
+' "$WORK_DIR/ruleset-rollback.json" >/dev/null ||
+  ! jq -e '
+  length == 1 and
+  .[0].ruleset_id == 19594795 and
+  .[0].ruleset_source == "manumissio/town-council" and
+  .[0].ruleset_source_type == "Repository" and
+  .[0].type == "required_status_checks" and
+  .[0].parameters.required_status_checks ==
+    [{"context":"python-guardrails","integration_id":15368}] and
+  .[0].parameters.strict_required_status_checks_policy == true and
+  .[0].parameters.do_not_enforce_on_create == true
+' "$WORK_DIR/effective-rollback.json" >/dev/null; then
+  echo "Rollback readback does not match the Python-only contract; external state is unknown" >&2
+  echo "Recovery artifacts: $WORK_DIR" >&2
+  exit 1
+fi
+
+if ! ROLLBACK_RULESET_COUNT=$(gh api -H "X-GitHub-Api-Version: $API_VERSION" \
+  "repos/manumissio/town-council/rulesets?includes_parents=false" \
+  --jq 'length'); then
+  echo "Rollback ruleset-count readback failed; external state is unknown" >&2
+  echo "Recovery artifacts: $WORK_DIR" >&2
+  exit 1
+fi
+if [ "$ROLLBACK_RULESET_COUNT" != "1" ]; then
+  echo "Rollback readback found an unexpected repository ruleset count" >&2
+  exit 1
+fi
+
+if gh api --include -H "X-GitHub-Api-Version: $API_VERSION" \
+  repos/manumissio/town-council/branches/master/protection \
+  > "$WORK_DIR/legacy-protection-after-rollback.txt" 2>&1; then
+  echo "Expected legacy branch protection to remain absent" >&2
+  exit 1
+fi
+ROLLBACK_LEGACY_STATUS=$(awk '
+  index($0, "HTTP/") == 1 { status=$2 }
+  END { print status }
+' "$WORK_DIR/legacy-protection-after-rollback.txt")
+if [ "$ROLLBACK_LEGACY_STATUS" != "404" ]; then
+  echo "Rollback readback could not prove legacy branch protection is absent" >&2
+  echo "Recovery artifacts: $WORK_DIR" >&2
+  exit 1
+fi
+```
+
+Never delete ruleset `19594795`, remove `python-guardrails`, add a bypass
+actor, or infer rollback success from a command exit alone. Revert tracked
+completion records only after both Python-only readbacks pass. Keep the safer
+rollback guidance in T-CI-1A.
+
+**w) Docs synchronization.**
+
+- This plan records the proposed request and defines how approval, evidence,
+  rollback, and final state will be recorded.
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md` records T-CI-2 completion,
+  T-CI-2A progress, approval, and final completion.
+- `docs/plans/T_CI_1_REQUIRED_CHECK_POLICY_PLAN.md` replaces the obsolete
+  ruleset-deletion rollback in the planning PR before the live update.
+- `AGENTS.md` first replaces stale landed-task annotations with accurate
+  T-CI-2A-pending text, then removes that temporary text after live readback.
+- `tests/test_repository_guardrails.py` enforces one canonical repository-wide
+  `frontend-tests` workflow job ID with no alternate occurrence or name
+  override.
+- README, architecture review, ADR, operations, security, data governance,
+  application contracts, and workflows: no changes.
+
+## 7. Delivery Self-Audit
+
+**x) Antipattern scan, diff pass.** Re-run A-F and H. Reject a second ruleset,
+extra check, bypass actor, copied API response as request, missing drift check,
+workflow edit, new script, weakened evidence, unrelated documentation edit,
+or transition removal before live proof.
+
+**y) Evidence.** Report PASS/FAIL for the Python-only precondition, expected
+two-check assertion failure, frontend and non-frontend PR contexts,
+integration IDs, explicit approval, update response, exact direct and
+effective readbacks, ruleset count, docs-link test, diff check, subagent
+planning and pre-commit review findings, commits, PR URL, unresolved-thread
+count, CI state, merge, and post-merge policy readback. Anything unrun is
+`NOT VERIFIED`.
+
+**z) Deviations.** The expected deviation report is none. Any changed tracked
+path outside the five owned files, any external policy field outside the
+approved request, missing frontend/non-frontend proof, skipped review,
+unresolved P1/P2, or unrun required check is a blocker.

--- a/pipeline/requirements-dev.txt
+++ b/pipeline/requirements-dev.txt
@@ -5,6 +5,7 @@ pytest==9.0.3
 pytest-mock==3.12.0
 pytest-benchmark==5.1.0
 locust==2.33.0
+PyYAML==6.0.3
 ruff==0.15.9
 pre-commit==4.5.1
 mypy==1.20.0

--- a/tests/test_docker_build_contracts.py
+++ b/tests/test_docker_build_contracts.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 
 
@@ -63,13 +64,25 @@ def test_compose_maps_worker_family_to_live_and_batch_images():
     assert 'profiles: ["batch-tools"]' in source
 
 
-def test_worker_runtime_requirements_exclude_dev_benchmark_tooling():
+def test_worker_runtime_requirements_exclude_development_tooling():
     runtime = Path("pipeline/requirements.txt").read_text(encoding="utf-8")
     dev = Path("pipeline/requirements-dev.txt").read_text(encoding="utf-8")
+    runtime_requirement_names = {
+        re.split(r"[<>=!~;\[\s]", requirement_line, maxsplit=1)[0].lower()
+        for runtime_line in runtime.splitlines()
+        if (requirement_line := runtime_line.partition("#")[0].strip())
+    }
 
-    for package in ("pytest==9.0.3", "pytest-mock==3.12.0", "pytest-benchmark==5.1.0", "locust==2.33.0"):
+    for package in (
+        "pytest==9.0.3",
+        "pytest-mock==3.12.0",
+        "pytest-benchmark==5.1.0",
+        "locust==2.33.0",
+    ):
         assert package not in runtime
         assert package in dev
+    assert "pyyaml" not in runtime_requirement_names
+    assert "PyYAML==6.0.3" in dev
 
 
 def test_semantic_dependencies_live_outside_worker_runtime():

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -967,6 +967,43 @@ def test_frontend_workflow_runs_for_every_pull_request_and_master_push():
     assert "paths-ignore:" not in event_configuration
 
 
+def test_frontend_required_check_uses_one_canonical_workflow_job():
+    workflow_directory = ROOT / ".github" / "workflows"
+    frontend_workflow_text = (workflow_directory / "frontend-tests.yml").read_text(
+        encoding="utf-8"
+    )
+    frontend_workflow_lines = frontend_workflow_text.splitlines()
+    frontend_job_start = frontend_workflow_lines.index("  frontend-tests:")
+    frontend_job_end = next(
+        (
+            line_number
+            for line_number, workflow_line in enumerate(
+                frontend_workflow_lines[frontend_job_start + 1 :],
+                start=frontend_job_start + 1,
+            )
+            if re.match(r"^ {2}\S.*:", workflow_line)
+        ),
+        len(frontend_workflow_lines),
+    )
+    frontend_job_text = "\n".join(
+        frontend_workflow_lines[frontend_job_start:frontend_job_end]
+    )
+    candidate_workflow_paths = sorted(
+        (*workflow_directory.glob("*.yml"), *workflow_directory.glob("*.yaml"))
+    )
+    required_check_occurrences = tuple(
+        (workflow_path.relative_to(ROOT).as_posix(), workflow_line.strip())
+        for workflow_path in candidate_workflow_paths
+        for workflow_line in workflow_path.read_text(encoding="utf-8").splitlines()
+        if "frontend-tests" in workflow_line
+    )
+
+    assert required_check_occurrences == (
+        (".github/workflows/frontend-tests.yml", "frontend-tests:"),
+    )
+    assert re.search(r"""(?m)^ {4}["']?name["']?[ ]*:""", frontend_job_text) is None
+
+
 def test_frontend_workflow_installs_locked_dependencies_before_tests():
     workflow_text = (ROOT / ".github" / "workflows" / "frontend-tests.yml").read_text(encoding="utf-8")
     install_step = "      - name: Install dependencies\n        run: npm ci"

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -12,11 +12,13 @@ from pathlib import Path
 from textwrap import indent
 
 import pytest
+import yaml
 
 
 ROOT = Path(__file__).resolve().parents[1]
 RUFF_CLEAN_EXIT = 0
 RUFF_VIOLATION_EXIT = 1
+GITHUB_EXPRESSION_OPEN = "${{"
 TEXT_FILE_SUFFIXES = {
     ".md",
     ".plist",
@@ -967,41 +969,102 @@ def test_frontend_workflow_runs_for_every_pull_request_and_master_push():
     assert "paths-ignore:" not in event_configuration
 
 
+def _workflow_job_check_producers(
+    workflow_text: str,
+    required_check_name: str,
+) -> tuple[tuple[str, str | None], ...]:
+    workflow_contract = yaml.safe_load(workflow_text)
+    assert isinstance(workflow_contract, dict)
+    workflow_jobs = workflow_contract.get("jobs")
+    assert isinstance(workflow_jobs, dict)
+
+    check_producers: list[tuple[str, str | None]] = []
+    for workflow_job_id, workflow_job_contract in workflow_jobs.items():
+        assert isinstance(workflow_job_id, str)
+        assert isinstance(workflow_job_contract, dict)
+        configured_job_name = workflow_job_contract.get("name")
+        assert configured_job_name is None or isinstance(configured_job_name, str)
+        assert configured_job_name is None or GITHUB_EXPRESSION_OPEN not in configured_job_name, (
+            f"Dynamic workflow job name cannot prove required-check identity: {workflow_job_id}"
+        )
+        if (configured_job_name or workflow_job_id) == required_check_name:
+            check_producers.append((workflow_job_id, configured_job_name))
+    return tuple(check_producers)
+
+
 def test_frontend_required_check_uses_one_canonical_workflow_job():
     workflow_directory = ROOT / ".github" / "workflows"
-    frontend_workflow_text = (workflow_directory / "frontend-tests.yml").read_text(
-        encoding="utf-8"
-    )
-    frontend_workflow_lines = frontend_workflow_text.splitlines()
-    frontend_job_start = frontend_workflow_lines.index("  frontend-tests:")
-    frontend_job_end = next(
-        (
-            line_number
-            for line_number, workflow_line in enumerate(
-                frontend_workflow_lines[frontend_job_start + 1 :],
-                start=frontend_job_start + 1,
-            )
-            if re.match(r"^ {2}\S.*:", workflow_line)
-        ),
-        len(frontend_workflow_lines),
-    )
-    frontend_job_text = "\n".join(
-        frontend_workflow_lines[frontend_job_start:frontend_job_end]
-    )
     candidate_workflow_paths = sorted(
         (*workflow_directory.glob("*.yml"), *workflow_directory.glob("*.yaml"))
     )
-    required_check_occurrences = tuple(
-        (workflow_path.relative_to(ROOT).as_posix(), workflow_line.strip())
+    frontend_check_producers = tuple(
+        (
+            workflow_path.relative_to(ROOT).as_posix(),
+            workflow_job_id,
+            configured_job_name,
+        )
         for workflow_path in candidate_workflow_paths
-        for workflow_line in workflow_path.read_text(encoding="utf-8").splitlines()
-        if "frontend-tests" in workflow_line
+        for workflow_job_id, configured_job_name in _workflow_job_check_producers(
+            workflow_path.read_text(encoding="utf-8"),
+            "frontend-tests",
+        )
     )
 
-    assert required_check_occurrences == (
-        (".github/workflows/frontend-tests.yml", "frontend-tests:"),
+    assert frontend_check_producers == (
+        (".github/workflows/frontend-tests.yml", "frontend-tests", None),
     )
-    assert re.search(r"""(?m)^ {4}["']?name["']?[ ]*:""", frontend_job_text) is None
+
+
+@pytest.mark.parametrize(
+    "configured_job_name",
+    (
+        "frontend-tests",
+        '"frontend-tests"',
+        ">-\n      frontend-tests",
+    ),
+)
+def test_frontend_required_check_detects_semantic_job_name_overrides(
+    configured_job_name: str,
+):
+    workflow_text = f"""\
+jobs:
+  alternate:
+    name: {configured_job_name}
+    runs-on: ubuntu-latest
+    steps: []
+"""
+
+    assert _workflow_job_check_producers(workflow_text, "frontend-tests") == (
+        ("alternate", "frontend-tests"),
+    )
+
+
+def test_frontend_required_check_ignores_comments_steps_and_command_text():
+    workflow_text = """\
+jobs:
+  alternate:
+    runs-on: ubuntu-latest
+    steps:
+      # frontend-tests: required check
+      - name: frontend-tests
+        run: |
+          echo "frontend-tests:"
+"""
+
+    assert _workflow_job_check_producers(workflow_text, "frontend-tests") == ()
+
+
+def test_frontend_required_check_rejects_dynamic_job_names():
+    workflow_text = """\
+jobs:
+  alternate:
+    name: ${{ vars.REQUIRED_CHECK }}
+    runs-on: ubuntu-latest
+    steps: []
+"""
+
+    with pytest.raises(AssertionError, match="Dynamic workflow job name"):
+        _workflow_job_check_producers(workflow_text, "frontend-tests")
 
 
 def test_frontend_workflow_installs_locked_dependencies_before_tests():


### PR DESCRIPTION
## What changed
- Adds the implementation-ready T-CI-2A plan for making `frontend-tests` a required check after explicit operator approval.
- Replaces the obsolete ruleset-deletion rollback with exact Python-only restoration.
- Adds a semantic repository guardrail that pins `frontend-tests` to one canonical workflow job identity.
- Pins `PyYAML==6.0.3` as development-only tooling and verifies it remains outside runtime requirements.
- Updates remediation and AGENTS transition text to current CI reality.

## Why
The frontend workflow now runs on every pull request, but repository policy still requires only `python-guardrails`. This planning PR establishes safe, independently reviewed mutation and rollback procedures and supplies the required non-frontend check-context proof without changing live policy.

## Risk and compatibility
- No workflow, runtime package, runtime behavior, application, or live ruleset change.
- PyYAML is a direct development-only dependency used to inspect tracked workflow contracts safely.
- The future ruleset `PUT` remains blocked on explicit approval of exact request and pre-state JSON plus SHA-256 digests.
- GitHub's full ruleset `PUT` has no documented atomic compare-and-swap; the plan requires an exclusive change window, immediate pre-state verification, and exact post-write readback.

## Verification
- PASS: `./.venv/bin/ruff check .`
- PASS: `./.venv/bin/ruff format --check . --config ruff-format.toml`
- PASS: `./.venv/bin/mypy`
- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_repository_guardrails.py tests/test_docker_build_contracts.py tests/test_docs_links.py` (107 passed)
- PASS: `PYTHONPATH=. .venv/bin/pytest -q` (1,106 passed)
- PASS: all seven Bash fences in the T-CI-2A plan pass independent `bash -n`
- PASS: `git diff --check`
- PASS: final independent review found no remaining P1/P2 issues

## Remaining deficit
Live policy still requires only `python-guardrails`. After this PR merges and both CI contexts are proven on this non-frontend change, the exact request and pre-state digests will be presented for separate operator approval.
