### PR TITLE
T-CI-2A: Close the frontend required-check policy task

### DIFF
--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,6 +1,6 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 2.6
+version: 2.7
 generated: 2026-07-23
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
@@ -10,6 +10,12 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v2.7:** Marks T-CI-2A complete after PR #120 merged under both required
+  checks, the direct and effective ruleset readbacks passed against the
+  advanced default branch, and the operator explicitly accepted the recorded
+  digest-approval deviation. The closure record still must merge under both
+  checks and receive the final no-drift readback required by its delivery
+  procedure.
 - **v2.6:** Records operator approval and live activation of the T-CI-2A
   frontend required check. Final completion remains pending until the policy
   record merges under both required checks and post-merge readback passes. It
@@ -53,8 +59,7 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 | State | Tasks |
 |---|---|
-| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-3, T-CI-4, T-CI-5, T-SEC-1 |
-| **Live policy active; merge verification pending** | T-CI-2A |
+| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1 |
 | **Partially landed; acceptance incomplete** | T-GOV-4, T-GOV-5, T-GOV-6 |
 | **Pending** | T-SEC-2..6, T-TIME-1..3, T-CRAWL-1..2, T-DA-1, T-DB-1, T-DC-1, T-DD-1, T-DE-1, T-PLAT-1..4, T-GOV-1..3 |
 
@@ -252,7 +257,7 @@ in `AGENTS.md`, `docs/TESTING.MD`, and
 ### T-CI-2A: Require the universal frontend test check
 - priority: P0
 - depends_on: T-CI-2
-- status: live policy active; merge verification pending
+- status: complete and verified 2026-07-23
 - files_owned: docs/plans/T_CI_2_REQUIRED_CHECK_POLICY_PLAN.md (new),
   docs/plans/T_CI_1_REQUIRED_CHECK_POLICY_PLAN.md,
   docs/plans/T_CI_2_FRONTEND_TESTS_PLAN.md (historical ruleset evidence and
@@ -268,13 +273,14 @@ in `AGENTS.md`, `docs/TESTING.MD`, and
 - decision: Operator approved the exact semantic ruleset update on 2026-07-23.
   Live direct and effective readbacks require `frontend-tests` from integration
   15368 alongside `python-guardrails` while preserving every other T-CI-1A
-  field.
+  field. After PR #120 merged under both checks, those readbacks passed against
+  the advanced default branch and the operator explicitly accepted the
+  documented digest-approval deviation.
 - implementation_plan: `docs/plans/T_CI_2_REQUIRED_CHECK_POLICY_PLAN.md`
 - do: Preserve ruleset 19594795 with exactly `python-guardrails` and
-  `frontend-tests` required. Merge the live-policy record under both checks,
-  verify direct and effective policy after `master` advances, obtain explicit
-  operator acceptance of the documented digest-approval deviation, then mark
-  T-CI-2A complete in a separate closure PR.
+  `frontend-tests` required. Keep the merged live-policy record and accepted
+  procedural deviation as the audit trail. Merge the closure record under both
+  checks and repeat the no-drift readback after `master` advances.
 - accept: Every pull request receives both contexts; the default branch cannot
   update unless both pass; strict policy, branch-creation exemption, empty
   bypass list, target, and all other T-CI-1A fields remain unchanged. Workflow

--- a/docs/plans/T_CI_2_REQUIRED_CHECK_POLICY_PLAN.md
+++ b/docs/plans/T_CI_2_REQUIRED_CHECK_POLICY_PLAN.md
@@ -5,8 +5,8 @@
 `execution: code`
 `task: T-CI-2A`
 `lane: CI`
-`implementation_status: live policy active; merge verification pending`
-`external_state_status: active`
+`implementation_status: complete`
+`external_state_status: active and verified`
 `external_ruleset_id: 19594795`
 `approved: 2026-07-23`
 `activated: 2026-07-23`
@@ -17,8 +17,9 @@
 push to `master`. Before T-CI-2A activation, the default-branch ruleset required
 only `python-guardrails`, so a frontend regression could remain mergeable even
 when the frontend test job failed. The approved live update now requires both
-checks. Final completion remains pending until this policy record merges under
-both checks and the post-merge ruleset readback passes.
+checks. PR #120 merged under both required checks, its post-merge direct and
+effective readbacks passed, and the operator explicitly accepted the recorded
+digest-approval deviation.
 
 **b) Canonical documents consulted.**
 
@@ -60,9 +61,9 @@ both checks and the post-merge ruleset readback passes.
 No workflow, runtime package, runtime behavior, or application file may change.
 
 **d) Decision-gate check.** No G1-G5 gate applies. The operator explicitly
-approved the T-CI-2A ruleset update on 2026-07-23, and the live direct and
-effective readbacks match the contracts below. G3 remains open and continues
-to block Phase 2.
+approved the T-CI-2A ruleset update and accepted its recorded procedural
+deviation on 2026-07-23. The live direct and effective readbacks match the
+contracts below. G3 remains open and continues to block Phase 2.
 
 ## 2. Design
 
@@ -132,7 +133,9 @@ to block Phase 2.
     recorded in 7z. Then open a final closure PR that records T-CI-2A complete
     only after that acceptance and the post-merge ruleset and
     effective-`master` readbacks pass. Merge it after both required checks
-    pass, then repeat the policy readback.
+    pass, then repeat the policy readback. The acceptance and first post-merge
+    readback completed on 2026-07-23; only closure delivery and its final
+    no-drift readback remain.
 
 No production function, module, workflow, helper script, compatibility path,
 or new configuration surface is added. The guardrail test uses the direct
@@ -352,12 +355,11 @@ post-merge recheck.
 
 The activation sequence below is historical audit evidence. It completed on
 2026-07-23 and **none of its repository setup, Python-only precondition,
-approval-artifact, or mutation commands may be rerun**. Current remaining work
-is limited to merging the completion record under both required checks,
-performing its post-merge direct and effective two-check readbacks, obtaining
-explicit operator acceptance of the deviation in 7z, merging the final closure
-record under both required checks, and repeating the policy readbacks after
-that second default-branch advance.
+approval-artifact, or mutation commands may be rerun**. PR #120 subsequently
+merged under both required checks, its direct and effective readbacks passed,
+and the operator explicitly accepted the deviation in 7z. The final delivery
+sequence is limited to merging this closure record under both required checks
+and repeating the no-drift policy readbacks after that default-branch advance.
 
 Historical repository setup:
 
@@ -1264,10 +1266,13 @@ The canonical pre-state SHA-256 was
 `335bce222d1664b91fd89e0eb16cc687654e1b24913f60ef78842bf69f04f98d`;
 the request SHA-256 was
 `9d0fd138be8c765b451098898c714c5cc50001333f07c0937835537d8e464065`.
-This completion-record pull request and its post-merge policy readback remain
-pending and must be reported separately before T-CI-2A is marked complete.
-Final closure also requires explicit operator acceptance of the procedural
-deviation below.
+PR #120 merged as `28d42a50ae574c6c5c8e83d07ed2e0830b497024`
+after `frontend-tests`, `python-guardrails`, and all other checks passed. The
+subsequent direct and effective readbacks matched the contract above, exactly
+one repository ruleset remained, and legacy branch protection remained absent
+with a `404` response. The operator explicitly accepted the procedural
+deviation below on 2026-07-23. T-CI-2A is complete; this closure record must
+still merge under both required checks and receive the final no-drift readback.
 
 **z) Deviations.** The operator approved the exact semantic old and new
 contracts after they were displayed, but did not separately approve the
@@ -1276,7 +1281,7 @@ outside that approved semantic contract, and complete direct and effective
 readbacks matched it. The first shell attempt was rejected before execution
 because it contained a prohibited cleanup command, so it changed no external
 state; the corrected fail-closed attempt performed the one approved update.
-This process deviation is recorded rather than hidden. The remaining
-acceptance path requires explicit operator acceptance of this deviation, both
-mandatory checks on this record PR, and a fresh post-merge readback. No tracked
-path outside ownership may change.
+This process deviation is recorded rather than hidden. The operator explicitly
+accepted it on 2026-07-23 after reviewing the semantic contract and recorded
+digests. The closure PR still requires both mandatory checks and a fresh
+post-merge no-drift readback. No tracked path outside ownership may change.


### PR DESCRIPTION
## What changed

- mark T-CI-2A complete in the remediation registry
- record PR #120's successful merge under both required checks
- record the successful direct and effective ruleset readbacks
- record the operator's explicit acceptance of the digest-approval deviation
- retain the final no-drift readback requirement after this closure PR merges

## Why

The live two-check policy is active and verified, its completion record merged successfully, and the remaining governance approval has now been provided. This PR closes the tracked remediation task without changing workflows or live repository policy.

## Risk and compatibility

Docs-only. No runtime, workflow, ruleset, API, schema, or dependency changes.

## Verification

- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py` (`2 passed`)
- PASS: `git diff --check`
- PASS: independent pre-commit review found no P1/P2/P3 issues
- PASS: PR #120 completed all six checks before merge
- PASS: post-merge direct and effective ruleset readbacks matched the exact two-check contract

## Remaining delivery check

After merge, repeat the direct and effective ruleset readbacks to prove no drift on the advanced default branch.
