### PR TITLE
T-CI-2A: Record the active frontend merge gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,10 +198,8 @@ authoritative CI verification is the full test suite run by both jobs on every
 pull request (`python-guardrails` for Python, `frontend-tests` for the
 frontend). The Python suite runs under the production scope and coverage floor
 configured in `.coveragerc`. A passing matrix row is necessary for proceeding,
-not sufficient for merge.
-[transition: both jobs run on every pull request, but only
-`python-guardrails` is mandatory until T-CI-2A adds `frontend-tests` to the
-required-check ruleset.]
+not sufficient for merge. Both jobs are mandatory under the active
+default-branch ruleset.
 
 All commands in applicable row(s) are mandatory, not advisory.
 If no row applies, run `PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py` at minimum.
@@ -255,7 +253,6 @@ Frontend contract changes (`frontend/**` affecting API/task/search behavior):
 
 Frontend component/behavior changes (`frontend/**` JS/JSX):
 - `cd frontend && npm test`
-  [transition: the runner is live; T-CI-2A makes its CI context mandatory]
 
 Broad cross-cutting changes:
 - Required: run all applicable rows above.

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -12,7 +12,9 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 - **v2.6:** Records operator approval and live activation of the T-CI-2A
   frontend required check. Final completion remains pending until the policy
-  record merges under both required checks and post-merge readback passes.
+  record merges under both required checks and post-merge readback passes. It
+  also retires T-CI-2's unsafe standalone rollback; any reversal must coordinate
+  the ruleset, producer, guardrails, dependency contract, and policy text.
 - **v2.5:** Records T-SEC-1 completion after local verification, independent
   review, and green pull-request checks.
 - **v2.4:** Records T-CI-3 completion and expands T-SEC-1 ownership so
@@ -253,6 +255,8 @@ in `AGENTS.md`, `docs/TESTING.MD`, and
 - status: live policy active; merge verification pending
 - files_owned: docs/plans/T_CI_2_REQUIRED_CHECK_POLICY_PLAN.md (new),
   docs/plans/T_CI_1_REQUIRED_CHECK_POLICY_PLAN.md,
+  docs/plans/T_CI_2_FRONTEND_TESTS_PLAN.md (historical ruleset evidence and
+  rollback section only),
   docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md, AGENTS.md (verification-matrix
   CI-status paragraph and transition markers only),
   pipeline/requirements-dev.txt,

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,6 +1,6 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 2.5
+version: 2.6
 generated: 2026-07-23
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
@@ -10,6 +10,9 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v2.6:** Records operator approval and live activation of the T-CI-2A
+  frontend required check. Final completion remains pending until the policy
+  record merges under both required checks and post-merge readback passes.
 - **v2.5:** Records T-SEC-1 completion after local verification, independent
   review, and green pull-request checks.
 - **v2.4:** Records T-CI-3 completion and expands T-SEC-1 ownership so
@@ -49,7 +52,7 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 | State | Tasks |
 |---|---|
 | **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-3, T-CI-4, T-CI-5, T-SEC-1 |
-| **Awaiting operator approval** | T-CI-2A |
+| **Live policy active; merge verification pending** | T-CI-2A |
 | **Partially landed; acceptance incomplete** | T-GOV-4, T-GOV-5, T-GOV-6 |
 | **Pending** | T-SEC-2..6, T-TIME-1..3, T-CRAWL-1..2, T-DA-1, T-DB-1, T-DC-1, T-DD-1, T-DE-1, T-PLAT-1..4, T-GOV-1..3 |
 
@@ -200,17 +203,17 @@ in `AGENTS.md`, `docs/TESTING.MD`, and
 - external_state_owned: repository ruleset `Require Python Guardrails`
 - decision: Approved by the operator on 2026-07-22 using the exact active
   ruleset payload in `docs/plans/T_CI_1_REQUIRED_CHECK_POLICY_PLAN.md`.
-- do: Maintain the active default-branch ruleset with no bypass actors. Its
-  sole required context is GitHub Actions `python-guardrails` from integration
-  15368, evaluated against the latest default-branch code.
-- accept: GitHub reports the ruleset active; its only required status context
-  is `python-guardrails`; the target is the default branch; no actor can bypass
-  it; branch creation remains exempt; T-CI-1's complete-suite check is
-  mandatory before the ref can update.
+- do: Maintain `python-guardrails` from integration 15368 as the foundational
+  required context. T-CI-2A now also requires `frontend-tests` under separate
+  operator approval.
+- accept: T-CI-1A's historical Python-only activation evidence remains
+  recorded. Current acceptance is owned by T-CI-2A and must preserve the
+  default-branch target, empty bypass list, strict policy, branch-creation
+  exemption, and mandatory Python gate.
 - forbidden: Requiring approvals, CodeQL, deployments, signed commits, linear
-  history, or any check other than `python-guardrails` before T-CI-2A is
-  approved and T-CI-2 is green; adding bypass actors; changing workflow code
-  or repository files outside `files_owned`.
+  history, or an unapproved third check; removing `python-guardrails`; adding
+  bypass actors; changing workflow code or repository files outside
+  `files_owned`.
 - verify: Read the ruleset back through GitHub's REST API and compare target,
   enforcement, conditions, bypass actors, context, integration, strict policy,
   and effective rules on `master` with the expected contract.
@@ -247,8 +250,7 @@ in `AGENTS.md`, `docs/TESTING.MD`, and
 ### T-CI-2A: Require the universal frontend test check
 - priority: P0
 - depends_on: T-CI-2
-- status: planning and scalar-parity guardrail complete; live policy update
-  awaits operator approval
+- status: live policy active; merge verification pending
 - files_owned: docs/plans/T_CI_2_REQUIRED_CHECK_POLICY_PLAN.md (new),
   docs/plans/T_CI_1_REQUIRED_CHECK_POLICY_PLAN.md,
   docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md, AGENTS.md (verification-matrix
@@ -259,16 +261,16 @@ in `AGENTS.md`, `docs/TESTING.MD`, and
   tests/test_repository_guardrails.py
   (canonical frontend required-check job identity only)
 - external_state_owned: repository ruleset `Require Python Guardrails`
-- decision_required: Operator approval of an exact update to ruleset 19594795
-  that adds GitHub Actions context `frontend-tests` from integration 15368
-  while preserving every T-CI-1A field.
+- decision: Operator approved the exact semantic ruleset update on 2026-07-23.
+  Live direct and effective readbacks require `frontend-tests` from integration
+  15368 alongside `python-guardrails` while preserving every other T-CI-1A
+  field.
 - implementation_plan: `docs/plans/T_CI_2_REQUIRED_CHECK_POLICY_PLAN.md`
-- do: After T-CI-2 is green on frontend and non-frontend pull requests, update
-  ruleset 19594795 so its required status checks are exactly
-  `python-guardrails` and `frontend-tests`. Replace stale landed-task
-  transition text with accurate T-CI-2A-pending text in the planning PR, then
-  remove both temporary markers only after live readback proves both checks
-  are mandatory.
+- do: Preserve ruleset 19594795 with exactly `python-guardrails` and
+  `frontend-tests` required. Merge the live-policy record under both checks,
+  verify direct and effective policy after `master` advances, obtain explicit
+  operator acceptance of the documented digest-approval deviation, then mark
+  T-CI-2A complete in a separate closure PR.
 - accept: Every pull request receives both contexts; the default branch cannot
   update unless both pass; strict policy, branch-creation exemption, empty
   bypass list, target, and all other T-CI-1A fields remain unchanged. Workflow
@@ -278,8 +280,9 @@ in `AGENTS.md`, `docs/TESTING.MD`, and
   adding any third check or rule; changing the existing Python gate; assuming
   approval from T-CI-1A.
 - verify: Demonstrate `frontend-tests` on one frontend and one non-frontend PR,
-  update the ruleset once, and assert exact ruleset and effective-`master`
-  readback through the pinned GitHub REST API.
+  preserve the one-time update evidence, require both checks on the policy
+  record PR, and assert exact ruleset and effective-`master` readback after
+  each default-branch advance.
 - rollback: Restore ruleset 19594795 to the exact T-CI-1A Python-only contract;
   never delete the ruleset or remove `python-guardrails` while rolling back the
   frontend requirement. Replace T-CI-1A's original creation-time rollback in

--- a/docs/plans/T_CI_1_REQUIRED_CHECK_POLICY_PLAN.md
+++ b/docs/plans/T_CI_1_REQUIRED_CHECK_POLICY_PLAN.md
@@ -9,6 +9,7 @@ implementation_status: complete
 external_state_status: active
 external_ruleset_id: 19594795
 activated: 2026-07-22
+current_required_checks: python-guardrails, frontend-tests
 
 ## 1. Context & Alignment
 
@@ -94,9 +95,10 @@ may be added or altered without a new decision.
    required-status-check rule.
 8. Confirm no second ruleset or legacy branch-protection policy was created.
 9. Keep `python-guardrails` as the sole required check until T-CI-2 runs a
-   stable `frontend-tests` context on every pull request. T-CI-2A then requires
-   a separate operator-approved update to this ruleset; this task does not
-   pre-authorize that future gate change.
+   stable `frontend-tests` context on every pull request. This historical
+   condition was satisfied before the operator separately approved T-CI-2A on
+   2026-07-23. The live ruleset now requires both contexts; T-CI-1A remains the
+   record of the foundational Python gate.
 
 No new function or module is added. The GitHub REST API remains the sole owner
 of external repository policy.
@@ -137,12 +139,11 @@ No wrapper, compatibility path, duplicate workflow, weakened test, ignored
 failure, broad edit, or import-time work is introduced. The ruleset is one
 source of enforcement rather than a second implementation of CI.
 
-**o) Ratchets.** Old value: zero default-branch protection rules and zero
-required checks. New value: one active default-branch ruleset requiring only
-`python-guardrails`. Remaining deficit: `frontend-tests` cannot become required
-until T-CI-2 emits that context on every pull request and T-CI-2A receives
-separate operator approval. Ruff, Mypy, coverage, formatter, and runtime policy
-remain unchanged.
+**o) Ratchets.** T-CI-1A changed the value from zero default-branch protection
+rules and zero required checks to one active default-branch ruleset requiring
+`python-guardrails`. T-CI-2A later added `frontend-tests` under separate
+operator approval. Ruff, Mypy, coverage, formatter, and runtime policy remain
+unchanged.
 
 **p) Dead code and duplication.** None. No existing protection policy is
 superseded because none exists. Expected tracked line delta is documentation
@@ -266,13 +267,12 @@ ruleset is active; do not duplicate the ruleset JSON into other docs.
 required check before T-CI-2A, external policy outside the default branch, or
 tracked file outside the two-file ownership set.
 
-**y) Evidence.** Ruleset 19594795 is active and exact REST readback confirms
-the approved target, enforcement, conditions, bypass list, sole required
-check, strict policy, and branch-creation exemption. Effective rules on
-`master` contain that sole rule; legacy branch protection remains absent.
-Report the docs-link result as canonical-map coverage only, plus the manual
-plan diff review, diff check, and rollback command. Mark GitHub UI behavior not
-directly exercised as `NOT VERIFIED` rather than inferring it.
+**y) Evidence.** T-CI-1A's activation evidence confirmed the original
+Python-only contract. The current exact REST readback is owned by T-CI-2A and
+confirms that ruleset 19594795 now requires both `python-guardrails` and
+`frontend-tests` while preserving the target, enforcement, conditions, empty
+bypass list, strict policy, and branch-creation exemption. Mark GitHub UI
+behavior not directly exercised as `NOT VERIFIED` rather than inferring it.
 
 **z) Deviations.** Expected result is none. Any API field change, additional
 ruleset, bypass, unverified readback, or tracked path outside ownership blocks

--- a/docs/plans/T_CI_2_FRONTEND_TESTS_PLAN.md
+++ b/docs/plans/T_CI_2_FRONTEND_TESTS_PLAN.md
@@ -274,7 +274,8 @@ only non-frontend policy documents and supplies the non-frontend
 demonstration. Do not update the ruleset until both checks are terminal and
 green.
 
-Read back the unchanged Python-only ruleset before delivery:
+Historical delivery evidence before T-CI-2A activation read back the unchanged
+Python-only ruleset:
 
 ```bash
 gh api repos/manumissio/town-council/rulesets/19594795 |
@@ -291,7 +292,7 @@ gh api repos/manumissio/town-council/rulesets/19594795 |
   '
 ```
 
-Expected required checks remain exactly:
+At that time, expected required checks remained exactly:
 
 The comparison exits zero only when `python-guardrails` is the sole required
 context, integration ID `15368` is preserved, strict checking remains enabled,
@@ -299,33 +300,35 @@ and branch creation remains exempt.
 
 **v) Rollback.**
 
-```bash
-git switch master
-git merge --ff-only origin/master
-git revert -m 1 <t_ci_2_merge_commit_sha>
-./.venv/bin/ruff check .
-./.venv/bin/mypy
-PYTHONPATH=. .venv/bin/pytest -q tests/test_repository_guardrails.py
-PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py
-PYTHONPATH=. .venv/bin/pytest -q
-test ! -e .github/workflows/frontend-tests.yml
-gh api repos/manumissio/town-council/rulesets/19594795 |
-  jq -e '
-    [.rules[] | select(.type == "required_status_checks") | .parameters] ==
-    [{
-      "do_not_enforce_on_create": true,
-      "required_status_checks": [{
-        "context": "python-guardrails",
-        "integration_id": 15368
-      }],
-      "strict_required_status_checks_policy": true
-    }]
-  '
-```
+Standalone T-CI-2 rollback is retired after T-CI-2A activation. Do not revert
+T-CI-2 or remove `.github/workflows/frontend-tests.yml`: that would remove the
+only producer of a required context while leaving its ruleset requirement,
+producer-identity guardrail, development dependency contract, and current
+policy text active.
 
-No migration, data remediation, dependency rollback, or external-state
-cleanup is required. Rollback knowingly removes the frontend merge signal;
-ruleset 19594795 must still require only `python-guardrails`.
+A future reversal requires a separately operator-approved Full task with
+explicit ownership of the external ruleset and every tracked T-CI-2/T-CI-2A
+contract it retires. Its ordered procedure must:
+
+1. Restore the exact Python-only contract through
+   `docs/plans/T_CI_2_REQUIRED_CHECK_POLICY_PLAN.md`.
+2. Prove ruleset `19594795` is the only repository ruleset, remains named
+   `Require Python Guardrails`, has repository source
+   `manumissio/town-council` and source type `Repository`, targets only the
+   default branch, remains active with no bypass actors, requires only
+   `python-guardrails` from integration `15368`, keeps strict checking and the
+   branch-creation exemption, has no extra rule or legacy branch protection,
+   and matches the effective-`master` readback.
+3. Retire the frontend producer-identity guardrail, its development dependency
+   contract, and current policy text in the same coordinated change that
+   removes the workflow.
+4. Run every applicable guardrail, dependency, frontend, docs, and complete
+   suite check before merge.
+5. Repeat direct and effective Python-only ruleset readbacks after the default
+   branch advances.
+
+This historical plan does not authorize that future policy reversal. No
+migration or data remediation is involved.
 
 **w) Docs synchronization.**
 

--- a/docs/plans/T_CI_2_REQUIRED_CHECK_POLICY_PLAN.md
+++ b/docs/plans/T_CI_2_REQUIRED_CHECK_POLICY_PLAN.md
@@ -350,7 +350,16 @@ post-merge recheck.
 
 **u) Exact commands.**
 
-Repository setup:
+The activation sequence below is historical audit evidence. It completed on
+2026-07-23 and **none of its repository setup, Python-only precondition,
+approval-artifact, or mutation commands may be rerun**. Current remaining work
+is limited to merging the completion record under both required checks,
+performing its post-merge direct and effective two-check readbacks, obtaining
+explicit operator acceptance of the deviation in 7z, merging the final closure
+record under both required checks, and repeating the policy readbacks after
+that second default-branch advance.
+
+Historical repository setup:
 
 ```bash
 git fetch origin --prune
@@ -605,10 +614,9 @@ jq . "$RULESET_REQUEST"
 shasum -a 256 "$RULESET_REQUEST"
 ```
 
-Historical activation procedure follows for auditability. It completed once on
-2026-07-23 and **must not be rerun**. Before activation, the procedure required
-approval of both displayed JSON documents and digests, an exclusive ruleset
-change window, and one fail-closed mutation block:
+The historical mutation procedure required approval of both displayed JSON
+documents and digests, an exclusive ruleset change window, and one fail-closed
+mutation block:
 
 ```bash
 set -euo pipefail

--- a/docs/plans/T_CI_2_REQUIRED_CHECK_POLICY_PLAN.md
+++ b/docs/plans/T_CI_2_REQUIRED_CHECK_POLICY_PLAN.md
@@ -45,6 +45,8 @@ both checks and the post-merge ruleset readback passes.
 
 - `docs/plans/T_CI_2_REQUIRED_CHECK_POLICY_PLAN.md`
 - `docs/plans/T_CI_1_REQUIRED_CHECK_POLICY_PLAN.md`
+- `docs/plans/T_CI_2_FRONTEND_TESTS_PLAN.md`, historical ruleset evidence and
+  rollback section only
 - `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`
 - `AGENTS.md`, verification-matrix CI-status paragraph and transition markers
   only
@@ -116,6 +118,9 @@ to block Phase 2.
     - mark T-CI-2A `live policy active; merge verification pending`;
     - update T-CI-1A's current-state wording without erasing its historical
       decision;
+    - retire T-CI-2's now-unsafe standalone rollback and require a separately
+      authorized coordinated reversal of the ruleset, producer, guardrails,
+      dependency contract, and policy text;
     - remove the two T-CI-2A-pending transition annotations from
       `AGENTS.md`.
 12. Run documentation verification and obtain a fresh subagent pre-commit
@@ -259,7 +264,7 @@ The external mutation is fail-fast and preceded by exact drift detection.
   planning PR before any live policy change; no destructive fallback survives.
 - D1-D3 corrected: no test is weakened or mocked; live policy equality is the
   observable contract.
-- E1-E3 corrected: only the seven tracked owned files and one owned external
+- E1-E3 corrected: only the eight tracked owned files and one owned external
   ruleset may change.
 - A4, B3, C2, F2, H2-H4: no planned violations.
 
@@ -275,8 +280,10 @@ The external mutation is fail-fast and preceded by exact drift detection.
 
 **p) Dead code and duplication audit.** Replace two obsolete transition
 annotations with accurate pending text, then remove that text after activation.
-Remove the obsolete ruleset-deletion rollback. Reuse all existing CI producers
-and readback commands. Runtime-code delta is zero.
+Remove the obsolete ruleset-deletion rollback and retire the unsafe T-CI-2
+standalone procedure, which cannot also reconcile later T-CI-2A guardrails and
+policy. Reuse all existing CI producers and readback commands. Runtime-code
+delta is zero.
 
 ## 5. Testing
 
@@ -1213,6 +1220,9 @@ rollback guidance in T-CI-1A.
   T-CI-2A progress, approval, and final completion.
 - `docs/plans/T_CI_1_REQUIRED_CHECK_POLICY_PLAN.md` replaces the obsolete
   ruleset-deletion rollback in the planning PR before the live update.
+- `docs/plans/T_CI_2_FRONTEND_TESTS_PLAN.md` preserves its historical
+  pre-activation evidence and retires standalone rollback after T-CI-2A
+  activation.
 - `AGENTS.md` first replaces stale landed-task annotations with accurate
   T-CI-2A-pending text, then removes that temporary text after live readback.
 - `tests/test_repository_guardrails.py` enforces one canonical repository-wide

--- a/docs/plans/T_CI_2_REQUIRED_CHECK_POLICY_PLAN.md
+++ b/docs/plans/T_CI_2_REQUIRED_CHECK_POLICY_PLAN.md
@@ -5,14 +5,20 @@
 `execution: code`
 `task: T-CI-2A`
 `lane: CI`
+`implementation_status: live policy active; merge verification pending`
+`external_state_status: active`
+`external_ruleset_id: 19594795`
+`approved: 2026-07-23`
+`activated: 2026-07-23`
 
 ## 1. Context & Alignment
 
-**a) Driver.** T-CI-2 is merged and now emits `frontend-tests` on every pull
-request and every push to `master`. The active default-branch ruleset still
-requires only `python-guardrails`, so a frontend regression can remain
-mergeable even when the frontend test job fails. T-CI-2A closes that gap after
-one frontend and one non-frontend pull request prove the context is universal.
+**a) Driver.** T-CI-2 emits `frontend-tests` on every pull request and every
+push to `master`. Before T-CI-2A activation, the default-branch ruleset required
+only `python-guardrails`, so a frontend regression could remain mergeable even
+when the frontend test job failed. The approved live update now requires both
+checks. Final completion remains pending until this policy record merges under
+both checks and the post-merge ruleset readback passes.
 
 **b) Canonical documents consulted.**
 
@@ -27,8 +33,8 @@ one frontend and one non-frontend pull request prove the context is universal.
 - `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md` requires T-CI-2A after T-CI-2
   and grants ownership of the live ruleset.
 - `docs/plans/T_CI_1_REQUIRED_CHECK_POLICY_PLAN.md` records every field in the
-  current Python-only ruleset and requires T-CI-2A to replace its obsolete
-  deletion rollback.
+  historical Python-only contract and requires T-CI-2A to preserve its
+  non-destructive rollback.
 - `docs/plans/T_CI_2_FRONTEND_TESTS_PLAN.md` records the universal workflow,
   its exact job context, and the required frontend/non-frontend proof.
 - `docs/reviews/architecture-review-2026-07-19.html` historically identified
@@ -51,10 +57,10 @@ one frontend and one non-frontend pull request prove the context is universal.
 
 No workflow, runtime package, runtime behavior, or application file may change.
 
-**d) Decision-gate check.** No G1-G5 gate applies. T-CI-2A has its own explicit
-operator decision. Repository planning work may proceed, but the ruleset
-`PUT` must not run until the operator approves the exact old and new contracts
-recorded below. G3 remains open and continues to block Phase 2.
+**d) Decision-gate check.** No G1-G5 gate applies. The operator explicitly
+approved the T-CI-2A ruleset update on 2026-07-23, and the live direct and
+effective readbacks match the contracts below. G3 remains open and continues
+to block Phase 2.
 
 ## 2. Design
 
@@ -117,9 +123,11 @@ recorded below. G3 remains open and continues to block Phase 2.
 13. Commit and push the completion policy record, open a second PR, wait for
     all checks, request review, merge, and verify the ruleset again after the
     default branch advances.
-14. Open a final closure PR that records T-CI-2A complete only after the
-    post-merge ruleset and effective-`master` readbacks pass. Merge it after
-    both required checks pass, then repeat the policy readback.
+14. Obtain explicit operator acceptance of the digest-approval deviation
+    recorded in 7z. Then open a final closure PR that records T-CI-2A complete
+    only after that acceptance and the post-merge ruleset and
+    effective-`master` readbacks pass. Merge it after both required checks
+    pass, then repeat the policy readback.
 
 No production function, module, workflow, helper script, compatibility path,
 or new configuration surface is added. The guardrail test uses the direct
@@ -141,7 +149,7 @@ that accidental relationship. It remains absent from runtime requirements.
 
 **g) Data contracts.**
 
-Current contract:
+Historical pre-activation contract:
 
 ```json
 {
@@ -170,7 +178,7 @@ Current contract:
 }
 ```
 
-Proposed contract:
+Activated live contract:
 
 ```json
 {
@@ -590,10 +598,10 @@ jq . "$RULESET_REQUEST"
 shasum -a 256 "$RULESET_REQUEST"
 ```
 
-After approval of both displayed JSON documents and digests, establish the
-exclusive ruleset change window, export `APPROVED_PRESTATE_SHA256` and
-`APPROVED_REQUEST_SHA256` with those exact digests, and run one fail-closed
-mutation block:
+Historical activation procedure follows for auditability. It completed once on
+2026-07-23 and **must not be rerun**. Before activation, the procedure required
+approval of both displayed JSON documents and digests, an exclusive ruleset
+change window, and one fail-closed mutation block:
 
 ```bash
 set -euo pipefail
@@ -1199,8 +1207,8 @@ rollback guidance in T-CI-1A.
 
 **w) Docs synchronization.**
 
-- This plan records the proposed request and defines how approval, evidence,
-  rollback, and final state will be recorded.
+- This plan records the activated request and defines how approval, evidence,
+  rollback, and final state are recorded.
 - `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md` records T-CI-2 completion,
   T-CI-2A progress, approval, and final completion.
 - `docs/plans/T_CI_1_REQUIRED_CHECK_POLICY_PLAN.md` replaces the obsolete
@@ -1222,15 +1230,35 @@ extra check, bypass actor, copied API response as request, missing drift check,
 workflow edit, new script, weakened evidence, unrelated documentation edit,
 or transition removal before live proof.
 
-**y) Evidence.** Report PASS/FAIL for the Python-only precondition, expected
-two-check assertion failure, frontend and non-frontend PR contexts,
-integration IDs, explicit approval, update response, exact direct and
-effective readbacks, ruleset count, docs-link test, diff check, subagent
-planning and pre-commit review findings, commits, PR URL, unresolved-thread
-count, CI state, merge, and post-merge policy readback. Anything unrun is
-`NOT VERIFIED`.
+**y) Evidence.** On 2026-07-23, the operator approved the exact semantic
+transition from one required check to two. The fail-closed update produced a
+live direct and effective readback with:
 
-**z) Deviations.** The expected deviation report is none. Any changed tracked
-path outside the seven owned files, any external policy field outside the
-approved request, missing frontend/non-frontend proof, skipped review,
-unresolved P1/P2, or unrun required check is a blocker.
+- ruleset ID `19594795`, target `branch`, enforcement `active`;
+- exactly one repository ruleset and no legacy branch protection (`404`);
+- default-branch-only condition and no bypass actors;
+- strict required-check policy and branch-creation exemption unchanged;
+- required contexts `python-guardrails` and `frontend-tests`, both from
+  integration `15368`;
+- observed update timestamp `2026-07-23T11:23:01.116-04:00`.
+
+The canonical pre-state SHA-256 was
+`335bce222d1664b91fd89e0eb16cc687654e1b24913f60ef78842bf69f04f98d`;
+the request SHA-256 was
+`9d0fd138be8c765b451098898c714c5cc50001333f07c0937835537d8e464065`.
+This completion-record pull request and its post-merge policy readback remain
+pending and must be reported separately before T-CI-2A is marked complete.
+Final closure also requires explicit operator acceptance of the procedural
+deviation below.
+
+**z) Deviations.** The operator approved the exact semantic old and new
+contracts after they were displayed, but did not separately approve the
+generated SHA-256 values before the update. The live request changed no field
+outside that approved semantic contract, and complete direct and effective
+readbacks matched it. The first shell attempt was rejected before execution
+because it contained a prohibited cleanup command, so it changed no external
+state; the corrected fail-closed attempt performed the one approved update.
+This process deviation is recorded rather than hidden. The remaining
+acceptance path requires explicit operator acceptance of this deviation, both
+mandatory checks on this record PR, and a fresh post-merge readback. No tracked
+path outside ownership may change.


### PR DESCRIPTION
## What changed

- records the approved live ruleset requiring both `python-guardrails` and `frontend-tests`
- preserves T-CI-1A as the historical Python-only activation record
- removes obsolete T-CI-2A transition markers from `AGENTS.md`
- keeps T-CI-2A at `live policy active; merge verification pending`

## Why

The external policy is active, but the repository still described `frontend-tests` as optional. This PR makes tracked policy match the live ruleset without prematurely marking T-CI-2A complete.

## Risk and compatibility

Documentation and repository policy text only. No workflow, runtime, API, data, or application behavior changes. The active ruleset remains unchanged.

## Verification

- PASS: `PYTHONPATH=. <REPO_VENV>/bin/pytest -q tests/test_docs_links.py` (`2 passed`)
- PASS: `PYTHONPATH=. <REPO_VENV>/bin/pytest -q tests/test_repository_guardrails.py` (`113 passed`)
- PASS: `git diff --check`
- PASS: direct ruleset and effective-`master` readbacks match both required checks, strict mode, branch-creation exemption, default-branch target, and empty bypass list
- PASS: one repository ruleset; legacy branch protection absent (`404`)
- PASS: independent planning and pre-commit reviews; no remaining P1/P2 findings

## Remaining deficits

T-CI-2A remains open until this PR passes both required checks and merges, the live policy is read back again after `master` advances, and the operator explicitly accepts the documented digest-approval deviation. G3 remains open and continues to block Phase 2.
