### PR TITLE
T-SEC-3C: Synchronize the security checklist

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -86,7 +86,7 @@ engineering decisions is `reachable`).
 - [x] Base compose publishes only `api:8000` and `frontend:3000` (T-SEC-1)
 - [ ] Non-default values for every key in the inventory above
 - [x] API aborts on default key outside dev (T-SEC-2)
-- [ ] Meilisearch search key enforced for API and semantic readers (T-SEC-3)
+- [x] Meilisearch search key enforced for API and semantic readers (T-SEC-3)
 - [ ] Client IP forwarded from proxy; limiter keys on it with trusted-proxy
       allowlist (T-SEC-4)
 - [ ] Origin/Sec-Fetch-Site check on proxy mutation routes (T-SEC-5)

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,6 +1,6 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 3.5
+version: 3.6
 generated: 2026-07-23
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
@@ -10,6 +10,8 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v3.6:** Marks merged T-CRAWL-1 complete and registers T-SEC-3C to
+  synchronize the canonical security checklist before closing T-SEC-3.
 - **v3.5:** Records T-SEC-3 as implemented but not closed because its canonical
   `SECURITY.md` checklist item remains open. A separate owned documentation
   change must synchronize that checklist before T-SEC-3 returns to complete.
@@ -83,8 +85,8 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 | State | Tasks |
 |---|---|
-| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2 |
-| **In progress** | T-CRAWL-1 |
+| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2, T-CRAWL-1 |
+| **In progress** | T-SEC-3C |
 | **Implementation merged; closure pending** | T-SEC-3 |
 | **Partially landed; acceptance incomplete** | T-GOV-4, T-GOV-5, T-GOV-6 |
 | **Pending** | T-SEC-4..6, T-TIME-1..3, T-CRAWL-2, T-DA-1, T-DB-1, T-DC-1, T-DD-1, T-DE-1, T-PLAT-1..4, T-GOV-1..3 |
@@ -503,6 +505,21 @@ in `AGENTS.md`, `docs/TESTING.MD`, and
 - verify: Follow the Full T-SEC-3 plan, including credential tests, resolved
   Compose contracts, live v1.6 permission smoke, API/semantic/indexer suites,
   Ruff, Mypy, docs links, and the complete Python suite.
+
+### T-SEC-3C: Synchronize the Meilisearch security checklist
+- priority: P1
+- status: in progress
+- implementation_plan: `docs/plans/T_SEC_3_CHECKLIST_CLOSURE_PLAN.md`
+- files_owned: docs/plans/T_SEC_3_CHECKLIST_CLOSURE_PLAN.md,
+  docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md, SECURITY.md
+- do: Verify the merged T-SEC-3 evidence, check its canonical `SECURITY.md`
+  item, and return T-SEC-3 to complete without reopening runtime code.
+- accept: The security checklist and remediation status agree; merged
+  T-CRAWL-1 is recorded complete; no unrelated checklist item changes.
+- forbidden: Runtime security changes, policy expansion, or edits outside the
+  three owned files.
+- verify: Docs links, targeted contradiction checks, clean diff, current-head
+  review, and green PR checks.
 
 ### T-SEC-4: Real client identity through the proxy; per-client rate limits
 - priority: P0

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,6 +1,6 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 3.6
+version: 3.7
 generated: 2026-07-23
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
@@ -10,6 +10,8 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v3.7:** Closes T-SEC-3 and T-SEC-3C after synchronizing the canonical
+  Meilisearch reader-key checklist with the merged, green implementation.
 - **v3.6:** Marks merged T-CRAWL-1 complete and registers T-SEC-3C to
   synchronize the canonical security checklist before closing T-SEC-3.
 - **v3.5:** Records T-SEC-3 as implemented but not closed because its canonical
@@ -85,9 +87,7 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 | State | Tasks |
 |---|---|
-| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2, T-CRAWL-1 |
-| **In progress** | T-SEC-3C |
-| **Implementation merged; closure pending** | T-SEC-3 |
+| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2, T-SEC-3, T-SEC-3C, T-CRAWL-1 |
 | **Partially landed; acceptance incomplete** | T-GOV-4, T-GOV-5, T-GOV-6 |
 | **Pending** | T-SEC-4..6, T-TIME-1..3, T-CRAWL-2, T-DA-1, T-DB-1, T-DC-1, T-DD-1, T-DE-1, T-PLAT-1..4, T-GOV-1..3 |
 
@@ -468,7 +468,7 @@ in `AGENTS.md`, `docs/TESTING.MD`, and
 
 ### T-SEC-3: API and semantic readers use a scoped Meilisearch search key
 - priority: P1
-- status: implementation merged; closure pending canonical security checklist synchronization
+- status: complete
 - implementation_plan: `docs/plans/T_SEC_3_MEILISEARCH_SEARCH_KEY_PLAN.md`
 - files_owned: docs/plans/T_SEC_3_MEILISEARCH_SEARCH_KEY_PLAN.md,
   docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md,
@@ -508,7 +508,7 @@ in `AGENTS.md`, `docs/TESTING.MD`, and
 
 ### T-SEC-3C: Synchronize the Meilisearch security checklist
 - priority: P1
-- status: in progress
+- status: complete
 - implementation_plan: `docs/plans/T_SEC_3_CHECKLIST_CLOSURE_PLAN.md`
 - files_owned: docs/plans/T_SEC_3_CHECKLIST_CLOSURE_PLAN.md,
   docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md, SECURITY.md
@@ -596,7 +596,7 @@ in `AGENTS.md`, `docs/TESTING.MD`, and
 
 ### T-CRAWL-1: Honest crawler identity
 - priority: P1
-- status: in-progress
+- status: complete
 - implementation_plan: `docs/plans/T_CRAWL_1_HONEST_CRAWLER_IDENTITY_PLAN.md`
 - files_owned: docs/plans/T_CRAWL_1_HONEST_CRAWLER_IDENTITY_PLAN.md,
   docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md,

--- a/docs/plans/T_SEC_3_CHECKLIST_CLOSURE_PLAN.md
+++ b/docs/plans/T_SEC_3_CHECKLIST_CLOSURE_PLAN.md
@@ -1,0 +1,73 @@
+# T-SEC-3C: Synchronize the Meilisearch Security Checklist
+
+`artifact_contract: ce-unified-plan/v1`  
+`artifact_readiness: implementation-ready`  
+`execution: docs`
+
+## 1. Implementation
+
+**a) Root cause and fix.** PR #123 implemented T-SEC-3 and passed its runtime,
+permission, and repository gates, but the canonical `SECURITY.md` checklist
+item remained unchecked. PR #124 correctly stopped declaring the task complete
+until that conflict was resolved. This closure task verifies the merged
+implementation evidence, checks the canonical item, and returns T-SEC-3 to
+complete. It also records merged T-CRAWL-1 as complete.
+
+Steps:
+
+1. Register this closure task and its three-file ownership before changing the
+   checklist.
+2. Confirm PR #123 is merged and its required checks passed.
+3. Check only the T-SEC-3 item in `SECURITY.md`.
+4. Mark T-SEC-3 and T-CRAWL-1 complete in the remediation status table.
+5. Run docs-link and contradiction checks, obtain current-head review, and
+   merge only with green CI and no unresolved P1/P2 findings.
+
+**b) Edge cases and failures.**
+
+1. If PR #123 is not merged or its required checks failed, leave T-SEC-3 open.
+2. If `SECURITY.md` names a different control, stop rather than checking an
+   adjacent item.
+3. If remediation status still says closure pending after the checklist
+   changes, fail the contradiction check.
+4. If another security checklist item changes, reject the diff as scope drift.
+
+**c) Code audit.** Docs only. No function, literal, nesting, parameter,
+timestamp, environment read, or runtime error behavior changes.
+
+**d) Dead code audit.** None. The closure-pending status is replaced by the
+verified completed status; no historical implementation evidence is deleted.
+
+**e) Boundary check.** `SECURITY.md` is canonical policy documentation but not
+an `AGENTS.md` security-sensitive runtime path. No trust boundary, person data,
+schema, facade family, Celery dispatch, crawler setting, runtime default, gate,
+or soak policy changes.
+
+**f) Antipattern quick-scan.** Pass. No invented API, abstraction,
+compatibility path, surviving superseded status, weakened test, unrelated
+formatting, or duplicated implementation.
+
+## 2. Testing & Execution
+
+**g) Tests.** No new test is justified for a one-time checklist-state
+synchronization. `tests/test_docs_links.py` verifies document references.
+Targeted text checks verify scenarios 2-4 directly against the canonical files.
+No fake or mock is used.
+
+**h) Verification and docs.**
+
+```bash
+gh pr view 123 --json state,mergedAt,statusCheckRollup
+PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py
+grep -n "Meilisearch search key enforced" SECURITY.md
+grep -nE "T-SEC-3|T-CRAWL-1" docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+git diff --check
+git status --short
+```
+
+The docs-only verification row applies. No README, ADR, operations, testing,
+architecture, API, or data-governance update is needed.
+
+**i) Delivery evidence.** Report each command above as PASS or FAIL, the
+current-head review outcome, commit hashes, PR URL, CI state, and any deviation.
+The expected deviation report is `None`.

--- a/docs/plans/T_SEC_3_CHECKLIST_CLOSURE_PLAN.md
+++ b/docs/plans/T_SEC_3_CHECKLIST_CLOSURE_PLAN.md
@@ -59,8 +59,14 @@ No fake or mock is used.
 ```bash
 gh pr view 123 --json state,mergedAt,statusCheckRollup
 PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py
-grep -n "Meilisearch search key enforced" SECURITY.md
-grep -nE "T-SEC-3|T-CRAWL-1" docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+grep -Fx -- \
+  "- [x] Meilisearch search key enforced for API and semantic readers (T-SEC-3)" \
+  SECURITY.md
+for task_id in T-SEC-3 T-SEC-3C T-CRAWL-1; do
+  sed -n "/^### ${task_id}:/,/^### /p" \
+    docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md |
+    grep -Fx -- "- status: complete"
+done
 git diff --check
 git status --short
 ```


### PR DESCRIPTION
## What changed
- added the T-SEC-3C docs-only closure plan
- checked the canonical T-SEC-3 Meilisearch reader-key control in `SECURITY.md`
- marked T-SEC-3, T-SEC-3C, and merged T-CRAWL-1 complete in the remediation plan

## Why
PR #123 implemented T-SEC-3 and passed all required checks, but its canonical security checklist item remained open. PR #124 review correctly prevented a false completion status until the documents were synchronized.

## Risk and compatibility
Docs-only. No runtime, credential, API, schema, crawler, gate, or soak behavior changes.

## Verification
- PASS: PR #123 is merged; all six recorded checks succeeded
- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py`
- PASS: targeted checklist and remediation status checks
- PASS: `git diff --check`

## Review deficit
The required local planning/pre-commit subagent could not start because the agent thread limit remains reached. A current-head GitHub Codex review is requested below as the independent review path.
