### PR TITLE
T-SEC-2: Reject unsafe API keys at startup

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -50,8 +50,11 @@ engineering decisions is `reachable`).
 
 ## Secret policy
 
-- No working default credential may permit non-dev operation. The API
-  refuses to start with the default `API_AUTH_KEY` when `APP_ENV != dev`
+- No working default or blank credential may permit non-development
+  operation. The API refuses to start outside development with a default
+  (including surrounding whitespace), empty, or whitespace-only
+  `API_AUTH_KEY`. It rejects non-ASCII API keys in every environment because
+  the constant-time string comparison cannot authenticate them
   `[remediation: T-SEC-2]`. Extend the same pattern to any future secret.
 - No secret in a `NEXT_PUBLIC_*` variable, ever. These ship to browser
   bundles.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -71,7 +71,7 @@ engineering decisions is `reachable`).
 
 - [x] Base compose publishes only `api:8000` and `frontend:3000` (T-SEC-1)
 - [ ] Non-default values for every key in the inventory above
-- [ ] API aborts on default key outside dev (T-SEC-2)
+- [x] API aborts on default key outside dev (T-SEC-2)
 - [ ] Meilisearch search key configured for the API (T-SEC-3)
 - [ ] Client IP forwarded from proxy; limiter keys on it with trusted-proxy
       allowlist (T-SEC-4)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -53,9 +53,10 @@ engineering decisions is `reachable`).
 - No working default or blank credential may permit non-development
   operation. The API refuses to start outside development with a default
   (including surrounding whitespace), empty, or whitespace-only
-  `API_AUTH_KEY`. It rejects non-ASCII API keys in every environment because
-  the constant-time string comparison cannot authenticate them
-  `[remediation: T-SEC-2]`. Extend the same pattern to any future secret.
+  `API_AUTH_KEY`. Every nonempty API key must contain printable ASCII
+  characters without leading or trailing whitespace so HTTP header parsing
+  cannot change the authenticated value `[remediation: T-SEC-2]`. Extend the
+  same pattern to any future secret.
 - No secret in a `NEXT_PUBLIC_*` variable, ever. These ship to browser
   bundles.
 - Secrets enter via environment/.env only; `.env` is gitignored. No secrets

--- a/api/app_setup.py
+++ b/api/app_setup.py
@@ -12,10 +12,14 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import sessionmaker
 
 from pipeline.config import SEMANTIC_ENABLED
+from pipeline.config_env import env_lower, env_raw
 from pipeline.models import db_connect
 from pipeline.startup_purge import run_startup_purge_if_enabled
 
 DEFAULT_API_AUTH_KEY = "dev_secret_key_change_me"
+DEVELOPMENT_APP_ENV = "dev"
+UNSAFE_API_AUTH_KEY_MESSAGE = "API_AUTH_KEY must be set to a non-default, nonblank value when APP_ENV is not dev."
+NON_ASCII_API_AUTH_KEY_MESSAGE = "API_AUTH_KEY must contain only ASCII characters."
 DATABASE_UNAVAILABLE_DETAIL = "Database service is unavailable"
 SEMANTIC_SERVICE_URL = os.getenv("SEMANTIC_SERVICE_URL", "http://semantic:8010").rstrip("/")
 
@@ -60,7 +64,7 @@ def get_db() -> Iterator[Any]:
 
 
 async def verify_api_key(request: Request, x_api_key: str = Header(None)) -> None:
-    expected_key = os.getenv("API_AUTH_KEY", DEFAULT_API_AUTH_KEY)
+    expected_key = env_raw("API_AUTH_KEY", DEFAULT_API_AUTH_KEY)
     if not hmac.compare_digest(x_api_key or "", expected_key):
         client_ip = request.client.host if request and request.client else "unknown"
         logger.warning(
@@ -87,8 +91,16 @@ def _semantic_healthcheck_from_facade() -> dict:
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     _ = app
-    key = os.getenv("API_AUTH_KEY", DEFAULT_API_AUTH_KEY)
-    if key == DEFAULT_API_AUTH_KEY:
+    api_auth_key = env_raw("API_AUTH_KEY", DEFAULT_API_AUTH_KEY)
+    app_env = env_lower("APP_ENV", DEVELOPMENT_APP_ENV)
+    normalized_api_auth_key = api_auth_key.strip()
+    if app_env != DEVELOPMENT_APP_ENV and (
+        normalized_api_auth_key == DEFAULT_API_AUTH_KEY or not normalized_api_auth_key
+    ):
+        raise RuntimeError(UNSAFE_API_AUTH_KEY_MESSAGE)
+    if not api_auth_key.isascii():
+        raise RuntimeError(NON_ASCII_API_AUTH_KEY_MESSAGE)
+    if api_auth_key == DEFAULT_API_AUTH_KEY:
         logger.critical("SECURITY WARNING: You are using the default API Key. Please set API_AUTH_KEY in production.")
     initialize_database()
     if not is_db_ready():

--- a/api/app_setup.py
+++ b/api/app_setup.py
@@ -19,7 +19,9 @@ from pipeline.startup_purge import run_startup_purge_if_enabled
 DEFAULT_API_AUTH_KEY = "dev_secret_key_change_me"
 DEVELOPMENT_APP_ENV = "dev"
 UNSAFE_API_AUTH_KEY_MESSAGE = "API_AUTH_KEY must be set to a non-default, nonblank value when APP_ENV is not dev."
-NON_ASCII_API_AUTH_KEY_MESSAGE = "API_AUTH_KEY must contain only ASCII characters."
+HEADER_UNSAFE_API_AUTH_KEY_MESSAGE = (
+    "API_AUTH_KEY must contain printable ASCII characters without leading or trailing whitespace."
+)
 DATABASE_UNAVAILABLE_DETAIL = "Database service is unavailable"
 SEMANTIC_SERVICE_URL = os.getenv("SEMANTIC_SERVICE_URL", "http://semantic:8010").rstrip("/")
 
@@ -98,8 +100,12 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         normalized_api_auth_key == DEFAULT_API_AUTH_KEY or not normalized_api_auth_key
     ):
         raise RuntimeError(UNSAFE_API_AUTH_KEY_MESSAGE)
-    if not api_auth_key.isascii():
-        raise RuntimeError(NON_ASCII_API_AUTH_KEY_MESSAGE)
+    if api_auth_key and (
+        not api_auth_key.isascii()
+        or not api_auth_key.isprintable()
+        or api_auth_key != normalized_api_auth_key
+    ):
+        raise RuntimeError(HEADER_UNSAFE_API_AUTH_KEY_MESSAGE)
     if api_auth_key == DEFAULT_API_AUTH_KEY:
         logger.critical("SECURITY WARNING: You are using the default API Key. Please set API_AUTH_KEY in production.")
     initialize_database()

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -427,15 +427,17 @@ in `AGENTS.md`, `docs/TESTING.MD`, and
 - files_owned: docs/plans/T_SEC_2_DEFAULT_API_KEY_PLAN.md,
   docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md, api/app_setup.py,
   tests/test_api_startup_security.py, SECURITY.md
-- do: In `lifespan`, if normalized `APP_ENV != "dev"` and `API_AUTH_KEY` is
-  the checked-in default, empty, or whitespace-only, raise `RuntimeError`
-  before database, purge, or semantic startup work. Read environment values
-  through `pipeline/config_env.py`, preserve the warning in dev, and preserve
-  the raw nonblank key for request authentication.
-- accept: Non-development boot with a default or blank key aborts with a clear
-  message before downstream startup work; development behavior is unchanged;
-  a configured nonblank key starts; focused tests cover every branch without
-  uncontrolled outbound HTTP.
+- do: In `lifespan`, reject non-ASCII `API_AUTH_KEY` values in every
+  environment. When normalized `APP_ENV != "dev"`, also reject the checked-in
+  default after trimming or a blank key. Raise `RuntimeError` before database,
+  purge, or semantic startup work. Read environment values through
+  `pipeline/config_env.py`, preserve the default-key warning in dev, and
+  preserve an accepted raw key for request authentication.
+- accept: A non-ASCII key always aborts with a clear message. Non-development
+  boot with a default or blank key also aborts before downstream startup work;
+  default-key development behavior is unchanged; a configured ASCII key
+  starts; focused tests cover every branch without uncontrolled outbound HTTP
+  or purge.
 - verify: Targeted pytest for the new test; full suite green.
 
 ### T-SEC-3: API read path uses a scoped Meilisearch search key, not the master key

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,6 +1,6 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 2.7
+version: 2.8
 generated: 2026-07-23
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
@@ -10,6 +10,9 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v2.8:** Marks T-GOV-4 complete and expands T-SEC-2 ownership so its
+  startup policy, focused tests, security checklist, registry, and Full plan
+  land together.
 - **v2.7:** Marks T-CI-2A complete after PR #120 merged under both required
   checks, the direct and effective ruleset readbacks passed against the
   advanced default branch, and the operator explicitly accepted the recorded
@@ -59,9 +62,10 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 | State | Tasks |
 |---|---|
-| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1 |
-| **Partially landed; acceptance incomplete** | T-GOV-4, T-GOV-5, T-GOV-6 |
-| **Pending** | T-SEC-2..6, T-TIME-1..3, T-CRAWL-1..2, T-DA-1, T-DB-1, T-DC-1, T-DD-1, T-DE-1, T-PLAT-1..4, T-GOV-1..3 |
+| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-GOV-4 |
+| **Implementation ready** | T-SEC-2 |
+| **Partially landed; acceptance incomplete** | T-GOV-5, T-GOV-6 |
+| **Pending** | T-SEC-3..6, T-TIME-1..3, T-CRAWL-1..2, T-DA-1, T-DB-1, T-DC-1, T-DD-1, T-DE-1, T-PLAT-1..4, T-GOV-1..3 |
 
 ---
 
@@ -418,12 +422,20 @@ in `AGENTS.md`, `docs/TESTING.MD`, and
 
 ### T-SEC-2: Fail fast on default API key outside dev
 - priority: P0
-- files_owned: api/app_setup.py
-- do: In `lifespan`, if `APP_ENV != "dev"` and API_AUTH_KEY equals
-  DEFAULT_API_AUTH_KEY, raise RuntimeError (mirror the startup_purge gating
-  pattern). Keep the warning in dev.
-- accept: Non-dev boot with default key aborts with a clear message; dev
-  behavior unchanged; test added in tests/ for both branches.
+- status: implementation-ready
+- implementation_plan: `docs/plans/T_SEC_2_DEFAULT_API_KEY_PLAN.md`
+- files_owned: docs/plans/T_SEC_2_DEFAULT_API_KEY_PLAN.md,
+  docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md, api/app_setup.py,
+  tests/test_api_startup_security.py, SECURITY.md
+- do: In `lifespan`, if normalized `APP_ENV != "dev"` and `API_AUTH_KEY` is
+  the checked-in default, empty, or whitespace-only, raise `RuntimeError`
+  before database, purge, or semantic startup work. Read environment values
+  through `pipeline/config_env.py`, preserve the warning in dev, and preserve
+  the raw nonblank key for request authentication.
+- accept: Non-development boot with a default or blank key aborts with a clear
+  message before downstream startup work; development behavior is unchanged;
+  a configured nonblank key starts; focused tests cover every branch without
+  uncontrolled outbound HTTP.
 - verify: Targeted pytest for the new test; full suite green.
 
 ### T-SEC-3: API read path uses a scoped Meilisearch search key, not the master key

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -10,9 +10,8 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
-- **v2.8:** Marks T-GOV-4 complete and expands T-SEC-2 ownership so its
-  startup policy, focused tests, security checklist, registry, and Full plan
-  land together.
+- **v2.8:** Expands T-SEC-2 ownership so its startup policy, focused tests,
+  security checklist, registry, and Full plan land together.
 - **v2.7:** Marks T-CI-2A complete after PR #120 merged under both required
   checks, the direct and effective ruleset readbacks passed against the
   advanced default branch, and the operator explicitly accepted the recorded
@@ -62,9 +61,9 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 | State | Tasks |
 |---|---|
-| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-GOV-4 |
+| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1 |
 | **Implementation ready** | T-SEC-2 |
-| **Partially landed; acceptance incomplete** | T-GOV-5, T-GOV-6 |
+| **Partially landed; acceptance incomplete** | T-GOV-4, T-GOV-5, T-GOV-6 |
 | **Pending** | T-SEC-3..6, T-TIME-1..3, T-CRAWL-1..2, T-DA-1, T-DB-1, T-DC-1, T-DD-1, T-DE-1, T-PLAT-1..4, T-GOV-1..3 |
 
 ---
@@ -427,17 +426,19 @@ in `AGENTS.md`, `docs/TESTING.MD`, and
 - files_owned: docs/plans/T_SEC_2_DEFAULT_API_KEY_PLAN.md,
   docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md, api/app_setup.py,
   tests/test_api_startup_security.py, SECURITY.md
-- do: In `lifespan`, reject non-ASCII `API_AUTH_KEY` values in every
-  environment. When normalized `APP_ENV != "dev"`, also reject the checked-in
-  default after trimming or a blank key. Raise `RuntimeError` before database,
-  purge, or semantic startup work. Read environment values through
-  `pipeline/config_env.py`, preserve the default-key warning in dev, and
-  preserve an accepted raw key for request authentication.
-- accept: A non-ASCII key always aborts with a clear message. Non-development
-  boot with a default or blank key also aborts before downstream startup work;
-  default-key development behavior is unchanged; a configured ASCII key
-  starts; focused tests cover every branch without uncontrolled outbound HTTP
-  or purge.
+- do: In `lifespan`, require every nonempty `API_AUTH_KEY` to contain printable
+  ASCII characters without leading or trailing whitespace. When normalized
+  `APP_ENV != "dev"`, also reject the checked-in default after trimming or a
+  blank key. Raise `RuntimeError` before database, purge, or semantic startup
+  work. Read environment values through `pipeline/config_env.py`, preserve the
+  default-key warning in dev, and preserve an accepted raw key for request
+  authentication.
+- accept: A key containing non-ASCII, control, or edge-whitespace characters
+  always aborts with a clear message. Non-development boot with a default or
+  blank key also aborts before downstream startup work; default-key development
+  behavior is unchanged; a configured transport-safe key starts and remains
+  case-sensitive; focused tests cover every branch without uncontrolled
+  outbound HTTP or purge.
 - verify: Targeted pytest for the new test; full suite green.
 
 ### T-SEC-3: API read path uses a scoped Meilisearch search key, not the master key

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,6 +1,6 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 2.8
+version: 2.9
 generated: 2026-07-23
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
@@ -10,6 +10,10 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v2.9:** Marks T-SEC-2 complete after transport-safe API-key validation,
+  focused and full-suite verification, independent review, and green
+  implementation-head pull-request checks. The closure commit must pass the
+  same required checks before merge.
 - **v2.8:** Expands T-SEC-2 ownership so its startup policy, focused tests,
   security checklist, registry, and Full plan land together.
 - **v2.7:** Marks T-CI-2A complete after PR #120 merged under both required
@@ -61,8 +65,7 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 | State | Tasks |
 |---|---|
-| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1 |
-| **Implementation ready** | T-SEC-2 |
+| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2 |
 | **Partially landed; acceptance incomplete** | T-GOV-4, T-GOV-5, T-GOV-6 |
 | **Pending** | T-SEC-3..6, T-TIME-1..3, T-CRAWL-1..2, T-DA-1, T-DB-1, T-DC-1, T-DD-1, T-DE-1, T-PLAT-1..4, T-GOV-1..3 |
 
@@ -421,7 +424,7 @@ in `AGENTS.md`, `docs/TESTING.MD`, and
 
 ### T-SEC-2: Fail fast on default API key outside dev
 - priority: P0
-- status: implementation-ready
+- status: complete
 - implementation_plan: `docs/plans/T_SEC_2_DEFAULT_API_KEY_PLAN.md`
 - files_owned: docs/plans/T_SEC_2_DEFAULT_API_KEY_PLAN.md,
   docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md, api/app_setup.py,

--- a/docs/plans/T_SEC_2_DEFAULT_API_KEY_PLAN.md
+++ b/docs/plans/T_SEC_2_DEFAULT_API_KEY_PLAN.md
@@ -1,0 +1,266 @@
+# T-SEC-2: Reject the Default API Key Outside Development
+
+`artifact_contract: ce-unified-plan/v1`  
+`artifact_readiness: implementation-ready`  
+`execution: code`
+
+## 1. Context & Alignment
+
+**a) Driver.** `SECURITY.md` states that a reachable deployment must refuse
+startup when `API_AUTH_KEY` still uses the checked-in development value, but
+`api/app_setup.py` currently logs a warning and continues in every environment.
+T-SEC-2 closes that policy/behavior gap before later proxy and scoped-key work.
+
+**b) Canonical documents consulted.**
+
+- `AGENTS.md` `<security_sensitive_paths>` requires a trust-boundary impact
+  statement for `api/app_setup.py`; `<workflow_contract>` requires the API and
+  full-suite verification rows.
+- `SECURITY.md` "Secret policy" requires non-development startup refusal for
+  working default credentials while preserving local development ergonomics.
+- `docs/TESTING.MD` requires observable startup behavior through real framework
+  boundaries and implementation-module patch targets.
+- `docs/ENGINEERING_GUARDRAILS.md` keeps Ruff and Mypy policy unchanged.
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md` assigns T-SEC-2 P0 priority
+  after completed T-SEC-1.
+- `docs/reviews/architecture-review-2026-07-19.html` keeps Phase 2 blocked but
+  permits Phase 1 security work.
+
+**c) Remediation alignment.** T-SEC-2 remains in the security lane. Expand its
+owned files before implementation to:
+
+- `docs/plans/T_SEC_2_DEFAULT_API_KEY_PLAN.md`
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`
+- `api/app_setup.py`
+- `tests/test_api_startup_security.py`
+- `SECURITY.md`
+
+No other tracked file may change.
+
+**d) Decision-gate check.** T-SEC-2 does not depend on or foreclose G1-G5.
+The plan's reachable-posture assumption requires the control regardless of
+whether the owner later declares G1 local or reachable. G2 remains open and is
+not an authentication claim: the API key authenticates the frontend deployment,
+not individual users.
+
+## 2. Design
+
+**e) Step-by-step approach.**
+
+1. Register the plan, expanded ownership, and implementation-ready status.
+2. Add failing FastAPI lifespan tests before production changes.
+3. In `api/app_setup.py`, replace both inline `API_AUTH_KEY` reads with
+   `env_raw` and read `APP_ENV` through `env_lower`, reusing
+   `pipeline/config_env.py`. Preserve the raw configured key for constant-time
+   request comparison.
+4. When normalized `APP_ENV` is not `dev` and the raw key is the checked-in
+   default, empty, or whitespace-only, raise `RuntimeError` with a named,
+   operator-facing message before database initialization, startup purge, or
+   semantic health checks. Use stripping only for the blank-key predicate; do
+   not silently rewrite a nonblank credential.
+5. When the key equals the default and normalized `APP_ENV` is `dev`, preserve
+   the current critical warning and continue startup.
+6. When a nonblank, non-default key is supplied, continue startup in every
+   environment.
+7. Mark the T-SEC-2 security checklist item complete only after local and pull
+   request verification are green.
+8. Run simplification and an independent pre-commit review, then commit, push,
+   open one PR, resolve all P1/P2 feedback, and merge only after current-head CI
+   and review are clean.
+
+No new module or production helper is required. The existing lifespan function
+owns startup policy and remains within the enforced complexity ceiling.
+
+**f) Reuse audit.** Reuse `DEFAULT_API_AUTH_KEY`, the existing lifespan
+boundary, `pipeline.config_env.env_lower`, `pipeline.config_env.env_raw`, and
+FastAPI's existing `TestClient` pattern. Do not introduce a secret manager,
+configuration object, compatibility path, middleware, or duplicate key
+validator.
+
+**g) Data contracts.** No application payload changes. The startup contract is:
+
+- missing `APP_ENV` defaults to `dev`;
+- whitespace and case in `APP_ENV` normalize through `env_lower`;
+- blank or any normalized value other than `dev` is non-development;
+- the known development key, an empty key, and a whitespace-only key are
+  rejected outside development;
+- a nonblank, non-default key starts normally and remains byte-for-byte
+  unchanged for request authentication.
+
+**h) Schema/migration impact.** None.
+
+## 3. Security & Data Governance
+
+**i) Security-sensitive path.** `api/app_setup.py` is the API startup,
+authentication, and rate-limit trust boundary. The change removes an attacker's
+ability to authenticate to a non-development API with the public checked-in
+key or with no request header when the configured key is empty. It implements
+`SECURITY.md` "Secret policy" and does not alter endpoint authorization, rate
+limiting, CORS, or proxy behavior.
+
+**j) Secrets.** No credential or default changes. The checked-in key remains a
+local-development fallback. No value is logged; only the policy violation is
+reported.
+
+**k) Person data.** No person-level data is created, linked, aggregated, or
+exposed. G4 is unaffected.
+
+**l) Untrusted input.** Environment values are the only inputs. `APP_ENV` is
+stripped and lowercased by the established helper. No scraped content,
+provider response, HTTP body, or browser input is parsed.
+
+## 4. Code Health
+
+**m) GED conformance sweep.** The modified lifespan retains one responsibility:
+ordered startup policy and initialization. The error text becomes a named
+constant. No new nesting beyond two levels, broad exception, timestamp,
+generic identifier, inline environment default, or import-time execution is
+added.
+
+**n) Antipattern scan, plan pass.**
+
+- A1/H1: FastAPI lifespan and `TestClient` context-manager behavior were
+  verified against `/websites/fastapi_tiangolo`; installed tests already use
+  the same API.
+- A2/B1: no environment variable or configuration layer is added.
+- B2/C1: no compatibility or warning-only non-development path survives.
+- D1-D3: tests assert startup success/failure and warning behavior, not helper
+  calls or private state.
+- E1-E3: only the five owned files may change.
+- A3-A4, B3, C2, F1-F2, H2-H4: no violations planned.
+
+**o) Ratchet interaction.** `api/app_setup.py` is not in a Ruff per-file-ignore
+entry. No selector, BLE001 boundary, type scope, formatter scope, coverage
+threshold, or workflow gate changes.
+
+**p) Dead code and duplication audit.** The unconditional warning branch is
+replaced by environment-aware fail-fast behavior in the same location. No
+production code is copied. Expected production delta is a named message,
+two config-helper imports, and one conditional branch.
+
+## 5. Testing
+
+**q) Edge and failure scenarios.**
+
+1. `APP_ENV=prod` with the default key aborts startup.
+2. Another non-development value such as `staging` with the default key aborts.
+3. Blank `APP_ENV` with the default key fails closed.
+4. An empty or whitespace-only key outside development aborts startup, so a
+   missing request header cannot authenticate against an empty expected key.
+5. Missing `APP_ENV` defaults to development and starts with the current
+   critical warning.
+6. Mixed-case or padded `dev` normalizes to development and starts.
+7. Non-default key starts in production.
+8. Rejection occurs before database, purge, or semantic startup work.
+9. No key value appears in the exception or log message.
+10. Accepted startup never performs an uncontrolled semantic-service request,
+    regardless of the process's imported feature-flag state.
+
+**r) Tests added.**
+
+| Test | Scenarios |
+|---|---|
+| `test_non_dev_startup_rejects_unsafe_api_key` | 1-4, 8, 9 |
+| `test_dev_startup_allows_default_api_key_with_warning` | 5, 6, 9, 10 |
+| `test_non_dev_startup_accepts_configured_api_key` | 7, 10 |
+
+Each test constructs a small `FastAPI(lifespan=app_setup.lifespan)` instance
+and enters it through `TestClient` so startup behavior is observable at the
+framework boundary. No fixed test-count assertion is added.
+
+**s) Fakes and mocks.** Tests use FastAPI's real lifespan boundary and the
+approved environment, database, and outbound-HTTP boundaries:
+
+- the existing autouse fixture replaces `api.app_setup.db_connect` with the
+  shared SQLite engine for accepted startup;
+- rejection tests replace that same implementation-module database boundary
+  with a fail-if-reached sentinel after resetting `SessionLocal`, proving the
+  first downstream startup stage was not entered. Because database
+  initialization precedes purge and semantic checks, that observable boundary
+  also proves later stages were not reached;
+- accepted tests patch `api.search.semantic_support.httpx.get` with a healthy
+  response at the approved outbound-HTTP boundary, preventing a real request
+  even if `SEMANTIC_ENABLED` was true before test collection;
+- startup purge remains disabled through its documented environment contract.
+
+No private semantic helper, facade re-export, or purge function is patched. No
+new production test seam is added.
+
+**t) Verification rows.** Apply the API/search behavior row because
+`api/app_setup.py` changes, the docs-only row because security and planning
+docs change, Ruff for Python changes, and the full suite because this modifies
+the shared API lifespan. Run current-head PR CI as the authoritative merge gate.
+
+## 6. Execution, Rollback, Docs
+
+**u) Exact commands.**
+
+```bash
+git fetch origin --prune
+git switch master
+git merge --ff-only origin/master
+git switch -c codex/t-sec-2-default-key-fail-fast
+```
+
+Tests-first red evidence:
+
+```bash
+PYTHONPATH=. .venv/bin/pytest -q tests/test_api_startup_security.py
+```
+
+Final local verification:
+
+```bash
+./.venv/bin/ruff check .
+./.venv/bin/pre-commit run ruff --all-files
+./.venv/bin/mypy
+PYTHONPATH=. .venv/bin/pytest -q tests/test_api_startup_security.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_api.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_query_builder_filters.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_query_builder_parity_search_vs_trends.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py
+PYTHONPATH=. .venv/bin/pytest -q
+git diff --check
+git status --short
+```
+
+Delivery uses two commits:
+
+1. `docs(remediation): authorize T-SEC-2 startup hardening`
+2. `fix(security): reject the default API key outside development`
+
+Push the branch, open one PR titled
+`T-SEC-2: Reject the default API key outside development`, request Codex
+review, and watch current-head CI to a decided state before merge.
+
+**v) Rollback.** Revert the T-SEC-2 merge commit and rerun the same targeted,
+API, docs, Ruff, Mypy, and complete-suite commands. No migration, data repair,
+credential rotation, or external-state cleanup is required. Rollback knowingly
+restores warning-only behavior for non-development use of the public default
+key.
+
+**w) Docs synchronization.**
+
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`: version, ownership, status,
+  plan link, acceptance, and completion ledger.
+- `SECURITY.md`: mark T-SEC-2 complete only after verified implementation.
+- New T-SEC-2 Full plan.
+- README, ADR, operations, architecture review, testing policy, data governance,
+  OpenAPI, and environment examples: no changes.
+
+## 7. Delivery Self-Audit
+
+**x) Diff scan.** Re-run A-F/H. Reject a second validator, inline `os.getenv`
+default, secret-bearing logs, dev behavior drift, uncontrolled outbound HTTP,
+endpoint changes, new configuration, private-state assertions, facade
+patching, unrelated formatting, or edits outside the five-file ownership set.
+
+**y) Evidence required.** Report the tests-first failure, every command in 6u,
+independent planning and pre-commit review findings, fixes, commit hashes, PR
+URL, unresolved-thread count, current-head review result, and final CI state.
+Anything unrun is `NOT VERIFIED`.
+
+**z) Deviations.** The authorized remediation-plan corrections are expanded
+T-SEC-2 ownership and moving functionally complete T-GOV-4 into the Complete
+status row. Any additional path, credential/default change, endpoint policy
+change, unresolved P1/P2, skipped review, or unrun required check is a blocker.

--- a/docs/plans/T_SEC_2_DEFAULT_API_KEY_PLAN.md
+++ b/docs/plans/T_SEC_2_DEFAULT_API_KEY_PLAN.md
@@ -60,9 +60,11 @@ not individual users.
    do not rewrite an accepted key.
 5. When the key equals the default and normalized `APP_ENV` is `dev`, preserve
    the current critical warning and continue startup.
-6. Reject non-ASCII keys in every environment because string
-   `hmac.compare_digest` cannot authenticate them. When an ASCII, nonblank,
-   non-default key is supplied, continue startup without rewriting it.
+6. Reject every nonempty key containing non-ASCII, control, or leading or
+   trailing whitespace characters because HTTP header parsing or string
+   comparison cannot authenticate it reliably. When a printable-ASCII,
+   nonblank, non-default key is supplied, continue startup without rewriting
+   it.
 7. Mark the T-SEC-2 security checklist item complete only after local and pull
    request verification are green.
 8. Run simplification and an independent pre-commit review, then commit, push,
@@ -85,10 +87,11 @@ validator.
 - blank or any normalized value other than `dev` is non-development;
 - the known development key with or without surrounding whitespace, an empty
   key, and a whitespace-only key are rejected outside development;
-- non-ASCII keys are rejected in every environment with an operator-facing
-  error instead of failing later during authentication;
-- an ASCII, nonblank, non-default key starts normally and remains
-  byte-for-byte unchanged for request authentication.
+- keys containing non-ASCII, control, or edge-whitespace characters are
+  rejected with an operator-facing error instead of failing later during HTTP
+  authentication;
+- a printable-ASCII, nonblank, non-default key starts normally and remains
+  byte-for-byte unchanged and case-sensitive for request authentication.
 
 **h) Schema/migration impact.** None.
 
@@ -98,10 +101,10 @@ validator.
 authentication, and rate-limit trust boundary. The change removes an attacker's
 ability to authenticate to a non-development API with the public checked-in
 key, a padded form of that key, or no request header when the configured key is
-empty. It also rejects non-ASCII keys that the current constant-time string
-comparison cannot authenticate. It implements `SECURITY.md` "Secret policy"
-and does not alter endpoint authorization, rate limiting, CORS, or proxy
-behavior.
+empty. It also rejects keys whose non-ASCII, control, or edge-whitespace
+characters cannot survive the HTTP header boundary unchanged. It implements
+`SECURITY.md` "Secret policy" and does not alter endpoint authorization, rate
+limiting, CORS, or proxy behavior.
 
 **j) Secrets.** No credential or default changes. The checked-in key remains a
 local-development fallback. No value is logged; only the policy violation is
@@ -154,12 +157,13 @@ two config-helper imports, and two conditional branches.
    missing request header cannot authenticate against an empty expected key.
 5. Surrounding whitespace cannot disguise the checked-in default key outside
    development.
-6. A non-ASCII key in either development or non-development aborts with a
-   clear startup error.
+6. A key containing non-ASCII, control, or edge-whitespace characters aborts
+   with a clear startup error before downstream startup work.
 7. Missing `APP_ENV` defaults to development and starts with the current
    critical warning.
 8. Mixed-case or padded `dev` normalizes to development and starts.
-9. Non-default ASCII key starts in production.
+9. A non-default printable-ASCII key starts in production and remains
+   case-sensitive.
 10. Rejection occurs before database, purge, or semantic startup work.
 11. No key value appears in the exception or log message.
 12. Accepted startup never performs an uncontrolled semantic-service request,
@@ -270,7 +274,7 @@ independent planning and pre-commit review findings, fixes, commit hashes, PR
 URL, unresolved-thread count, current-head review result, and final CI state.
 Anything unrun is `NOT VERIFIED`.
 
-**z) Deviations.** The authorized remediation-plan corrections are expanded
-T-SEC-2 ownership and moving functionally complete T-GOV-4 into the Complete
-status row. Any additional path, credential/default change, endpoint policy
-change, unresolved P1/P2, skipped review, or unrun required check is a blocker.
+**z) Deviations.** The authorized remediation-plan correction is expanded
+T-SEC-2 ownership. Any additional path, credential/default change, endpoint
+policy change, unrelated task-status change, unresolved P1/P2, skipped review,
+or unrun required check is a blocker.

--- a/docs/plans/T_SEC_2_DEFAULT_API_KEY_PLAN.md
+++ b/docs/plans/T_SEC_2_DEFAULT_API_KEY_PLAN.md
@@ -1,7 +1,7 @@
 # T-SEC-2: Reject the Default API Key Outside Development
 
-`artifact_contract: ce-unified-plan/v1`  
-`artifact_readiness: implementation-ready`  
+`artifact_contract: ce-unified-plan/v1`
+`artifact_readiness: implementation-ready`
 `execution: code`
 
 ## 1. Context & Alignment
@@ -53,15 +53,16 @@ not individual users.
    `env_raw` and read `APP_ENV` through `env_lower`, reusing
    `pipeline/config_env.py`. Preserve the raw configured key for constant-time
    request comparison.
-4. When normalized `APP_ENV` is not `dev` and the raw key is the checked-in
-   default, empty, or whitespace-only, raise `RuntimeError` with a named,
+4. When normalized `APP_ENV` is not `dev` and the stripped key is the
+   checked-in default or blank, raise `RuntimeError` with a named,
    operator-facing message before database initialization, startup purge, or
-   semantic health checks. Use stripping only for the blank-key predicate; do
-   not silently rewrite a nonblank credential.
+   semantic health checks. Use stripping only to classify unsafe credentials;
+   do not rewrite an accepted key.
 5. When the key equals the default and normalized `APP_ENV` is `dev`, preserve
    the current critical warning and continue startup.
-6. When a nonblank, non-default key is supplied, continue startup in every
-   environment.
+6. Reject non-ASCII keys in every environment because string
+   `hmac.compare_digest` cannot authenticate them. When an ASCII, nonblank,
+   non-default key is supplied, continue startup without rewriting it.
 7. Mark the T-SEC-2 security checklist item complete only after local and pull
    request verification are green.
 8. Run simplification and an independent pre-commit review, then commit, push,
@@ -82,10 +83,12 @@ validator.
 - missing `APP_ENV` defaults to `dev`;
 - whitespace and case in `APP_ENV` normalize through `env_lower`;
 - blank or any normalized value other than `dev` is non-development;
-- the known development key, an empty key, and a whitespace-only key are
-  rejected outside development;
-- a nonblank, non-default key starts normally and remains byte-for-byte
-  unchanged for request authentication.
+- the known development key with or without surrounding whitespace, an empty
+  key, and a whitespace-only key are rejected outside development;
+- non-ASCII keys are rejected in every environment with an operator-facing
+  error instead of failing later during authentication;
+- an ASCII, nonblank, non-default key starts normally and remains
+  byte-for-byte unchanged for request authentication.
 
 **h) Schema/migration impact.** None.
 
@@ -94,9 +97,11 @@ validator.
 **i) Security-sensitive path.** `api/app_setup.py` is the API startup,
 authentication, and rate-limit trust boundary. The change removes an attacker's
 ability to authenticate to a non-development API with the public checked-in
-key or with no request header when the configured key is empty. It implements
-`SECURITY.md` "Secret policy" and does not alter endpoint authorization, rate
-limiting, CORS, or proxy behavior.
+key, a padded form of that key, or no request header when the configured key is
+empty. It also rejects non-ASCII keys that the current constant-time string
+comparison cannot authenticate. It implements `SECURITY.md` "Secret policy"
+and does not alter endpoint authorization, rate limiting, CORS, or proxy
+behavior.
 
 **j) Secrets.** No credential or default changes. The checked-in key remains a
 local-development fallback. No value is logged; only the policy violation is
@@ -135,8 +140,8 @@ threshold, or workflow gate changes.
 
 **p) Dead code and duplication audit.** The unconditional warning branch is
 replaced by environment-aware fail-fast behavior in the same location. No
-production code is copied. Expected production delta is a named message,
-two config-helper imports, and one conditional branch.
+production code is copied. Expected production delta is two named messages,
+two config-helper imports, and two conditional branches.
 
 ## 5. Testing
 
@@ -147,22 +152,26 @@ two config-helper imports, and one conditional branch.
 3. Blank `APP_ENV` with the default key fails closed.
 4. An empty or whitespace-only key outside development aborts startup, so a
    missing request header cannot authenticate against an empty expected key.
-5. Missing `APP_ENV` defaults to development and starts with the current
+5. Surrounding whitespace cannot disguise the checked-in default key outside
+   development.
+6. A non-ASCII key in either development or non-development aborts with a
+   clear startup error.
+7. Missing `APP_ENV` defaults to development and starts with the current
    critical warning.
-6. Mixed-case or padded `dev` normalizes to development and starts.
-7. Non-default key starts in production.
-8. Rejection occurs before database, purge, or semantic startup work.
-9. No key value appears in the exception or log message.
-10. Accepted startup never performs an uncontrolled semantic-service request,
+8. Mixed-case or padded `dev` normalizes to development and starts.
+9. Non-default ASCII key starts in production.
+10. Rejection occurs before database, purge, or semantic startup work.
+11. No key value appears in the exception or log message.
+12. Accepted startup never performs an uncontrolled semantic-service request,
     regardless of the process's imported feature-flag state.
 
 **r) Tests added.**
 
 | Test | Scenarios |
 |---|---|
-| `test_non_dev_startup_rejects_unsafe_api_key` | 1-4, 8, 9 |
-| `test_dev_startup_allows_default_api_key_with_warning` | 5, 6, 9, 10 |
-| `test_non_dev_startup_accepts_configured_api_key` | 7, 10 |
+| `test_non_dev_startup_rejects_unsafe_api_key` | 1-6, 10, 11 |
+| `test_dev_startup_allows_default_api_key_with_warning` | 7, 8, 11, 12 |
+| `test_non_dev_startup_accepts_configured_api_key` | 9, 12 |
 
 Each test constructs a small `FastAPI(lifespan=app_setup.lifespan)` instance
 and enters it through `TestClient` so startup behavior is observable at the
@@ -181,7 +190,8 @@ approved environment, database, and outbound-HTTP boundaries:
 - accepted tests patch `api.search.semantic_support.httpx.get` with a healthy
   response at the approved outbound-HTTP boundary, preventing a real request
   even if `SEMANTIC_ENABLED` was true before test collection;
-- startup purge remains disabled through its documented environment contract.
+- accepted tests explicitly disable startup purge through its documented
+  environment contract.
 
 No private semantic helper, facade re-export, or purge function is patched. No
 new production test seam is added.

--- a/docs/plans/T_SEC_2_DEFAULT_API_KEY_PLAN.md
+++ b/docs/plans/T_SEC_2_DEFAULT_API_KEY_PLAN.md
@@ -1,7 +1,7 @@
 # T-SEC-2: Reject the Default API Key Outside Development
 
 `artifact_contract: ce-unified-plan/v1`
-`artifact_readiness: implementation-ready`
+`artifact_readiness: complete`
 `execution: code`
 
 ## 1. Context & Alignment
@@ -269,12 +269,29 @@ default, secret-bearing logs, dev behavior drift, uncontrolled outbound HTTP,
 endpoint changes, new configuration, private-state assertions, facade
 patching, unrelated formatting, or edits outside the five-file ownership set.
 
-**y) Evidence required.** Report the tests-first failure, every command in 6u,
-independent planning and pre-commit review findings, fixes, commit hashes, PR
-URL, unresolved-thread count, current-head review result, and final CI state.
-Anything unrun is `NOT VERIFIED`.
+**y) Evidence.**
 
-**z) Deviations.** The authorized remediation-plan correction is expanded
-T-SEC-2 ownership. Any additional path, credential/default change, endpoint
-policy change, unrelated task-status change, unresolved P1/P2, skipped review,
-or unrun required check is a blocker.
+- Tests-first: `4 failed, 9 passed`; the edge-whitespace and internal-whitespace
+  cases reached the database sentinel before the production correction.
+- Focused startup security: `14 passed`.
+- API and docs verification: `63 passed`.
+- Complete Python suite: `1,143 passed`.
+- Ruff, pre-commit Ruff, Mypy, and `git diff --check`: PASS.
+- Independent pre-commit review: two P2 findings corrected; final re-review
+  reported no P1/P2 findings.
+- Pull request: [#122](https://github.com/manumissio/town-council/pull/122).
+- Commits: `eb41624`, `109cb46`, and P1 correction `97ff76f`.
+- Implementation-head review: Codex reported no major issues on `97ff76f`.
+- Implementation-head CI: frontend, Python Guardrails, and CodeQL checks
+  passed. The closure commit must pass the same pull-request gates before
+  merge.
+- Review threads: `0` unresolved.
+
+**z) Deviations.** The authorized remediation-plan correction expanded
+T-SEC-2 ownership. Delivery uses a fourth, docs-only closure commit because the
+security checklist and registry could not truthfully close until implementation
+CI and review passed. A narrow `sed -i` removed only merge-conflict markers
+during rebase after `apply_patch` could not match them. Context7 had no h11
+entry, so the installed h11 0.16.0 parser provided executable API and boundary
+evidence. No additional path, credential/default, endpoint policy, or unrelated
+task status changed.

--- a/tests/test_api_startup_security.py
+++ b/tests/test_api_startup_security.py
@@ -1,0 +1,114 @@
+import logging
+from typing import Never
+
+import pytest
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+
+from api import app_setup
+from api.search import semantic_support
+
+
+DEFAULT_KEY_WARNING = "SECURITY WARNING: You are using the default API Key."
+UNSAFE_KEY_MESSAGE = "API_AUTH_KEY must be set to a non-default, nonblank value when APP_ENV is not dev."
+NON_ASCII_KEY_MESSAGE = "API_AUTH_KEY must contain only ASCII characters."
+CONFIGURED_API_KEY = "  configured-production-key  "
+
+
+class _HealthySemanticResponse:
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict[str, str]:
+        return {"status": "ok"}
+
+
+def _healthy_semantic_get(_url: str, *, timeout: float) -> _HealthySemanticResponse:
+    _ = timeout
+    return _HealthySemanticResponse()
+
+
+def _fail_database_initialization() -> Never:
+    raise AssertionError("database initialization must not run after unsafe key rejection")
+
+
+def _protected_status() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@pytest.mark.parametrize(
+    ("app_env", "api_auth_key", "expected_message"),
+    [
+        ("prod", app_setup.DEFAULT_API_AUTH_KEY, UNSAFE_KEY_MESSAGE),
+        ("staging", app_setup.DEFAULT_API_AUTH_KEY, UNSAFE_KEY_MESSAGE),
+        (" ", app_setup.DEFAULT_API_AUTH_KEY, UNSAFE_KEY_MESSAGE),
+        ("prod", "", UNSAFE_KEY_MESSAGE),
+        ("prod", "   ", UNSAFE_KEY_MESSAGE),
+        ("prod", f" {app_setup.DEFAULT_API_AUTH_KEY} ", UNSAFE_KEY_MESSAGE),
+        ("prod", "configured-key-\u00e9", NON_ASCII_KEY_MESSAGE),
+        ("dev", "configured-key-\u00e9", NON_ASCII_KEY_MESSAGE),
+    ],
+)
+def test_startup_rejects_unsafe_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+    app_env: str,
+    api_auth_key: str,
+    expected_message: str,
+) -> None:
+    monkeypatch.setenv("APP_ENV", app_env)
+    monkeypatch.setenv("API_AUTH_KEY", api_auth_key)
+    monkeypatch.setattr(app_setup, "db_connect", _fail_database_initialization)
+    app_setup.SessionLocal = None
+    application = FastAPI(lifespan=app_setup.lifespan)
+
+    with pytest.raises(RuntimeError, match=expected_message) as startup_error:
+        with TestClient(application):
+            pass
+
+    if api_auth_key:
+        assert api_auth_key not in str(startup_error.value)
+
+
+@pytest.mark.parametrize("app_env", [None, " DeV "])
+def test_dev_startup_allows_default_api_key_with_warning(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    app_env: str | None,
+) -> None:
+    if app_env is None:
+        monkeypatch.delenv("APP_ENV", raising=False)
+    else:
+        monkeypatch.setenv("APP_ENV", app_env)
+    monkeypatch.setenv("API_AUTH_KEY", app_setup.DEFAULT_API_AUTH_KEY)
+    monkeypatch.setenv("STARTUP_PURGE_DERIVED", "false")
+    monkeypatch.setattr(semantic_support.httpx, "get", _healthy_semantic_get)
+    application = FastAPI(lifespan=app_setup.lifespan)
+
+    with caplog.at_level(logging.CRITICAL, logger="town-council-api"):
+        with TestClient(application):
+            pass
+
+    assert DEFAULT_KEY_WARNING in caplog.text
+    assert app_setup.DEFAULT_API_AUTH_KEY not in caplog.text
+
+
+def test_non_dev_startup_accepts_configured_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("APP_ENV", "prod")
+    monkeypatch.setenv("API_AUTH_KEY", CONFIGURED_API_KEY)
+    monkeypatch.setenv("STARTUP_PURGE_DERIVED", "false")
+    monkeypatch.setattr(semantic_support.httpx, "get", _healthy_semantic_get)
+    application = FastAPI(lifespan=app_setup.lifespan)
+    application.add_api_route(
+        "/protected",
+        _protected_status,
+        dependencies=[Depends(app_setup.verify_api_key)],
+    )
+
+    with TestClient(application) as client:
+        exact_key_response = client.get("/protected", headers={"X-API-Key": CONFIGURED_API_KEY})
+        stripped_key_response = client.get("/protected", headers={"X-API-Key": CONFIGURED_API_KEY.strip()})
+
+    assert exact_key_response.status_code == 200
+    assert stripped_key_response.status_code == 401

--- a/tests/test_api_startup_security.py
+++ b/tests/test_api_startup_security.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Never
 
+import h11
 import pytest
 from fastapi import Depends, FastAPI
 from fastapi.testclient import TestClient
@@ -11,8 +12,10 @@ from api.search import semantic_support
 
 DEFAULT_KEY_WARNING = "SECURITY WARNING: You are using the default API Key."
 UNSAFE_KEY_MESSAGE = "API_AUTH_KEY must be set to a non-default, nonblank value when APP_ENV is not dev."
-NON_ASCII_KEY_MESSAGE = "API_AUTH_KEY must contain only ASCII characters."
-CONFIGURED_API_KEY = "  configured-production-key  "
+HEADER_UNSAFE_KEY_MESSAGE = (
+    "API_AUTH_KEY must contain printable ASCII characters without leading or trailing whitespace."
+)
+CONFIGURED_API_KEY = "Configured Production Key_123"
 
 
 class _HealthySemanticResponse:
@@ -45,8 +48,10 @@ def _protected_status() -> dict[str, str]:
         ("prod", "", UNSAFE_KEY_MESSAGE),
         ("prod", "   ", UNSAFE_KEY_MESSAGE),
         ("prod", f" {app_setup.DEFAULT_API_AUTH_KEY} ", UNSAFE_KEY_MESSAGE),
-        ("prod", "configured-key-\u00e9", NON_ASCII_KEY_MESSAGE),
-        ("dev", "configured-key-\u00e9", NON_ASCII_KEY_MESSAGE),
+        ("prod", " configured-production-key ", HEADER_UNSAFE_KEY_MESSAGE),
+        ("prod", "configured-key-\x7f", HEADER_UNSAFE_KEY_MESSAGE),
+        ("prod", "configured-key-\u00e9", HEADER_UNSAFE_KEY_MESSAGE),
+        ("dev", "configured-key-\u00e9", HEADER_UNSAFE_KEY_MESSAGE),
     ],
 )
 def test_startup_rejects_unsafe_api_key(
@@ -108,7 +113,22 @@ def test_non_dev_startup_accepts_configured_api_key(
 
     with TestClient(application) as client:
         exact_key_response = client.get("/protected", headers={"X-API-Key": CONFIGURED_API_KEY})
-        stripped_key_response = client.get("/protected", headers={"X-API-Key": CONFIGURED_API_KEY.strip()})
+        changed_key_response = client.get("/protected", headers={"X-API-Key": CONFIGURED_API_KEY.lower()})
 
     assert exact_key_response.status_code == 200
-    assert stripped_key_response.status_code == 401
+    assert changed_key_response.status_code == 401
+
+
+def test_h11_removes_edge_whitespace_but_preserves_internal_api_key_space() -> None:
+    connection = h11.Connection(h11.SERVER)
+    connection.receive_data(
+        b"GET /protected HTTP/1.1\r\n"
+        b"Host: test\r\n"
+        b"X-API-Key:   Configured Production Key_123   \r\n"
+        b"\r\n"
+    )
+
+    request = connection.next_event()
+
+    assert isinstance(request, h11.Request)
+    assert dict(request.headers)[b"x-api-key"] == CONFIGURED_API_KEY.encode()


### PR DESCRIPTION
## What changed

- reject blank and checked-in default API keys outside development before database or service startup
- reject non-ASCII API keys in every environment because the current constant-time string comparison cannot authenticate them
- preserve accepted configured keys byte-for-byte for request authentication
- retain the existing default-key warning in development
- add framework-level startup and authentication regression tests
- align the security policy and register the implementation-ready remediation plan

## Why

A reachable deployment could previously start with the public development key or an empty key. That made the frontend-to-API trust boundary ineffective. Padded default keys and non-ASCII keys also exposed configuration traps that now fail clearly at startup.

## Risk and compatibility

- Development continues to start with the checked-in default and emits the existing critical warning.
- Non-development deployments using a blank, padded-default, exact-default, or non-ASCII key now fail fast by design.
- Valid ASCII configured keys are not trimmed or rewritten.
- No API payload, endpoint, schema, dependency, or runtime default changes.

## Verification

- PASS: `./.venv/bin/ruff check .`
- PASS: `./.venv/bin/pre-commit run ruff --all-files`
- PASS: `./.venv/bin/mypy`
- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_api_startup_security.py` (`11 passed`)
- PASS: API/search verification row (`40 + 6 + 1 passed`)
- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py` (`2 passed`)
- PASS: `PYTHONPATH=. .venv/bin/pytest -q` (`1140 passed`)
- PASS: `git diff --check origin/master`
- PASS: independent pre-commit review found no remaining P1/P2/P3 issues

## Security boundary impact

This changes `api/app_setup.py`, the frontend-to-API authentication/startup boundary. An attacker loses the ability to authenticate to a reachable deployment using the public checked-in key or an absent header against a blank configured key. The change implements the `SECURITY.md` secret-policy control without altering endpoint authorization, rate limiting, CORS, or proxy behavior.

## Completion

The remediation checklist remains open until both required PR checks validate this exact commit. A final docs commit will record completion after those checks pass.
