### PR TITLE
T-PLAT-2A: Patch the transitive Sharp runtime

### DIFF
--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,6 +1,6 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 3.10
+version: 3.11
 generated: 2026-07-23
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
@@ -10,6 +10,9 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v3.11:** Marks merged T-TIME-3 complete and activates urgent T-PLAT-2A
+  to pin Next.js's transitive Sharp runtime to patched version 0.35.3 for
+  Dependabot alert 106.
 - **v3.10:** Marks merged T-CRAWL-2 complete and activates T-TIME-3 with
   tests-first ownership for PostgreSQL checkout pre-ping and its Full
   implementation plan.
@@ -95,10 +98,10 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 | State | Tasks |
 |---|---|
-| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2, T-SEC-3, T-SEC-3C, T-CRAWL-1, T-CRAWL-2 |
-| **In progress** | T-TIME-3 |
+| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2, T-SEC-3, T-SEC-3C, T-TIME-3, T-CRAWL-1, T-CRAWL-2 |
+| **In progress** | T-PLAT-2A |
 | **Partially landed; acceptance incomplete** | T-GOV-4, T-GOV-5, T-GOV-6 |
-| **Pending** | T-SEC-4..6, T-TIME-1..2, T-DA-1, T-DB-1, T-DC-1, T-DD-1, T-DE-1, T-PLAT-1..4, T-GOV-1..3 |
+| **Pending** | T-SEC-4..6, T-TIME-1..2, T-DA-1, T-DB-1, T-DC-1, T-DD-1, T-DE-1, T-PLAT-1..4 excluding T-PLAT-2A, T-GOV-1..3 |
 
 ---
 
@@ -599,7 +602,7 @@ in `AGENTS.md`, `docs/TESTING.MD`, and
 
 ### T-TIME-3: pool_pre_ping
 - priority: P2
-- status: in progress
+- status: complete and verified 2026-07-23 (PR #127)
 - implementation_plan: `docs/plans/T_TIME_3_POOL_PRE_PING_PLAN.md`
 - files_owned: docs/plans/T_TIME_3_POOL_PRE_PING_PLAN.md,
   docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md,
@@ -760,6 +763,28 @@ files (GED-5 grant).
 - accept: Fresh DB via alembic == create_all schema (diff empty);
   OPERATIONS documents upgrade/downgrade.
 - verify: Schema diff script output empty; suite green.
+
+### T-PLAT-2A: Patch Next.js's transitive Sharp runtime
+- priority: P0 (urgent dependency security patch)
+- status: in progress
+- implementation_plan: `docs/plans/T_PLAT_2A_SHARP_SECURITY_PATCH_PLAN.md`
+- files_owned: docs/plans/T_PLAT_2A_SHARP_SECURITY_PATCH_PLAN.md,
+  docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md, frontend/package.json,
+  frontend/package-lock.json,
+  frontend/components/__tests__/SharpDependency.security.test.js
+- do: Pin Sharp 0.35.3 only beneath Next.js through npm's nested override,
+  regenerate the lockfile without lifecycle scripts, then verify a clean
+  install, native module load, frontend tests, production build, and
+  high-severity audit.
+- accept: Next.js remains 16.2.11; the manifest and lockfile select Sharp
+  0.35.3; `npm ci`, the native Sharp smoke, frontend tests, production build,
+  and `npm audit --omit=dev --audit-level=high` pass; Dependabot alert 106
+  closes after merge.
+- forbidden: `npm audit fix --force`, a Next.js downgrade, a direct Sharp
+  application dependency, audit suppression, or unrelated dependency churn.
+- verify: Follow the Full T-PLAT-2A plan, including tests-first red evidence,
+  lockfile-only generation, clean install, native and Docker build smokes,
+  frontend tests, audit, docs links, independent review, and diff checks.
 
 ### T-PLAT-2: Dependency hygiene
 - priority: P2

--- a/docs/plans/T_PLAT_2A_SHARP_SECURITY_PATCH_PLAN.md
+++ b/docs/plans/T_PLAT_2A_SHARP_SECURITY_PATCH_PLAN.md
@@ -48,8 +48,8 @@ data, test-seam policy, or migration tooling.
 
 **e) Step-by-step approach.**
 
-1. Add a Node test that requires Next.js to remain 16.2.11, forbids Sharp as a
-   direct or development dependency, and requires both the nested override and
+1. Add a Node test that requires Next.js to remain 16.2.11, forbids Sharp in
+   every root dependency section, and requires both the nested override and
    lockfile to select Sharp 0.35.3.
 2. Run the new test and capture its expected failure against Sharp 0.34.5.
 3. Extend the existing `overrides` object in `frontend/package.json` with a
@@ -153,7 +153,7 @@ planning text; npm generates the lockfile delta.
 **q) Edge and failure scenarios.**
 
 1. The manifest lacks the nested Sharp override.
-2. Sharp is added as a direct or development dependency.
+2. Sharp is added to any root dependency section.
 3. The lockfile still resolves vulnerable Sharp 0.34.5.
 4. Updating Sharp changes Next.js away from 16.2.11.
 5. Manifest and lockfile disagree, causing `npm ci` to fail.

--- a/docs/plans/T_PLAT_2A_SHARP_SECURITY_PATCH_PLAN.md
+++ b/docs/plans/T_PLAT_2A_SHARP_SECURITY_PATCH_PLAN.md
@@ -1,0 +1,306 @@
+# T-PLAT-2A: Patch Next.js's Transitive Sharp Runtime
+
+`artifact_contract: ce-unified-plan/v1`
+
+`artifact_readiness: implementation-ready`
+
+`execution: code`
+
+## 1. Context & Alignment
+
+**a) Driver.** Dependabot alert 106 reports high-severity vulnerabilities in
+Sharp versions before 0.35.0 through bundled libvips. Town Council locks
+Next.js 16.2.11, whose optional dependency range currently resolves Sharp
+0.34.5. The narrow remediation is to keep Next.js unchanged and pin only its
+Sharp child to patched version 0.35.3.
+
+**b) Canonical documents consulted.**
+
+- `AGENTS.md` requires current dependency documentation, tests-first work,
+  exact verification evidence, local-first behavior, and scoped delivery.
+- `SECURITY.md` identifies browser input entering Next.js as an Internet to
+  frontend trust boundary and assigns dependency auditing to T-PLAT-2.
+- `docs/TESTING.md` requires observable contracts and permits filesystem and
+  subprocess verification without a production test seam.
+- `docs/ENGINEERING_GUARDRAILS.md` requires current frontend and docs checks.
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md` owns dependency hygiene in the
+  PLAT lane but does not yet isolate this urgent alert.
+- `docs/reviews/architecture-review-2026-07-19.html` keeps platform work
+  separate from facade-removal tasks and open decision gates.
+
+**c) Remediation alignment.** T-PLAT-2A is an urgent, narrow child of
+T-PLAT-2. It owns exactly:
+
+- `docs/plans/T_PLAT_2A_SHARP_SECURITY_PATCH_PLAN.md`
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`
+- `frontend/package.json`
+- `frontend/package-lock.json`
+- `frontend/components/__tests__/SharpDependency.security.test.js`
+
+The ledger marks merged T-TIME-3 complete and activates T-PLAT-2A before any
+dependency implementation changes.
+
+**d) Decision-gate check.** No G1-G5 decision is required or foreclosed. This
+patch changes neither deployment posture nor product authorization, person
+data, test-seam policy, or migration tooling.
+
+## 2. Design
+
+**e) Step-by-step approach.**
+
+1. Add a Node test that requires Next.js to remain 16.2.11, forbids Sharp as a
+   direct or development dependency, and requires both the nested override and
+   lockfile to select Sharp 0.35.3.
+2. Run the new test and capture its expected failure against Sharp 0.34.5.
+3. Extend the existing `overrides` object in `frontend/package.json` with a
+   nested `next.sharp` pin to 0.35.3. Preserve the existing PostCSS override.
+4. Run `npm install --package-lock-only --ignore-scripts` so npm 11 updates
+   only dependency resolution metadata.
+5. Inspect the lockfile diff and reject unrelated package-version churn.
+6. Run `npm ci` to prove the manifest and lockfile agree and to install the
+   correct platform-specific Sharp binary.
+7. Use `sharp.versions` to prove Sharp 0.35.3 loads with bundled libvips
+   8.18.3, then perform a one-pixel in-memory PNG conversion.
+8. Run frontend tests and the production frontend build.
+9. Build the Linux-musl Docker builder stage, then run the same version and
+   PNG smoke inside that image so the native runtime is exercised.
+10. Run the high-severity npm audit, docs links, and diff checks.
+11. Obtain independent pre-commit review, apply eligible findings, and rerun
+   affected checks before delivery.
+
+No application function, helper module, runtime route, or compatibility path
+is added.
+
+**f) Reuse audit.** Extend the existing npm `overrides` object and Node test
+runner. npm's lockfile remains the only dependency graph. Do not add a direct
+Sharp dependency, audit wrapper, package-manager script, alternate lockfile,
+or separate security-test runner.
+
+Rejected alternatives:
+
+- `npm audit fix --force`: npm proposes Next.js 14.2.35, a breaking downgrade.
+- Direct `sharp` dependency: application code does not import Sharp, so this
+  would misrepresent ownership and create an unnecessary public dependency.
+- Upgrade Next.js: 16.2.11 is already current in the repository and still
+  declares `sharp@^0.34.5`; a framework change is wider than the alert.
+- Accept the risk because no `next/image` component was found: the framework
+  still ships an image route and vulnerable native code; the patch is small.
+
+**g) Data contracts.**
+
+- Old graph: Next.js 16.2.11 resolves optional Sharp 0.34.5.
+- New graph: Next.js 16.2.11 resolves optional Sharp 0.35.3 through a nested
+  npm override.
+- Unchanged: frontend API, routes, browser bundle, runtime configuration,
+  Next.js version, React versions, and PostCSS override.
+
+The committed test reads `package.json` and lockfile version 3 as JSON. It
+does not import Sharp as an application dependency.
+
+**h) Schema and migration impact.** None.
+
+## 3. Security & Data Governance
+
+**i) Security boundary.** The changed files are not listed in
+`AGENTS.md` `<security_sensitive_paths>`, but the dependency participates in
+the Internet to frontend boundary because Next.js can decode image input.
+The patch removes known vulnerable libvips code from the resolved frontend
+runtime without broadening accepted image sources or network exposure. This
+implements the immediate patch portion of `SECURITY.md`'s dependency and
+supply-chain control; broader audit automation remains T-PLAT-2.
+
+**j) Secrets.** No credential, key, environment variable, package token, or
+default is added.
+
+**k) Person data.** No person-level data is created, linked, aggregated, or
+exposed.
+
+**l) Untrusted input.** No parser or route changes. Existing Next.js image
+handling remains the decoding boundary; only its native decoder version
+changes.
+
+## 4. Code Health
+
+**m) GED conformance sweep.** The implementation is one nested override plus
+its generated lockfile. The test has no custom version parser, mocks,
+timestamps, environment reads, exception handler, or nested control flow.
+
+**n) Antipattern scan, plan pass.**
+
+- A1/H1: npm CLI 11 documentation confirms nested transitive overrides,
+  lockfile-only generation, and `npm ci` lock validation. npm registry
+  metadata confirms Next.js 16.2.11 and Sharp 0.35.3 both require Node
+  20.9.0 or newer. Sharp documentation confirms `sharp.versions`.
+- B1/F1: reuse npm and the existing Node runner; add no wrapper or registry.
+- B3: runtime and Docker smokes are required because Sharp is a native
+  optional dependency across macOS ARM and Linux musl.
+- D1: do not suppress the alert, force a downgrade, skip a test, or weaken an
+  audit level.
+- D3: exact dependency versions are the observable security contract.
+- E1/E2: accept generated lockfile changes only for Sharp and its native
+  packages.
+- A2-A4, B2, C1-C2, D2, E3, F2, and H2-H4: no planned violations.
+
+**o) Ratchet interaction.** No Ruff, Mypy, coverage, formatter, exception, or
+workflow allowlist changes.
+
+**p) Dead code and duplication audit.** Nothing is deleted or duplicated.
+Expected handwritten delta is one override object, one focused test file, and
+planning text; npm generates the lockfile delta.
+
+## 5. Testing
+
+**q) Edge and failure scenarios.**
+
+1. The manifest lacks the nested Sharp override.
+2. Sharp is added as a direct or development dependency.
+3. The lockfile still resolves vulnerable Sharp 0.34.5.
+4. Updating Sharp changes Next.js away from 16.2.11.
+5. Manifest and lockfile disagree, causing `npm ci` to fail.
+6. The macOS ARM native module cannot load after clean installation.
+7. Sharp loads but does not report 0.35.3 and libvips 8.18.3.
+8. A minimal in-memory decode/encode operation fails.
+9. The Linux-musl Docker builder cannot install or load the patched native
+   dependency.
+10. The frontend test or production build regresses.
+11. A high-severity production dependency remains in `npm audit`.
+12. Lockfile generation updates unrelated dependencies.
+13. Dependabot alert 106 remains open after the patch reaches `master`.
+
+**r) Tests and evidence.**
+
+| Test or command | Scenarios |
+|---|---|
+| `SharpDependency.security.test.js` | 1-4 |
+| `npm ci` | 5 |
+| `sharp.versions` plus one-pixel PNG smoke | 6-8 |
+| Docker builder-stage build and in-container smoke | 9 |
+| `npm test` and `npm run build -- --webpack` | 10 |
+| `npm audit --omit=dev --audit-level=high` | 11 |
+| Lockfile diff inspection | 12 |
+| Dependabot API readback after merge | 13 |
+
+The new test is written and run red before modifying dependency files.
+
+**s) Fakes and mocks.** None. Tests use the approved filesystem boundary.
+Install, audit, build, and native-load evidence use real package-manager,
+process, and container boundaries.
+
+**t) Verification rows.** Apply frontend component/behavior and docs-only
+verification. Run the complete frontend test command, production build, and
+security-specific package checks. Python application code is unchanged, so
+the complete Python suite is not required locally; PR Python Guardrails
+remains an authoritative merge check.
+
+## 6. Execution, Rollback, Docs
+
+**u) Exact commands.**
+
+```bash
+git fetch origin --prune
+git switch master
+git merge --ff-only origin/master
+git switch -c codex/t-plat-2a-sharp-security-patch
+```
+
+Tests-first red evidence:
+
+```bash
+cd frontend
+node --test components/__tests__/SharpDependency.security.test.js
+```
+
+Implementation and lockfile generation:
+
+```bash
+cd frontend
+npm install --package-lock-only --ignore-scripts
+git diff -- package.json package-lock.json
+npm ci
+```
+
+Final verification:
+
+```bash
+cd frontend
+node --test components/__tests__/SharpDependency.security.test.js
+node - <<'NODE'
+const assert = require("node:assert/strict");
+const sharp = require("sharp");
+
+(async () => {
+  assert.equal(sharp.versions.sharp, "0.35.3");
+  assert.equal(sharp.versions.vips, "8.18.3");
+  const pngBuffer = await sharp({
+    create: {
+      width: 1,
+      height: 1,
+      channels: 4,
+      background: { r: 0, g: 0, b: 0, alpha: 1 },
+    },
+  })
+    .png()
+    .toBuffer();
+  assert.ok(pngBuffer.length > 0);
+})().catch((sharpError) => {
+  console.error(sharpError);
+  process.exitCode = 1;
+});
+NODE
+npm test
+npm run build -- --webpack
+npm audit --omit=dev --audit-level=high
+cd ..
+docker build --target builder \
+  --tag town-council-frontend-sharp-smoke \
+  frontend
+docker run --rm \
+  --entrypoint node \
+  town-council-frontend-sharp-smoke \
+  -e 'const assert=require("node:assert/strict");const sharp=require("sharp");assert.equal(sharp.versions.sharp,"0.35.3");assert.equal(sharp.versions.vips,"8.18.3");sharp({create:{width:1,height:1,channels:4,background:{r:0,g:0,b:0,alpha:1}}}).png().toBuffer().then((pngBuffer)=>assert.ok(pngBuffer.length>0)).catch((sharpError)=>{console.error(sharpError);process.exitCode=1;});'
+PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py
+git diff --check
+git status --short
+```
+
+Post-merge alert verification:
+
+```bash
+gh api repos/manumissio/town-council/dependabot/alerts/106 \
+  --jq '{state, fixed_at, dependency: .dependency.package.name}'
+```
+
+**v) Rollback.** There is no safe version rollback because reverting restores
+vulnerable Sharp 0.34.5. If a pre-merge check fails, do not merge. If an
+operational incompatibility appears after merge, stop the affected frontend
+deployment and roll forward in a new branch to another verified Sharp version
+at or above 0.35.0, regenerate the lockfile, and rerun every command in 6u
+before deployment. No database, migration, configuration, or data repair is
+required. Reverting to 0.34.5 requires explicit emergency risk acceptance and
+must record the reopened high-severity alert.
+
+**w) Docs synchronization.** Add this plan and update the remediation
+ledger's version, changelog, T-TIME-3 completion, T-PLAT-2A status,
+ownership, acceptance, and verification. README, ADR, architecture,
+operations, testing policy, engineering guardrails, security policy, API
+contracts, and data-governance docs remain unchanged because their current
+contracts are still accurate.
+
+## 7. Delivery Self-Audit
+
+**x) Antipattern scan, diff pass.** Re-run A-F and H. Reject any Next.js
+downgrade, direct Sharp dependency, audit suppression, alternate lockfile,
+new package script, unrelated dependency churn, workflow change, or edit
+outside the five owned files.
+
+**y) Evidence.** Report the expected red test, npm and Node versions, exact
+lockfile delta, clean install, native versions and PNG smoke, frontend tests,
+production and Docker builds, audit result, docs links, independent planning
+and pre-commit review findings, commit hashes, PR URL, unresolved threads,
+CI state, and post-merge alert readback. Mark anything unrun as
+`NOT VERIFIED`.
+
+**z) Deviations.** Authorized remediation-plan changes are T-TIME-3 closure
+and the five-file T-PLAT-2A registration. Any additional path, unresolved
+high-severity audit finding, skipped review, failed required check, unrelated
+lockfile update, or unresolved P1/P2 is a blocker.

--- a/frontend/components/__tests__/SharpDependency.security.test.js
+++ b/frontend/components/__tests__/SharpDependency.security.test.js
@@ -1,0 +1,42 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const NEXT_VERSION = "16.2.11";
+const PATCHED_SHARP_VERSION = "0.35.3";
+const ROOT_DEPENDENCY_SECTIONS = [
+  "dependencies",
+  "devDependencies",
+  "optionalDependencies",
+  "peerDependencies",
+];
+const packageManifest = JSON.parse(
+  fs.readFileSync(path.resolve(process.cwd(), "package.json"), "utf8"),
+);
+const packageLock = JSON.parse(
+  fs.readFileSync(path.resolve(process.cwd(), "package-lock.json"), "utf8"),
+);
+
+test("keeps Sharp transitive and pins the patched Next.js child", () => {
+  assert.equal(packageManifest.dependencies.next, NEXT_VERSION);
+  for (const dependencySectionName of ROOT_DEPENDENCY_SECTIONS) {
+    assert.equal(
+      packageManifest[dependencySectionName]?.sharp,
+      undefined,
+      `${dependencySectionName} must not declare Sharp`,
+    );
+  }
+  assert.equal(
+    packageManifest.overrides?.next?.sharp,
+    PATCHED_SHARP_VERSION,
+  );
+});
+
+test("locks patched Sharp without changing Next.js", () => {
+  assert.equal(packageLock.packages["node_modules/next"].version, NEXT_VERSION);
+  assert.equal(
+    packageLock.packages["node_modules/sharp"].version,
+    PATCHED_SHARP_VERSION,
+  );
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -232,9 +232,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
-      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -293,9 +293,9 @@
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="
     },
     "node_modules/@img/colour": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.0.0.tgz",
-      "integrity": "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -303,9 +303,9 @@
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
+      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
       "cpu": [
         "arm64"
       ],
@@ -315,19 +315,19 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+        "@img/sharp-libvips-darwin-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
+      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
       "cpu": [
         "x64"
       ],
@@ -337,19 +337,38 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
+        "@img/sharp-libvips-darwin-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
+      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
+      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
       "cpu": [
         "arm64"
       ],
@@ -363,9 +382,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
+      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
       "cpu": [
         "x64"
       ],
@@ -379,11 +398,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
+      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
       "cpu": [
         "arm"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -395,11 +417,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
+      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -411,11 +436,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
+      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
       "cpu": [
         "ppc64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -427,11 +455,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
+      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -443,11 +474,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
+      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
       "cpu": [
         "s390x"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -459,11 +493,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
+      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -475,11 +512,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
+      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -491,11 +531,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
+      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -507,33 +550,39 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
+      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
+        "@img/sharp-libvips-linux-arm": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
+      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -541,87 +590,99 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
+        "@img/sharp-libvips-linux-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
+      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+        "@img/sharp-libvips-linux-ppc64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
+      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
       "cpu": [
         "riscv64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+        "@img/sharp-libvips-linux-riscv64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
+      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.4"
+        "@img/sharp-libvips-linux-s390x": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
+      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -629,43 +690,49 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
+        "@img/sharp-libvips-linux-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
+      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
+      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -673,38 +740,54 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-      "cpu": [
-        "wasm32"
-      ],
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
+      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.7.0"
+        "@emnapi/runtime": "^1.11.1"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
+      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
+      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
       "cpu": [
         "arm64"
       ],
@@ -714,16 +797,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
+      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
       "cpu": [
         "ia32"
       ],
@@ -733,16 +816,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": "^20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
+      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
       "cpu": [
         "x64"
       ],
@@ -752,7 +835,7 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
@@ -3101,9 +3184,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "optional": true,
       "bin": {
@@ -3114,48 +3197,53 @@
       }
     },
     "node_modules/sharp": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-      "hasInstallScript": true,
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
+      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@img/colour": "^1.0.0",
+        "@img/colour": "^1.1.0",
         "detect-libc": "^2.1.2",
-        "semver": "^7.7.3"
+        "semver": "^7.8.5"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.5",
-        "@img/sharp-darwin-x64": "0.34.5",
-        "@img/sharp-libvips-darwin-arm64": "1.2.4",
-        "@img/sharp-libvips-darwin-x64": "1.2.4",
-        "@img/sharp-libvips-linux-arm": "1.2.4",
-        "@img/sharp-libvips-linux-arm64": "1.2.4",
-        "@img/sharp-libvips-linux-ppc64": "1.2.4",
-        "@img/sharp-libvips-linux-riscv64": "1.2.4",
-        "@img/sharp-libvips-linux-s390x": "1.2.4",
-        "@img/sharp-libvips-linux-x64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-        "@img/sharp-linux-arm": "0.34.5",
-        "@img/sharp-linux-arm64": "0.34.5",
-        "@img/sharp-linux-ppc64": "0.34.5",
-        "@img/sharp-linux-riscv64": "0.34.5",
-        "@img/sharp-linux-s390x": "0.34.5",
-        "@img/sharp-linux-x64": "0.34.5",
-        "@img/sharp-linuxmusl-arm64": "0.34.5",
-        "@img/sharp-linuxmusl-x64": "0.34.5",
-        "@img/sharp-wasm32": "0.34.5",
-        "@img/sharp-win32-arm64": "0.34.5",
-        "@img/sharp-win32-ia32": "0.34.5",
-        "@img/sharp-win32-x64": "0.34.5"
+        "@img/sharp-darwin-arm64": "0.35.3",
+        "@img/sharp-darwin-x64": "0.35.3",
+        "@img/sharp-freebsd-wasm32": "0.35.3",
+        "@img/sharp-libvips-darwin-arm64": "1.3.2",
+        "@img/sharp-libvips-darwin-x64": "1.3.2",
+        "@img/sharp-libvips-linux-arm": "1.3.2",
+        "@img/sharp-libvips-linux-arm64": "1.3.2",
+        "@img/sharp-libvips-linux-ppc64": "1.3.2",
+        "@img/sharp-libvips-linux-riscv64": "1.3.2",
+        "@img/sharp-libvips-linux-s390x": "1.3.2",
+        "@img/sharp-libvips-linux-x64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
+        "@img/sharp-linux-arm": "0.35.3",
+        "@img/sharp-linux-arm64": "0.35.3",
+        "@img/sharp-linux-ppc64": "0.35.3",
+        "@img/sharp-linux-riscv64": "0.35.3",
+        "@img/sharp-linux-s390x": "0.35.3",
+        "@img/sharp-linux-x64": "0.35.3",
+        "@img/sharp-linuxmusl-arm64": "0.35.3",
+        "@img/sharp-linuxmusl-x64": "0.35.3",
+        "@img/sharp-webcontainers-wasm32": "0.35.3",
+        "@img/sharp-win32-arm64": "0.35.3",
+        "@img/sharp-win32-ia32": "0.35.3",
+        "@img/sharp-win32-x64": "0.35.3"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/source-map-js": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,6 +34,9 @@
     "tailwindcss": "3.4.1"
   },
   "overrides": {
-    "postcss": "8.5.14"
+    "postcss": "8.5.14",
+    "next": {
+      "sharp": "0.35.3"
+    }
   }
 }


### PR DESCRIPTION
## What changed
- Pin Next.js's transitive Sharp dependency to 0.35.3 through a nested npm override.
- Regenerate the lockfile for Sharp, libvips, native packages, and their helper dependencies.
- Add a durable Node test that keeps Sharp transitive and locks Next.js 16.2.11 plus Sharp 0.35.3.
- Register the reviewed T-PLAT-2A remediation plan and close merged T-TIME-3 in the ledger.

## Why
Dependabot alert 106 reports high-severity libvips vulnerabilities in Sharp versions before 0.35.0. The previous lock selected Sharp 0.34.5.

## Risk and compatibility
- Next.js remains 16.2.11.
- Sharp remains a transitive optional dependency; application code does not import it.
- Node 20.9.0 or newer is required by both Next.js 16.2.11 and Sharp 0.35.3; CI and the Docker image use Node 20.
- No API, route, runtime default, schema, secret, or person-data behavior changes.

## Verification
- EXPECTED FAIL before implementation: `node --test components/__tests__/SharpDependency.security.test.js` (missing override and locked 0.34.5).
- PASS: `npm install --package-lock-only --ignore-scripts`.
- PASS: `npm ci` (210 packages installed locally; zero vulnerabilities).
- PASS: `npm ls next sharp --all` (Next.js 16.2.11; Sharp 0.35.3 overridden).
- PASS: host `sharp.versions` and one-pixel PNG smoke (Sharp 0.35.3, libvips 8.18.3).
- PASS: `npm test` (13 tests).
- PASS: `npm run build -- --webpack`.
- PASS: `npm audit --omit=dev --audit-level=high` (zero vulnerabilities).
- PASS: `docker build --target builder --tag town-council-frontend-sharp-smoke frontend`.
- PASS: Linux-musl in-container Sharp/libvips PNG smoke.
- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py` (2 tests).
- PASS: `git diff --check`.

## Review
- Planning review found and corrected Linux-musl runtime proof, unsafe rollback wording, and direct-dependency test coverage.
- Pre-commit review found and corrected the optional-dependency bypass.

## Remaining
Dependabot alert 106 can close only after this patch reaches `master`; post-merge API readback is required.