### PR TITLE
T-CI-2A: Match GitHub workflow scalar semantics

### DIFF
--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,10 +1,12 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 2.1
+version: 2.2
 generated: 2026-07-23
-changelog: v2.1 adds the direct development-only PyYAML contract required to
-validate workflow check identities semantically instead of approximating YAML
-with regular expressions. v2.0 records T-CI-2 completion and adds the implementation-ready
+changelog: v2.2 corrects the T-CI-2A workflow identity guardrail to preserve
+GitHub string semantics for YAML 1.1 Boolean-like scalars. v2.1 adds the direct
+development-only PyYAML contract required to validate workflow check
+identities semantically instead of approximating YAML with regular
+expressions. v2.0 records T-CI-2 completion and adds the implementation-ready
 T-CI-2A plan for the separately approval-gated frontend required-check policy.
 v1.9 corrects T-CI-2 to use the existing Node 20 test runner,
 permits the stale CSP contract to follow its current proxy owner, expands
@@ -229,7 +231,8 @@ contract test only; later GOV work retains all other ownership.
 ### T-CI-2A: Require the universal frontend test check
 - priority: P0
 - depends_on: T-CI-2
-- status: planning complete; live policy update awaits operator approval
+- status: planning and scalar-parity guardrail complete; live policy update
+  awaits operator approval
 - files_owned: docs/plans/T_CI_2_REQUIRED_CHECK_POLICY_PLAN.md (new),
   docs/plans/T_CI_1_REQUIRED_CHECK_POLICY_PLAN.md,
   docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md, AGENTS.md (verification-matrix
@@ -252,7 +255,9 @@ contract test only; later GOV work retains all other ownership.
   are mandatory.
 - accept: Every pull request receives both contexts; the default branch cannot
   update unless both pass; strict policy, branch-creation exemption, empty
-  bypass list, target, and all other T-CI-1A fields remain unchanged.
+  bypass list, target, and all other T-CI-1A fields remain unchanged. Workflow
+  identity validation preserves GitHub string semantics for Boolean-like job
+  IDs and display names.
 - forbidden: Adding the check while the workflow is path-filtered or unproven;
   adding any third check or rule; changing the existing Python gate; assuming
   approval from T-CI-1A.

--- a/docs/plans/T_CI_2_REQUIRED_CHECK_POLICY_PLAN.md
+++ b/docs/plans/T_CI_2_REQUIRED_CHECK_POLICY_PLAN.md
@@ -65,12 +65,15 @@ recorded below. G3 remains open and continues to block Phase 2.
 2. Confirm PR #114 supplies the post-T-CI-2 frontend-change proof:
    `frontend-tests` completed successfully from GitHub Actions integration
    `15368`.
-3. Pin PyYAML in development requirements and use `yaml.safe_load` to prove
+3. Pin PyYAML in development requirements and use
+   `yaml.load(..., Loader=yaml.BaseLoader)` to prove
    `.github/workflows/frontend-tests.yml` contains the only workflow job whose
    effective check name is `frontend-tests`, as canonical job ID
-   `frontend-tests` with no display-name override. Semantic parsing must cover
-   comments, quoted keys, folded scalars, and command blocks without treating
-   their text as workflow jobs.
+   `frontend-tests` with no display-name override. The string-only loader is
+   deliberately narrow: it preserves GitHub's treatment of `on`, `off`, `yes`,
+   and `no` as strings while parsing only the job mappings needed by this
+   contract. Regression cases must cover comments, quoted keys, folded scalars,
+   command blocks, and Boolean-like job IDs and names.
 4. Add this Full plan, update the remediation registry, replace T-CI-1A's
    obsolete deletion rollback with a non-destructive restoration policy, and
    replace the stale AGENTS transition annotations with accurate T-CI-2A
@@ -120,14 +123,16 @@ recorded below. G3 remains open and continues to block Phase 2.
 
 No production function, module, workflow, helper script, compatibility path,
 or new configuration surface is added. The guardrail test uses the direct
-development-only PyYAML dependency rather than maintaining a partial YAML
-parser.
+development-only PyYAML dependency and its string-only `BaseLoader` rather
+than maintaining a partial YAML parser or mutating a shared loader resolver.
 
 **f) Reuse audit.** Reuse the existing universal frontend workflow, its
 GitHub Actions check identity, ruleset `19594795`, T-CI-1A readback
-assertions, GitHub CLI authentication, `jq`, and PyYAML's safe loader. A second
-ruleset, legacy branch protection, custom policy script, or workflow
-duplication is rejected because each would create another enforcement owner.
+assertions, GitHub CLI authentication, `jq`, and PyYAML's `BaseLoader` for the
+two string-valued workflow fields under inspection. A second ruleset, legacy
+branch protection, custom loader subclass, custom resolver, policy script, or
+workflow duplication is rejected because each would create another
+enforcement owner.
 
 **Dependencies.** Add `PyYAML==6.0.3` to
 `pipeline/requirements-dev.txt`. It is already present locally as a transitive
@@ -218,8 +223,10 @@ exposed. G4 is unaffected.
 
 **l) Untrusted input.** GitHub API responses are external input. Verification
 selects and compares named JSON fields with `jq`; no response text is executed.
-Tracked workflow YAML is parsed with `yaml.safe_load`, which does not construct
-arbitrary Python objects.
+Tracked workflow YAML is parsed with PyYAML's `BaseLoader`, which performs
+minimal construction and preserves scalar values as strings. This avoids both
+arbitrary Python object construction and YAML 1.1 Boolean coercion. It is not
+treated as a complete GitHub Actions parser.
 
 ## 4. Code Health
 
@@ -230,7 +237,9 @@ The external mutation is fail-fast and preceded by exact drift detection.
 **n) Antipattern scan, plan pass.**
 
 - A1/H1 corrected: current GitHub REST and OpenAPI documentation verify the
-  ruleset update method and required-status-check fields.
+  ruleset update method and required-status-check fields. PyYAML 6.0.3
+  documentation verifies the explicit `yaml.load(stream, Loader)` call and
+  string-only `BaseLoader` behavior.
 - A2 corrected: no new setting or hidden default is introduced; every changed
   field appears in the approved contract.
 - A3 corrected: repository, PR, and effective-rule claims require fresh API
@@ -287,6 +296,8 @@ and readback commands. Runtime-code delta is zero.
     requirements.
 16. A dynamic top-level job name resolves to `frontend-tests` only at runtime,
     preventing static proof that the required-check producer is unique.
+17. PyYAML's YAML 1.1 Boolean resolver coerces valid GitHub job IDs or names
+    such as `yes` and `On`, causing false guardrail failures.
 
 **r) Verification mapping.**
 
@@ -307,6 +318,7 @@ and readback commands. Runtime-code delta is zero.
 | Semantic workflow-parser regression cases | 14 |
 | Development/runtime dependency boundary contract | 15 |
 | Fail-closed dynamic job-name regression case | 16 |
+| GitHub Boolean-like scalar parity regression cases | 17 |
 
 No fixed test count or inferred UI behavior is used as acceptance evidence.
 
@@ -1197,7 +1209,7 @@ rollback guidance in T-CI-1A.
   T-CI-2A-pending text, then removes that temporary text after live readback.
 - `tests/test_repository_guardrails.py` enforces one canonical repository-wide
   `frontend-tests` workflow job ID and no alternate effective job-name
-  producer, using semantic YAML parsing.
+  producer, using string-preserving structural YAML parsing.
 - `pipeline/requirements-dev.txt` and `tests/test_docker_build_contracts.py`
   make the parser a direct development-only dependency.
 - README, architecture review, ADR, operations, security, data governance,

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -973,7 +973,7 @@ def _workflow_job_check_producers(
     workflow_text: str,
     required_check_name: str,
 ) -> tuple[tuple[str, str | None], ...]:
-    workflow_contract = yaml.safe_load(workflow_text)
+    workflow_contract = yaml.load(workflow_text, Loader=yaml.BaseLoader)
     assert isinstance(workflow_contract, dict)
     workflow_jobs = workflow_contract.get("jobs")
     assert isinstance(workflow_jobs, dict)
@@ -1065,6 +1065,41 @@ jobs:
 
     with pytest.raises(AssertionError, match="Dynamic workflow job name"):
         _workflow_job_check_producers(workflow_text, "frontend-tests")
+
+
+@pytest.mark.parametrize(
+    "github_string_scalar",
+    ("on", "off", "yes", "no", "On", "OFF", "Yes", "NO"),
+)
+def test_frontend_required_check_preserves_github_string_job_ids(
+    github_string_scalar: str,
+):
+    workflow_text = f"""\
+jobs:
+  {github_string_scalar}:
+    runs-on: ubuntu-latest
+    steps: []
+"""
+
+    assert _workflow_job_check_producers(workflow_text, "frontend-tests") == ()
+
+
+@pytest.mark.parametrize(
+    "github_string_scalar",
+    ("on", "off", "yes", "no", "On", "OFF", "Yes", "NO"),
+)
+def test_frontend_required_check_preserves_github_string_job_names(
+    github_string_scalar: str,
+):
+    workflow_text = f"""\
+jobs:
+  alternate:
+    name: {github_string_scalar}
+    runs-on: ubuntu-latest
+    steps: []
+"""
+
+    assert _workflow_job_check_producers(workflow_text, "frontend-tests") == ()
 
 
 def test_frontend_workflow_installs_locked_dependencies_before_tests():


### PR DESCRIPTION
## What changed
- Replaces `yaml.safe_load` with the explicit string-only `yaml.BaseLoader` for workflow job identity inspection.
- Adds regression coverage for GitHub-valid Boolean-like job IDs and display names.
- Updates the T-CI-2A plan and remediation registry to document the narrow parser boundary.

## Why
PyYAML's `SafeLoader` applies YAML 1.1 Boolean coercion, while GitHub Actions treats values such as `on`, `off`, `yes`, and `no` as strings. The merged guardrail could therefore reject valid unrelated workflow jobs.

## Risk and compatibility
- No workflow, runtime, dependency, application, or live ruleset change.
- `BaseLoader` performs minimal construction and keeps all inspected scalars as strings.
- The loader is used only for top-level workflow job IDs and display names; it is not treated as a complete GitHub Actions parser.

## Verification
- FAIL before implementation: 16 Boolean-like scalar regression cases failed under `SafeLoader`.
- PASS: `./.venv/bin/ruff check .`
- PASS: `./.venv/bin/ruff format --check . --config ruff-format.toml`
- PASS: `./.venv/bin/mypy`
- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_repository_guardrails.py` (111 passed)
- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py` (2 passed)
- PASS: `PYTHONPATH=. .venv/bin/pytest -q` (1,122 passed)
- PASS: all seven T-CI-2A Bash fences pass `bash -n`
- PASS: `git diff --check`
- PASS: independent planning and pre-commit reviews found no P1/P2 issues

## Remaining deficit
The live ruleset still requires only `python-guardrails`. That separate mutation remains blocked on explicit approval of the exact pre-state and request artifacts.
