### PR TITLE
T-SEC-1: Restrict backing-service host ports

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,7 +19,8 @@ API_AUTH_KEY=dev_secret_key_change_me
 # Format: comma-separated list
 ALLOWED_ORIGINS=http://localhost:3000
 
-# Grafana admin credentials (local dev)
+# Grafana admin credentials (local development only)
+# These defaults are unsafe for reachable deployments.
 GRAFANA_ADMIN_USER=admin
 GRAFANA_ADMIN_PASSWORD=admin
 

--- a/README.md
+++ b/README.md
@@ -160,11 +160,22 @@ docker compose run --rm pipeline python reindex_only.py
 ```
 
 ## Access URLs
+The base stack publishes only the UI and API. To publish local operator
+interfaces for backing and monitoring services on `127.0.0.1`, start only
+those services through the development overlay:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d \
+  postgres redis meilisearch prometheus grafana
+```
+
+Using the development overlay for the full stack also enables `STARTUP_PURGE_DERIVED=true`.
+
 - UI: [http://localhost:3000](http://localhost:3000)
 - API docs: [http://localhost:8000/docs](http://localhost:8000/docs)
-- Meilisearch: [http://localhost:7700](http://localhost:7700)
-- Grafana: [http://localhost:3001](http://localhost:3001)
-- Prometheus: [http://localhost:9090](http://localhost:9090)
+- Meilisearch with the dev overlay: [http://localhost:7700](http://localhost:7700)
+- Grafana with the dev overlay: [http://localhost:3001](http://localhost:3001)
+- Prometheus with the dev overlay: [http://localhost:9090](http://localhost:9090)
 - Static demo (GitHub Pages): [https://manumissio.github.io/town-council/](https://manumissio.github.io/town-council/)
 
 ## Search Behavior (Meetings vs Agenda Items)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -65,7 +65,8 @@ engineering decisions is `reachable`).
 
 ## Hardening checklist (reachable posture)
 
-- [ ] Base compose publishes only `api:8000` and `frontend:3000` (T-SEC-1)
+- [ ] Base compose publishes only `api:8000` and `frontend:3000` (T-SEC-1;
+  implementation complete, merge pending)
 - [ ] Non-default values for every key in the inventory above
 - [ ] API aborts on default key outside dev (T-SEC-2)
 - [ ] Meilisearch search key configured for the API (T-SEC-3)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -65,8 +65,7 @@ engineering decisions is `reachable`).
 
 ## Hardening checklist (reachable posture)
 
-- [ ] Base compose publishes only `api:8000` and `frontend:3000` (T-SEC-1;
-  implementation complete, merge pending)
+- [x] Base compose publishes only `api:8000` and `frontend:3000` (T-SEC-1)
 - [ ] Non-default values for every key in the inventory above
 - [ ] API aborts on default key outside dev (T-SEC-2)
 - [ ] Meilisearch search key configured for the API (T-SEC-3)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,4 +1,26 @@
+# These opt-in bindings preserve local operator access without exposing
+# backing or monitoring services beyond the host loopback interface.
 services:
+  postgres:
+    ports:
+      - "127.0.0.1:5432:5432"
+
+  meilisearch:
+    ports:
+      - "127.0.0.1:7700:7700"
+
+  redis:
+    ports:
+      - "127.0.0.1:6379:6379"
+
+  prometheus:
+    ports:
+      - "127.0.0.1:9090:9090"
+
+  grafana:
+    ports:
+      - "127.0.0.1:3001:3000"
+
   api:
     command: uvicorn main:app --host 0.0.0.0 --port 8000 --reload
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+# Inter-container traffic uses the Compose network; opt-in host bindings for
+# backing and monitoring services belong in docker-compose.dev.yml.
 services:
   # PostgreSQL Database: Replaces SQLite for production-grade concurrency and performance.
   postgres:
@@ -8,8 +10,6 @@ services:
       POSTGRES_USER: ${POSTGRES_USER:-town_council}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-secure_dev_password}
       POSTGRES_DB: ${POSTGRES_DB:-town_council_db}
-    ports:
-      - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
 
@@ -393,8 +393,6 @@ services:
   # Meilisearch: A fast, typo-tolerant search engine (FOSS).
   meilisearch:
     image: getmeili/meilisearch:v1.6
-    ports:
-      - "7700:7700"
     environment:
       - MEILI_MASTER_KEY=${MEILI_MASTER_KEY:-masterKey}
     volumes:
@@ -445,8 +443,6 @@ services:
   # This reduces database load by ~95% for read-heavy operations.
   redis:
     image: redis:7-alpine
-    ports:
-      - "6379:6379"
     command: redis-server --requirepass ${REDIS_PASSWORD:-secure_redis_password} --maxmemory 256mb --maxmemory-policy allkeys-lru
     volumes:
       - redis_data:/data
@@ -570,8 +566,6 @@ services:
     volumes:
       - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml
       - prometheus_data:/prometheus
-    ports:
-      - "9090:9090"
 
   # Grafana: FOSS analytics and interactive visualization web application.
   grafana:
@@ -580,8 +574,6 @@ services:
       - grafana_data:/var/lib/grafana
       - ./monitoring/grafana/provisioning:/etc/grafana/provisioning
       - ./monitoring/grafana/dashboards:/var/lib/grafana/dashboards
-    ports:
-      - "3001:3000" # Mapped to 3001 to avoid conflict with frontend
     environment:
       - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
       - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -26,6 +26,14 @@ Optional helper (same steps, fewer flags to remember):
 bash ./scripts/dev_up.sh
 ```
 
+After upgrading a stack created before T-SEC-1, recreate the affected services
+once so their removed host bindings do not survive in existing containers:
+
+```bash
+docker compose -f docker-compose.yml up -d --force-recreate \
+  postgres redis meilisearch prometheus grafana
+```
+
 The base stack publishes only the API and frontend. For loopback-only access
 to backing and monitoring interfaces, start only those services with the
 development overlay:

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,6 +1,6 @@
 # Operations Runbook
 
-Last updated: 2026-05-17
+Last updated: 2026-07-23
 
 ## Core workflow
 
@@ -25,6 +25,17 @@ Optional helper (same steps, fewer flags to remember):
 ```bash
 bash ./scripts/dev_up.sh
 ```
+
+The base stack publishes only the API and frontend. For loopback-only access
+to backing and monitoring interfaces, start only those services with the
+development overlay:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d \
+  postgres redis meilisearch prometheus grafana
+```
+
+Using the development overlay for the full stack also enables `STARTUP_PURGE_DERIVED=true`.
 
 M5 Pro MLX opt-in path:
 ```bash
@@ -1524,7 +1535,9 @@ Targets should be UP:
 - `cadvisor`
 
 Check:
-- Prometheus targets: [http://localhost:9090/targets](http://localhost:9090/targets)
+- After starting the service-scoped development overlay above, inspect
+  Prometheus targets at
+  [http://localhost:9090/targets](http://localhost:9090/targets).
 
 ## Code scanning hygiene
 - Keep captured portal snapshots and fixtures out of runtime source roots when possible.

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,6 +1,6 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 2.4
+version: 2.5
 generated: 2026-07-23
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
@@ -10,6 +10,8 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v2.5:** Records T-SEC-1 completion after local verification, independent
+  review, and green pull-request checks.
 - **v2.4:** Records T-CI-3 completion and expands T-SEC-1 ownership so
   backing-service port hardening, contract tests, and operator documentation
   land together. Includes Prometheus and limits development bindings to
@@ -46,9 +48,8 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 | State | Tasks |
 |---|---|
-| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-3, T-CI-4, T-CI-5 |
+| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-3, T-CI-4, T-CI-5, T-SEC-1 |
 | **Awaiting operator approval** | T-CI-2A |
-| **Implementation complete; review pending** | T-SEC-1 |
 | **Partially landed; acceptance incomplete** | T-GOV-4, T-GOV-5, T-GOV-6 |
 | **Pending** | T-SEC-2..6, T-TIME-1..3, T-CRAWL-1..2, T-DA-1, T-DB-1, T-DC-1, T-DD-1, T-DE-1, T-PLAT-1..4, T-GOV-1..3 |
 
@@ -381,7 +382,7 @@ in `AGENTS.md`, `docs/TESTING.MD`, and
 
 ### T-SEC-1: Stop publishing backing-store ports; remove default-cred blast radius
 - priority: P0
-- status: implementation complete; review pending
+- status: complete
 - implementation_plan: `docs/plans/T_SEC_1_BACKEND_PORT_HARDENING_PLAN.md`
 - files_owned: docs/plans/T_SEC_1_BACKEND_PORT_HARDENING_PLAN.md,
   docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md, docker-compose.yml,

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,8 +1,11 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 2.3
+version: 2.4
 generated: 2026-07-23
-changelog: v2.3 expands T-CI-3 ownership and defines a production-only,
+changelog: v2.4 records T-CI-3 completion and expands T-SEC-1 ownership so
+backing-service port hardening, contract tests, and operator documentation land
+together. It reconciles the security acceptance rule by including Prometheus
+and limits development-overlay bindings to loopback. v2.3 expands T-CI-3 ownership and defines a production-only,
 subprocess-aware coverage contract before activating the existing 71% floor.
 It prevents test code from inflating the gate and keeps coverage dependencies
 out of runtime images. v2.2 corrects the T-CI-2A workflow identity guardrail to preserve
@@ -279,7 +282,7 @@ in `AGENTS.md`, `docs/TESTING.MD`, and
 ### T-CI-3: Enforce coverage threshold
 - priority: P2
 - depends_on: T-CI-1
-- status: implementation-ready
+- status: complete and verified 2026-07-23 (PR #118)
 - files_owned: docs/plans/T_CI_3_COVERAGE_GATE_PLAN.md,
   docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md, AGENTS.md,
   docs/TESTING.MD, docs/ENGINEERING_GUARDRAILS.md,
@@ -373,15 +376,26 @@ in `AGENTS.md`, `docs/TESTING.MD`, and
 
 ### T-SEC-1: Stop publishing backing-store ports; remove default-cred blast radius
 - priority: P0
-- files_owned: docker-compose.yml, docker-compose.dev.yml, .env.example
-- do: Remove host `ports:` for postgres, redis, meilisearch, grafana-admin
-  defaults note. Move dev-convenience port publishing to
-  docker-compose.dev.yml only. Add comment: inter-container traffic uses the
-  compose network.
+- status: implementation-ready
+- implementation_plan: `docs/plans/T_SEC_1_BACKEND_PORT_HARDENING_PLAN.md`
+- files_owned: docs/plans/T_SEC_1_BACKEND_PORT_HARDENING_PLAN.md,
+  docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md, docker-compose.yml,
+  docker-compose.dev.yml, .env.example, tests/test_docker_build_contracts.py,
+  README.md, docs/OPERATIONS.md, SECURITY.md
+- do: Remove host `ports:` for postgres, redis, meilisearch, prometheus, and
+  grafana from the base file. Add loopback-only development mappings to
+  docker-compose.dev.yml. Label Grafana defaults as local-development values
+  and synchronize operator access guidance. Add a comment that inter-container
+  traffic uses the Compose network.
 - accept: Base compose exposes only api:8000 and frontend:3000;
-  `docker compose config` valid; dev overlay restores old behavior.
-- forbidden: Changing service images, env defaults, or dependencies.
-- verify: `docker compose config >/dev/null` (base and base+dev).
+  `docker compose config` is valid; the explicit dev overlay restores local
+  host access for all five moved services without publishing them beyond
+  loopback.
+- forbidden: Changing service images, env defaults, dependencies, credentials,
+  startup-purge behavior, or the standard `scripts/dev_up.sh` path.
+- verify: Follow the Full T-SEC-1 plan: base and merged Compose validation,
+  Docker contract tests, startup-purge contract, Ruff, docs links, complete
+  Python suite, and `git diff --check`.
 
 ### T-SEC-2: Fail fast on default API key outside dev
 - priority: P0

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -2,50 +2,55 @@
 
 version: 2.4
 generated: 2026-07-23
-changelog: v2.4 records T-CI-3 completion and expands T-SEC-1 ownership so
-backing-service port hardening, contract tests, and operator documentation land
-together. It reconciles the security acceptance rule by including Prometheus
-and limits development-overlay bindings to loopback. v2.3 expands T-CI-3 ownership and defines a production-only,
-subprocess-aware coverage contract before activating the existing 71% floor.
-It prevents test code from inflating the gate and keeps coverage dependencies
-out of runtime images. v2.2 corrects the T-CI-2A workflow identity guardrail to preserve
-GitHub string semantics for YAML 1.1 Boolean-like scalars. v2.1 adds the direct
-development-only PyYAML contract required to validate workflow check
-identities semantically instead of approximating YAML with regular
-expressions. v2.0 records T-CI-2 completion and adds the implementation-ready
-T-CI-2A plan for the separately approval-gated frontend required-check policy.
-v1.9 corrects T-CI-2 to use the existing Node 20 test runner,
-permits the stale CSP contract to follow its current proxy owner, expands
-planning and testing-policy ownership, and records completed Phase 0 work.
-v1.8 expands T-CI-4 ownership and records the dedicated
-formatter-scope config required to preserve repository-wide lint discovery.
-v1.7 adds T-CI-1A to make the green `python-guardrails` check
-mandatory through an active default-branch repository ruleset and schedules
-T-CI-2A to add the universal frontend check only after T-CI-2 is green. v1.6 expands T-CI-1 ownership so the complete-suite workflow,
-contract tests, runbook, and implementation plan land together. It also adds
-the crawler and Python 3.14-compatible topic dependencies, preserves the local
-`.venv/bin/python` subprocess contract, and removes event path filters so the
-gate runs on every pull request and master push. v1.5 expands T-CI-5 ownership so lint entrypoints, contributor
-commands, policy tests, and the implementation plan change together. It also
-records that the tightened Ruff configuration is already landed and corrects
-the pre-commit verification command. v1.4 expands T-CI-0 workflow ownership to keep CI triggers aligned
-with Ruff discovery. v1.3 adds T-CI-0 to restore the Python guardrail baseline before
-T-CI-5 and T-CI-1. v1.2 adds T-CI-5 (land the tightened ruff.toml, delivered as a
-drop-in draft verified against the tree at plan date), registers the lint
-ratchet couplings in T-TIME-1, T-SEC-6, T-CRAWL-2, T-DA-1, and T-PLAT-4
-acceptance criteria, re-scopes T-GOV-3 (complexity ceiling now enforced via
-ruff C901), and adds .pre-commit-config.yaml to CI-lane ownership. v1.1
-added the documentation workstream (T-GOV-4..6), expanded GOV lane
-ownership, and registered draft documents delivered with this plan
-(updated AGENTS.md, rewritten docs/ENGINEERING_GUARDRAILS.md, new
-SECURITY.md, docs/TESTING.md, docs/DATA_GOVERNANCE.md, drop-in ruff.toml).
-Doc tasks land the drafts alongside their enabling mechanical tasks; agents
-reconcile transition markers, they do not re-author policy.
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
 orchestrator_contract: Codex instantiates one agent per lane. Agents run in
 parallel ONLY within the same phase and ONLY on their owned paths. AGENTS.md
 remains in force; where this plan is stricter, this plan wins for these tasks.
+
+## Changelog
+
+- **v2.4:** Records T-CI-3 completion and expands T-SEC-1 ownership so
+  backing-service port hardening, contract tests, and operator documentation
+  land together. Includes Prometheus and limits development bindings to
+  loopback.
+- **v2.3:** Defines a production-only, subprocess-aware T-CI-3 coverage
+  contract without adding coverage tools to runtime images.
+- **v2.2:** Corrects T-CI-2A workflow identity checks for GitHub's YAML scalar
+  semantics.
+- **v2.1:** Adds the development-only PyYAML contract used to validate workflow
+  check identities semantically.
+- **v2.0:** Records T-CI-2 completion and adds the approval-gated T-CI-2A
+  frontend required-check plan.
+- **v1.9:** Aligns T-CI-2 with the existing Node 20 test runner, current CSP
+  owner, testing policy, and completed Phase 0 work.
+- **v1.8:** Expands T-CI-4 ownership and adds a dedicated formatter-scope
+  config.
+- **v1.7:** Adds T-CI-1A for the required Python Guardrails check and schedules
+  T-CI-2A after the frontend check is proven.
+- **v1.6:** Expands T-CI-1 ownership for the complete Python suite, crawler and
+  Python 3.14 topic dependencies, subprocess environment, and universal CI
+  triggers.
+- **v1.5:** Expands T-CI-5 ownership for aligned Ruff entrypoints, policy tests,
+  and pre-commit guidance.
+- **v1.4:** Expands T-CI-0 ownership to keep workflow triggers aligned with Ruff
+  discovery.
+- **v1.3:** Adds T-CI-0 to restore the Python guardrail baseline before other
+  Phase 0 work.
+- **v1.2:** Adds T-CI-5, lint-ratchet ownership, the T-GOV-3 complexity
+  correction, and pre-commit ownership.
+- **v1.1:** Adds the T-GOV-4..6 documentation workstream and registers the
+  initial policy-document drafts.
+
+## Task Status
+
+| State | Tasks |
+|---|---|
+| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-3, T-CI-4, T-CI-5 |
+| **Awaiting operator approval** | T-CI-2A |
+| **Implementation complete; review pending** | T-SEC-1 |
+| **Partially landed; acceptance incomplete** | T-GOV-4, T-GOV-5, T-GOV-6 |
+| **Pending** | T-SEC-2..6, T-TIME-1..3, T-CRAWL-1..2, T-DA-1, T-DB-1, T-DC-1, T-DD-1, T-DE-1, T-PLAT-1..4, T-GOV-1..3 |
 
 ---
 
@@ -376,7 +381,7 @@ in `AGENTS.md`, `docs/TESTING.MD`, and
 
 ### T-SEC-1: Stop publishing backing-store ports; remove default-cred blast radius
 - priority: P0
-- status: implementation-ready
+- status: implementation complete; review pending
 - implementation_plan: `docs/plans/T_SEC_1_BACKEND_PORT_HARDENING_PLAN.md`
 - files_owned: docs/plans/T_SEC_1_BACKEND_PORT_HARDENING_PLAN.md,
   docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md, docker-compose.yml,

--- a/docs/plans/T_SEC_1_BACKEND_PORT_HARDENING_PLAN.md
+++ b/docs/plans/T_SEC_1_BACKEND_PORT_HARDENING_PLAN.md
@@ -1,0 +1,342 @@
+# T-SEC-1: Restrict Backing-Service Host Ports
+
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+execution: code
+task: T-SEC-1
+lane: SEC
+
+## 1. Context & Alignment
+
+**a) Driver.** The base Compose file publishes PostgreSQL, Redis,
+Meilisearch, Prometheus, and Grafana on every host interface while those
+services use development credentials or expose operational data. This lets a
+network peer bypass the API boundary and reach internal services directly.
+T-SEC-1 must make the base stack expose only the API and frontend while
+preserving explicit, loopback-only operator access through the existing
+development overlay.
+
+**b) Canonical documents.** `AGENTS.md` `<hard_invariants>`,
+`<security_sensitive_paths>`, `<workflow_contract>`,
+`<verification_matrix>`, and `<docs_sync_rules>` require a trust-boundary
+statement, local-first behavior, exact verification, and synchronized
+commands. `SECURITY.md` "Deployment posture", "Trust boundaries", and
+"Hardening checklist" require backing stores to remain on the Compose network
+in the base stack. `docs/TESTING.MD` requires observable contract tests.
+`docs/OPERATIONS.md` and `README.md` currently advertise host URLs that will
+require the development overlay after this change. The remediation plan places
+T-SEC-1 at the start of the Phase 1 security lane. The architecture review
+confirms Phase 1 security work may proceed while G3 blocks Phase 2.
+
+**c) Remediation alignment.** Expand T-SEC-1 ownership before implementation
+to exactly:
+
+- `docs/plans/T_SEC_1_BACKEND_PORT_HARDENING_PLAN.md`
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`
+- `docker-compose.yml`
+- `docker-compose.dev.yml`
+- `.env.example`
+- `tests/test_docker_build_contracts.py`
+- `README.md`
+- `docs/OPERATIONS.md`
+- `SECURITY.md`
+
+The remediation plan also records T-CI-3 as complete in PR #118. No other
+tracked file may change. In particular, `scripts/dev_up.sh` remains unchanged
+because loading the development overlay there would also enable
+`STARTUP_PURGE_DERIVED=true`.
+
+**d) Decision gates.** No G1-G5 decision blocks this task. G1 remains formally
+open, but `SECURITY.md` and the remediation plan explicitly use the reachable
+posture as the hardening assumption. G2 is unrelated to backing-service
+publication. G3 continues to block Phase 2 only.
+
+## 2. Design
+
+**e) Approach.**
+
+1. Register the expanded ownership and this Full plan before implementation.
+2. Reproduce the current exposure with
+   `docker compose -f docker-compose.yml config --format json`: seven services
+   publish ports, including five internal or administrative services.
+3. Add failing tests before changing Compose or documentation. The tests
+   render Docker Compose JSON and require:
+   - the base project to publish only `api:8000` and `frontend:3000`;
+   - the merged development project to publish exact loopback mappings for
+     PostgreSQL, Redis, Meilisearch, Prometheus, and Grafana;
+   - the base and merged dependency graphs to remain identical;
+   - neither project to use host network mode;
+   - the checked-in Grafana credentials must be labeled local-development
+     defaults that are unsafe for reachable deployments.
+4. Remove the five internal or administrative `ports` blocks from
+   `docker-compose.yml`. Add a top-level intent comment explaining that
+   inter-container traffic uses the Compose network and host bindings belong
+   in the explicit development overlay.
+5. Add the five mappings to `docker-compose.dev.yml` with
+   `127.0.0.1:HOST:CONTAINER`. This deliberately restores local operator
+   access rather than the old all-interface exposure.
+6. Keep the existing API `8000` and frontend `3000` mappings unchanged. Do
+   not add `expose`, networks, profiles, or service changes because Compose
+   service-name routing already provides internal access.
+7. Clarify the `.env.example` Grafana comment without changing any value.
+8. Update README access guidance and the operations observability check with
+   an exact service-scoped command:
+
+   ```bash
+   docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d \
+     postgres redis meilisearch prometheus grafana
+   ```
+
+   The service list prevents this access-only command from starting the
+   purge-enabled API, worker, or pipeline definitions in the same overlay.
+   State that using the overlay for the full stack also enables development
+   startup purge behavior.
+9. Mark the T-SEC-1 checklist item complete in `SECURITY.md`; leave all other
+   security tasks and the G1 blank unchanged.
+10. Validate both rendered configurations, run all applicable tests, simplify
+    the diff, obtain a fresh independent pre-commit review, and deliver one
+    planning commit plus one implementation commit.
+
+No new production function or module is introduced. The only new test helper
+renders one effective Compose project as JSON. It does not start containers or
+require a Docker daemon connection.
+
+**f) Reuse audit.** Reuse the existing Compose base/overlay model,
+`tests/test_docker_build_contracts.py`, Docker Compose CLI, and canonical
+security/runbook sections. No new overlay, parser framework, network
+abstraction, helper script, compatibility path, or duplicate port inventory is
+added. The old all-interface backing-service publication is removed in the
+same change.
+
+Rejected alternatives:
+
+- Leave Prometheus in the base file: rejected because the acceptance contract
+  and security checklist require only API and frontend host publication.
+- Restore development mappings without a host address: rejected because it
+  recreates the network blast radius that T-SEC-1 removes.
+- Make `scripts/dev_up.sh` load the overlay: rejected because the same overlay
+  also enables derived-data startup purge and would change the standard helper
+  beyond this security task.
+- Add `expose` for internal ports: rejected because Compose networking already
+  permits service-to-service traffic and `expose` would add redundant config.
+
+**g) Contracts.**
+
+- Base host-publication contract:
+  `{"api": ["8000:8000"], "frontend": ["3000:3000"]}`.
+- Development overlay contract:
+  - PostgreSQL `127.0.0.1:5432:5432`
+  - Redis `127.0.0.1:6379:6379`
+  - Meilisearch `127.0.0.1:7700:7700`
+  - Prometheus `127.0.0.1:9090:9090`
+  - Grafana `127.0.0.1:3001:3000`
+- Service names, container ports, credentials, images, volumes, dependencies,
+  health checks, API contracts, and runtime defaults remain unchanged.
+
+The tests invoke `docker compose config --format json`, which is the semantic
+authority for interpolation and multi-file merging. The test environment must
+provide the Docker Compose CLI, but no daemon or running container is needed.
+
+**h) Schema and migrations.** None. Named volumes and stored data are
+unchanged.
+
+## 3. Security & Data Governance
+
+**i) Security boundary.** This task touches `docker-compose.yml` and
+`docker-compose.dev.yml`, which are security-sensitive. Before the change,
+network peers can directly reach services protected only by development
+credentials or no authentication. After the change, base-stack peers can reach
+only the API and frontend host interfaces; backing and monitoring services
+remain reachable by containers on the Compose network. The explicit
+development overlay grants only loopback access. This implements
+`SECURITY.md` trust boundary 3 and hardening checklist item T-SEC-1.
+
+**j) Secrets.** No credential, key, value, environment variable, or fallback
+changes. The `.env.example` edit only labels existing Grafana values as
+local-development defaults. T-SEC-2 and T-SEC-3 retain ownership of API-key
+and Meilisearch-key policy.
+
+**k) Person data.** No person-level data is created, linked, aggregated, or
+exposed. G4 is unaffected.
+
+**l) Untrusted input.** No scraped content or user input is parsed. Tests parse
+tracked repository YAML. Docker Compose environment interpolation remains
+unchanged.
+
+## 4. Code Health
+
+**m) GED conformance sweep.** No Python production logic, error handler,
+timestamp, environment read, function signature, or nested control flow
+changes. Port literals are policy values and remain centralized in the two
+Compose files. Test names use service and publication vocabulary. No exception
+is required.
+
+**n) Antipattern scan, plan pass.**
+
+- A1/H1: Docker Compose multi-file merge, `config --quiet`, and
+  `config --format json` behavior were verified against `/docker/compose` and
+  local Compose 5.2.0.
+- B1/F1: no new config framework, parser package, helper script, or duplicate
+  overlay.
+- B2/C1: no compatibility path; superseded base port mappings are deleted.
+- B3: no redundant `expose` declarations or new validation in production.
+- D1-D3: tests assert the checked-in security contract and rendered behavior;
+  no skip, xfail, tolerance, or implementation mock.
+- E1-E3: only the nine owned files may change; the historical architecture
+  review remains untouched.
+- A2-A4, C2, F2, H2-H4: no violations planned.
+
+**o) Ratchet interaction.** No Ruff selector, BLE001 boundary, formatter
+scope, Mypy scope, coverage threshold, or soak gate changes.
+
+**p) Dead code and duplication audit.** Delete five base `ports` blocks.
+Re-home those five mappings once in the development overlay. Reuse current
+service definitions and docs sections. Expected net config delta is small;
+documentation and tests account for most added lines.
+
+## 5. Testing
+
+**q) Edge and failure scenarios.**
+
+1. A backing or monitoring service regains a base host mapping.
+2. API or frontend publication is accidentally removed or changed.
+3. Development overlay omits one required operator mapping.
+4. Development overlay binds an internal service to all interfaces.
+5. Prometheus is missed because the old work list named only four services.
+6. Compose merge or interpolation becomes invalid.
+7. Container-to-container dependencies change.
+8. Operator docs advertise unavailable URLs without the overlay command.
+9. Existing dev credentials are mistaken for reachable-deployment values.
+10. Existing running containers retain old published bindings until recreated.
+11. Loading the overlay unexpectedly remains undocumented as also enabling
+    startup purge.
+12. A service bypasses port policy through `network_mode: host`.
+13. Compose merging changes a service dependency.
+
+**r) Test mapping.**
+
+| Test or verification | Scenarios |
+|---|---|
+| `test_base_compose_publishes_only_application_interfaces` | 1, 2, 5, 12 |
+| `test_dev_overlay_publishes_operator_services_on_loopback_only` | 3, 4, 5, 12, 13 |
+| `test_example_grafana_credentials_are_labeled_local_only` | 9 |
+| `test_operator_docs_scope_dev_overlay_to_port_services` | 8, 11 |
+| Existing startup-purge contract | 11 |
+| Base and merged `docker compose config --quiet` | 6 |
+| Docs-link test plus semantic doc review | 8, 10, 11 |
+| Complete Python suite | Regression check |
+
+The four new contracts are written and run red before Compose, env, or docs
+implementation changes.
+
+**s) Fakes and mocks.** None. Tests use the approved filesystem and subprocess
+boundaries. Docker Compose renders configuration directly; no facade,
+environment, Docker daemon, or production implementation is mocked.
+
+**t) Verification rows.** Apply the security-sensitive Compose trust-boundary
+report, Docker contract tests, docs-only row, Ruff because Python tests change,
+and the complete Python suite for this cross-cutting infrastructure change.
+Docker Compose rendering is an additional mandatory acceptance check.
+
+## 6. Execution, Rollback, Docs
+
+**u) Commands.**
+
+```bash
+git fetch origin --prune
+git switch master
+git merge --ff-only origin/master
+git switch -c codex/t-sec-1-backend-port-hardening
+```
+
+Current exposure:
+
+```bash
+docker compose -f docker-compose.yml config --format json |
+  .venv/bin/python -c \
+  'import json,sys; services=json.load(sys.stdin)["services"]; print({name: service["ports"] for name, service in services.items() if service.get("ports")})'
+```
+
+Tests-first red evidence:
+
+```bash
+PYTHONPATH=. .venv/bin/pytest -q \
+  tests/test_docker_build_contracts.py::test_base_compose_publishes_only_application_interfaces \
+  tests/test_docker_build_contracts.py::test_dev_overlay_publishes_operator_services_on_loopback_only \
+  tests/test_docker_build_contracts.py::test_example_grafana_credentials_are_labeled_local_only \
+  tests/test_docker_build_contracts.py::test_operator_docs_scope_dev_overlay_to_port_services
+```
+
+Final verification:
+
+```bash
+docker compose -f docker-compose.yml config --quiet
+docker compose -f docker-compose.yml -f docker-compose.dev.yml config --quiet
+docker compose -f docker-compose.yml config --format json |
+  .venv/bin/python -c \
+  'import json,sys; services=json.load(sys.stdin)["services"]; print({name: service["ports"] for name, service in services.items() if service.get("ports")})'
+docker compose -f docker-compose.yml -f docker-compose.dev.yml config --format json |
+  .venv/bin/python -c \
+  'import json,sys; services=json.load(sys.stdin)["services"]; print({name: service["ports"] for name, service in services.items() if service.get("ports")})'
+./.venv/bin/ruff check .
+PYTHONPATH=. .venv/bin/pytest -q tests/test_docker_build_contracts.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_startup_purge_gating.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py
+PYTHONPATH=. .venv/bin/python -m pytest -q tests/
+git diff --check
+git status --short
+```
+
+After merge, recreate affected services so old bindings do not survive in
+running containers:
+
+```bash
+docker compose -f docker-compose.yml up -d --force-recreate \
+  postgres redis meilisearch prometheus grafana
+```
+
+**v) Rollback.** Revert the T-SEC-1 merge commit, validate both Compose
+configurations, and recreate the five affected services with the restored base
+file:
+
+```bash
+docker compose -f docker-compose.yml up -d --force-recreate \
+  postgres redis meilisearch prometheus grafana
+```
+
+Named volumes preserve PostgreSQL, Redis, Meilisearch, Prometheus, and Grafana
+data. No migration or data remediation is required.
+
+**w) Docs synchronization.**
+
+- `README.md` "Access URLs": distinguish base URLs from explicit
+  development-overlay URLs and show the exact service-scoped command.
+- `docs/OPERATIONS.md` "Start stack" and "Observability quick checks": explain
+  opt-in loopback bindings, startup-purge interaction, and service recreation;
+  update `Last updated`.
+- `SECURITY.md` "Hardening checklist": mark T-SEC-1 complete.
+- `.env.example`: label Grafana defaults as local-development only.
+- Remediation registry: version 2.4, T-CI-3 completion, T-SEC-1 ownership and
+  clarified acceptance.
+- `AGENTS.md`, testing/guardrail policy, ADR, architecture review, API docs,
+  and data-governance docs: no change.
+
+## 7. Delivery Self-Audit
+
+**x) Diff scan.** Re-run A-F/H. Reject any all-interface backing-service
+mapping, new port, changed credential, `expose` declaration, service/dependency
+change, automatic `dev_up.sh` overlay loading, unrelated formatting, weakened
+test, historical-review edit, or changed gate/default policy.
+
+**y) Evidence required.** Report the tests-first red result, both Compose
+validation results, exact rendered base and merged port inventories, Ruff,
+targeted contract tests, startup-purge tests, docs links, complete-suite
+counts, independent planning and pre-commit review findings, commit hashes, PR
+URL, unresolved-thread count, and final CI state. Mark anything unrun as
+`NOT VERIFIED`.
+
+**z) Deviations.** Authorized corrections are adding Prometheus to the move,
+using loopback-only development bindings rather than all-interface mappings,
+expanding ownership to nine files, and synchronizing the stale T-CI-3 status.
+Any additional path, changed service behavior, credential/default change,
+unresolved P1/P2, skipped review, or unrun required check is a blocker.

--- a/docs/plans/T_SEC_1_BACKEND_PORT_HARDENING_PLAN.md
+++ b/docs/plans/T_SEC_1_BACKEND_PORT_HARDENING_PLAN.md
@@ -338,5 +338,7 @@ URL, unresolved-thread count, and final CI state. Mark anything unrun as
 **z) Deviations.** Authorized corrections are adding Prometheus to the move,
 using loopback-only development bindings rather than all-interface mappings,
 expanding ownership to nine files, and synchronizing the stale T-CI-3 status.
+The operator additionally directed the remediation changelog to become a
+versioned list and requested a scannable task-status summary.
 Any additional path, changed service behavior, credential/default change,
 unresolved P1/P2, skipped review, or unrun required check is a blocker.

--- a/tests/test_docker_build_contracts.py
+++ b/tests/test_docker_build_contracts.py
@@ -109,11 +109,16 @@ def test_operator_docs_scope_dev_overlay_to_port_services():
         "  postgres redis meilisearch prometheus grafana"
     )
     purge_warning = "Using the development overlay for the full stack also enables `STARTUP_PURGE_DERIVED=true`."
+    upgrade_command = (
+        "docker compose -f docker-compose.yml up -d --force-recreate \\\n"
+        "  postgres redis meilisearch prometheus grafana"
+    )
 
     assert access_command in readme
     assert access_command in operations
     assert purge_warning in readme
     assert purge_warning in operations
+    assert upgrade_command in operations
 
 
 def test_dockerfile_defines_split_python_targets():

--- a/tests/test_docker_build_contracts.py
+++ b/tests/test_docker_build_contracts.py
@@ -1,5 +1,46 @@
+import json
 import re
+import subprocess
 from pathlib import Path
+
+
+def _compose_services(*compose_paths: str) -> dict[str, dict[str, object]]:
+    compose_command = ["docker", "compose"]
+    for compose_path in compose_paths:
+        compose_command.extend(("-f", compose_path))
+    compose_command.extend(("config", "--format", "json"))
+    completed_process = subprocess.run(
+        compose_command,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    compose_project = json.loads(completed_process.stdout)
+    return compose_project["services"]
+
+
+def _published_port_bindings(
+    compose_services: dict[str, dict[str, object]],
+) -> set[tuple[str, str | None, str, int]]:
+    return {
+        (
+            service_name,
+            port_mapping.get("host_ip"),
+            port_mapping["published"],
+            port_mapping["target"],
+        )
+        for service_name, service_config in compose_services.items()
+        for port_mapping in service_config.get("ports", [])
+    }
+
+
+def _service_dependencies(
+    compose_services: dict[str, dict[str, object]],
+) -> dict[str, set[str]]:
+    return {
+        service_name: set(service_config.get("depends_on", {}))
+        for service_name, service_config in compose_services.items()
+    }
 
 
 def _requirement_names(requirements_path: Path) -> set[str]:
@@ -24,6 +65,55 @@ def test_compose_uses_role_specific_python_images_and_model_volume():
     assert "enrichment-worker:" in source
     assert "semantic-worker:" in source
     assert "models_data:/models" in source
+
+
+def test_base_compose_publishes_only_application_interfaces():
+    compose_services = _compose_services("docker-compose.yml")
+
+    assert _published_port_bindings(compose_services) == {
+        ("api", None, "8000", 8000),
+        ("frontend", None, "3000", 3000),
+    }
+    assert all(service_config.get("network_mode") != "host" for service_config in compose_services.values())
+
+
+def test_dev_overlay_publishes_operator_services_on_loopback_only():
+    base_services = _compose_services("docker-compose.yml")
+    development_services = _compose_services("docker-compose.yml", "docker-compose.dev.yml")
+
+    assert _published_port_bindings(development_services) == {
+        ("api", None, "8000", 8000),
+        ("frontend", None, "3000", 3000),
+        ("grafana", "127.0.0.1", "3001", 3000),
+        ("meilisearch", "127.0.0.1", "7700", 7700),
+        ("postgres", "127.0.0.1", "5432", 5432),
+        ("prometheus", "127.0.0.1", "9090", 9090),
+        ("redis", "127.0.0.1", "6379", 6379),
+    }
+    assert _service_dependencies(development_services) == _service_dependencies(base_services)
+    assert all(service_config.get("network_mode") != "host" for service_config in development_services.values())
+
+
+def test_example_grafana_credentials_are_labeled_local_only():
+    example_environment = Path(".env.example").read_text(encoding="utf-8")
+
+    assert "Grafana admin credentials (local development only)" in example_environment
+    assert "unsafe for reachable deployments" in example_environment
+
+
+def test_operator_docs_scope_dev_overlay_to_port_services():
+    readme = Path("README.md").read_text(encoding="utf-8")
+    operations = Path("docs/OPERATIONS.md").read_text(encoding="utf-8")
+    access_command = (
+        "docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d \\\n"
+        "  postgres redis meilisearch prometheus grafana"
+    )
+    purge_warning = "Using the development overlay for the full stack also enables `STARTUP_PURGE_DERIVED=true`."
+
+    assert access_command in readme
+    assert access_command in operations
+    assert purge_warning in readme
+    assert purge_warning in operations
 
 
 def test_dockerfile_defines_split_python_targets():


### PR DESCRIPTION
## What changed
- stop publishing PostgreSQL, Redis, Meilisearch, Prometheus, and Grafana from the base Compose stack
- add loopback-only development-overlay bindings for those operator interfaces
- document the service-scoped overlay command and its `STARTUP_PURGE_DERIVED` risk
- label checked-in Grafana credentials as local-development-only
- validate effective rendered Compose ports, dependencies, and network mode
- replace the remediation plan's dense changelog with a concise version list and task-status table

## Why
The base stack exposed backing and monitoring services on every host interface. Inter-container traffic already uses the Compose network, so those host bindings were unnecessary and increased the reachable attack surface.

## Trust-boundary impact
The Docker host boundary is narrowed. Base Compose now exposes only the API and frontend. Operator-only services are reachable from the host only when explicitly selected through the development overlay, and then only on `127.0.0.1`. No credential values, image versions, service dependencies, or container-network paths changed. This implements the T-SEC-1 reachable-posture control in `SECURITY.md`.

## Risk and compatibility
Existing running containers retain their current published ports until recreated after merge. Operators who need direct database, search, cache, or monitoring access must use the documented service-scoped overlay command. Using that overlay for the full stack remains unsafe because it enables `STARTUP_PURGE_DERIVED=true`.

## Verification
- PASS: `docker compose -f docker-compose.yml config --quiet`
- PASS: `docker compose -f docker-compose.yml -f docker-compose.dev.yml config --quiet`
- PASS: `./.venv/bin/ruff check .`
- PASS: `./.venv/bin/pre-commit run ruff --all-files`
- PASS: `./.venv/bin/ruff format --check . --config ruff-format.toml`
- PASS: `./.venv/bin/mypy`
- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_docker_build_contracts.py` (15 passed)
- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_startup_purge_gating.py` (4 passed)
- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py` (2 passed)
- PASS: `PYTHONPATH=. .venv/bin/pytest -q` (1129 passed)
- PASS: `git diff --check`
- PASS: independent pre-commit review, no remaining P1/P2 findings

## Remaining deficit
After merge, recreate affected services and verify host listeners. No runtime recreation was performed from this branch.
