### PR TITLE
T-SEC-3: Scope Meilisearch reader credentials

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,9 @@
 .git
 .gitignore
 .dockerignore
+**/.env
+**/.env.*
+!**/.env.example
 **/__pycache__
 **/*.pyc
 **/*.pyo

--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,10 @@ POSTGRES_DB=town_council_db
 
 # SEARCH: MEILISEARCH
 MEILI_HOST=http://meilisearch:7700
+# Required outside development for API and semantic search reads.
+MEILI_SEARCH_KEY=
+# Local development value only. Production requires a unique key of at least 16 bytes.
+# Writer and administration credential; never provide this to reader services.
 MEILI_MASTER_KEY=masterKey
 
 # SECURITY: API KEYS

--- a/README.md
+++ b/README.md
@@ -30,9 +30,12 @@ This project ingests agendas/minutes, extracts text, indexes search content, and
 
 ### 2) Start stack and initialize DB
 ```bash
-docker compose up -d --build postgres redis meilisearch tika inference semantic semantic-worker api worker enrichment-worker monitor frontend
+test -f .env || cp .env.example .env
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build \
+  postgres redis meilisearch tika inference semantic semantic-worker api worker enrichment-worker monitor frontend
 bash ./scripts/bootstrap_local_models.sh
-docker compose run --rm pipeline python db_init.py
+docker compose -f docker-compose.yml -f docker-compose.dev.yml run --rm \
+  pipeline python db_init.py
 ```
 
 Optional helper (same steps, fewer flags to remember):
@@ -45,6 +48,11 @@ What `scripts/dev_up.sh` does:
 - bootstraps the shared local model volume
 - initializes the DB schema
 - runs a small smoke check (`/health`)
+
+Local development may use the fake Meilisearch reader fallback. Any reachable
+deployment must configure a scoped read `MEILI_SEARCH_KEY` for the API and
+semantic service and replace the example master key; create and verify it with the
+[scoped-key runbook](docs/OPERATIONS.md#meilisearch-reader-key-operations).
 
 What it does *not* do:
 - scrape any city data (no crawler runs)
@@ -217,10 +225,17 @@ Runtime profile commands:
 mlx_lm.server --model mlx-community/gemma-3-text-4b-it-4bit --host 127.0.0.1 --port 8080
 
 # terminal 2
-docker compose up -d --build postgres redis meilisearch tika semantic semantic-worker
-docker compose --env-file env/profiles/m5_mlx_conservative.env up -d --build --no-deps worker api pipeline frontend
-docker compose --env-file env/profiles/m5_conservative.env up -d --build inference worker api pipeline frontend
-docker compose --env-file env/profiles/desktop_balanced.env up -d --build inference worker api pipeline frontend
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build \
+  postgres redis meilisearch tika semantic semantic-worker
+docker compose --env-file .env --env-file env/profiles/m5_mlx_conservative.env \
+  -f docker-compose.yml -f docker-compose.dev.yml up -d --build --no-deps \
+  worker api pipeline frontend
+docker compose --env-file .env --env-file env/profiles/m5_conservative.env \
+  -f docker-compose.yml -f docker-compose.dev.yml up -d --build \
+  inference worker api pipeline frontend
+docker compose --env-file .env --env-file env/profiles/desktop_balanced.env \
+  -f docker-compose.yml -f docker-compose.dev.yml up -d --build \
+  inference worker api pipeline frontend
 ```
 
 Model policy:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,10 +36,13 @@ engineering decisions is `reachable`).
    therefore depends on forwarding real client identity
    `[remediation: T-SEC-4]`, and any "operator only" action requires auth at
    the proxy, not just the key (decision G2, currently open).
-3. API -> backing stores (Postgres, Redis, Meilisearch, inference): compose
+3. API and semantic service -> backing stores (Postgres, Redis, Meilisearch,
+   inference): compose
    network only. No host port publication in the base compose file
-   `[remediation: T-SEC-1]`. The API read path uses a scoped Meilisearch
-   search key, never the master key `[remediation: T-SEC-3]`.
+   `[remediation: T-SEC-1]`. API and semantic Meilisearch readers use
+   `MEILI_SEARCH_KEY`, scoped to `search` and `stats.get` on `documents`; only
+   writer and administration services receive `MEILI_MASTER_KEY`
+   `[remediation: T-SEC-3]`.
 4. Crawler -> municipal portals: outbound only. Honest identifying
    user agent, `ROBOTSTXT_OBEY=True`, per-domain delay
    `[remediation: T-CRAWL-1]`.
@@ -57,13 +60,24 @@ engineering decisions is `reachable`).
   characters without leading or trailing whitespace so HTTP header parsing
   cannot change the authenticated value `[remediation: T-SEC-2]`. Extend the
   same pattern to any future secret.
+- API and semantic startup rejects a missing, development-fallback, or
+  transport-unsafe `MEILI_SEARCH_KEY` outside development. The fake reader
+  fallback is development-only. Operators must verify the candidate key's
+  exact action and index scope before restarting either reader.
+- Base Compose runs Meilisearch in production mode and requires a master key;
+  the development overlay is the only checked-in path that selects
+  Meilisearch development mode.
 - No secret in a `NEXT_PUBLIC_*` variable, ever. These ship to browser
   bundles.
 - Secrets enter via environment/.env only; `.env` is gitignored. No secrets
   in compose files beyond dev-only fallbacks, and dev fallbacks must be
   obviously fake (`dev_secret_key_change_me` style).
+- Base reader services do not bind-mount the repository, and Docker build
+  context excludes local `.env` variants. The development overlay may restore
+  targeted source-directory mounts for local iteration, never the repository
+  root.
 - Key inventory: `API_AUTH_KEY` (frontend->API), `MEILI_MASTER_KEY`
-  (pipeline writes + admin), `MEILI_SEARCH_KEY` (API reads,
+  (pipeline/worker writes + admin), `MEILI_SEARCH_KEY` (API and semantic reads,
   `[remediation: T-SEC-3]`), `POSTGRES_PASSWORD`, `REDIS_PASSWORD`,
   Grafana admin credentials.
 
@@ -72,7 +86,7 @@ engineering decisions is `reachable`).
 - [x] Base compose publishes only `api:8000` and `frontend:3000` (T-SEC-1)
 - [ ] Non-default values for every key in the inventory above
 - [x] API aborts on default key outside dev (T-SEC-2)
-- [ ] Meilisearch search key configured for the API (T-SEC-3)
+- [ ] Meilisearch search key enforced for API and semantic readers (T-SEC-3)
 - [ ] Client IP forwarded from proxy; limiter keys on it with trusted-proxy
       allowlist (T-SEC-4)
 - [ ] Origin/Sec-Fetch-Site check on proxy mutation routes (T-SEC-5)

--- a/api/app_setup.py
+++ b/api/app_setup.py
@@ -114,7 +114,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         logger.critical("SECURITY WARNING: You are using the default API Key. Please set API_AUTH_KEY in production.")
     from api.search import support_core
 
-    if not support_core.MEILI_SEARCH_KEY.strip() and support_core.MEILI_MASTER_KEY == DEVELOPMENT_MEILI_SEARCH_KEY:
+    if support_core.MEILI_MASTER_KEY == DEVELOPMENT_MEILI_SEARCH_KEY:
         logger.warning(MEILI_SEARCH_KEY_FALLBACK_WARNING)
     initialize_database()
     if not is_db_ready():

--- a/api/app_setup.py
+++ b/api/app_setup.py
@@ -13,6 +13,10 @@ from sqlalchemy.orm import sessionmaker
 
 from pipeline.config import SEMANTIC_ENABLED
 from pipeline.config_env import env_lower, env_raw
+from pipeline.meilisearch_credentials import (
+    DEVELOPMENT_MEILI_SEARCH_KEY,
+    MEILI_SEARCH_KEY_FALLBACK_WARNING,
+)
 from pipeline.models import db_connect
 from pipeline.startup_purge import run_startup_purge_if_enabled
 
@@ -108,6 +112,10 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         raise RuntimeError(HEADER_UNSAFE_API_AUTH_KEY_MESSAGE)
     if api_auth_key == DEFAULT_API_AUTH_KEY:
         logger.critical("SECURITY WARNING: You are using the default API Key. Please set API_AUTH_KEY in production.")
+    from api.search import support_core
+
+    if not support_core.MEILI_SEARCH_KEY.strip() and support_core.MEILI_MASTER_KEY == DEVELOPMENT_MEILI_SEARCH_KEY:
+        logger.warning(MEILI_SEARCH_KEY_FALLBACK_WARNING)
     initialize_database()
     if not is_db_ready():
         logger.warning("database_session_factory=unavailable")

--- a/api/search/support_core.py
+++ b/api/search/support_core.py
@@ -1,13 +1,20 @@
 import logging
-import os
 from typing import Any
 
 import meilisearch
 
 from pipeline import config as pipeline_config
+from pipeline.config_env import env_lower, env_raw
+from pipeline.meilisearch_credentials import DEVELOPMENT_APP_ENV, resolve_meilisearch_reader_key
 
-MEILI_HOST = os.getenv("MEILI_HOST", "http://meilisearch:7700")
-MEILI_MASTER_KEY = os.getenv("MEILI_MASTER_KEY", "masterKey")
+MEILI_HOST = env_raw("MEILI_HOST", "http://meilisearch:7700")
+APP_ENV = env_lower("APP_ENV", DEVELOPMENT_APP_ENV)
+MEILI_SEARCH_KEY = env_raw("MEILI_SEARCH_KEY", "")
+# G3 defers facade removal; the legacy export now carries reader privilege only.
+MEILI_MASTER_KEY = resolve_meilisearch_reader_key(
+    APP_ENV,
+    MEILI_SEARCH_KEY,
+)
 
 DOCUMENT_INDEX_NAME = "documents"
 TOPICS_FACET_NAME = "topics"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -30,6 +30,7 @@ services:
       - ./pipeline:/app/pipeline
     environment:
       - APP_ENV=dev
+      - MEILI_SEARCH_KEY=${MEILI_SEARCH_KEY:-${MEILI_MASTER_KEY:-masterKey}}
       - STARTUP_PURGE_DERIVED=${STARTUP_PURGE_DERIVED:-true}
 
   semantic:
@@ -38,6 +39,7 @@ services:
       - ./semantic_service:/app/semantic_service
     environment:
       - APP_ENV=dev
+      - MEILI_SEARCH_KEY=${MEILI_SEARCH_KEY:-${MEILI_MASTER_KEY:-masterKey}}
 
   worker:
     environment:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -8,6 +8,8 @@ services:
   meilisearch:
     ports:
       - "127.0.0.1:7700:7700"
+    environment:
+      - MEILI_ENV=development
 
   redis:
     ports:
@@ -23,13 +25,24 @@ services:
 
   api:
     command: uvicorn main:app --host 0.0.0.0 --port 8000 --reload
+    volumes:
+      - ./api:/app/api
+      - ./pipeline:/app/pipeline
     environment:
-      - STARTUP_PURGE_DERIVED=true
+      - APP_ENV=dev
+      - STARTUP_PURGE_DERIVED=${STARTUP_PURGE_DERIVED:-true}
+
+  semantic:
+    volumes:
+      - ./pipeline:/app/pipeline
+      - ./semantic_service:/app/semantic_service
+    environment:
+      - APP_ENV=dev
 
   worker:
     environment:
-      - STARTUP_PURGE_DERIVED=true
+      - STARTUP_PURGE_DERIVED=${STARTUP_PURGE_DERIVED:-true}
 
   pipeline:
     environment:
-      - STARTUP_PURGE_DERIVED=true
+      - STARTUP_PURGE_DERIVED=${STARTUP_PURGE_DERIVED:-true}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,8 @@ services:
       - PYTHONUNBUFFERED=1
       - PYTHONPATH=/app
       - DATABASE_URL=${DATABASE_URL:-postgresql://town_council:secure_dev_password@postgres:5432/town_council_db}
+      - MEILI_HOST=${MEILI_HOST:-http://meilisearch:7700}
+      - MEILI_MASTER_KEY=${MEILI_MASTER_KEY:?MEILI_MASTER_KEY must be set}
       - REDIS_HOST=redis
       - REDIS_PASSWORD=${REDIS_PASSWORD:-secure_redis_password}
       - CELERY_BROKER_URL=redis://:${REDIS_PASSWORD:-secure_redis_password}@redis:6379/0
@@ -109,6 +111,8 @@ services:
       - PYTHONUNBUFFERED=1
       - PYTHONPATH=/app
       - DATABASE_URL=${DATABASE_URL:-postgresql://town_council:secure_dev_password@postgres:5432/town_council_db}
+      - MEILI_HOST=${MEILI_HOST:-http://meilisearch:7700}
+      - MEILI_MASTER_KEY=${MEILI_MASTER_KEY:?MEILI_MASTER_KEY must be set}
       - REDIS_HOST=redis
       - REDIS_PASSWORD=${REDIS_PASSWORD:-secure_redis_password}
       - CELERY_BROKER_URL=redis://:${REDIS_PASSWORD:-secure_redis_password}@redis:6379/0
@@ -206,7 +210,7 @@ services:
       - PYTHONPATH=/app
       - DATABASE_URL=${DATABASE_URL:-postgresql://town_council:secure_dev_password@postgres:5432/town_council_db}
       - MEILI_HOST=${MEILI_HOST:-http://meilisearch:7700}
-      - MEILI_MASTER_KEY=${MEILI_MASTER_KEY:-masterKey}
+      - MEILI_MASTER_KEY=${MEILI_MASTER_KEY:?MEILI_MASTER_KEY must be set}
       - REDIS_HOST=redis
       - REDIS_PASSWORD=${REDIS_PASSWORD:-secure_redis_password}
       - CELERY_BROKER_URL=redis://:${REDIS_PASSWORD:-secure_redis_password}@redis:6379/0
@@ -271,7 +275,7 @@ services:
       - PYTHONPATH=/app
       - DATABASE_URL=${DATABASE_URL:-postgresql://town_council:secure_dev_password@postgres:5432/town_council_db}
       - MEILI_HOST=${MEILI_HOST:-http://meilisearch:7700}
-      - MEILI_MASTER_KEY=${MEILI_MASTER_KEY:-masterKey}
+      - MEILI_MASTER_KEY=${MEILI_MASTER_KEY:?MEILI_MASTER_KEY must be set}
       - REDIS_HOST=redis
       - REDIS_PASSWORD=${REDIS_PASSWORD:-secure_redis_password}
       - CELERY_BROKER_URL=redis://:${REDIS_PASSWORD:-secure_redis_password}@redis:6379/0
@@ -394,7 +398,8 @@ services:
   meilisearch:
     image: getmeili/meilisearch:v1.6
     environment:
-      - MEILI_MASTER_KEY=${MEILI_MASTER_KEY:-masterKey}
+      - MEILI_ENV=production
+      - MEILI_MASTER_KEY=${MEILI_MASTER_KEY:?MEILI_MASTER_KEY must be set}
     volumes:
       - meili_data:/meili_data
 
@@ -404,7 +409,6 @@ services:
       target: python-semantic
     image: town-council-python-semantic
     volumes:
-      - .:/app
       - data:/app/data
       - models_data:/models
     working_dir: /app/semantic_service
@@ -412,9 +416,10 @@ services:
     environment:
       - PYTHONUNBUFFERED=1
       - PYTHONPATH=/app
+      - APP_ENV=${APP_ENV:-production}
       - DATABASE_URL=${DATABASE_URL:-postgresql://town_council:secure_dev_password@postgres:5432/town_council_db}
       - MEILI_HOST=${MEILI_HOST:-http://meilisearch:7700}
-      - MEILI_MASTER_KEY=${MEILI_MASTER_KEY:-masterKey}
+      - MEILI_SEARCH_KEY=${MEILI_SEARCH_KEY:-}
       - SEMANTIC_ENABLED=${SEMANTIC_ENABLED:-false}
       - SEMANTIC_BACKEND=${SEMANTIC_BACKEND:-faiss}
       - SEMANTIC_MODEL_NAME=${SEMANTIC_MODEL_NAME:-all-MiniLM-L6-v2}
@@ -461,7 +466,6 @@ services:
       target: python-api
     image: town-council-python-api
     volumes:
-      - .:/app
       - data:/app/data
       - models_data:/models
     working_dir: /app/api
@@ -470,7 +474,7 @@ services:
       - "8000:8000"
     environment:
       - MEILI_HOST=${MEILI_HOST:-http://meilisearch:7700}
-      - MEILI_MASTER_KEY=${MEILI_MASTER_KEY:-masterKey}
+      - MEILI_SEARCH_KEY=${MEILI_SEARCH_KEY:-}
       - DATABASE_URL=${DATABASE_URL:-postgresql://town_council:secure_dev_password@postgres:5432/town_council_db}
       - REDIS_HOST=redis
       - REDIS_PASSWORD=${REDIS_PASSWORD:-secure_redis_password}
@@ -479,7 +483,7 @@ services:
       - PYTHONPATH=/app
       - API_AUTH_KEY=${API_AUTH_KEY:-dev_secret_key_change_me}
       - ALLOWED_ORIGINS=${ALLOWED_ORIGINS:-http://localhost:3000}
-      - APP_ENV=${APP_ENV:-dev}
+      - APP_ENV=${APP_ENV:-production}
       - STARTUP_PURGE_DERIVED=${STARTUP_PURGE_DERIVED:-false}
       - FEATURE_TRENDS_DASHBOARD=${FEATURE_TRENDS_DASHBOARD:-false}
       - SEMANTIC_SERVICE_URL=${SEMANTIC_SERVICE_URL:-http://semantic:8010}

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -16,9 +16,12 @@ cd "$REPO_ROOT"
 
 ### 1) Start stack
 ```bash
-docker compose up -d --build postgres redis meilisearch tika inference semantic semantic-worker api worker enrichment-worker monitor frontend
+test -f .env || cp .env.example .env
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build \
+  postgres redis meilisearch tika inference semantic semantic-worker api worker enrichment-worker monitor frontend
 bash ./scripts/bootstrap_local_models.sh
-docker compose run --rm pipeline python db_init.py
+docker compose -f docker-compose.yml -f docker-compose.dev.yml run --rm \
+  pipeline python db_init.py
 ```
 
 Optional helper (same steps, fewer flags to remember):
@@ -30,7 +33,7 @@ After upgrading a stack created before T-SEC-1, recreate the affected services
 once so their removed host bindings do not survive in existing containers:
 
 ```bash
-docker compose -f docker-compose.yml up -d --force-recreate \
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --force-recreate \
   postgres redis meilisearch prometheus grafana
 ```
 
@@ -51,8 +54,11 @@ M5 Pro MLX opt-in path:
 mlx_lm.server --model mlx-community/gemma-3-text-4b-it-4bit --host 127.0.0.1 --port 8080
 
 # terminal 2
-docker compose up -d --build postgres redis meilisearch tika semantic semantic-worker
-docker compose --env-file env/profiles/m5_mlx_conservative.env up -d --build --no-deps worker api pipeline frontend
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build \
+  postgres redis meilisearch tika semantic semantic-worker
+docker compose --env-file .env --env-file env/profiles/m5_mlx_conservative.env \
+  -f docker-compose.yml -f docker-compose.dev.yml up -d --build --no-deps \
+  worker api pipeline frontend
 docker compose exec -T worker python scripts/worker_healthcheck.py
 ```
 
@@ -103,7 +109,8 @@ Use Docker/Ollama for reproducible baseline runs, or M5 MLX for the preferred
 M5 Pro opt-in path.
 
 ### 1.6) Verify stack health contracts
-Use this after `docker compose up -d --build` and before running onboarding or soak flows.
+Use this after starting the local stack with the base-plus-development Compose
+files and before running onboarding or soak flows.
 
 ```bash
 docker ps --format '{{.Names}} {{.Status}}'
@@ -621,6 +628,97 @@ Override (not recommended):
 Security logging rule:
 - Do not log API key values or key fragments. Log only path/client metadata on auth failures.
 
+### Meilisearch reader-key operations
+
+API and semantic readers use `MEILI_SEARCH_KEY`. Pipeline and worker indexing
+paths use `MEILI_MASTER_KEY`. Outside development, both readers fail startup
+when the reader key is missing or unsafe; they never retry with the master key.
+Base Compose runs Meilisearch with `MEILI_ENV=production`, which enforces its
+production master-key requirements. The development overlay is the only
+checked-in path that selects Meilisearch development mode.
+
+Create a key scoped to search and read statistics from the `documents` index:
+
+```bash
+: "${MEILI_URL:?set the Meilisearch URL}"
+: "${MEILI_MASTER_KEY:?set the operator master key}"
+umask 077
+MEILI_MASTER_HEADER_FILE=$(mktemp)
+MEILI_SEARCH_HEADER_FILE=$(mktemp)
+trap 'rm -f "$MEILI_MASTER_HEADER_FILE" "$MEILI_SEARCH_HEADER_FILE"' EXIT
+printf 'Authorization: Bearer %s\n' "$MEILI_MASTER_KEY" >"$MEILI_MASTER_HEADER_FILE"
+KEY_RESPONSE=$(curl --connect-timeout 2 --max-time 10 -fsS -X POST \
+  "$MEILI_URL/keys" \
+  -H "@$MEILI_MASTER_HEADER_FILE" \
+  -H "Content-Type: application/json" \
+  --data-binary '{"name":"Town Council readers","actions":["search","stats.get"],"indexes":["documents"],"expiresAt":null}')
+MEILI_SEARCH_KEY=$(printf '%s' "$KEY_RESPONSE" | .venv/bin/python -c \
+  'import json,sys; print(json.load(sys.stdin)["key"])')
+MEILI_SEARCH_KEY_UID=$(printf '%s' "$KEY_RESPONSE" | .venv/bin/python -c \
+  'import json,sys; print(json.load(sys.stdin)["uid"])')
+printf 'Authorization: Bearer %s\n' "$MEILI_SEARCH_KEY" >"$MEILI_SEARCH_HEADER_FILE"
+export MEILI_SEARCH_KEY MEILI_SEARCH_KEY_UID
+```
+
+Store `MEILI_SEARCH_KEY` in the deployment secret source and retain
+`MEILI_SEARCH_KEY_UID` in the operator key inventory. Do not print either
+value. The UID is not passed to application containers.
+
+Before deploying, use the master key only from the operator shell to inspect
+`GET /keys/{uid}` and prove the candidate value and scope are exact:
+
+```bash
+KEY_RECORD=$(curl --connect-timeout 2 --max-time 10 -fsS \
+  "$MEILI_URL/keys/$MEILI_SEARCH_KEY_UID" \
+  -H "@$MEILI_MASTER_HEADER_FILE")
+printf '%s' "$KEY_RECORD" | .venv/bin/python -c \
+  'import json,sys; from pathlib import Path; r=json.load(sys.stdin); expected=Path(sys.argv[1]).read_text().removeprefix("Authorization: Bearer ").strip(); assert r["uid"] == sys.argv[2] and r["key"] == expected and r["actions"] == ["search","stats.get"] and r["indexes"] == ["documents"]' \
+  "$MEILI_SEARCH_HEADER_FILE" "$MEILI_SEARCH_KEY_UID"
+```
+
+Verify reader behavior without modifying index data:
+
+```bash
+curl --connect-timeout 2 --max-time 10 -fsS -X POST \
+  "$MEILI_URL/indexes/documents/search" \
+  -H "@$MEILI_SEARCH_HEADER_FILE" -H "Content-Type: application/json" \
+  --data-binary '{"q":"","limit":1}' >/dev/null
+curl --connect-timeout 2 --max-time 10 -fsS \
+  "$MEILI_URL/indexes/documents/stats" -H "@$MEILI_SEARCH_HEADER_FILE" >/dev/null
+test "$(curl --connect-timeout 2 --max-time 10 -sS -o /dev/null \
+  -w '%{http_code}' "$MEILI_URL/indexes/documents/settings" \
+  -H "@$MEILI_SEARCH_HEADER_FILE")" = 403
+test "$(curl --connect-timeout 2 --max-time 10 -sS -o /dev/null \
+  -w '%{http_code}' "$MEILI_URL/keys" -H "@$MEILI_SEARCH_HEADER_FILE")" = 403
+```
+
+Deploy or rotate:
+
+1. Create and preflight the replacement key.
+2. Set `MEILI_SEARCH_KEY` in the deployment secret source.
+3. For a non-development deployment, run
+   `APP_ENV=production docker compose -f docker-compose.yml up -d --build
+   --force-recreate api semantic` so reader images are rebuilt without local
+   environment files. Local development uses the base-plus-development
+   Compose files documented in the quickstart.
+4. Verify API health and a representative lexical/semantic search.
+5. Revoke the previous key only after both readers pass.
+
+Revoke a retired key:
+
+```bash
+curl --connect-timeout 2 --max-time 10 -fsS -X DELETE \
+  "$MEILI_URL/keys/$RETIRED_MEILI_SEARCH_KEY_UID" \
+  -H "@$MEILI_MASTER_HEADER_FILE"
+rm -f "$MEILI_MASTER_HEADER_FILE" "$MEILI_SEARCH_HEADER_FILE"
+trap - EXIT
+```
+
+Rollback by restoring the previous scoped reader key, recreating `api` and
+`semantic` with `--build --force-recreate`, and verifying health/search. Never
+restore `MEILI_MASTER_KEY` to reader containers. If the previous key was
+already revoked, create and preflight a new scoped key instead.
+
 Provider error policy:
 - Provider transport code raises typed errors (`ProviderTimeoutError`, `ProviderUnavailableError`, `ProviderResponseError`).
 - Orchestrator mapping:
@@ -825,7 +923,8 @@ Scripts:
     - strategy A: HTTP probe to `http://localhost:8001/metrics`
     - strategy B: collector-based registry exposition (`RedisProviderMetricsCollector`)
   - preflight `/health` poll for 60 seconds (default)
-  - one fast self-heal attempt via `docker compose up -d inference worker api pipeline frontend`
+  - one fast self-heal attempt via the base-plus-development Compose stack for
+    `inference`, `worker`, `api`, `pipeline`, and `frontend`
   - falls back to `scripts/dev_up.sh` only if fast recovery fails
   - treats a successful pre-run worker scrape with no provider series yet as a valid zero baseline (`provider_counters_before_run_source=zero_baseline_no_provider_series`)
   - marks day `stack_offline` and exits cleanly if recovery fails
@@ -1077,7 +1176,9 @@ Notes:
 
 1. Enable HTTP backend:
 ```bash
-LOCAL_AI_BACKEND=http docker compose up -d --build worker api pipeline inference
+LOCAL_AI_BACKEND=http docker compose \
+  -f docker-compose.yml -f docker-compose.dev.yml \
+  up -d --build worker api pipeline inference
 ```
 2. Create the local inference model alias once:
 ```bash
@@ -1089,7 +1190,9 @@ LOCAL_AI_BACKEND=http docker compose up -d --build worker api pipeline inference
 ```
 4. If parity or SLOs regress, rollback immediately:
 ```bash
-LOCAL_AI_BACKEND=inprocess WORKER_CONCURRENCY=1 WORKER_POOL=solo docker compose up -d --build worker api pipeline
+LOCAL_AI_BACKEND=inprocess WORKER_CONCURRENCY=1 WORKER_POOL=solo docker compose \
+  -f docker-compose.yml -f docker-compose.dev.yml \
+  up -d --build worker api pipeline
 ```
 5. If the recent inference hardening commits cause regressions, rollback code explicitly:
 ```bash
@@ -1139,8 +1242,11 @@ M5 MLX conservative opt-in:
 mlx_lm.server --model mlx-community/gemma-3-text-4b-it-4bit --host 127.0.0.1 --port 8080
 
 # terminal 2
-docker compose up -d --build postgres redis meilisearch tika semantic semantic-worker
-docker compose --env-file env/profiles/m5_mlx_conservative.env up -d --build --no-deps worker api pipeline frontend
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build \
+  postgres redis meilisearch tika semantic semantic-worker
+docker compose --env-file .env --env-file env/profiles/m5_mlx_conservative.env \
+  -f docker-compose.yml -f docker-compose.dev.yml up -d --build --no-deps \
+  worker api pipeline frontend
 docker compose exec -T worker python scripts/worker_healthcheck.py
 ```
 
@@ -1150,19 +1256,26 @@ M5 MLX balanced opt-in:
 mlx_lm.server --model mlx-community/gemma-3-text-4b-it-4bit --host 127.0.0.1 --port 8080
 
 # terminal 2
-docker compose up -d --build postgres redis meilisearch tika semantic semantic-worker
-docker compose --env-file env/profiles/m5_mlx_balanced.env up -d --build --no-deps worker api pipeline frontend
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build \
+  postgres redis meilisearch tika semantic semantic-worker
+docker compose --env-file .env --env-file env/profiles/m5_mlx_balanced.env \
+  -f docker-compose.yml -f docker-compose.dev.yml up -d --build --no-deps \
+  worker api pipeline frontend
 docker compose exec -T worker python scripts/worker_healthcheck.py
 ```
 
 M5 conservative baseline:
 ```bash
-docker compose --env-file env/profiles/m5_conservative.env up -d --build inference worker api pipeline frontend
+docker compose --env-file .env --env-file env/profiles/m5_conservative.env \
+  -f docker-compose.yml -f docker-compose.dev.yml up -d --build \
+  inference worker api pipeline frontend
 ```
 
 Desktop balanced:
 ```bash
-docker compose --env-file env/profiles/desktop_balanced.env up -d --build inference worker api pipeline frontend
+docker compose --env-file .env --env-file env/profiles/desktop_balanced.env \
+  -f docker-compose.yml -f docker-compose.dev.yml up -d --build \
+  inference worker api pipeline frontend
 ```
 
 Interpretation rules:
@@ -1200,14 +1313,20 @@ same 270M model.
 
 2) Run Arm A (control, conservative):
 ```bash
-LOCAL_AI_BACKEND=http LOCAL_AI_HTTP_MODEL=gemma-3-270m-custom LOCAL_AI_HTTP_PROFILE=conservative WORKER_CONCURRENCY=3 WORKER_POOL=prefork docker compose up -d --build inference worker api pipeline
+LOCAL_AI_BACKEND=http LOCAL_AI_HTTP_MODEL=gemma-3-270m-custom \
+  LOCAL_AI_HTTP_PROFILE=conservative WORKER_CONCURRENCY=3 WORKER_POOL=prefork \
+  docker compose -f docker-compose.yml -f docker-compose.dev.yml \
+  up -d --build inference worker api pipeline
 ./scripts/run_ab_eval.sh --arm A --catalog-file experiments/ab_catalogs_v1.txt --run-id A_run1
 python scripts/collect_ab_results.py --run-id A_run1
 ```
 
 3) Run Arm B (treatment, balanced):
 ```bash
-LOCAL_AI_BACKEND=http LOCAL_AI_HTTP_MODEL=gemma-3-270m-custom LOCAL_AI_HTTP_PROFILE=balanced WORKER_CONCURRENCY=3 WORKER_POOL=prefork docker compose up -d --build inference worker api pipeline
+LOCAL_AI_BACKEND=http LOCAL_AI_HTTP_MODEL=gemma-3-270m-custom \
+  LOCAL_AI_HTTP_PROFILE=balanced WORKER_CONCURRENCY=3 WORKER_POOL=prefork \
+  docker compose -f docker-compose.yml -f docker-compose.dev.yml \
+  up -d --build inference worker api pipeline
 ./scripts/run_ab_eval.sh --arm B --catalog-file experiments/ab_catalogs_v1.txt --run-id B_run1
 python scripts/collect_ab_results.py --run-id B_run1
 ```
@@ -1279,7 +1398,10 @@ The probe writes:
 
 Arm A (control):
 ```bash
-LOCAL_AI_BACKEND=http LOCAL_AI_HTTP_MODEL=gemma-3-270m-custom LOCAL_AI_HTTP_PROFILE=conservative WORKER_CONCURRENCY=3 WORKER_POOL=prefork docker compose up -d --build inference worker api pipeline
+LOCAL_AI_BACKEND=http LOCAL_AI_HTTP_MODEL=gemma-3-270m-custom \
+  LOCAL_AI_HTTP_PROFILE=conservative WORKER_CONCURRENCY=3 WORKER_POOL=prefork \
+  docker compose -f docker-compose.yml -f docker-compose.dev.yml \
+  up -d --build inference worker api pipeline
 ./scripts/run_ab_eval.sh --arm A --catalog-file experiments/ab_catalogs_v1.txt --run-id gemma4_ab_control --arm-model gemma-3-270m-custom
 python scripts/collect_ab_results.py --run-id gemma4_ab_control
 ```
@@ -1289,7 +1411,10 @@ between arms.
 
 Arm B (treatment):
 ```bash
-LOCAL_AI_BACKEND=http LOCAL_AI_HTTP_MODEL=gemma4:e2b LOCAL_AI_HTTP_PROFILE=conservative WORKER_CONCURRENCY=3 WORKER_POOL=prefork docker compose up -d --build inference worker api pipeline
+LOCAL_AI_BACKEND=http LOCAL_AI_HTTP_MODEL=gemma4:e2b \
+  LOCAL_AI_HTTP_PROFILE=conservative WORKER_CONCURRENCY=3 WORKER_POOL=prefork \
+  docker compose -f docker-compose.yml -f docker-compose.dev.yml \
+  up -d --build inference worker api pipeline
 ./scripts/run_ab_eval.sh --arm B --catalog-file experiments/ab_catalogs_v1.txt --run-id gemma4_ab_treatment --arm-model gemma4:e2b
 python scripts/collect_ab_results.py --run-id gemma4_ab_treatment
 ```
@@ -1311,13 +1436,19 @@ The scorer now preserves arm identity from `run_config.json`:
 
 Control:
 ```bash
-LOCAL_AI_BACKEND=http LOCAL_AI_HTTP_MODEL=gemma-3-270m-custom LOCAL_AI_HTTP_PROFILE=conservative WORKER_CONCURRENCY=3 WORKER_POOL=prefork docker compose up -d --build inference worker api pipeline enrichment-worker
+LOCAL_AI_BACKEND=http LOCAL_AI_HTTP_MODEL=gemma-3-270m-custom \
+  LOCAL_AI_HTTP_PROFILE=conservative WORKER_CONCURRENCY=3 WORKER_POOL=prefork \
+  docker compose -f docker-compose.yml -f docker-compose.dev.yml \
+  up -d --build inference worker api pipeline enrichment-worker
 sleep 1 && PYTHONPATH=. .venv/bin/python scripts/profile_pipeline.py --mode baseline --manifest profiling/manifests/baseline_representative_v1.txt
 ```
 
 Treatment:
 ```bash
-LOCAL_AI_BACKEND=http LOCAL_AI_HTTP_MODEL=gemma4:e2b LOCAL_AI_HTTP_PROFILE=conservative WORKER_CONCURRENCY=3 WORKER_POOL=prefork docker compose up -d --build inference worker api pipeline enrichment-worker
+LOCAL_AI_BACKEND=http LOCAL_AI_HTTP_MODEL=gemma4:e2b \
+  LOCAL_AI_HTTP_PROFILE=conservative WORKER_CONCURRENCY=3 WORKER_POOL=prefork \
+  docker compose -f docker-compose.yml -f docker-compose.dev.yml \
+  up -d --build inference worker api pipeline enrichment-worker
 sleep 1 && PYTHONPATH=. .venv/bin/python scripts/profile_pipeline.py --mode baseline --manifest profiling/manifests/baseline_representative_v1.txt
 ```
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -636,6 +636,9 @@ when the reader key is missing or unsafe; they never retry with the master key.
 Base Compose runs Meilisearch with `MEILI_ENV=production`, which enforces its
 production master-key requirements. The development overlay is the only
 checked-in path that selects Meilisearch development mode.
+When local `.env` customizes `MEILI_MASTER_KEY` but leaves `MEILI_SEARCH_KEY`
+blank, the development overlay gives readers the same local credential. An
+explicit `MEILI_SEARCH_KEY` still takes precedence.
 
 Create a key scoped to search and read statistics from the `documents` index:
 

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,6 +1,6 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 2.9
+version: 3.2
 generated: 2026-07-23
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
@@ -10,6 +10,15 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v3.2:** Closes T-SEC-3 review gaps by aligning base and development reader
+  identities, preserving the development stack during bootstrap, soak
+  recovery, and local experiments, and protecting the frontend's independent
+  Docker build context.
+- **v3.1:** Expands T-SEC-3 ownership to keep local model bootstrap and runtime
+  profile commands on the explicit development Compose stack.
+- **v3.0:** Expands T-SEC-3 to cover both Meilisearch reader services,
+  non-development fail-fast behavior, writer credential wiring, tests,
+  operations guidance, and its Full implementation plan.
 - **v2.9:** Marks T-SEC-2 complete after transport-safe API-key validation,
   focused and full-suite verification, independent review, and green
   implementation-head pull-request checks. The closure commit must pass the
@@ -66,8 +75,9 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 | State | Tasks |
 |---|---|
 | **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2 |
+| **In review** | T-SEC-3 |
 | **Partially landed; acceptance incomplete** | T-GOV-4, T-GOV-5, T-GOV-6 |
-| **Pending** | T-SEC-3..6, T-TIME-1..3, T-CRAWL-1..2, T-DA-1, T-DB-1, T-DC-1, T-DD-1, T-DE-1, T-PLAT-1..4, T-GOV-1..3 |
+| **Pending** | T-SEC-4..6, T-TIME-1..3, T-CRAWL-1..2, T-DA-1, T-DB-1, T-DC-1, T-DD-1, T-DE-1, T-PLAT-1..4, T-GOV-1..3 |
 
 ---
 
@@ -118,7 +128,7 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 | lane      | agent id   | owned paths (exclusive within phase)                      |
 |-----------|-----------|------------------------------------------------------------|
 | CI        | agent-ci   | .github/workflows/**, ruff.toml, ruff-format.toml (new), .pre-commit-config.yaml, .coveragerc, frontend/package.json, frontend/jest.config.* (new) |
-| SEC       | agent-sec  | docker-compose.yml, docker-compose.dev.yml, .env.example, api/app_setup.py, api/main.py (CORS+/stats sections only), api/search/support_core.py, frontend/app/api/** |
+| SEC       | agent-sec  | docker-compose.yml, docker-compose.dev.yml, .dockerignore, .env.example, api/app_setup.py, api/main.py (CORS+/stats sections only), api/search/support_core.py, pipeline/meilisearch_credentials.py, semantic_service/main.py, frontend/app/api/** |
 | TIME      | agent-time | pipeline/model_base.py, model_civic.py, model_events.py, model_records.py, model_runtime.py, models.py, db_migrate.py, migrate_v10.py (new), pipeline/summary_freshness.py (verify-only) |
 | CRAWL     | agent-crawl| council_crawler/**                                          |
 | DEDUP-A   | agent-da   | pipeline/metrics.py, pipeline/metrics_redis_backend.py, tests/test_*metrics* |
@@ -444,19 +454,45 @@ in `AGENTS.md`, `docs/TESTING.MD`, and
   outbound HTTP or purge.
 - verify: Targeted pytest for the new test; full suite green.
 
-### T-SEC-3: API read path uses a scoped Meilisearch search key, not the master key
+### T-SEC-3: API and semantic readers use a scoped Meilisearch search key
 - priority: P1
-- files_owned: api/search/support_core.py, docker-compose.yml (api env only),
-  .env.example, README.md (search-key setup note only)
-- do: Introduce `MEILI_SEARCH_KEY` env; api client prefers it, falls back to
-  master key with a logged warning (preserves dev ergonomics). Document key
-  creation (`/keys` endpoint) in README search section or OPERATIONS. The
-  pipeline/indexer keeps the master key (it writes).
-- accept: With MEILI_SEARCH_KEY set, api never sends the master key.
-- forbidden: New config module; put the env read next to the existing ones
-  in support_core.
-- verify: grep confirms api/ has no MEILI_MASTER_KEY usage on the request
-  path when search key present; suite green.
+- status: in-review
+- implementation_plan: `docs/plans/T_SEC_3_MEILISEARCH_SEARCH_KEY_PLAN.md`
+- files_owned: docs/plans/T_SEC_3_MEILISEARCH_SEARCH_KEY_PLAN.md,
+  docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md,
+  pipeline/meilisearch_credentials.py, api/app_setup.py,
+  api/search/support_core.py, semantic_service/main.py, docker-compose.yml,
+  docker-compose.dev.yml, .dockerignore, .env.example, README.md,
+  scripts/dev_up.sh, scripts/bootstrap_local_models.sh,
+  scripts/run_soak_day.sh, frontend/.dockerignore,
+  env/profiles/README.md, docs/OPERATIONS.md, SECURITY.md,
+  tests/test_api_startup_security.py, tests/test_meilisearch_key_security.py,
+  tests/test_docker_build_contracts.py, tests/test_run_soak_day_contract.py,
+  tests/test_startup_purge_gating.py
+- do: Introduce `MEILI_SEARCH_KEY` for API and semantic readers. Keep the fake
+  master fallback only in development with a value-free warning; fail
+  non-development startup when the scoped key is absent, equals the development
+  fallback, or is unsafe. Scope the reader key to `search` and `stats.get` on
+  `documents` so the existing API statistics read remains available. Remove
+  the deployed master key from reader containers, require it in base Compose,
+  run Meilisearch in production mode by default, and provide the key to
+  pipeline writer containers. Document key creation, verification, rotation,
+  and revocation.
+- accept: API and semantic clients use only the scoped key when configured;
+  reader containers do not receive the deployed master key or repository
+  `.env`; development mounts expose only required source directories; build
+  contexts exclude local environment files; base readers default to
+  non-development while the overlay marks them as development; local
+  bootstrap, soak recovery, and runtime profile commands preserve the
+  development overlay; soak recovery explicitly disables startup purge; writer
+  containers retain indexing access; isolated and deployed-key permission
+  checks prove search and statistics reads succeed while write and
+  administration fail.
+- forbidden: Master retry, duplicate credential-policy implementations, facade
+  removal before G3, public key exposure, or new client/config registries.
+- verify: Follow the Full T-SEC-3 plan, including credential tests, resolved
+  Compose contracts, live v1.6 permission smoke, API/semantic/indexer suites,
+  Ruff, Mypy, docs links, and the complete Python suite.
 
 ### T-SEC-4: Real client identity through the proxy; per-client rate limits
 - priority: P0

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,6 +1,6 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 3.2
+version: 3.3
 generated: 2026-07-23
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
@@ -10,6 +10,9 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v3.3:** Preserves customized local Meilisearch credentials by deriving the
+  development reader key from the local master only when no explicit search
+  key is configured.
 - **v3.2:** Closes T-SEC-3 review gaps by aligning base and development reader
   identities, preserving the development stack during bootstrap, soak
   recovery, and local experiments, and protecting the frontend's independent

--- a/docs/plans/T_SEC_3_MEILISEARCH_SEARCH_KEY_PLAN.md
+++ b/docs/plans/T_SEC_3_MEILISEARCH_SEARCH_KEY_PLAN.md
@@ -119,6 +119,8 @@ implementation. Legacy API facade re-exports remain deferred to Phase 2.
   Its deployed permissions are `search` and `stats.get` on `documents`.
 - `MEILI_MASTER_KEY` remains the writer/admin credential.
 - Development may use the fake master fallback when no search key is set.
+- In the development overlay, a missing search key follows the configured
+  local master so existing customized local environments remain usable.
 - Non-development startup fails if the search key is missing, blank, equal to
   the development fallback, or transport-unsafe.
 - A rejected search request never retries with the master key.

--- a/docs/plans/T_SEC_3_MEILISEARCH_SEARCH_KEY_PLAN.md
+++ b/docs/plans/T_SEC_3_MEILISEARCH_SEARCH_KEY_PLAN.md
@@ -1,0 +1,418 @@
+# T-SEC-3: Scope Meilisearch Reader Credentials
+
+`artifact_contract: ce-unified-plan/v1`
+`artifact_readiness: in-review`
+`execution: code`
+## 1. Context & Alignment
+
+**a) Driver.** The API and semantic service currently construct read clients
+with `MEILI_MASTER_KEY`. Compromise of either reader therefore exposes
+Meilisearch administration and write capability. T-SEC-3 limits both reader
+services to a scoped read key while preserving the master key for indexing and
+administration.
+
+**b) Canonical documents consulted.**
+
+- `AGENTS.md` `<security_sensitive_paths>` requires a trust-boundary impact
+  statement for Compose changes; `<hard_invariants>` requires local-first
+  behavior and fail-fast non-development configuration.
+- `SECURITY.md` "Trust boundaries" requires API-to-Meilisearch reads to use a
+  scoped key; T-SEC-3 expands that control to the semantic lexical reader.
+- `docs/TESTING.md` permits Meilisearch client substitution at its construction
+  point and filesystem/subprocess verification without production test seams.
+- `docs/ENGINEERING_GUARDRAILS.md` leaves Ruff, Mypy, formatter, and coverage
+  policy unchanged.
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md` assigns T-SEC-3 to Phase 1 and
+  keeps facade removal behind G3.
+- `docs/reviews/architecture-review-2026-07-19.html` permits Phase 1 security
+  work while Phase 2 remains blocked.
+
+**c) Remediation alignment.** T-SEC-3 remains in the security lane. Expand its
+owned files before implementation to
+`docs/plans/T_SEC_3_MEILISEARCH_SEARCH_KEY_PLAN.md`,
+`docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`,
+`pipeline/meilisearch_credentials.py`, `api/app_setup.py`,
+`api/search/support_core.py`, `semantic_service/main.py`, `docker-compose.yml`,
+`docker-compose.dev.yml`, `.dockerignore`, `.env.example`, `README.md`,
+`scripts/dev_up.sh`, `scripts/bootstrap_local_models.sh`,
+`scripts/run_soak_day.sh`, `frontend/.dockerignore`,
+`env/profiles/README.md`, `docs/OPERATIONS.md`, `SECURITY.md`,
+`tests/test_api_startup_security.py`,
+`tests/test_meilisearch_key_security.py`, and
+`tests/test_docker_build_contracts.py`, and
+`tests/test_run_soak_day_contract.py`, and
+`tests/test_startup_purge_gating.py`.
+
+No other tracked file may change.
+**d) Decision-gate check.** T-SEC-3 does not depend on or foreclose G1-G5.
+G1's reachable default requires this hardening. G3 still blocks removal of
+`MEILI_MASTER_KEY` facade re-exports, so this task leaves them intact while
+ensuring reader containers do not receive the deployed master credential.
+
+## 2. Design
+
+**e) Step-by-step approach.**
+
+1. Register this Full plan, corrected ownership, and implementation-ready
+   status before behavior changes.
+2. Add failing tests for reader-key selection, production refusal, Compose role
+   separation, and documentation contracts.
+3. Add `pipeline/meilisearch_credentials.py` as the single policy owner. Its
+   only function validates and selects a reader credential from `APP_ENV` and
+   `MEILI_SEARCH_KEY`; a named constant owns the fake development key. It
+   performs no environment reads, logging, client creation, or network work and
+   never imports API or semantic modules.
+4. Update API and semantic client construction to pass the selected reader key
+   to the existing Meilisearch SDK client. Preserve raw valid keys. Until G3,
+   the existing API `MEILI_MASTER_KEY` facade export remains but contains the
+   resolved reader key and never reads the deployed master environment value.
+5. Validate the reader credential when each reader module selects its
+   import-time client configuration. Outside development, reject missing,
+   blank, development-fallback, or transport-unsafe reader keys before serving
+   requests. Use the API lifespan and a new semantic-service lifespan only to
+   emit a value-free warning when development uses the fake-key fallback.
+6. Update Compose:
+   - API and semantic receive `MEILI_SEARCH_KEY` and no deployed master key.
+   - Base Meilisearch runs in production mode with a required master key; only
+     the development overlay selects development mode.
+   - Base reader services use image code and cannot read a repository-mounted
+     `.env`; the development overlay mounts only required source directories.
+   - Semantic also receives `APP_ENV`.
+   - Pipeline and pipeline-batch receive `MEILI_HOST` and `MEILI_MASTER_KEY`
+     because both execute indexing paths.
+   - Existing worker, enrichment-worker, and Meilisearch master-key wiring
+     remains unchanged.
+7. Exclude local `.env` variants from the Docker build context while retaining
+   `.env.example`. Add the environment example and concise README pointer. Put
+   create, verify, rotate, revoke, and rollback commands in
+   `docs/OPERATIONS.md`; reader deployment rebuilds images before recreation.
+8. Keep local startup commands on the base-plus-development Compose stack,
+   including model bootstrap and opt-in runtime profile examples, so starting
+   support services cannot silently restore production-mode Meilisearch. Base
+   reader services default to non-development; the overlay explicitly marks
+   API and semantic as development. Soak self-recovery and active local
+   inference/A-B runbook commands use the same overlay. Soak recovery overrides
+   the existing purge setting to `false` so recovery cannot invalidate the
+   measurement corpus.
+9. Exclude every `.env.*` variant from the frontend's independent Docker build
+   context; the root ignore file does not govern that context.
+10. Run a disposable, volume-free smoke against pinned Meilisearch v1.6. Seed
+   `documents`, create a short-lived scoped reader key, verify search and index
+   statistics succeed while document writes, settings changes, and key
+   creation return 403, then revoke the key and remove the container.
+11. Run full local verification, simplification, independent pre-commit review,
+   atomic commits, PR review, current-head CI, and merge.
+
+The shared credential module is justified because two independently deployed
+reader services enforce the same security policy. Duplicating the policy in
+both services would create a convention-synchronized implementation.
+
+**f) Reuse audit.** Reuse `pipeline/config_env.py` environment helpers, current
+Meilisearch client constructors, existing FastAPI lifespan boundaries, Compose
+configuration parsing, and subprocess test patterns. Do not add a config
+registry, client factory, retry path, compatibility alias, or second fallback
+implementation. Legacy API facade re-exports remain deferred to Phase 2.
+
+**g) Data contracts.**
+
+- `MEILI_SEARCH_KEY` is the reader credential for API and semantic services.
+  Its deployed permissions are `search` and `stats.get` on `documents`.
+- `MEILI_MASTER_KEY` remains the writer/admin credential.
+- Development may use the fake master fallback when no search key is set.
+- Non-development startup fails if the search key is missing, blank, equal to
+  the development fallback, or transport-unsafe.
+- A rejected search request never retries with the master key.
+- A distinct master sentinel never reaches a reader client or legacy export.
+- API and semantic clients require restart after key rotation because they are
+  created during module import under the existing architecture.
+
+No public API, Celery signature, database contract, or inference default
+changes.
+**h) Schema/migration impact.** None.
+
+## 3. Security & Data Governance
+
+**i) Security-sensitive path.** `docker-compose.yml` controls the API and
+semantic-to-Meilisearch trust boundary. Before this change, compromise of a
+reader container reveals an administrative credential. Afterward, reader
+containers receive no master variable, and deployment requires permission
+preflight of the candidate reader key. Writer services retain the master key.
+This implements `SECURITY.md` trust-boundary control T-SEC-3.
+
+**j) Secrets.** One new environment variable, `MEILI_SEARCH_KEY`, carries a
+server-side secret. It has no working non-development default and is never
+exposed through `NEXT_PUBLIC_*`, logs, test output, or committed files.
+
+**k) Person data.** No person-level data is created, linked, aggregated, or
+exposed. G4 is unaffected.
+
+**l) Untrusted input.** No scraped or browser input parsing changes. The
+Meilisearch key is untrusted environment input and is validated before reader
+services accept requests.
+
+## 4. Code Health
+
+**m) GED conformance sweep.** The new policy function has two parameters, one
+responsibility, complete type annotations, no nested branching beyond two
+levels, and named constants for environment and error policy. No broad
+exception, timestamp, retry, or silent fallback is added.
+
+**n) Antipattern scan, plan pass.**
+
+- A1/H1: Context7 verified `POST /keys`, `GET /keys/{uid}`, master
+  authentication, action/index scoping, nullable `expiresAt`, and response
+  `key`/`uid` fields. The repository
+  pins server v1.6 and Python SDK 0.31.0; a live v1.6 smoke remains required
+  because Context7 is not version-pinned.
+- B1/F1: one side-effect-free policy module replaces two otherwise duplicated
+  reader implementations; no factory or registry is added.
+- B2/C1/C2: no compatibility alias or facade patch seam is added. Existing
+  facades remain only because G3 forbids their removal in this phase.
+- B3: validation covers concrete deployment failures and HTTP header transport.
+- D1-D3: tests assert outbound authorization behavior, startup outcomes,
+  Compose role separation, and live permissions.
+- E1-E3: only owned files and named documentation sections change.
+- A2-A4, F2, H2-H4: no violations planned. Existing import-time client
+  creation remains but is not expanded with network work.
+
+**o) Ratchet interaction.** No Ruff selector, BLE001 boundary, formatter scope,
+Mypy scope, coverage threshold, or test tolerance changes.
+
+**p) Dead code and duplication audit.** The API and semantic master-key client
+selection is replaced by one shared reader policy. No facade symbol is removed
+before G3. Expected production delta is one small policy module plus startup
+validation; Compose gains role-correct credential entries.
+
+## 5. Testing
+
+**q) Edge and failure scenarios.**
+
+1. Search key present: API and semantic clients use it, never the master key.
+2. Search key missing or blank in development: fake master fallback works and
+   emits a value-free warning.
+3. Search key missing, blank, or equal to the development fallback outside
+   development: startup fails.
+4. Search key contains non-ASCII, control, or edge-whitespace characters:
+   startup fails before serving requests.
+5. Search key is invalid, expired, or unauthorized: one request fails without
+   a second request or master-key retry.
+6. API and semantic Compose services receive only the reader key, and semantic
+   receives `APP_ENV`.
+7. Base reader containers cannot read a repository-mounted `.env`, local
+   environment files are absent from image build context, and development
+   readers mount only required source directories rather than the repository
+   root.
+8. Pipeline writer services receive host and master key.
+9. Existing worker and indexer writer paths retain master-key access.
+10. Base Meilisearch uses production mode and refuses a missing or invalid
+    master key; the development overlay alone selects development mode.
+11. The disposable live key can search and read statistics for `documents` but
+    cannot write documents, change settings, or manage keys.
+12. Key rotation requires reader-service restart; revocation occurs only after
+    the replacement key passes health and search checks.
+13. Permission preflight rejects a candidate whose UID, key, actions, or index
+    scope differs from the exact generated scoped-reader record.
+
+**r) Tests.**
+
+| Test | Scenarios |
+|---|---|
+| Reader policy unit tests | 2-4 |
+| Isolated API and semantic client-selection/sentinel tests | 1 |
+| API and semantic startup tests | 2-4 |
+| One-request HTTP boundary test | 5 |
+| Compose credential-role contract | 6-10 |
+| Docker build-context contract | 7 |
+| Environment/docs contract | 6, 12, 13 |
+| Isolated Meilisearch v1.6 smoke | 1, 5, 10-13 |
+| Existing API, semantic, and indexer suites | Regression coverage |
+
+Tests are written and run red before runtime or Compose edits.
+
+**s) Fakes and mocks.** Client tests use isolated subprocesses and the approved
+Meilisearch construction boundary. A local fake HTTP server records the
+authorization header and request count for scenario 5. Startup tests use
+FastAPI `TestClient` and implementation modules. No facade is patched.
+
+**t) Verification rows.** Apply security-sensitive trust-boundary reporting,
+API/search, docs, Docker contract, semantic-service, and broad cross-cutting
+verification. Run the complete Python suite and authoritative PR gates.
+
+## 6. Execution, Rollback, Docs
+
+**u) Exact commands.**
+
+```bash
+git fetch origin --prune
+git switch master
+git merge --ff-only origin/master
+git switch -c codex/t-sec-3-scoped-meilisearch-key
+
+PYTHONPATH=. .venv/bin/pytest -q \
+  tests/test_meilisearch_key_security.py \
+  tests/test_api_startup_security.py \
+  tests/test_docker_build_contracts.py
+
+docker compose --profile batch-tools config --quiet
+
+./.venv/bin/ruff check .
+./.venv/bin/pre-commit run ruff --all-files
+./.venv/bin/mypy
+PYTHONPATH=. .venv/bin/pytest -q tests/test_meilisearch_key_security.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_api_startup_security.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_api.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_query_builder_filters.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_query_builder_parity_search_vs_trends.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_semantic_service_api.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_search_pgvector_hybrid_rerank.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_semantic_recall_filters.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_indexer_logic.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_docker_build_contracts.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_env_example_profile_alignment.py
+PYTHONPATH=. .venv/bin/python -m pytest -q tests/
+git diff --check
+```
+
+Isolated server-v1.6 permission smoke:
+
+```bash
+(
+set -euo pipefail
+MASTER_KEY=$(openssl rand -hex 24)
+bounded_curl() { command curl --connect-timeout 2 --max-time 10 "$@"; }
+umask 077
+MEILI_ENV_FILE=$(mktemp)
+MASTER_HEADER_FILE=$(mktemp)
+SEARCH_HEADER_FILE=$(mktemp)
+printf 'MEILI_ENV=production\nMEILI_MASTER_KEY=%s\n' "$MASTER_KEY" >"$MEILI_ENV_FILE"
+printf 'Authorization: Bearer %s\n' "$MASTER_KEY" >"$MASTER_HEADER_FILE"
+CID=$(docker run --rm -d --env-file "$MEILI_ENV_FILE" \
+  -p 127.0.0.1::7700 getmeili/meilisearch:v1.6)
+KEY_UID=
+cleanup() {
+  test -z "$KEY_UID" || bounded_curl -fsS -X DELETE "$MEILI_URL/keys/$KEY_UID" \
+    -H "@$MASTER_HEADER_FILE" >/dev/null || true
+  docker rm -f "$CID" >/dev/null 2>&1 || true
+  rm -f "$MEILI_ENV_FILE" "$MASTER_HEADER_FILE" "$SEARCH_HEADER_FILE"
+}
+# Container removal destroys the volume-free instance even if revocation fails.
+trap cleanup EXIT
+PORT=$(docker port "$CID" 7700/tcp | sed 's/.*://')
+MEILI_URL="http://127.0.0.1:$PORT"
+for _ in {1..60}; do bounded_curl -fsS "$MEILI_URL/health" >/dev/null && break; sleep 1; done
+bounded_curl -fsS "$MEILI_URL/health" >/dev/null
+VERSION=$(bounded_curl -fsS "$MEILI_URL/version" -H "@$MASTER_HEADER_FILE" |
+  .venv/bin/python -c 'import json,sys; print(json.load(sys.stdin)["pkgVersion"])')
+case "$VERSION" in 1.6.*) ;; *) exit 1 ;; esac
+
+# Seed documents and wait for the asynchronous task before testing search.
+TASK_UID=$(bounded_curl -fsS -X POST "$MEILI_URL/indexes/documents/documents?primaryKey=id" \
+  -H "@$MASTER_HEADER_FILE" -H "Content-Type: application/json" \
+  --data-binary '[{"id":"t-sec-3","title":"permission probe"}]' |
+  .venv/bin/python -c 'import json,sys; print(json.load(sys.stdin)["taskUid"])')
+for _ in {1..60}; do
+  TASK_STATUS=$(bounded_curl -fsS "$MEILI_URL/tasks/$TASK_UID" \
+    -H "@$MASTER_HEADER_FILE" | .venv/bin/python -c \
+    'import json,sys; print(json.load(sys.stdin)["status"])')
+  case "$TASK_STATUS" in succeeded) break ;; failed|canceled) exit 1 ;; esac
+  sleep 1
+done
+test "$TASK_STATUS" = succeeded
+
+EXPIRES_AT=$(.venv/bin/python -c \
+  'from datetime import UTC,datetime,timedelta; print((datetime.now(UTC)+timedelta(minutes=15)).isoformat())')
+KEY_JSON=$(bounded_curl -fsS -X POST "$MEILI_URL/keys" \
+  -H "@$MASTER_HEADER_FILE" -H "Content-Type: application/json" \
+  --data-binary "{\"name\":\"T-SEC-3 probe\",\"actions\":[\"search\",\"stats.get\"],\"indexes\":[\"documents\"],\"expiresAt\":\"$EXPIRES_AT\"}")
+MEILI_SEARCH_KEY=$(printf '%s' "$KEY_JSON" | .venv/bin/python -c \
+  'import json,sys; print(json.load(sys.stdin)["key"])')
+KEY_UID=$(printf '%s' "$KEY_JSON" | .venv/bin/python -c \
+  'import json,sys; print(json.load(sys.stdin)["uid"])')
+printf 'Authorization: Bearer %s\n' "$MEILI_SEARCH_KEY" >"$SEARCH_HEADER_FILE"
+bounded_curl -fsS -X POST "$MEILI_URL/indexes/documents/search" \
+  -H "@$SEARCH_HEADER_FILE" -H "Content-Type: application/json" \
+  --data-binary '{"q":"permission"}' >/dev/null
+bounded_curl -fsS "$MEILI_URL/indexes/documents/stats" \
+  -H "@$SEARCH_HEADER_FILE" >/dev/null
+test "$(bounded_curl -sS -o /dev/null -w '%{http_code}' -X POST \
+  "$MEILI_URL/indexes/documents/documents" -H "@$SEARCH_HEADER_FILE" \
+  -H "Content-Type: application/json" --data-binary '[{"id":"denied"}]')" = 403
+test "$(bounded_curl -sS -o /dev/null -w '%{http_code}' -X PATCH \
+  "$MEILI_URL/indexes/documents/settings" -H "@$SEARCH_HEADER_FILE" \
+  -H "Content-Type: application/json" --data-binary '{"displayedAttributes":["id"]}')" = 403
+test "$(bounded_curl -sS -o /dev/null -w '%{http_code}' -X POST \
+  "$MEILI_URL/keys" -H "@$SEARCH_HEADER_FILE" -H "Content-Type: application/json" \
+  --data-binary '{"actions":["search"],"indexes":["*"],"expiresAt":null}')" = 403
+)
+```
+
+Preflight the actual reader key before restarting API or semantic:
+
+```bash
+(
+set -euo pipefail
+bounded_curl() { command curl --connect-timeout 2 --max-time 10 "$@"; }
+: "${MEILI_URL:?set the deployed Meilisearch URL}"
+: "${MEILI_MASTER_KEY:?set the deployed master key for operator preflight}"
+: "${MEILI_SEARCH_KEY:?set the candidate reader key}"
+: "${MEILI_SEARCH_KEY_UID:?set the candidate reader key UID}"
+umask 077
+MASTER_HEADER_FILE=$(mktemp)
+SEARCH_HEADER_FILE=$(mktemp)
+trap 'rm -f "$MASTER_HEADER_FILE" "$SEARCH_HEADER_FILE"' EXIT
+printf 'Authorization: Bearer %s\n' "$MEILI_MASTER_KEY" >"$MASTER_HEADER_FILE"
+printf 'Authorization: Bearer %s\n' "$MEILI_SEARCH_KEY" >"$SEARCH_HEADER_FILE"
+KEY_RECORD=$(bounded_curl -fsS "$MEILI_URL/keys/$MEILI_SEARCH_KEY_UID" \
+  -H "@$MASTER_HEADER_FILE")
+printf '%s' "$KEY_RECORD" | .venv/bin/python -c \
+  'import json,sys; from pathlib import Path; r=json.load(sys.stdin); expected=Path(sys.argv[1]).read_text().removeprefix("Authorization: Bearer ").strip(); assert r["uid"] == sys.argv[2] and r["key"] == expected and r["actions"] == ["search","stats.get"] and r["indexes"] == ["documents"]' \
+  "$SEARCH_HEADER_FILE" "$MEILI_SEARCH_KEY_UID"
+bounded_curl -fsS -X POST "$MEILI_URL/indexes/documents/search" \
+  -H "@$SEARCH_HEADER_FILE" -H "Content-Type: application/json" \
+  --data-binary '{"q":"","limit":1}' >/dev/null
+bounded_curl -fsS "$MEILI_URL/indexes/documents/stats" \
+  -H "@$SEARCH_HEADER_FILE" >/dev/null
+test "$(bounded_curl -sS -o /dev/null -w '%{http_code}' \
+  "$MEILI_URL/indexes/documents/settings" -H "@$SEARCH_HEADER_FILE")" = 403
+test "$(bounded_curl -sS -o /dev/null -w '%{http_code}' \
+  "$MEILI_URL/keys" -H "@$SEARCH_HEADER_FILE")" = 403
+)
+```
+
+**v) Rollback.** Revert the T-SEC-3 merge commit. Restore reader containers to
+their previous environment, recreate API and semantic services, and verify
+health/search before revoking any deployed scoped key. If a disposable key
+remains, delete it by captured UID through `DELETE /keys/{uid}` using the
+master key. Rerun Compose validation, targeted tests, Ruff, Mypy, docs links,
+and the complete suite. No database or index data remediation is required.
+
+**w) Docs synchronization.**
+
+- `README.md`: concise reader-key requirement and operations link.
+- `env/profiles/README.md`: development-overlay and layered environment
+  commands for opt-in profiles.
+- `docs/OPERATIONS.md`: create, deploy, verify, rotate, revoke, and rollback.
+- `SECURITY.md`: reader boundary and T-SEC-3 checklist.
+- Remediation registry and this Full plan.
+- ADR, architecture, roadmap, testing policy, data governance, and OpenAPI:
+  no changes.
+
+## 7. Delivery Self-Audit
+
+**x) Diff scan.** Re-run A-F/H. Reject master-key exposure to reader
+containers, non-development fallback, master retry, duplicate policy, facade
+cleanup, secret-bearing logs, unrelated Compose edits, invented Meilisearch
+fields, weakened tests, or files outside ownership.
+
+**y) Evidence required.** Report tests-first red output, every command in 6u,
+live v1.6 permission results, local environment versions, independent planning
+and pre-commit reviews, commit hashes, PR URL, unresolved-thread count,
+current-head review, and final CI. Anything unrun is `NOT VERIFIED`.
+
+**z) Deviations.** Authorized corrections to the original registry task are
+semantic-reader coverage, non-development fail-fast behavior, a shared policy
+module, writer-service credential injection, tests, operations documentation,
+and expanded ownership. Any other file, facade removal before G3, permission
+expansion, skipped review, unresolved P1/P2, or unrun required check is a
+blocker.

--- a/env/profiles/README.md
+++ b/env/profiles/README.md
@@ -20,8 +20,11 @@ Start MLX-LM on the Mac host before using either profile:
 mlx_lm.server --model mlx-community/gemma-3-text-4b-it-4bit --host 127.0.0.1 --port 8080
 
 # terminal 2
-docker compose up -d --build postgres redis meilisearch tika semantic semantic-worker
-docker compose --env-file env/profiles/m5_mlx_conservative.env up -d --build --no-deps worker api pipeline frontend
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build \
+  postgres redis meilisearch tika semantic semantic-worker
+docker compose --env-file .env --env-file env/profiles/m5_mlx_conservative.env \
+  -f docker-compose.yml -f docker-compose.dev.yml up -d --build --no-deps \
+  worker api pipeline frontend
 docker compose exec -T worker python scripts/worker_healthcheck.py
 ```
 

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -11,7 +11,4 @@ npm-debug.log
 yarn-debug.log
 yarn-error.log
 .env
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env.*

--- a/pipeline/meilisearch_credentials.py
+++ b/pipeline/meilisearch_credentials.py
@@ -1,0 +1,31 @@
+DEVELOPMENT_APP_ENV = "dev"
+DEVELOPMENT_MEILI_SEARCH_KEY = "masterKey"
+MISSING_MEILI_SEARCH_KEY_MESSAGE = "MEILI_SEARCH_KEY must be set when APP_ENV is not dev."
+DEVELOPMENT_MEILI_SEARCH_KEY_MESSAGE = (
+    "MEILI_SEARCH_KEY must not use the development fallback when APP_ENV is not dev."
+)
+UNSAFE_MEILI_SEARCH_KEY_MESSAGE = (
+    "MEILI_SEARCH_KEY must contain printable ASCII characters without leading or trailing whitespace."
+)
+MEILI_SEARCH_KEY_FALLBACK_WARNING = "Meilisearch reader is using the development fallback key."
+
+
+def resolve_meilisearch_reader_key(app_env: str, search_key: str) -> str:
+    normalized_app_env = app_env.strip().lower()
+    normalized_search_key = search_key.strip()
+    if not normalized_search_key:
+        if normalized_app_env == DEVELOPMENT_APP_ENV:
+            return DEVELOPMENT_MEILI_SEARCH_KEY
+        raise RuntimeError(MISSING_MEILI_SEARCH_KEY_MESSAGE)
+    if (
+        normalized_app_env != DEVELOPMENT_APP_ENV
+        and normalized_search_key == DEVELOPMENT_MEILI_SEARCH_KEY
+    ):
+        raise RuntimeError(DEVELOPMENT_MEILI_SEARCH_KEY_MESSAGE)
+    if (
+        not search_key.isascii()
+        or not search_key.isprintable()
+        or search_key != normalized_search_key
+    ):
+        raise RuntimeError(UNSAFE_MEILI_SEARCH_KEY_MESSAGE)
+    return search_key

--- a/scripts/bootstrap_local_models.sh
+++ b/scripts/bootstrap_local_models.sh
@@ -3,19 +3,21 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
+COMPOSE=(docker compose -f docker-compose.yml -f docker-compose.dev.yml)
+
 echo "[bootstrap_models] Starting core inference services..."
-docker compose up -d inference semantic >/dev/null
+"${COMPOSE[@]}" up -d inference semantic >/dev/null
 
 echo "[bootstrap_models] Caching sentence-transformer model in shared volume..."
-docker compose run --rm semantic python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('all-MiniLM-L6-v2')"
+"${COMPOSE[@]}" run --rm semantic python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('all-MiniLM-L6-v2')"
 
 echo "[bootstrap_models] Downloading Gemma GGUF into shared volume..."
-docker compose run --rm semantic python -c "from huggingface_hub import hf_hub_download; hf_hub_download(repo_id='unsloth/gemma-3-270m-it-GGUF', filename='gemma-3-270m-it-Q4_K_M.gguf', local_dir='/models')"
+"${COMPOSE[@]}" run --rm semantic python -c "from huggingface_hub import hf_hub_download; hf_hub_download(repo_id='unsloth/gemma-3-270m-it-GGUF', filename='gemma-3-270m-it-Q4_K_M.gguf', local_dir='/models')"
 
 echo "[bootstrap_models] Registering local Ollama model alias..."
 bash ./scripts/setup_ollama_270m.sh /models/gemma-3-270m-it-Q4_K_M.gguf
 
 echo "[bootstrap_models] Verifying Ollama model is available..."
-docker compose exec -T inference ollama show "${LOCAL_AI_HTTP_MODEL:-gemma-3-270m-custom}" >/dev/null
+"${COMPOSE[@]}" exec -T inference ollama show "${LOCAL_AI_HTTP_MODEL:-gemma-3-270m-custom}" >/dev/null
 
 echo "[bootstrap_models] OK"

--- a/scripts/dev_up.sh
+++ b/scripts/dev_up.sh
@@ -9,19 +9,25 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
+if [[ ! -f .env ]]; then
+  echo "[dev_up] Missing .env. Create it from .env.example before starting the stack." >&2
+  exit 1
+fi
+
 CORE_SERVICES=(postgres redis meilisearch tika inference semantic semantic-worker api worker enrichment-worker monitor frontend)
+COMPOSE=(docker compose -f docker-compose.yml -f docker-compose.dev.yml)
 
 echo "[dev_up] Building and starting core services..."
-docker compose up -d --build "${CORE_SERVICES[@]}"
+"${COMPOSE[@]}" up -d --build "${CORE_SERVICES[@]}"
 
 echo "[dev_up] Bootstrapping local model artifacts..."
 bash ./scripts/bootstrap_local_models.sh
 
 echo "[dev_up] Initializing database schema..."
-docker compose run --rm pipeline python db_init.py
+"${COMPOSE[@]}" run --rm pipeline python db_init.py
 
 echo "[dev_up] Smoke check: verify API container can import BeautifulSoup (bs4)..."
-docker compose run --rm api python -c "import bs4; print('bs4', bs4.__version__)"
+"${COMPOSE[@]}" run --rm api python -c "import bs4; print('bs4', bs4.__version__)"
 
 echo "[dev_up] Smoke check: verify API health endpoint..."
 curl -fsS http://localhost:8000/health >/dev/null

--- a/scripts/run_soak_day.sh
+++ b/scripts/run_soak_day.sh
@@ -9,6 +9,7 @@ API_KEY="${API_KEY:-dev_secret_key_change_me}"
 WAIT_SECONDS="${WAIT_SECONDS:-2}"
 HEALTH_TIMEOUT_SECONDS="${HEALTH_TIMEOUT_SECONDS:-60}"
 TASK_MAX_WAIT_SECONDS="${TASK_MAX_WAIT_SECONDS:-900}"
+DEVELOPMENT_MEILI_MASTER_KEY="masterKey"
 COMPOSE=(docker compose -f docker-compose.yml -f docker-compose.dev.yml)
 
 usage() {
@@ -113,6 +114,9 @@ if ! health_ok; then
   PREFLIGHT_RECOVERY_ATTEMPTED="true"
   # Prefer a fast, no-build recovery path for scheduled soak runs.
   # Full dev_up rebuilds are slower and increase false stack_offline failures.
+  if [[ ! -f .env && -z "${MEILI_MASTER_KEY:-}" ]]; then
+    export MEILI_MASTER_KEY="$DEVELOPMENT_MEILI_MASTER_KEY"
+  fi
   if STARTUP_PURGE_DERIVED=false "${COMPOSE[@]}" up -d inference worker api pipeline frontend >"$PREFLIGHT_RECOVERY_LOG" 2>&1; then
     PREFLIGHT_RECOVERY_RESULT="docker_compose_succeeded"
   else

--- a/scripts/run_soak_day.sh
+++ b/scripts/run_soak_day.sh
@@ -9,6 +9,7 @@ API_KEY="${API_KEY:-dev_secret_key_change_me}"
 WAIT_SECONDS="${WAIT_SECONDS:-2}"
 HEALTH_TIMEOUT_SECONDS="${HEALTH_TIMEOUT_SECONDS:-60}"
 TASK_MAX_WAIT_SECONDS="${TASK_MAX_WAIT_SECONDS:-900}"
+COMPOSE=(docker compose -f docker-compose.yml -f docker-compose.dev.yml)
 
 usage() {
   echo "usage: $0 --run-id <id> --catalog-file <path> [--output-dir <path>] [--api-url <url>] [--api-key <key>] [--task-max-wait-seconds <n>]"
@@ -112,7 +113,7 @@ if ! health_ok; then
   PREFLIGHT_RECOVERY_ATTEMPTED="true"
   # Prefer a fast, no-build recovery path for scheduled soak runs.
   # Full dev_up rebuilds are slower and increase false stack_offline failures.
-  if docker compose up -d inference worker api pipeline frontend >"$PREFLIGHT_RECOVERY_LOG" 2>&1; then
+  if STARTUP_PURGE_DERIVED=false "${COMPOSE[@]}" up -d inference worker api pipeline frontend >"$PREFLIGHT_RECOVERY_LOG" 2>&1; then
     PREFLIGHT_RECOVERY_RESULT="docker_compose_succeeded"
   else
     PREFLIGHT_RECOVERY_RESULT="docker_compose_failed"
@@ -126,7 +127,7 @@ if ! health_ok; then
   fi
   if ! health_ok; then
     preflight_status="stack_offline"
-    docker compose ps >"$PREFLIGHT_COMPOSE_PS_LOG" 2>&1 || true
+    "${COMPOSE[@]}" ps >"$PREFLIGHT_COMPOSE_PS_LOG" 2>&1 || true
     python3 - <<'PY' "$RUN_ID" "$API_URL" "$preflight_status" "$DAY_SUMMARY_JSON" "$PREFLIGHT_RECOVERY_ATTEMPTED" "$PREFLIGHT_RECOVERY_RESULT"
 import json
 import sys

--- a/semantic_service/main.py
+++ b/semantic_service/main.py
@@ -1,6 +1,7 @@
 import logging
-import os
 import time
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from typing import Any, Optional
 
 import meilisearch
@@ -15,6 +16,13 @@ from pipeline.config import (
     SEMANTIC_FILTER_EXPANSION_FACTOR,
     SEMANTIC_MAX_TOP_K,
     SEMANTIC_RERANK_CANDIDATE_LIMIT,
+)
+from pipeline.config_env import env_lower, env_raw
+from pipeline.meilisearch_credentials import (
+    DEVELOPMENT_APP_ENV,
+    DEVELOPMENT_MEILI_SEARCH_KEY,
+    MEILI_SEARCH_KEY_FALLBACK_WARNING,
+    resolve_meilisearch_reader_key,
 )
 from pipeline.models import db_connect
 from pipeline.semantic_index import (
@@ -48,14 +56,26 @@ from semantic_service.retrieval import (
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 logger = logging.getLogger("town-council-semantic")
 
-MEILI_HOST = os.getenv("MEILI_HOST", "http://meilisearch:7700")
-MEILI_MASTER_KEY = os.getenv("MEILI_MASTER_KEY", "masterKey")
-client = meilisearch.Client(MEILI_HOST, MEILI_MASTER_KEY, timeout=5)
+MEILI_HOST = env_raw("MEILI_HOST", "http://meilisearch:7700")
+MEILI_SEARCH_KEY = env_raw("MEILI_SEARCH_KEY", "")
+MEILI_READER_KEY = resolve_meilisearch_reader_key(
+    env_lower("APP_ENV", DEVELOPMENT_APP_ENV),
+    MEILI_SEARCH_KEY,
+)
+client = meilisearch.Client(MEILI_HOST, MEILI_READER_KEY, timeout=5)
 
 engine = db_connect()
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
 
-app = FastAPI(title="Town Council Semantic Service")
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    _ = app
+    if not MEILI_SEARCH_KEY.strip() and MEILI_READER_KEY == DEVELOPMENT_MEILI_SEARCH_KEY:
+        logger.warning(MEILI_SEARCH_KEY_FALLBACK_WARNING)
+    yield
+
+
+app = FastAPI(title="Town Council Semantic Service", lifespan=lifespan)
 
 SEMANTIC_BACKEND_UNHEALTHY_DETAIL = "Semantic backend unhealthy"
 SEMANTIC_SERVICE_MISCONFIGURED_DETAIL = "Semantic service is misconfigured"

--- a/semantic_service/main.py
+++ b/semantic_service/main.py
@@ -70,7 +70,7 @@ SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     _ = app
-    if not MEILI_SEARCH_KEY.strip() and MEILI_READER_KEY == DEVELOPMENT_MEILI_SEARCH_KEY:
+    if MEILI_READER_KEY == DEVELOPMENT_MEILI_SEARCH_KEY:
         logger.warning(MEILI_SEARCH_KEY_FALLBACK_WARNING)
     yield
 

--- a/tests/test_api_startup_security.py
+++ b/tests/test_api_startup_security.py
@@ -125,14 +125,14 @@ def test_non_dev_startup_accepts_configured_api_key(
     assert changed_key_response.status_code == 401
 
 
-def test_api_dev_startup_warns_without_search_key(
+def test_api_dev_startup_warns_with_development_search_key(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     monkeypatch.setenv("APP_ENV", "dev")
     monkeypatch.setenv("API_AUTH_KEY", CONFIGURED_API_KEY)
     monkeypatch.setenv("MEILI_MASTER_KEY", MASTER_KEY_SENTINEL)
-    monkeypatch.setattr(support_core, "MEILI_SEARCH_KEY", "")
+    monkeypatch.setattr(support_core, "MEILI_SEARCH_KEY", DEVELOPMENT_MEILI_SEARCH_KEY)
     monkeypatch.setattr(support_core, "MEILI_MASTER_KEY", DEVELOPMENT_MEILI_SEARCH_KEY)
     monkeypatch.setenv("STARTUP_PURGE_DERIVED", "false")
     monkeypatch.setattr(semantic_support.httpx, "get", _healthy_semantic_get)

--- a/tests/test_api_startup_security.py
+++ b/tests/test_api_startup_security.py
@@ -7,7 +7,8 @@ from fastapi import Depends, FastAPI
 from fastapi.testclient import TestClient
 
 from api import app_setup
-from api.search import semantic_support
+from api.search import semantic_support, support_core
+from pipeline.meilisearch_credentials import DEVELOPMENT_MEILI_SEARCH_KEY
 
 
 DEFAULT_KEY_WARNING = "SECURITY WARNING: You are using the default API Key."
@@ -16,6 +17,9 @@ HEADER_UNSAFE_KEY_MESSAGE = (
     "API_AUTH_KEY must contain printable ASCII characters without leading or trailing whitespace."
 )
 CONFIGURED_API_KEY = "Configured Production Key_123"
+CONFIGURED_MEILI_SEARCH_KEY = "Configured Search Key_123"
+MEILI_FALLBACK_WARNING = "Meilisearch reader is using the development fallback key"
+MASTER_KEY_SENTINEL = "master-key-must-not-appear-in-logs"
 
 
 class _HealthySemanticResponse:
@@ -102,6 +106,8 @@ def test_non_dev_startup_accepts_configured_api_key(
 ) -> None:
     monkeypatch.setenv("APP_ENV", "prod")
     monkeypatch.setenv("API_AUTH_KEY", CONFIGURED_API_KEY)
+    monkeypatch.setattr(support_core, "MEILI_SEARCH_KEY", CONFIGURED_MEILI_SEARCH_KEY)
+    monkeypatch.setattr(support_core, "MEILI_MASTER_KEY", CONFIGURED_MEILI_SEARCH_KEY)
     monkeypatch.setenv("STARTUP_PURGE_DERIVED", "false")
     monkeypatch.setattr(semantic_support.httpx, "get", _healthy_semantic_get)
     application = FastAPI(lifespan=app_setup.lifespan)
@@ -117,6 +123,28 @@ def test_non_dev_startup_accepts_configured_api_key(
 
     assert exact_key_response.status_code == 200
     assert changed_key_response.status_code == 401
+
+
+def test_api_dev_startup_warns_without_search_key(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setenv("APP_ENV", "dev")
+    monkeypatch.setenv("API_AUTH_KEY", CONFIGURED_API_KEY)
+    monkeypatch.setenv("MEILI_MASTER_KEY", MASTER_KEY_SENTINEL)
+    monkeypatch.setattr(support_core, "MEILI_SEARCH_KEY", "")
+    monkeypatch.setattr(support_core, "MEILI_MASTER_KEY", DEVELOPMENT_MEILI_SEARCH_KEY)
+    monkeypatch.setenv("STARTUP_PURGE_DERIVED", "false")
+    monkeypatch.setattr(semantic_support.httpx, "get", _healthy_semantic_get)
+    application = FastAPI(lifespan=app_setup.lifespan)
+
+    with caplog.at_level(logging.WARNING, logger="town-council-api"):
+        with TestClient(application):
+            pass
+
+    assert MEILI_FALLBACK_WARNING in caplog.text
+    assert DEVELOPMENT_MEILI_SEARCH_KEY not in caplog.text
+    assert MASTER_KEY_SENTINEL not in caplog.text
 
 
 def test_h11_removes_edge_whitespace_but_preserves_internal_api_key_space() -> None:

--- a/tests/test_docker_build_contracts.py
+++ b/tests/test_docker_build_contracts.py
@@ -1,18 +1,31 @@
 import json
+import os
 import re
 import subprocess
 from pathlib import Path
 
+import pytest
 
-def _compose_services(*compose_paths: str) -> dict[str, dict[str, object]]:
+TEST_MEILI_MASTER_KEY = "test-only-meilisearch-master-key"
+
+
+def _compose_services(
+    *compose_paths: str,
+    profiles: tuple[str, ...] = (),
+) -> dict[str, dict[str, object]]:
     compose_command = ["docker", "compose"]
+    for profile in profiles:
+        compose_command.extend(("--profile", profile))
     for compose_path in compose_paths:
         compose_command.extend(("-f", compose_path))
     compose_command.extend(("config", "--format", "json"))
+    compose_environment = os.environ.copy()
+    compose_environment.setdefault("MEILI_MASTER_KEY", TEST_MEILI_MASTER_KEY)
     completed_process = subprocess.run(
         compose_command,
         check=True,
         capture_output=True,
+        env=compose_environment,
         text=True,
     )
     compose_project = json.loads(completed_process.stdout)
@@ -94,6 +107,108 @@ def test_dev_overlay_publishes_operator_services_on_loopback_only():
     assert all(service_config.get("network_mode") != "host" for service_config in development_services.values())
 
 
+def test_compose_separates_meilisearch_reader_and_writer_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scoped_search_key = "compose-scoped-search-key"
+    master_key_sentinel = "compose-master-key-sentinel"
+    monkeypatch.setenv("MEILI_SEARCH_KEY", scoped_search_key)
+    monkeypatch.setenv("MEILI_MASTER_KEY", master_key_sentinel)
+    compose_services = _compose_services("docker-compose.yml", profiles=("batch-tools",))
+
+    for reader_service_name in ("api", "semantic"):
+        reader_service = compose_services[reader_service_name]
+        reader_environment = reader_service["environment"]
+        assert reader_environment["MEILI_SEARCH_KEY"] == scoped_search_key
+        assert "MEILI_MASTER_KEY" not in reader_environment
+        assert all(volume.get("type") != "bind" for volume in reader_service["volumes"])
+
+    for reader_service_name in ("api", "semantic"):
+        assert compose_services[reader_service_name]["environment"]["APP_ENV"] == "production"
+    assert compose_services["meilisearch"]["environment"]["MEILI_ENV"] == "production"
+    for writer_service_name in ("pipeline", "pipeline-batch", "worker", "enrichment-worker"):
+        writer_environment = compose_services[writer_service_name]["environment"]
+        assert writer_environment["MEILI_HOST"] == "http://meilisearch:7700"
+        assert writer_environment["MEILI_MASTER_KEY"] == master_key_sentinel
+
+
+def test_base_compose_requires_meilisearch_master_key() -> None:
+    compose_environment = os.environ.copy()
+    compose_environment.pop("MEILI_MASTER_KEY", None)
+    compose_environment.pop("COMPOSE_ENV_FILES", None)
+    completed_process = subprocess.run(
+        [
+            "docker",
+            "compose",
+            "--env-file",
+            "/dev/null",
+            "-f",
+            "docker-compose.yml",
+            "config",
+            "--quiet",
+        ],
+        check=False,
+        capture_output=True,
+        env=compose_environment,
+        text=True,
+    )
+
+    assert completed_process.returncode != 0
+    assert "MEILI_MASTER_KEY must be set" in completed_process.stderr
+
+
+def test_dev_overlay_mounts_reader_source_without_repository_secrets() -> None:
+    development_services = _compose_services("docker-compose.yml", "docker-compose.dev.yml")
+    expected_targets = {
+        "api": {"/app/api", "/app/pipeline"},
+        "semantic": {"/app/pipeline", "/app/semantic_service"},
+    }
+
+    for reader_service_name in ("api", "semantic"):
+        reader_volumes = development_services[reader_service_name]["volumes"]
+        bind_targets = {
+            volume["target"]
+            for volume in reader_volumes
+            if volume.get("type") == "bind"
+        }
+        assert bind_targets == expected_targets[reader_service_name]
+        assert "/app" not in bind_targets
+        assert development_services[reader_service_name]["environment"]["APP_ENV"] == "dev"
+    assert development_services["meilisearch"]["environment"]["MEILI_ENV"] == "development"
+
+
+def test_dev_overlay_allows_soak_recovery_to_disable_startup_purge(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("STARTUP_PURGE_DERIVED", "false")
+    development_services = _compose_services("docker-compose.yml", "docker-compose.dev.yml")
+
+    for service_name in ("api", "worker", "pipeline"):
+        assert development_services[service_name]["environment"]["STARTUP_PURGE_DERIVED"] == "false"
+
+
+def test_docker_build_context_excludes_local_environment_files() -> None:
+    dockerignore = Path(".dockerignore").read_text(encoding="utf-8").splitlines()
+    frontend_dockerignore = Path("frontend/.dockerignore").read_text(encoding="utf-8").splitlines()
+
+    assert "**/.env" in dockerignore
+    assert "**/.env.*" in dockerignore
+    assert "!**/.env.example" in dockerignore
+    assert "!.env" not in dockerignore
+    assert "!.env.*" not in dockerignore
+    assert ".env" in frontend_dockerignore
+    assert ".env.*" in frontend_dockerignore
+
+
+def test_dev_helper_requires_local_environment_file() -> None:
+    dev_helper = Path("scripts/dev_up.sh").read_text(encoding="utf-8")
+
+    assert 'if [[ ! -f .env ]]' in dev_helper
+    assert "Create it from .env.example" in dev_helper
+    assert "COMPOSE=(docker compose -f docker-compose.yml -f docker-compose.dev.yml)" in dev_helper
+    assert dev_helper.count('"${COMPOSE[@]}"') == 3
+
+
 def test_example_grafana_credentials_are_labeled_local_only():
     example_environment = Path(".env.example").read_text(encoding="utf-8")
 
@@ -110,7 +225,7 @@ def test_operator_docs_scope_dev_overlay_to_port_services():
     )
     purge_warning = "Using the development overlay for the full stack also enables `STARTUP_PURGE_DERIVED=true`."
     upgrade_command = (
-        "docker compose -f docker-compose.yml up -d --force-recreate \\\n"
+        "docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --force-recreate \\\n"
         "  postgres redis meilisearch prometheus grafana"
     )
 
@@ -142,7 +257,7 @@ def test_dockerfile_defines_split_python_targets():
 def test_dev_up_bootstraps_models_before_db_init():
     source = Path("scripts/dev_up.sh").read_text(encoding="utf-8")
 
-    assert 'docker compose up -d --build "${CORE_SERVICES[@]}"' in source
+    assert '"${COMPOSE[@]}" up -d --build "${CORE_SERVICES[@]}"' in source
     assert "semantic" in source
     assert "semantic-worker" in source
     assert "enrichment-worker" in source
@@ -150,7 +265,7 @@ def test_dev_up_bootstraps_models_before_db_init():
     assert " nlp" not in source
     assert "bash ./scripts/bootstrap_local_models.sh" in source
     assert source.index("bash ./scripts/bootstrap_local_models.sh") < source.index(
-        "docker compose run --rm pipeline python db_init.py"
+        '"${COMPOSE[@]}" run --rm pipeline python db_init.py'
     )
 
 
@@ -246,7 +361,14 @@ def test_bootstrap_and_runbook_use_semantic_image_for_semantic_artifacts():
     bootstrap = Path("scripts/bootstrap_local_models.sh").read_text(encoding="utf-8")
     ops = Path("docs/OPERATIONS.md").read_text(encoding="utf-8")
 
-    assert 'docker compose run --rm semantic python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer(\'all-MiniLM-L6-v2\')"' in bootstrap
+    assert "COMPOSE=(docker compose -f docker-compose.yml -f docker-compose.dev.yml)" in bootstrap
+    assert bootstrap.count('"${COMPOSE[@]}"') == 4
+    assert (
+        '"${COMPOSE[@]}" run --rm semantic python -c '
+        '"from sentence_transformers import SentenceTransformer; '
+        "SentenceTransformer('all-MiniLM-L6-v2')\""
+    ) in bootstrap
+    assert "\ndocker compose " not in bootstrap
     assert "docker compose run --rm semantic python ../pipeline/reindex_semantic.py" in ops
 
 

--- a/tests/test_docker_build_contracts.py
+++ b/tests/test_docker_build_contracts.py
@@ -187,6 +187,29 @@ def test_dev_overlay_allows_soak_recovery_to_disable_startup_purge(
         assert development_services[service_name]["environment"]["STARTUP_PURGE_DERIVED"] == "false"
 
 
+def test_dev_overlay_reader_key_tracks_customized_local_master(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    customized_local_master_key = "customized-local-meilisearch-master-key"
+    monkeypatch.delenv("MEILI_SEARCH_KEY", raising=False)
+    monkeypatch.setenv("MEILI_MASTER_KEY", customized_local_master_key)
+    development_services = _compose_services("docker-compose.yml", "docker-compose.dev.yml")
+
+    for reader_service_name in ("api", "semantic"):
+        reader_environment = development_services[reader_service_name]["environment"]
+        assert reader_environment["MEILI_SEARCH_KEY"] == customized_local_master_key
+        assert "MEILI_MASTER_KEY" not in reader_environment
+
+    explicit_search_key = "explicit-local-reader-key"
+    monkeypatch.setenv("MEILI_SEARCH_KEY", explicit_search_key)
+    explicit_search_services = _compose_services("docker-compose.yml", "docker-compose.dev.yml")
+    for reader_service_name in ("api", "semantic"):
+        assert (
+            explicit_search_services[reader_service_name]["environment"]["MEILI_SEARCH_KEY"]
+            == explicit_search_key
+        )
+
+
 def test_docker_build_context_excludes_local_environment_files() -> None:
     dockerignore = Path(".dockerignore").read_text(encoding="utf-8").splitlines()
     frontend_dockerignore = Path("frontend/.dockerignore").read_text(encoding="utf-8").splitlines()

--- a/tests/test_meilisearch_key_security.py
+++ b/tests/test_meilisearch_key_security.py
@@ -272,12 +272,12 @@ def test_legacy_api_export_contains_reader_key_not_master_key() -> None:
     assert MASTER_KEY_SENTINEL not in completed_process.stdout
 
 
-def test_semantic_dev_startup_warns_without_search_key(
+def test_semantic_dev_startup_warns_with_development_search_key(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     monkeypatch.setenv("MEILI_MASTER_KEY", MASTER_KEY_SENTINEL)
-    monkeypatch.setattr(semantic_main, "MEILI_SEARCH_KEY", "")
+    monkeypatch.setattr(semantic_main, "MEILI_SEARCH_KEY", DEVELOPMENT_MEILI_SEARCH_KEY)
     monkeypatch.setattr(semantic_main, "MEILI_READER_KEY", DEVELOPMENT_MEILI_SEARCH_KEY)
     application = FastAPI(lifespan=semantic_main.lifespan)
 

--- a/tests/test_meilisearch_key_security.py
+++ b/tests/test_meilisearch_key_security.py
@@ -1,0 +1,323 @@
+import json
+import logging
+import os
+import subprocess
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from pipeline.meilisearch_credentials import (
+    DEVELOPMENT_MEILI_SEARCH_KEY,
+    resolve_meilisearch_reader_key,
+)
+from semantic_service import main as semantic_main
+
+
+SCOPED_SEARCH_KEY = "scoped-search-key"
+MASTER_KEY_SENTINEL = "master-key-must-not-reach-readers"
+UNSAFE_SEARCH_KEY_MESSAGE = "MEILI_SEARCH_KEY must contain printable ASCII characters"
+MISSING_SEARCH_KEY_MESSAGE = "MEILI_SEARCH_KEY must be set when APP_ENV is not dev"
+DEVELOPMENT_SEARCH_KEY_MESSAGE = "MEILI_SEARCH_KEY must not use the development fallback"
+FALLBACK_WARNING = "Meilisearch reader is using the development fallback key"
+
+
+@pytest.mark.parametrize("app_env", ["prod", "staging", ""])
+@pytest.mark.parametrize("search_key", ["", "   "])
+def test_non_dev_reader_policy_rejects_missing_search_key(
+    app_env: str,
+    search_key: str,
+) -> None:
+    with pytest.raises(RuntimeError, match=MISSING_SEARCH_KEY_MESSAGE):
+        resolve_meilisearch_reader_key(app_env, search_key)
+
+
+@pytest.mark.parametrize(
+    "search_key",
+    [
+        " scoped-search-key",
+        "scoped-search-key ",
+        "scoped-search-key\n",
+        "scoped-search-key\x7f",
+        "scoped-search-key-é",
+    ],
+)
+def test_reader_policy_rejects_transport_unsafe_key(search_key: str) -> None:
+    with pytest.raises(RuntimeError, match=UNSAFE_SEARCH_KEY_MESSAGE) as search_key_error:
+        resolve_meilisearch_reader_key("dev", search_key)
+
+    assert search_key not in str(search_key_error.value)
+
+
+@pytest.mark.parametrize("search_key", ["", "   "])
+def test_dev_reader_policy_uses_named_fallback(search_key: str) -> None:
+    selected_key = resolve_meilisearch_reader_key("dev", search_key)
+
+    assert selected_key == DEVELOPMENT_MEILI_SEARCH_KEY
+
+
+def test_reader_policy_preserves_valid_key() -> None:
+    assert resolve_meilisearch_reader_key("prod", SCOPED_SEARCH_KEY) == SCOPED_SEARCH_KEY
+
+
+def test_non_dev_reader_policy_rejects_development_fallback_key() -> None:
+    with pytest.raises(RuntimeError, match=DEVELOPMENT_SEARCH_KEY_MESSAGE):
+        resolve_meilisearch_reader_key("prod", DEVELOPMENT_MEILI_SEARCH_KEY)
+
+
+@pytest.mark.parametrize("module_name", ["api.main", "semantic_service.main"])
+def test_reader_module_rejects_missing_non_dev_search_key(module_name: str) -> None:
+    reader_environment = {**os.environ, "APP_ENV": "prod", "MEILI_MASTER_KEY": MASTER_KEY_SENTINEL}
+    reader_environment.pop("MEILI_SEARCH_KEY", None)
+
+    completed_process = subprocess.run(
+        [sys.executable, "-c", f"import {module_name}"],
+        check=False,
+        capture_output=True,
+        env=reader_environment,
+        text=True,
+        timeout=10,
+    )
+
+    assert completed_process.returncode != 0
+    assert MISSING_SEARCH_KEY_MESSAGE in completed_process.stderr
+    assert MASTER_KEY_SENTINEL not in completed_process.stderr
+
+
+@pytest.mark.parametrize("module_name", ["api.main", "semantic_service.main"])
+def test_reader_module_rejects_development_key_outside_dev(module_name: str) -> None:
+    reader_environment = {
+        **os.environ,
+        "APP_ENV": "prod",
+        "MEILI_SEARCH_KEY": DEVELOPMENT_MEILI_SEARCH_KEY,
+        "MEILI_MASTER_KEY": MASTER_KEY_SENTINEL,
+    }
+    completed_process = subprocess.run(
+        [sys.executable, "-c", f"import {module_name}"],
+        check=False,
+        capture_output=True,
+        env=reader_environment,
+        text=True,
+        timeout=10,
+    )
+
+    assert completed_process.returncode != 0
+    assert DEVELOPMENT_SEARCH_KEY_MESSAGE in completed_process.stderr
+    assert DEVELOPMENT_MEILI_SEARCH_KEY not in completed_process.stderr
+    assert MASTER_KEY_SENTINEL not in completed_process.stderr
+
+
+def _reader_request_handler(
+    authorization_headers: list[str],
+    request_paths: list[str],
+) -> type[BaseHTTPRequestHandler]:
+    class ReaderRequestHandler(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:
+            authorization_headers.append(self.headers.get("Authorization", ""))
+            request_paths.append(self.path)
+            response_body = json.dumps(
+                {
+                    "message": "denied",
+                    "code": "invalid_api_key",
+                    "type": "auth",
+                    "link": "https://docs.meilisearch.com/errors#invalid_api_key",
+                }
+            ).encode()
+            self.send_response(403)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(response_body)))
+            self.end_headers()
+            self.wfile.write(response_body)
+
+        def do_GET(self) -> None:
+            authorization_headers.append(self.headers.get("Authorization", ""))
+            request_paths.append(self.path)
+            response_body = json.dumps(
+                {
+                    "numberOfDocuments": 1,
+                    "isIndexing": False,
+                    "fieldDistribution": {"title": 1},
+                }
+            ).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(response_body)))
+            self.end_headers()
+            self.wfile.write(response_body)
+
+        def log_message(self, _format: str, *_arguments: object) -> None:
+            return None
+
+    return ReaderRequestHandler
+
+
+@pytest.mark.parametrize(
+    "client_import",
+    [
+        "from api.search.support_core import client",
+        "from semantic_service.main import client",
+    ],
+    ids=["api", "semantic"],
+)
+def test_rejected_reader_search_uses_scoped_key_once_without_master_retry(
+    client_import: str,
+) -> None:
+    authorization_headers: list[str] = []
+    request_paths: list[str] = []
+    server = HTTPServer(
+        ("127.0.0.1", 0),
+        _reader_request_handler(authorization_headers, request_paths),
+    )
+    server_thread = threading.Thread(target=server.serve_forever)
+    server_thread.start()
+    search_environment = {
+        **os.environ,
+        "APP_ENV": "prod",
+        "MEILI_HOST": f"http://127.0.0.1:{server.server_port}",
+        "MEILI_SEARCH_KEY": SCOPED_SEARCH_KEY,
+        "MEILI_MASTER_KEY": MASTER_KEY_SENTINEL,
+    }
+    request_code = (
+        "from meilisearch.errors import MeilisearchApiError;"
+        f"{client_import};"
+        "\ntry:\n client.index('documents').search('zoning')"
+        "\nexcept MeilisearchApiError:\n print('denied')"
+    )
+    try:
+        completed_process = subprocess.run(
+            [sys.executable, "-c", request_code],
+            check=True,
+            capture_output=True,
+            env=search_environment,
+            text=True,
+            timeout=10,
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+        server_thread.join(timeout=5)
+
+    assert not server_thread.is_alive()
+    assert completed_process.stdout.strip() == "denied"
+    assert authorization_headers == [f"Bearer {SCOPED_SEARCH_KEY}"]
+    assert request_paths == ["/indexes/documents/search"]
+
+
+def test_api_stats_uses_scoped_reader_key() -> None:
+    authorization_headers: list[str] = []
+    request_paths: list[str] = []
+    server = HTTPServer(
+        ("127.0.0.1", 0),
+        _reader_request_handler(authorization_headers, request_paths),
+    )
+    server_thread = threading.Thread(target=server.serve_forever)
+    server_thread.start()
+    stats_environment = {
+        **os.environ,
+        "APP_ENV": "prod",
+        "MEILI_HOST": f"http://127.0.0.1:{server.server_port}",
+        "MEILI_SEARCH_KEY": SCOPED_SEARCH_KEY,
+        "MEILI_MASTER_KEY": MASTER_KEY_SENTINEL,
+    }
+    try:
+        completed_process = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "from api import main; print(main.get_stats().number_of_documents)",
+            ],
+            check=True,
+            capture_output=True,
+            env=stats_environment,
+            text=True,
+            timeout=10,
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+        server_thread.join(timeout=5)
+
+    assert not server_thread.is_alive()
+    assert completed_process.stdout.strip() == "1"
+    assert authorization_headers == [f"Bearer {SCOPED_SEARCH_KEY}"]
+    assert request_paths == ["/indexes/documents/stats"]
+
+
+def test_legacy_api_export_contains_reader_key_not_master_key() -> None:
+    reader_environment = {
+        **os.environ,
+        "APP_ENV": "prod",
+        "MEILI_SEARCH_KEY": SCOPED_SEARCH_KEY,
+        "MEILI_MASTER_KEY": MASTER_KEY_SENTINEL,
+    }
+    completed_process = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from api.search.support_core import MEILI_MASTER_KEY; print(MEILI_MASTER_KEY)",
+        ],
+        check=True,
+        capture_output=True,
+        env=reader_environment,
+        text=True,
+        timeout=10,
+    )
+
+    assert completed_process.stdout.strip() == SCOPED_SEARCH_KEY
+    assert MASTER_KEY_SENTINEL not in completed_process.stdout
+
+
+def test_semantic_dev_startup_warns_without_search_key(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setenv("MEILI_MASTER_KEY", MASTER_KEY_SENTINEL)
+    monkeypatch.setattr(semantic_main, "MEILI_SEARCH_KEY", "")
+    monkeypatch.setattr(semantic_main, "MEILI_READER_KEY", DEVELOPMENT_MEILI_SEARCH_KEY)
+    application = FastAPI(lifespan=semantic_main.lifespan)
+
+    with caplog.at_level(logging.WARNING, logger="town-council-semantic"):
+        with TestClient(application):
+            pass
+
+    assert FALLBACK_WARNING in caplog.text
+    assert DEVELOPMENT_MEILI_SEARCH_KEY not in caplog.text
+    assert MASTER_KEY_SENTINEL not in caplog.text
+
+
+def test_meilisearch_reader_key_contract_is_documented() -> None:
+    example_environment = Path(".env.example").read_text(encoding="utf-8")
+    readme = Path("README.md").read_text(encoding="utf-8")
+    operations = Path("docs/OPERATIONS.md").read_text(encoding="utf-8")
+    profile_readme = Path("env/profiles/README.md").read_text(encoding="utf-8")
+    security = Path("SECURITY.md").read_text(encoding="utf-8")
+
+    assert "MEILI_SEARCH_KEY=" in example_environment
+    assert "MEILI_SEARCH_KEY" in readme
+    assert "MEILI_SEARCH_KEY_UID" in operations
+    assert "GET /keys/{uid}" in operations
+    assert '"actions":["search","stats.get"]' in operations
+    assert 'Authorization: Bearer $MEILI_' not in operations
+    assert 'MEILI_SEARCH_KEY="$MEILI_SEARCH_KEY"' not in operations
+    assert '-H "@$MEILI_MASTER_HEADER_FILE"' in operations
+    assert '-H "@$MEILI_SEARCH_HEADER_FILE"' in operations
+    assert (
+        "APP_ENV=production docker compose -f docker-compose.yml up -d --build\n"
+        "   --force-recreate api semantic"
+    ) in operations
+    assert "docker compose up -d --build postgres redis meilisearch" not in readme
+    assert "docker compose up -d --build postgres redis meilisearch" not in operations
+    assert "docker compose up -d" not in operations
+    assert "--env-file .env --env-file env/profiles/" in readme
+    assert "--env-file .env --env-file env/profiles/" in operations
+    assert "--env-file .env --env-file env/profiles/" in profile_readme
+    assert "docker compose --env-file env/profiles/" not in readme
+    assert "docker compose --env-file env/profiles/" not in operations
+    assert "docker compose --env-file env/profiles/" not in profile_readme
+    assert "docker-compose.dev.yml" in profile_readme
+    assert "API and semantic" in security
+    assert "MEILI_SEARCH_KEY" in security

--- a/tests/test_meilisearch_key_security.py
+++ b/tests/test_meilisearch_key_security.py
@@ -24,6 +24,7 @@ UNSAFE_SEARCH_KEY_MESSAGE = "MEILI_SEARCH_KEY must contain printable ASCII chara
 MISSING_SEARCH_KEY_MESSAGE = "MEILI_SEARCH_KEY must be set when APP_ENV is not dev"
 DEVELOPMENT_SEARCH_KEY_MESSAGE = "MEILI_SEARCH_KEY must not use the development fallback"
 FALLBACK_WARNING = "Meilisearch reader is using the development fallback key"
+READER_SUBPROCESS_TIMEOUT_SECONDS = 30
 
 
 @pytest.mark.parametrize("app_env", ["prod", "staging", ""])
@@ -80,7 +81,7 @@ def test_reader_module_rejects_missing_non_dev_search_key(module_name: str) -> N
         capture_output=True,
         env=reader_environment,
         text=True,
-        timeout=10,
+        timeout=READER_SUBPROCESS_TIMEOUT_SECONDS,
     )
 
     assert completed_process.returncode != 0
@@ -102,7 +103,7 @@ def test_reader_module_rejects_development_key_outside_dev(module_name: str) -> 
         capture_output=True,
         env=reader_environment,
         text=True,
-        timeout=10,
+        timeout=READER_SUBPROCESS_TIMEOUT_SECONDS,
     )
 
     assert completed_process.returncode != 0
@@ -194,7 +195,7 @@ def test_rejected_reader_search_uses_scoped_key_once_without_master_retry(
             capture_output=True,
             env=search_environment,
             text=True,
-            timeout=10,
+            timeout=READER_SUBPROCESS_TIMEOUT_SECONDS,
         )
     finally:
         server.shutdown()
@@ -234,7 +235,7 @@ def test_api_stats_uses_scoped_reader_key() -> None:
             capture_output=True,
             env=stats_environment,
             text=True,
-            timeout=10,
+            timeout=READER_SUBPROCESS_TIMEOUT_SECONDS,
         )
     finally:
         server.shutdown()
@@ -264,7 +265,7 @@ def test_legacy_api_export_contains_reader_key_not_master_key() -> None:
         capture_output=True,
         env=reader_environment,
         text=True,
-        timeout=10,
+        timeout=READER_SUBPROCESS_TIMEOUT_SECONDS,
     )
 
     assert completed_process.stdout.strip() == SCOPED_SEARCH_KEY

--- a/tests/test_run_soak_day_contract.py
+++ b/tests/test_run_soak_day_contract.py
@@ -10,10 +10,13 @@ def test_run_soak_day_script_contract():
     assert "scripts/dev_up.sh" in text
     assert "[[ -f \"scripts/dev_up.sh\" ]]" in text
     assert "COMPOSE=(docker compose -f docker-compose.yml -f docker-compose.dev.yml)" in text
-    assert (
-        'STARTUP_PURGE_DERIVED=false "${COMPOSE[@]}" up -d '
-        "inference worker api pipeline frontend"
-    ) in text
+    fallback_guard = '[[ ! -f .env && -z "${MEILI_MASTER_KEY:-}" ]]'
+    fallback_export = 'export MEILI_MASTER_KEY="$DEVELOPMENT_MEILI_MASTER_KEY"'
+    recovery_command = 'STARTUP_PURGE_DERIVED=false "${COMPOSE[@]}" up -d '
+    assert fallback_guard in text
+    assert fallback_export in text
+    assert text.index(fallback_guard) < text.index(fallback_export) < text.index(recovery_command)
+    assert recovery_command + "inference worker api pipeline frontend" in text
     assert '"${COMPOSE[@]}" ps' in text
     assert "\ndocker compose up " not in text
     assert "stack_offline" in text

--- a/tests/test_run_soak_day_contract.py
+++ b/tests/test_run_soak_day_contract.py
@@ -9,7 +9,13 @@ def test_run_soak_day_script_contract():
     assert "TASK_MAX_WAIT_SECONDS" in text
     assert "scripts/dev_up.sh" in text
     assert "[[ -f \"scripts/dev_up.sh\" ]]" in text
-    assert "docker compose up -d inference worker api pipeline frontend" in text
+    assert "COMPOSE=(docker compose -f docker-compose.yml -f docker-compose.dev.yml)" in text
+    assert (
+        'STARTUP_PURGE_DERIVED=false "${COMPOSE[@]}" up -d '
+        "inference worker api pipeline frontend"
+    ) in text
+    assert '"${COMPOSE[@]}" ps' in text
+    assert "\ndocker compose up " not in text
     assert "stack_offline" in text
     assert "task_poll_timeout" in text
     assert "scripts/parse_task_launch.py" in text

--- a/tests/test_startup_purge_gating.py
+++ b/tests/test_startup_purge_gating.py
@@ -51,5 +51,5 @@ def test_base_compose_defaults_are_safe_and_dev_override_restores_convenience():
     assert "healthcheck:" in compose_source.split("redis:", 1)[1]
     assert "restart: unless-stopped" in compose_source.split("api:", 1)[1]
     assert "--reload" in dev_compose_source
-    assert "STARTUP_PURGE_DERIVED=true" in dev_compose_source
+    assert "STARTUP_PURGE_DERIVED=${STARTUP_PURGE_DERIVED:-true}" in dev_compose_source
     assert "sys.exit(1)" in dockerfile_source


### PR DESCRIPTION
## What changed

- Give API and semantic readers `MEILI_SEARCH_KEY`; retain `MEILI_MASTER_KEY` only for writers and administration.
- Reject missing, development-fallback, or transport-unsafe reader keys outside development.
- Make base Compose non-development and the development overlay explicit, while preserving local bootstrap, runtime profiles, and soak recovery.
- Exclude local environment files from root and frontend Docker build contexts.
- Add scoped-key creation, preflight, rotation, revocation, rollback, and permission verification guidance.

## Why

Compromise of a reader service previously exposed the Meilisearch administrative key. This change reduces that trust boundary to search and index-statistics permissions without changing public APIs, database data, inference defaults, or model policy.

## Risk and compatibility

- Non-development deployments must provision a reader key with `search` and `stats.get` on `documents` before restarting API or semantic.
- Local development retains the `masterKey` fallback only through the explicit development mode.
- Soak recovery uses the development overlay but forces `STARTUP_PURGE_DERIVED=false` to preserve baseline comparability.
- No schema migration or data remediation is required.

## Verification

- PASS: `./.venv/bin/ruff check .`
- PASS: `./.venv/bin/pre-commit run ruff --all-files`
- PASS: `./.venv/bin/mypy`
- PASS: focused security, API startup, Compose, soak, purge, docs-link, and profile-alignment tests: 73 passed
- PASS: broader API, search, semantic, and indexer tests: 66 passed
- PASS: `PYTHONPATH=. .venv/bin/python -m pytest -q tests/`: 1,175 passed, 469 warnings
- PASS: base, development, and batch-profile Compose resolution
- PASS: shell syntax for modified operator scripts
- PASS: Meilisearch v1.6 live permission smoke: search/stats 200; write/settings/keys 403
- PASS: Docker probes excluded root and frontend environment files
- PASS: independent current-head review found no remaining P1/P2 findings

## Remaining deficits

- Existing warning debt remains unchanged.
- GitHub reports one pre-existing high-severity Dependabot alert on the default branch; it is outside T-SEC-3 scope.
