### PR TITLE
T-CI-3: Enforce the production Python coverage floor

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,15 @@
 [run]
 branch = False
+source =
+    .
+omit =
+    tests/*
+    archive/*
+    experiments/*
+    .venv*/*
+patch =
+    subprocess
 
 [report]
 fail_under = 71
+include_namespace_packages = True

--- a/.github/workflows/python-guardrails.yml
+++ b/.github/workflows/python-guardrails.yml
@@ -47,4 +47,4 @@ jobs:
           PYTHONPATH=. python -m pytest -q tests/test_docs_links.py
 
       - name: Run full Python test suite
-        run: PYTHONPATH=. python -m pytest -q tests/
+        run: PYTHONPATH=. python -m pytest -q --cov --cov-config=.coveragerc --cov-report=term-missing:skip-covered tests/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,8 +195,10 @@ If the impact is unclear, invoke the objection protocol rather than guessing.
 <verification_matrix>
 Scope: the matrix is a fast local pre-check for iterating on a change. The
 authoritative CI verification is the full test suite run by both jobs on every
-pull request (`python-guardrails` for Python, `frontend-tests` for the frontend).
-A passing matrix row is necessary for proceeding, not sufficient for merge.
+pull request (`python-guardrails` for Python, `frontend-tests` for the
+frontend). The Python suite runs under the production scope and coverage floor
+configured in `.coveragerc`. A passing matrix row is necessary for proceeding,
+not sufficient for merge.
 [transition: both jobs run on every pull request, but only
 `python-guardrails` is mandatory until T-CI-2A adds `frontend-tests` to the
 required-check ruleset.]
@@ -217,6 +219,12 @@ Guardrail/tooling changes (`ruff.toml`, `ruff-format.toml`, `mypy.ini`,
 - `./.venv/bin/mypy`
 - `PYTHONPATH=. .venv/bin/pytest -q tests/test_repository_guardrails.py`
 - `PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py`
+
+Coverage-gate changes (`.coveragerc`, coverage pins in
+`pipeline/requirements-dev.txt`):
+- `PYTHONPATH=. .venv/bin/python -m pytest -q --cov --cov-config=.coveragerc --cov-report=term-missing:skip-covered tests/`
+- `PYTHONPATH=. .venv/bin/pytest -q tests/test_repository_guardrails.py`
+- `PYTHONPATH=. .venv/bin/pytest -q tests/test_docker_build_contracts.py`
 
 API/search behavior changes (`api/**`, query contracts):
 - `PYTHONPATH=. .venv/bin/pytest -q tests/test_api.py`
@@ -281,7 +289,10 @@ Commit/PR summaries must include:
 - Update operational metadata markers (`Last updated`) when materially changing runbooks.
 - Commands, gates, and workflow guidance in docs must reflect current repository reality.
 - Do not duplicate Entry Points / Code Map content from `ARCHITECTURE.md` into `AGENTS.md`; `AGENTS.md` defines constraints/workflow, `ARCHITECTURE.md` defines system map.
-- File-set enumerations (typed subtree, formatter scope, smell-test scope) live in machine-readable config only (`mypy.ini`, `ruff-format.toml`, guardrail test constants). Docs reference the config location; they never duplicate the list.
+- File-set enumerations (typed subtree, formatter scope, coverage scope,
+  smell-test scope) live in machine-readable config only (`mypy.ini`,
+  `ruff-format.toml`, `.coveragerc`, guardrail test constants). Docs reference
+  the config location; they never duplicate the list.
 </docs_sync_rules>
 
 <maintenance>

--- a/docs/ENGINEERING_GUARDRAILS.md
+++ b/docs/ENGINEERING_GUARDRAILS.md
@@ -18,6 +18,7 @@ list (see `AGENTS.md` `<docs_sync_rules>`).
 | Lint                 | `ruff.toml` (rule selection + paths)             |
 | Formatter            | `ruff-format.toml` `include`                         |
 | Typed subtree        | `mypy.ini` `files`/per-module sections           |
+| Coverage             | `.coveragerc`                                     |
 | Smell tests          | constants at the top of `tests/test_repository_guardrails.py` |
 | CI orchestration     | `.github/workflows/python-guardrails.yml`, `.github/workflows/frontend-tests.yml` |
 
@@ -36,10 +37,21 @@ cd <REPO_ROOT>
 PYTHONPATH=. .venv/bin/pytest -q tests/test_repository_guardrails.py
 ```
 
-CI runs the static checks, fast-fail test subset, and complete Python suite on
-every pull request and master push. The fast-fail subset provides earlier
-diagnostics; the complete suite remains the Python merge gate (see
+CI runs the static checks, fast-fail test subset, and complete Python suite
+under the `.coveragerc` production scope and coverage floor on every pull
+request and master push. The fast-fail subset provides earlier diagnostics;
+the coverage-enabled complete suite remains the Python merge gate (see
 `docs/TESTING.md`).
+
+Run that gate locally when changing coverage policy:
+
+```bash
+cd <REPO_ROOT>
+PYTHONPATH=. .venv/bin/python -m pytest -q --cov \
+  --cov-config=.coveragerc \
+  --cov-report=term-missing:skip-covered \
+  tests/
+```
 
 ## What the static checks block
 

--- a/docs/TESTING.MD
+++ b/docs/TESTING.MD
@@ -71,7 +71,7 @@ under test is reaching through a boundary it shouldn't.
    `PYTHONPATH=. .venv/bin/pytest -q`.
 3. CI, authoritative merge gate: full Python suite + guardrail fast-fail
    steps + frontend suite + coverage threshold (`.coveragerc`
-   `fail_under`) [transition: T-CI-1..3].
+   `fail_under`).
 
 A change is "verified" only at layer 3. Layers 1–2 are diagnostic (matching
 the existing `AGENTS.md` workflow contract).
@@ -85,8 +85,17 @@ skip without a linked issue.
 
 ## Coverage
 
-`fail_under = 71` in `.coveragerc` is the enforced floor [transition:
-T-CI-3]. Raising it is a ratchet decision: report old value, new value, and
+`.coveragerc` owns the production file scope, subprocess measurement, and the
+enforced `fail_under = 71` floor. Reproduce the CI gate locally with:
+
+```bash
+PYTHONPATH=. .venv/bin/python -m pytest -q --cov \
+  --cov-config=.coveragerc \
+  --cov-report=term-missing:skip-covered \
+  tests/
+```
+
+Raising the floor is a ratchet decision: report old value, new value, and
 rationale per the status-reporting contract. Do not chase coverage with
-assertion-free tests; the floor exists to catch untested new modules, not to
-be gamed.
+assertion-free tests; the floor exists to catch untested new production
+modules, not to be gamed.

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,8 +1,11 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 2.2
+version: 2.3
 generated: 2026-07-23
-changelog: v2.2 corrects the T-CI-2A workflow identity guardrail to preserve
+changelog: v2.3 expands T-CI-3 ownership and defines a production-only,
+subprocess-aware coverage contract before activating the existing 71% floor.
+It prevents test code from inflating the gate and keeps coverage dependencies
+out of runtime images. v2.2 corrects the T-CI-2A workflow identity guardrail to preserve
 GitHub string semantics for YAML 1.1 Boolean-like scalars. v2.1 adds the direct
 development-only PyYAML contract required to validate workflow check
 identities semantically instead of approximating YAML with regular
@@ -112,6 +115,10 @@ plus the corresponding repository guardrail tests; later GOV work retains all
 other ownership of those files. T-CI-4 receives the same narrow temporary
 coordination grant for formatter config-location prose and the formatter
 contract test only; later GOV work retains all other ownership.
+T-CI-3 receives a narrow temporary coordination grant for coverage scope
+references, verification commands, merge-gate prose, and transition markers
+in `AGENTS.md`, `docs/TESTING.MD`, and
+`docs/ENGINEERING_GUARDRAILS.md`; later GOV work retains all other ownership.
 
 ---
 
@@ -272,12 +279,33 @@ contract test only; later GOV work retains all other ownership.
 ### T-CI-3: Enforce coverage threshold
 - priority: P2
 - depends_on: T-CI-1
-- files_owned: .github/workflows/python-guardrails.yml, .coveragerc,
-  tests/test_repository_guardrails.py
-- do: Run pytest under coverage in CI; `fail_under = 71` becomes enforced.
-  Replace T-CI-1's temporary contract assertion that coverage remains absent.
-- accept: CI fails if coverage < 71%.
-- verify: `PYTHONPATH=. python -m pytest --cov -q tests/` reports >= 71.
+- status: implementation-ready
+- files_owned: docs/plans/T_CI_3_COVERAGE_GATE_PLAN.md,
+  docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md, AGENTS.md,
+  docs/TESTING.MD, docs/ENGINEERING_GUARDRAILS.md,
+  .github/workflows/python-guardrails.yml, .coveragerc,
+  pipeline/requirements-dev.txt, tests/test_repository_guardrails.py,
+  tests/test_docker_build_contracts.py
+- do: Follow the implementation-ready T-CI-3 plan. Pin pytest-cov and
+  coverage.py as development-only dependencies. Measure repository production
+  Python from `.coveragerc`, omit tests, archives, experiments, and local
+  virtual environments, include namespace-package files, enable coverage.py
+  subprocess patching, and replace only the authoritative full-suite workflow
+  command with the coverage-aware command.
+- accept: CI fails below the unchanged 71% floor; tests do not inflate the
+  measured total; every tracked production Python file, including
+  namespace-package, repository-root, and subprocess-executed files, remains
+  eligible for measurement; coverage tooling remains absent from runtime
+  requirements; fast-fail tests, workflow identity, permissions, triggers,
+  static checks, and runtime behavior remain unchanged.
+- forbidden: Raising or lowering the threshold; counting tests or archived
+  code; using explicit `--cov=SOURCE` arguments that override `.coveragerc`;
+  adding coverage to fast-fail tests; adding a job, retry, skip, xfail,
+  tolerance, cache, external upload, or runtime dependency.
+- verify: Ruff lint and configured formatter, pre-commit Ruff, Mypy,
+  repository guardrails, Docker dependency contracts, docs links, the
+  complete production-only coverage command, `git diff --check`, and PR CI as
+  specified in `docs/plans/T_CI_3_COVERAGE_GATE_PLAN.md`.
 
 ### T-CI-4: Move formatter file list out of the workflow
 - priority: P2

--- a/docs/plans/T_CI_3_COVERAGE_GATE_PLAN.md
+++ b/docs/plans/T_CI_3_COVERAGE_GATE_PLAN.md
@@ -1,0 +1,345 @@
+# T-CI-3: Enforce the Production Python Coverage Floor
+
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+execution: code
+task: T-CI-3
+lane: CI
+
+## 1. Context & Alignment
+
+**a) Driver.** T-CI-1 made the complete Python suite authoritative, but the
+existing `fail_under = 71` setting is not part of the CI command. A bare
+coverage run on current `master` reports 90.37% because it counts test code,
+which would make the gate easier to satisfy as tests grow. T-CI-3 must enforce
+the existing floor against production Python, include subprocess-executed
+operator scripts, and keep coverage tooling out of runtime images.
+
+**b) Canonical documents.** `AGENTS.md` `<workflow_contract>`,
+`<verification_matrix>`, `<status_reporting_contract>`, and
+`<docs_sync_rules>` require exact evidence, config-owned scopes, old/new gate
+reporting, and aligned contributor commands. `docs/TESTING.MD` defines the
+three verification layers and the 71% floor. `docs/ENGINEERING_GUARDRAILS.md`
+requires one machine-readable owner per enforced file set. The remediation
+plan places T-CI-3 after T-CI-1 and before Phase 2. The architecture review
+requires the Phase 0 safety net before de-facading work begins. The PR #108
+postmortem requires durable contract tests for enforcement changes.
+
+**c) Remediation alignment.** T-CI-3 owns exactly:
+
+- `docs/plans/T_CI_3_COVERAGE_GATE_PLAN.md`
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`
+- `AGENTS.md`
+- `docs/TESTING.MD`
+- `docs/ENGINEERING_GUARDRAILS.md`
+- `.github/workflows/python-guardrails.yml`
+- `.coveragerc`
+- `pipeline/requirements-dev.txt`
+- `tests/test_repository_guardrails.py`
+- `tests/test_docker_build_contracts.py`
+
+The remediation plan is updated to version 2.3 before implementation. No
+other tracked file may change.
+
+**d) Decision gates.** T-CI-3 is the already-authorized Phase 0 coverage gate
+and does not depend on or foreclose G1-G5. The threshold remains 71%, so no
+new threshold decision is introduced. G3 remains open and continues to block
+Phase 2 after this task.
+
+## 2. Design
+
+**e) Approach.**
+
+1. Record current evidence using the checked-in configuration:
+   `PYTHONPATH=. .venv/bin/python -m pytest --cov -q tests/` passes but
+   reports 90.37% because tests are measured.
+2. Validate a production-only configuration before editing. The selected
+   contract reports 81.03% on current `master` and includes all 360 currently
+   tracked production Python files.
+3. Add failing contract tests before changing configuration, dependencies,
+   workflow, or policy docs.
+4. Make `.coveragerc` the sole coverage-scope owner:
+   - `source = .` automatically enrolls new repository Python.
+   - omit `tests/*`, `archive/*`, `experiments/*`, and `.venv*/*`.
+   - retain `branch = False` and `fail_under = 71`.
+   - add `patch = subprocess` for pytest-cov 7 and coverage.py 7.
+   - add `include_namespace_packages = True` so unexecuted Python below
+     namespace-style directories remains reportable.
+5. Pin `pytest-cov==7.0.0` and `coverage==7.13.3` in
+   `pipeline/requirements-dev.txt`. Keep both absent from all runtime
+   requirement files.
+6. Replace only the `Run full Python test suite` command with:
+
+   ```bash
+   PYTHONPATH=. python -m pytest -q --cov \
+     --cov-config=.coveragerc \
+     --cov-report=term-missing:skip-covered \
+     tests/
+   ```
+
+   Bare `--cov` is deliberate: pytest-cov documents that `--cov=SOURCE`
+   overrides coverage.py's configured source list.
+7. Keep the seven-command fast-fail step outside coverage so early diagnostics
+   remain fast and the authoritative run measures the suite once.
+8. Replace the temporary "coverage absent" workflow assertion with exact
+   coverage-command, source, omission, namespace-package, subprocess,
+   threshold, and dependency contracts.
+9. Add an executable inventory regression. It runs pinned coverage against one
+   tracked production module, generates a JSON report, and compares its file
+   keys with dynamically discovered tracked production Python after the
+   configured omission classes. This catches configuration that parses
+   correctly but silently drops unexecuted namespace-package files. The test
+   stores its data, config, and report under `tmp_path` and removes
+   `COVERAGE_PROCESS_CONFIG` and `COVERAGE_PROCESS_START` from the child
+   environment so an outer coverage-enabled suite cannot create nested
+   collectors.
+10. Remove completed T-CI-3 transition markers and add the coverage command to
+   testing and guardrail policy without duplicating its file inventory.
+11. Run complete verification, simplify the diff, and obtain an independent
+    pre-commit review. Apply every eligible P1/P2 before delivery.
+
+No production function, helper module, facade, environment variable, runtime
+dependency, or external coverage service is added.
+
+**f) Reuse audit.** Extend the existing Python Guardrails job, `.coveragerc`,
+development requirement file, workflow contract test, runtime dependency
+contract test, and canonical policy docs. No YAML parser, coverage wrapper,
+source registry, compatibility path, or custom reporting utility is created.
+
+Rejected alternatives:
+
+- Bare `--cov` with the current config: rejected because it counts tests and
+  inflates current coverage from 81.03% to 90.37%.
+- Repeated `--cov=SOURCE`: rejected because it moves scope into CI and
+  overrides `.coveragerc`.
+- An explicit production-directory list: rejected because it would require
+  maintenance whenever a new production directory or root module lands.
+- Coverage in the fast-fail step: rejected because the same tests would be
+  measured twice and early feedback would slow down.
+- Coverage upload service: rejected because the task needs a local merge gate,
+  not a new network dependency or credential boundary.
+
+**g) Contracts.**
+
+- Scope contract: all repository Python under `source = .`, excluding only
+  configured non-production and local-environment paths. Namespace-package
+  discovery keeps unexecuted tracked files in the report.
+- Gate contract: coverage.py exits nonzero when total production coverage is
+  below 71%.
+- Subprocess contract: coverage.py patches Python subprocess startup;
+  pytest-cov combines measured process data.
+- Dependency contract: coverage tooling is development-only.
+- CI contract: the fast-fail tests precede one authoritative coverage-enabled
+  complete-suite step.
+
+No application API, schema, Celery signature, CLI, runtime default, inference
+policy, or soak baseline changes.
+
+**h) Schema and migrations.** None.
+
+## 3. Security & Data Governance
+
+**i) Security boundary.** No `AGENTS.md` security-sensitive path is touched.
+Workflow permissions remain `contents: read`; no secrets or external upload
+step is introduced. Measuring more production code reduces untested-change
+risk without altering execution privileges.
+
+**j) Secrets.** None added, read, logged, or exposed.
+
+**k) Person data.** None created, linked, aggregated, or exposed. G4 is
+unaffected.
+
+**l) Untrusted input.** Pull-request code and tests remain untrusted CI input.
+The workflow installs checked-in pinned development dependencies and runs them
+in GitHub's ephemeral runner. No scraped content, provider response, user
+payload, or external coverage artifact is parsed by new application code.
+
+## 4. Code Health
+
+**m) Conformance.** No production Python logic, timestamp, environment read,
+exception handler, or runtime literal changes. Test additions use
+`configparser` and `pathlib.Path`, have complete annotations where helpers are
+needed, and assert checked-in policy rather than private production state.
+
+**n) Antipattern scan, plan pass.**
+
+- A1/H1 corrected: installed pytest-cov 7.0.0 and coverage.py 7.13.3 match the
+  proposed pins. Context7 verified bare `--cov`, `--cov-config`,
+  `--cov-report`, configured source behavior, `patch = subprocess`, and
+  `fail_under` exit status.
+- A3 corrected: 90.37% and 81.03% are fresh local measurements; the final PR
+  report must distinguish local pytest 8.3.4 from authoritative CI pytest
+  9.0.3.
+- B1/F1 corrected: `.coveragerc` remains the single policy owner; no wrapper,
+  manager, parser framework, or duplicate source inventory is added.
+- D1 corrected: the threshold remains 71%; no skip, xfail, retry, or tolerance
+  changes.
+- D3 accepted narrowly: exact workflow and config assertions are the
+  observable merge-gate contract.
+- E1/E2 corrected: only the ten owned files may change.
+- A2, A4, B2-B3, C1-C2, D2, E3, F2, and H2-H4 do not apply.
+
+**o) Ratchets.**
+
+- Coverage threshold: 71% configured but unenforced -> 71% enforced in CI.
+- Measured scope: implicit pytest-cov discovery that counts tests ->
+  repository production Python with four omission classes.
+- Branch coverage: unchanged at false.
+- Ruff selectors, BLE001 boundaries, formatter scope, Mypy scope, test
+  selection, workflow triggers, required-check policy, and permissions:
+  unchanged.
+
+**p) Dead code and duplication.** Delete the temporary assertion that coverage
+is absent and the completed transition markers. Reuse the existing full-suite
+step rather than adding another job or test run. Expected net growth is one
+implementation plan plus focused policy tests and configuration.
+
+## 5. Testing
+
+**q) Edge and failure scenarios.**
+
+1. Tests or archived Python inflate the total.
+2. A new production directory is omitted from measurement.
+3. The repository-root diagnostic wrapper is omitted.
+4. Unexecuted files under namespace-style directories are omitted.
+5. Python subprocesses execute production scripts without measurement.
+6. CI uses `--cov=SOURCE` and overrides `.coveragerc`.
+7. CI stops using the checked-in coverage config or actionable terminal
+   report.
+8. Coverage falls below 71% but the job passes.
+9. Coverage packages enter a runtime requirement file.
+10. Fast-fail tests gain coverage overhead or move after the complete suite.
+11. Workflow triggers, permissions, static checks, formatter, Mypy, or
+    required-check identity drift.
+12. Dependency installation omits the pinned coverage packages.
+13. Local installed versions differ from CI; local results must be reported
+    as reduced confidence rather than treated as authoritative.
+
+**r) Tests.**
+
+| Test or command | Scenarios |
+|---|---|
+| Updated complete-suite workflow contract | 6-8, 10-12 |
+| New `.coveragerc` contract test | 1-8 |
+| `test_coverage_configuration_reports_every_tracked_production_python_file` | 1-4 |
+| Runtime/development dependency contract | 9, 12 |
+| Existing workflow trigger and check-identity tests | 10-11 |
+| Actual production-only coverage command | 1-8, 13 |
+| Repository guardrail and Docker contract suites | 1-12 |
+| PR Python Guardrails check | 1-13 |
+
+Tests are written and run red before implementation. No fixed collected-test
+count is asserted.
+
+The dependency contract parses `api/requirements.txt`,
+`council_crawler/requirements.txt`, `pipeline/requirements.txt`,
+`pipeline/requirements-batch.txt`, and
+`semantic_service/requirements.txt`; normalizes distribution names; requires
+`coverage` and `pytest-cov` to be absent from each runtime surface; and
+requires the exact two development pins.
+
+**s) Fakes and mocks.** None. Tests use approved filesystem and subprocess
+boundaries and patch no facade, re-export, or implementation symbol.
+
+**t) Verification rows.** Apply the guardrail/tooling and docs-only rows.
+Run the Docker dependency contract test and the complete Python suite under
+the coverage gate. The PR's Python Guardrails run is authoritative for Python
+3.14, pytest 9.0.3, pytest-cov 7.0.0, and coverage.py 7.13.3.
+
+## 6. Execution, Rollback, Docs
+
+**u) Commands.**
+
+```bash
+git fetch origin --prune
+git switch master
+git merge --ff-only origin/master
+git switch -c codex/t-ci-3-coverage-gate
+```
+
+Baseline evidence:
+
+```bash
+PYTHONPATH=. .venv/bin/python -m pytest --cov -q tests/
+```
+
+Expected on pre-change `master`: the suite passes and reports an inflated
+90.37% because test files are included.
+
+Tests-first red evidence:
+
+```bash
+PYTHONPATH=. .venv/bin/pytest -q \
+  tests/test_repository_guardrails.py::test_python_guardrail_workflow_enforces_production_coverage \
+  tests/test_repository_guardrails.py::test_coverage_configuration_measures_repository_production_python \
+  tests/test_repository_guardrails.py::test_coverage_configuration_reports_every_tracked_production_python_file \
+  tests/test_docker_build_contracts.py::test_coverage_tooling_is_development_only
+```
+
+Final verification:
+
+```bash
+./.venv/bin/ruff check .
+./.venv/bin/ruff format --check . --config ruff-format.toml
+./.venv/bin/pre-commit run ruff --all-files
+./.venv/bin/mypy
+PYTHONPATH=. .venv/bin/pytest -q tests/test_repository_guardrails.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_docker_build_contracts.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py
+PYTHONPATH=. .venv/bin/python -m pytest -q --cov \
+  --cov-config=.coveragerc \
+  --cov-report=term-missing:skip-covered \
+  tests/
+git diff --check
+git status --short
+```
+
+Delivery uses two commits:
+
+1. `docs(remediation): authorize T-CI-3 coverage enforcement`
+2. `fix(ci): enforce the production Python coverage floor`
+
+Push `codex/t-ci-3-coverage-gate`, open one PR titled
+`T-CI-3: Enforce the production Python coverage floor`, request Codex review,
+and watch CI until every check is decided. Browser testing is not applicable.
+
+**v) Rollback.** Revert the T-CI-3 merge commit, then rerun Ruff, formatter,
+Mypy, repository guardrails, Docker contracts, docs links, and the complete
+suite. No migration, data repair, environment restoration, external artifact,
+or ruleset mutation exists. Rollback knowingly restores the configured but
+unenforced 71% floor.
+
+**w) Docs synchronization.**
+
+- `AGENTS.md`: authoritative Python merge-gate wording and coverage command.
+- `docs/TESTING.MD`: remove completed T-CI-3 markers and document the
+  production-only command.
+- `docs/ENGINEERING_GUARDRAILS.md`: point coverage scope to `.coveragerc` and
+  state that CI enforces the floor.
+- Remediation plan: version 2.3, expanded ownership, corrected measurement
+  semantics, and acceptance criteria.
+- README, ADR, architecture review, operations, API contracts, security, and
+  data-governance docs: no changes.
+
+## 7. Delivery Self-Audit
+
+**x) Diff scan.** Re-run A-F and H. Reject any threshold change, branch
+coverage change, explicit `--cov=SOURCE`, duplicated source list, runtime
+coverage dependency, external upload, workflow job or permission change,
+fast-fail modification, skip/xfail/retry, unrelated formatting, type
+suppression, or edit outside the ten-file ownership set.
+
+**y) Evidence required.** Report the tests-first failures; Ruff, formatter,
+pre-commit, Mypy, repository guardrail, Docker contract, docs-link, and
+coverage-suite outcomes; exact pass/skip/fail counts; measured percentage;
+local and CI package versions; independent planning and pre-commit review
+findings; commit hashes; PR URL; unresolved-thread count; and final CI state.
+Anything unrun is `NOT VERIFIED`.
+
+**z) Deviations.** Expected authorized changes are the ten-file ownership
+expansion, production-only scope, namespace-package discovery, executable
+inventory check, subprocess patch, two direct development pins, workflow
+command replacement, and completed transition-marker removal.
+Any other changed path, threshold adjustment, workflow-step change, skipped
+review, unresolved P1/P2, or unrun required check is a blocker and must be
+reported.

--- a/pipeline/requirements-dev.txt
+++ b/pipeline/requirements-dev.txt
@@ -2,6 +2,8 @@
 # Keep these packages out of the worker runtime image so Docker installs only
 # what the service needs to boot and process jobs.
 pytest==9.0.3
+pytest-cov==7.0.0
+coverage==7.13.3
 pytest-mock==3.12.0
 pytest-benchmark==5.1.0
 locust==2.33.0

--- a/tests/test_docker_build_contracts.py
+++ b/tests/test_docker_build_contracts.py
@@ -2,6 +2,17 @@ import re
 from pathlib import Path
 
 
+def _requirement_names(requirements_path: Path) -> set[str]:
+    requirement_names = set()
+    for requirement_line in requirements_path.read_text(encoding="utf-8").splitlines():
+        requirement_specifier = requirement_line.partition("#")[0].strip()
+        if not requirement_specifier:
+            continue
+        requirement_name = re.split(r"[<>=!~;\[\s]", requirement_specifier, maxsplit=1)[0]
+        requirement_names.add(re.sub(r"[-_.]+", "-", requirement_name).lower())
+    return requirement_names
+
+
 def test_compose_uses_role_specific_python_images_and_model_volume():
     source = Path("docker-compose.yml").read_text(encoding="utf-8")
 
@@ -83,6 +94,35 @@ def test_worker_runtime_requirements_exclude_development_tooling():
         assert package in dev
     assert "pyyaml" not in runtime_requirement_names
     assert "PyYAML==6.0.3" in dev
+
+
+def test_coverage_tooling_is_development_only():
+    runtime_requirement_paths = (
+        Path("api/requirements.txt"),
+        Path("council_crawler/requirements.txt"),
+        Path("pipeline/requirements.txt"),
+        Path("pipeline/requirements-batch.txt"),
+        Path("semantic_service/requirements.txt"),
+    )
+    development_requirements = Path("pipeline/requirements-dev.txt").read_text(encoding="utf-8")
+
+    for runtime_requirement_path in runtime_requirement_paths:
+        runtime_requirements = runtime_requirement_path.read_text(encoding="utf-8")
+        runtime_requirement_names = _requirement_names(runtime_requirement_path)
+        runtime_requirement_directives = [
+            requirement_line.partition("#")[0].strip()
+            for requirement_line in runtime_requirements.splitlines()
+        ]
+        assert "coverage" not in runtime_requirement_names
+        assert "pytest-cov" not in runtime_requirement_names
+        assert not any(
+            requirement_directive.startswith(("-r", "--requirement"))
+            and "requirements-dev.txt" in requirement_directive
+            for requirement_directive in runtime_requirement_directives
+        )
+
+    assert "coverage==7.13.3" in development_requirements
+    assert "pytest-cov==7.0.0" in development_requirements
 
 
 def test_semantic_dependencies_live_outside_worker_runtime():

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import ast
+import configparser
 import json
+import os
 import re
 import subprocess
 import sys
 import tomllib
 import tokenize
+from fnmatch import fnmatch
 from io import StringIO
 from pathlib import Path
 from textwrap import indent
@@ -19,6 +22,10 @@ ROOT = Path(__file__).resolve().parents[1]
 RUFF_CLEAN_EXIT = 0
 RUFF_VIOLATION_EXIT = 1
 GITHUB_EXPRESSION_OPEN = "${{"
+COVERAGE_PROCESS_ENVIRONMENT_KEYS = (
+    "COVERAGE_PROCESS_CONFIG",
+    "COVERAGE_PROCESS_START",
+)
 TEXT_FILE_SUFFIXES = {
     ".md",
     ".plist",
@@ -890,7 +897,7 @@ def test_formatter_scope_is_config_owned_and_preserved():
     ]
 
 
-def test_python_guardrail_workflow_runs_complete_suite_after_fast_fail_checks():
+def test_python_guardrail_workflow_enforces_production_coverage():
     workflow_text = (ROOT / ".github" / "workflows" / "python-guardrails.yml").read_text(encoding="utf-8")
     expected_dependency_commands = (
         "python -m pip install -r pipeline/requirements.txt",
@@ -911,7 +918,9 @@ def test_python_guardrail_workflow_runs_complete_suite_after_fast_fail_checks():
     )
     full_suite_step = (
         "      - name: Run full Python test suite\n"
-        "        run: PYTHONPATH=. python -m pytest -q tests/"
+        "        run: PYTHONPATH=. python -m pytest -q --cov "
+        "--cov-config=.coveragerc "
+        "--cov-report=term-missing:skip-covered tests/"
     )
 
     dependency_step = workflow_text.partition("      - name: Install guardrail and runtime dependencies\n")[2]
@@ -937,11 +946,96 @@ def test_python_guardrail_workflow_runs_complete_suite_after_fast_fail_checks():
     assert configured_fast_fail_commands == expected_fast_fail_commands
     assert "continue-on-error:" not in fast_fail_step
     assert "if:" not in fast_fail_step
+    assert "--cov" not in fast_fail_step
 
     full_suite_step_body = full_suite_tail.partition("\n      - name:")[0]
     assert "continue-on-error:" not in full_suite_step_body
     assert "if:" not in full_suite_step_body
-    assert "--cov" not in workflow_text
+
+
+def test_coverage_configuration_measures_repository_production_python():
+    coverage_config = configparser.ConfigParser()
+    coverage_config.read(ROOT / ".coveragerc")
+
+    assert coverage_config["run"].getboolean("branch") is False
+    assert coverage_config["run"]["source"].split() == ["."]
+    assert coverage_config["run"]["omit"].split() == [
+        "tests/*",
+        "archive/*",
+        "experiments/*",
+        ".venv*/*",
+    ]
+    assert coverage_config["run"]["patch"].split() == ["subprocess"]
+    assert coverage_config["report"].getfloat("fail_under") == 71
+    assert coverage_config["report"].getboolean("include_namespace_packages") is True
+
+
+def test_coverage_configuration_reports_every_tracked_production_python_file(
+    tmp_path: Path,
+):
+    coverage_data_path = tmp_path / "coverage-data"
+    coverage_report_path = tmp_path / "coverage.json"
+    coverage_environment = os.environ.copy()
+    for environment_key in COVERAGE_PROCESS_ENVIRONMENT_KEYS:
+        coverage_environment.pop(environment_key, None)
+    coverage_environment["COVERAGE_FILE"] = str(coverage_data_path)
+
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "coverage",
+            "run",
+            "--rcfile=.coveragerc",
+            "pipeline/content_hash.py",
+        ],
+        cwd=ROOT,
+        env=coverage_environment,
+        check=True,
+    )
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "coverage",
+            "combine",
+            "--rcfile=.coveragerc",
+            str(tmp_path),
+        ],
+        cwd=ROOT,
+        env=coverage_environment,
+        check=True,
+    )
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "coverage",
+            "json",
+            "--rcfile=.coveragerc",
+            "--fail-under=0",
+            "-o",
+            str(coverage_report_path),
+            "-q",
+        ],
+        cwd=ROOT,
+        env=coverage_environment,
+        check=True,
+    )
+
+    coverage_config = configparser.ConfigParser()
+    coverage_config.read(ROOT / ".coveragerc")
+    omit_patterns = coverage_config["run"]["omit"].split()
+    tracked_production_paths = {
+        tracked_path.relative_to(ROOT).as_posix()
+        for tracked_path in _tracked_files()
+        if tracked_path.suffix == ".py"
+        and not any(fnmatch(tracked_path.relative_to(ROOT).as_posix(), omit_pattern) for omit_pattern in omit_patterns)
+    }
+    coverage_report = json.loads(coverage_report_path.read_text(encoding="utf-8"))
+    reported_paths = {Path(reported_path).as_posix() for reported_path in coverage_report["files"]}
+
+    assert reported_paths == tracked_production_paths
 
 
 def test_python_guardrail_workflow_runs_for_every_pull_request_and_master_push():


### PR DESCRIPTION
## What changed
- run the authoritative Python CI suite with the repository-owned `.coveragerc` scope
- measure every tracked production Python file, including namespace packages and subprocesses
- keep the existing 71% floor and pin coverage tooling as development-only dependencies
- add durable workflow, configuration, inventory, and dependency-boundary contracts
- synchronize testing and guardrail documentation

## Why
T-CI-3 completes the next ordered CI remediation task by turning the existing coverage threshold into an enforced merge gate without inflating coverage with test files.

## Risk and compatibility
- no runtime, API, schema, task, or default-policy changes
- CI runtime increases because the complete suite now records production coverage
- local pytest 8.3.4 differs from CI pytest 9.0.3, so the PR workflow is authoritative

## Verification
- PASS `./.venv/bin/ruff check .`
- PASS `./.venv/bin/pre-commit run ruff --all-files`
- PASS `./.venv/bin/mypy`
- PASS `PYTHONPATH=. .venv/bin/pytest -q tests/test_repository_guardrails.py` (113 passed)
- PASS `PYTHONPATH=. .venv/bin/pytest -q tests/test_docker_build_contracts.py` (11 passed)
- PASS `PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py` (2 passed)
- PASS `PYTHONPATH=. .venv/bin/python -m pytest -q --cov --cov-config=.coveragerc --cov-report=term-missing:skip-covered tests/` (1,125 passed; 81.03% coverage; 71% required)
- PASS `git diff --check`

## Review
An independent pre-commit review found one P2: runtime requirements could indirectly include the development requirements file. The contract now rejects that path; no P1 findings remain.

## Remaining deficits
- CI on Python 3.14 with pytest 9.0.3 is not yet verified; this PR run is authoritative.
- T-CI-2A live required-check mutation still requires explicit operator approval.
- G3 remains open and continues to block Phase 2 architecture work.