### PR TITLE
T-SEC-5: Reject non-same-origin proxy mutations

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,8 +27,14 @@ engineering decisions is `reachable`).
 ## Trust boundaries
 
 1. Internet -> Frontend (Next.js): untrusted browsers. CSP (nonce +
-   strict-dynamic), security headers, and origin checks on mutation routes
-   `[remediation: T-SEC-5]` apply here.
+   strict-dynamic), security headers, and same-origin checks on mutation
+   routes apply here. The mutation guard rejects `same-site` and `cross-site`
+   Fetch Metadata plus mismatched `Origin` values; requests with neither
+   browser signal remain compatible for non-browser callers
+   `[remediation: T-SEC-5]`.
+   Reverse proxies must preserve the public `Host` header and overwrite any
+   incoming `X-Forwarded-Proto`; the guard deliberately ignores
+   `X-Forwarded-Host`.
 2. Frontend server -> API: the proxy injects `X-API-Key` server-side
    (`frontend/app/api/_lib/backend.js`). Consequence: the API key does NOT
    authenticate end users; it only authenticates the frontend deployment.
@@ -89,7 +95,7 @@ engineering decisions is `reachable`).
 - [x] Meilisearch search key enforced for API and semantic readers (T-SEC-3)
 - [ ] Client IP forwarded from proxy; limiter keys on it with trusted-proxy
       allowlist (T-SEC-4)
-- [ ] Origin/Sec-Fetch-Site check on proxy mutation routes (T-SEC-5)
+- [x] Origin/Sec-Fetch-Site check on proxy mutation routes (T-SEC-5)
 - [ ] `NEXT_CSP_ENFORCE=true` after a report-only soak
 - [ ] `/stats` gated or minimized; CORS without `allow_credentials`
       (T-SEC-6)

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,6 +1,6 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 3.12
+version: 3.13
 generated: 2026-07-23
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
@@ -10,6 +10,8 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v3.13:** Activates T-SEC-5 with a Full implementation plan and expands
+  ownership to its executable frontend test and canonical security checklist.
 - **v3.12:** Marks T-PLAT-2A complete after PR #128 merged with required
   checks green, its final review found no unresolved P1/P2 issues, and
   Dependabot alert 106 closed as fixed.
@@ -102,9 +104,9 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 | State | Tasks |
 |---|---|
 | **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2, T-SEC-3, T-SEC-3C, T-TIME-3, T-CRAWL-1, T-CRAWL-2, T-PLAT-2A |
-| **In progress** | None |
+| **In progress** | T-SEC-5 |
 | **Partially landed; acceptance incomplete** | T-GOV-4, T-GOV-5, T-GOV-6 |
-| **Pending** | T-SEC-4..6, T-TIME-1..2, T-DA-1, T-DB-1, T-DC-1, T-DD-1, T-DE-1, T-PLAT-1, T-PLAT-2, T-PLAT-3, T-PLAT-4, T-GOV-1..3 |
+| **Pending** | T-SEC-4, T-SEC-6, T-TIME-1..2, T-DA-1, T-DB-1, T-DC-1, T-DD-1, T-DE-1, T-PLAT-1, T-PLAT-2, T-PLAT-3, T-PLAT-4, T-GOV-1..3 |
 
 ---
 
@@ -552,13 +554,20 @@ in `AGENTS.md`, `docs/TESTING.MD`, and
 
 ### T-SEC-5: CSRF/origin check on proxy mutation routes
 - priority: P1
-- files_owned: frontend/app/api/** (route handlers + _lib)
+- status: in progress
+- implementation_plan: `docs/plans/T_SEC_5_PROXY_ORIGIN_GUARD_PLAN.md`
+- files_owned: docs/plans/T_SEC_5_PROXY_ORIGIN_GUARD_PLAN.md,
+  docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md, SECURITY.md,
+  frontend/app/api/**,
+  frontend/components/__tests__/BackendProxy.origin.test.js
 - do: In proxyBackendJson (or a small shared check), reject POSTs whose
-  Origin/Sec-Fetch-Site indicate cross-site with 403. Same-origin and
-  server-side calls pass.
+  Origin/Sec-Fetch-Site indicate a non-same-origin browser request with 403.
+  Same-origin and non-browser calls pass.
 - accept: Cross-origin POST to /api/summarize/* returns 403; app UX
-  unchanged; jest test added.
-- verify: `npm test` green.
+  unchanged; `node:test` coverage added.
+- verify: Follow the Full T-SEC-5 plan, including tests-first evidence,
+  frontend tests and build, Python frontend contracts, full-suite
+  verification, independent review, and diff checks.
 
 ### T-SEC-6: Small closures
 - priority: P2

--- a/docs/plans/T_SEC_5_PROXY_ORIGIN_GUARD_PLAN.md
+++ b/docs/plans/T_SEC_5_PROXY_ORIGIN_GUARD_PLAN.md
@@ -1,0 +1,295 @@
+# T-SEC-5: Reject Non-Same-Origin Proxy Mutations
+
+`artifact_contract: ce-unified-plan/v1`  
+`artifact_readiness: implementation-ready`  
+`execution: code`
+
+## 1. Context & Alignment
+
+**a) Driver.** Town Council's frontend proxy injects the deployment API key
+into every backend request, so that key authenticates the frontend service,
+not the visitor. The current POST route handlers accept cross-site browser
+requests without checking `Origin` or `Sec-Fetch-Site`. T-SEC-5 closes that
+request-forgery gap without deciding who may use AI actions, changing the API
+key contract, or altering local-first runtime defaults.
+
+**b) Canonical documents consulted.**
+
+- `AGENTS.md` `<security_sensitive_paths>` requires a trust-boundary impact
+  statement for `frontend/app/api/**`.
+- `SECURITY.md` "Trust boundaries" identifies Internet-to-Frontend mutations
+  as untrusted and assigns origin checks to T-SEC-5.
+- `docs/TESTING.md` "Test placement" requires frontend tests under
+  `frontend/components/__tests__/` and observable behavior at approved
+  boundaries.
+- `docs/ENGINEERING_GUARDRAILS.md` keeps configuration and tests aligned with
+  current automation; this task does not change its policy.
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md` assigns same-origin mutation
+  enforcement to T-SEC-5.
+- `docs/reviews/architecture-review-2026-07-19.html` identifies the shared
+  frontend proxy as the correct enforcement boundary.
+
+**c) Remediation alignment.** T-SEC-5 is the active SEC-lane task. Expand its
+ownership before implementation to exactly:
+
+- `docs/plans/T_SEC_5_PROXY_ORIGIN_GUARD_PLAN.md`
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`
+- `SECURITY.md`
+- `frontend/app/api/**`
+- `frontend/components/__tests__/BackendProxy.origin.test.js`
+
+The test path and security checklist were missing from the original task
+ownership. No other path may change.
+
+**d) Decision-gate check.** T-SEC-5 does not depend on or foreclose G1-G5.
+G2 remains open because origin validation establishes request provenance, not
+visitor authorization. T-SEC-4 remains blocked on G2, and Phase 2 remains
+blocked on G3.
+
+## 2. Design
+
+**e) Step-by-step approach.**
+
+1. Register this Full Template plan and corrected ownership in the remediation
+   ledger.
+2. Add failing Node tests before implementation for cross-site, mismatched
+   origin, same-origin, and headerless server-side POST requests.
+3. Remove the `next/server` dependency from the shared backend helper by using
+   the standard `Response.json` supported by Next.js route handlers. This
+   makes the actual proxy boundary directly testable with Node's built-in Web
+   APIs; it does not change response semantics.
+4. Add one private `isCrossSiteMutation` predicate to
+   `frontend/app/api/_lib/backend.js`. Its only responsibility is to classify
+   POST requests from `Origin`, `Sec-Fetch-Site`, and the request URL.
+5. Require each existing POST route to pass its incoming request to
+   `proxyBackendJson`. GET routes remain unchanged because the predicate
+   returns before request-header access for non-POST methods.
+6. Return a JSON 403 before reading the API key or calling the backend when
+   `Sec-Fetch-Site` is `cross-site` or `same-site`, or when a present `Origin`
+   differs from the route request origin. Town Council does not define trusted
+   sibling subdomains, so same-site is not equivalent to same-origin.
+7. Permit exact same-origin requests and requests with neither browser header;
+   the latter preserves callers that do not originate in a browser. This is a
+   compatibility exception, not complete CSRF protection for legacy browsers
+   that omit both signals.
+8. Mark the T-SEC-5 security checklist control implemented in the branch.
+   Keep the remediation task in progress until the implementation PR merges
+   and receives a post-merge evidence readback.
+9. Run frontend tests, frontend production build, Python frontend-contract
+   tests, docs links, full Python suite, independent pre-commit review, PR
+   review, and CI.
+
+No new module is added. `proxyBackendJson` remains the single proxy facade, and
+the private predicate never imports route modules.
+
+**f) Reuse audit.** Extend `frontend/app/api/_lib/backend.js` and the existing
+Node test runner. Reuse standard `Request`, `Response`, `Headers`, and `fetch`
+interfaces already supplied by the supported Node and Next runtimes. Do not
+add middleware, a CSRF package, a test loader, a route wrapper, or a second
+origin-policy implementation.
+
+Rejected alternatives:
+
+- Global Next proxy enforcement: rejected because it would cover safe reads
+  and unrelated routes rather than the shared backend mutation boundary.
+- Referer-only validation: rejected because `Origin` and Fetch Metadata are
+  the explicit browser security signals in the remediation contract.
+- A synchronizer token: rejected because no browser session or user identity
+  exists, and adding either would decide G2 by implication.
+- Static source assertions only: rejected because they would not prove the
+  runtime 403 and pass-through behavior.
+
+**g) Data contracts.** This adds one rejection contract: blocked mutations
+return `{"detail": "Cross-site mutation requests are not allowed."}` with
+HTTP 403 and JSON content type. Successful and backend-error responses retain
+the existing proxy contract. No typed application contract is needed for this
+JavaScript request-boundary change.
+
+**h) Schema/migration impact.** None.
+
+## 3. Security & Data Governance
+
+**i) Security-sensitive path.** This task changes the
+Internet-to-Frontend trust boundary defined by `SECURITY.md`. An attacker loses
+the ability to cause a visitor's browser to submit a cross-site mutation
+through Town Council's API-key-injecting proxy. It does not add visitor
+authentication or change who may intentionally invoke a same-origin action.
+
+**j) Secrets.** No credential, key, environment variable, or default changes.
+The API key remains server-side and is not logged or returned.
+
+**k) Person data.** No person-level data is created, linked, aggregated, or
+exposed. G4 is unaffected.
+
+**l) Untrusted input.** `Origin` and `Sec-Fetch-Site` are untrusted request
+headers. The boundary compares exact normalized header values through the
+standard `Headers` interface and compares a supplied origin with
+`new URL(request.url).origin`. No scraped content or HTML is parsed.
+
+## 4. Code Health
+
+**m) GED conformance sweep.** The private predicate has two parameters, no
+deep nesting, and one responsibility. HTTP methods, response status, header
+names, and rejection text use named constants. No environment read, timestamp,
+exception handler, type suppression, or import-time side effect is added.
+
+**n) Antipattern scan, plan pass.**
+
+- A1/H1: Next.js route-handler `Request`/`Response` behavior was verified
+  against official Next.js 16.2.9 documentation and installed Next.js
+  16.2.11. Node 20 `node:test` cleanup and global Fetch APIs were verified
+  against official Node 20 documentation.
+- B1/F1: no middleware, package, wrapper, registry, or duplicate policy module
+  is added.
+- B3: validation covers only existing POST proxy calls and the explicit
+  non-browser no-header compatibility case.
+- D1-D3: behavior tests exercise response status and backend pass-through;
+  one source contract verifies that every POST route supplies the request
+  object because direct route imports are not supported by the dependency's
+  Node ESM entrypoint.
+- E1-E3: only owned proxy routes, one test, the ledger, plan, and checklist
+  change.
+- A2-A4, B2, C1-C2, F2, H2-H4: no violations planned.
+
+**o) Ratchet interaction.** No Ruff, Mypy, formatter, coverage, or broad
+exception selector changes. No exception boundary is added or widened.
+
+**p) Dead code and duplication audit.** Delete the `next/server` import after
+replacing its sole `NextResponse.json` use with standard `Response.json`.
+Reuse the shared proxy instead of repeating checks in five route handlers.
+Expected runtime delta is one private predicate plus five request-property
+additions.
+
+## 5. Testing
+
+**q) Edge cases and failure scenarios.**
+
+1. `Sec-Fetch-Site: cross-site` must return 403 even without `Origin`.
+2. `Sec-Fetch-Site: same-site` must return 403 because sibling subdomains are
+   not trusted.
+3. A present `Origin` that differs by scheme, host, or port must return 403.
+4. `Origin: null` and malformed origins must return 403.
+5. Exact same-origin POST must reach the backend proxy.
+6. A POST request object with neither browser header must reach the backend
+   proxy.
+7. A same-origin `Origin` paired with blocked Fetch Metadata must return 403
+   because either signal can identify a non-same-origin request.
+8. Unknown future `Sec-Fetch-Site` values must fall back to Origin validation.
+9. Rejection must occur before API-key lookup or backend fetch.
+10. Every existing POST route must supply its request object; a missing
+   request is a programming error and must fail closed.
+11. Existing JSON body, query, authentication header, and backend-response
+   forwarding must remain unchanged for allowed requests.
+12. GET routes and frontend build behavior must remain unchanged.
+13. Missing `API_AUTH_KEY` on an allowed request must retain the existing 500
+   response.
+
+**r) Tests added or updated.**
+
+| Test | Scenarios |
+|---|---|
+| Cross-site and same-site Fetch Metadata return JSON 403 | 1, 2, 9 |
+| Scheme, host, and port Origin mismatches return JSON 403 | 3, 9 |
+| Null and malformed Origin values return JSON 403 | 4, 9 |
+| Blocked Fetch Metadata overrides matching Origin | 7, 9 |
+| Unknown Fetch Metadata falls back to Origin validation | 8 |
+| Same-origin POST forwards the backend response | 5, 11 |
+| Headerless POST forwards the backend response | 6, 11 |
+| Missing POST request fails before backend access | 10 |
+| Every POST route forwards its request object | 10 |
+| Allowed request without API key retains configuration error | 13 |
+| Existing frontend suite and production build | 11, 12 |
+| Existing Python frontend-contract tests | 12 |
+
+The test file is written and run red before proxy implementation.
+
+**s) Fakes and mocks.** Tests replace only `globalThis.fetch`, the approved
+outbound HTTP boundary, and restore it after every test with Node's
+`afterEach`. They set and restore `API_AUTH_KEY` as process configuration.
+No production symbol, facade, or private predicate is patched.
+
+**t) Verification rows.** Apply the frontend contract and frontend
+component/behavior rows from `AGENTS.md`, plus docs links because `SECURITY.md`
+and `docs/plans/**` change. Run the complete Python suite before handoff
+because this is a security-boundary change.
+
+## 6. Execution, Rollback, Docs
+
+**u) Exact commands.**
+
+```bash
+git fetch origin --prune
+git switch master
+git merge --ff-only origin/master
+git switch -c codex/t-sec-5-proxy-origin-guard
+```
+
+Tests-first red evidence:
+
+```bash
+cd frontend
+node --test components/__tests__/BackendProxy.origin.test.js
+```
+
+Final local verification:
+
+```bash
+cd frontend
+npm test
+npm run build -- --webpack
+cd ..
+
+PYTHONPATH=. .venv/bin/pytest -q tests/test_frontend_pages_config.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_resultcard_agenda_status_refresh.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_search_sort_ui_guardrails.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_semantic_search_ui_guardrails.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py
+PYTHONPATH=. .venv/bin/pytest -q
+git diff --check
+git status --short
+```
+
+Delivery uses two atomic commits:
+
+1. `docs(remediation): authorize the proxy origin guard`
+2. `fix(frontend): reject non-same-origin proxy mutations`
+
+Push `codex/t-sec-5-proxy-origin-guard`, open one PR, request Codex review, and
+wait for all required checks. After merge, verify the default branch and
+close T-SEC-5 in a separate evidence-only ledger change.
+
+**v) Rollback.** If the evidence-only closure has merged, first run
+`git revert -m 1 <t-sec-5-closure-merge-sha>`, then run
+`git revert -m 1 <t-sec-5-implementation-merge-sha>`. Rerun frontend tests and
+build, the four Python frontend-contract tests, docs links, and the complete
+Python suite. The closure reversal reopens the `SECURITY.md` checklist and
+ledger status before implementation is removed. No migration, secret
+rotation, environment restore, or data repair is required. Rollback restores
+the known non-same-origin mutation gap.
+
+**w) Docs sync.**
+
+- `SECURITY.md` "Trust boundaries" and hardening checklist: record active
+  same-origin mutation enforcement.
+- Remediation plan: version, active status, corrected ownership, acceptance,
+  and verification details.
+- New T-SEC-5 Full Template plan.
+- README, ADR, operations, testing policy, architecture review, API contract,
+  and data-governance docs: no change.
+
+## 7. Delivery Self-Audit
+
+**x) Antipattern scan, diff pass.** Re-run A-F and H. Reject a new middleware
+layer, duplicate route checks, user-auth behavior, test-only production
+exports, swallowed errors, source-only assertions, unrelated formatting, or
+any changed path outside the ownership set.
+
+**y) Evidence.** Report the tests-first failure, every command from 6u, exact
+frontend and Python counts, independent planning and pre-commit review
+findings, commit hashes, PR URL, unresolved-thread count, and final CI state.
+Mark anything unrun as `NOT VERIFIED`.
+
+**z) Deviations.** Authorized ledger corrections are the Full plan, test path,
+and `SECURITY.md` ownership. Any other changed file, new package, middleware,
+route contract, visitor-auth policy, unresolved P1/P2, skipped review, or
+unrun required command is a blocker.

--- a/docs/plans/T_SEC_5_PROXY_ORIGIN_GUARD_PLAN.md
+++ b/docs/plans/T_SEC_5_PROXY_ORIGIN_GUARD_PLAN.md
@@ -1,11 +1,10 @@
 # T-SEC-5: Reject Non-Same-Origin Proxy Mutations
 
-`artifact_contract: ce-unified-plan/v1`  
-`artifact_readiness: implementation-ready`  
+`artifact_contract: ce-unified-plan/v1`
+`artifact_readiness: implementation-ready`
 `execution: code`
 
 ## 1. Context & Alignment
-
 **a) Driver.** Town Council's frontend proxy injects the deployment API key
 into every backend request, so that key authenticates the frontend service,
 not the visitor. The current POST route handlers accept cross-site browser
@@ -14,7 +13,6 @@ request-forgery gap without deciding who may use AI actions, changing the API
 key contract, or altering local-first runtime defaults.
 
 **b) Canonical documents consulted.**
-
 - `AGENTS.md` `<security_sensitive_paths>` requires a trust-boundary impact
   statement for `frontend/app/api/**`.
 - `SECURITY.md` "Trust boundaries" identifies Internet-to-Frontend mutations
@@ -47,9 +45,7 @@ visitor authorization. T-SEC-4 remains blocked on G2, and Phase 2 remains
 blocked on G3.
 
 ## 2. Design
-
 **e) Step-by-step approach.**
-
 1. Register this Full Template plan and corrected ownership in the remediation
    ledger.
 2. Add failing Node tests before implementation for cross-site, mismatched
@@ -58,15 +54,16 @@ blocked on G3.
    the standard `Response.json` supported by Next.js route handlers. This
    makes the actual proxy boundary directly testable with Node's built-in Web
    APIs; it does not change response semantics.
-4. Add one private `isCrossSiteMutation` predicate to
-   `frontend/app/api/_lib/backend.js`. Its only responsibility is to classify
-   POST requests from `Origin`, `Sec-Fetch-Site`, and the request URL.
+4. Add private target-origin and mutation predicates to the existing backend
+   helper. The target origin uses the standard `Host`, the first
+   `X-Forwarded-Proto` value after the edge proxy overwrites it, and the
+   request URL as fallback; it never trusts `X-Forwarded-Host`.
 5. Require each existing POST route to pass its incoming request to
-   `proxyBackendJson`. GET routes remain unchanged because the predicate
-   returns before request-header access for non-POST methods.
+   `proxyBackendJson` and keep method metadata aligned. The guard activates
+   when either method is POST, so a wiring mismatch fails closed.
 6. Return a JSON 403 before reading the API key or calling the backend when
    `Sec-Fetch-Site` is `cross-site` or `same-site`, or when a present `Origin`
-   differs from the route request origin. Town Council does not define trusted
+   differs from that external target origin. Town Council defines no trusted
    sibling subdomains, so same-site is not equivalent to same-origin.
 7. Permit exact same-origin requests and requests with neither browser header;
    the latter preserves callers that do not originate in a browser. This is a
@@ -89,7 +86,6 @@ add middleware, a CSRF package, a test loader, a route wrapper, or a second
 origin-policy implementation.
 
 Rejected alternatives:
-
 - Global Next proxy enforcement: rejected because it would cover safe reads
   and unrelated routes rather than the shared backend mutation boundary.
 - Referer-only validation: rejected because `Origin` and Fetch Metadata are
@@ -108,7 +104,6 @@ JavaScript request-boundary change.
 **h) Schema/migration impact.** None.
 
 ## 3. Security & Data Governance
-
 **i) Security-sensitive path.** This task changes the
 Internet-to-Frontend trust boundary defined by `SECURITY.md`. An attacker loses
 the ability to cause a visitor's browser to submit a cross-site mutation
@@ -121,20 +116,18 @@ The API key remains server-side and is not logged or returned.
 **k) Person data.** No person-level data is created, linked, aggregated, or
 exposed. G4 is unaffected.
 
-**l) Untrusted input.** `Origin` and `Sec-Fetch-Site` are untrusted request
-headers. The boundary compares exact normalized header values through the
-standard `Headers` interface and compares a supplied origin with
-`new URL(request.url).origin`. No scraped content or HTML is parsed.
+**l) Untrusted input.** `Origin`, `Sec-Fetch-Site`, and forwarded protocol are
+untrusted request headers. The guard normalizes the target through `URL`,
+uses standard `Host` rather than spoofable `X-Forwarded-Host`, and rejects
+invalid target metadata. No scraped content or HTML is parsed.
 
 ## 4. Code Health
-
-**m) GED conformance sweep.** The private predicate has two parameters, no
-deep nesting, and one responsibility. HTTP methods, response status, header
-names, and rejection text use named constants. No environment read, timestamp,
-exception handler, type suppression, or import-time side effect is added.
+**m) GED conformance sweep.** Each private function has one responsibility and
+no deep nesting. Named constants own policy literals. URL parsing catches only
+`TypeError` and maps invalid target metadata to rejection. No environment read,
+timestamp, type suppression, or import-time side effect is added.
 
 **n) Antipattern scan, plan pass.**
-
 - A1/H1: Next.js route-handler `Request`/`Response` behavior was verified
   against official Next.js 16.2.9 documentation and installed Next.js
   16.2.11. Node 20 `node:test` cleanup and global Fetch APIs were verified
@@ -157,13 +150,11 @@ exception selector changes. No exception boundary is added or widened.
 **p) Dead code and duplication audit.** Delete the `next/server` import after
 replacing its sole `NextResponse.json` use with standard `Response.json`.
 Reuse the shared proxy instead of repeating checks in five route handlers.
-Expected runtime delta is one private predicate plus five request-property
-additions.
+Expected runtime delta is focused private parsing/classification helpers plus
+five request-property additions.
 
 ## 5. Testing
-
 **q) Edge cases and failure scenarios.**
-
 1. `Sec-Fetch-Site: cross-site` must return 403 even without `Origin`.
 2. `Sec-Fetch-Site: same-site` must return 403 because sibling subdomains are
    not trusted.
@@ -176,16 +167,19 @@ additions.
    because either signal can identify a non-same-origin request.
 8. Unknown future `Sec-Fetch-Site` values must fall back to Origin validation.
 9. Rejection must occur before API-key lookup or backend fetch.
-10. Every existing POST route must supply its request object; a missing
-   request is a programming error and must fail closed.
+10. Every existing POST route must supply its request object and matching
+    method metadata; missing or mismatched metadata must fail closed.
 11. Existing JSON body, query, authentication header, and backend-response
    forwarding must remain unchanged for allowed requests.
-12. GET routes and frontend build behavior must remain unchanged.
-13. Missing `API_AUTH_KEY` on an allowed request must retain the existing 500
+12. Next standalone's internal URL must honor standard Host and the first
+   forwarded protocol value for a matching external origin.
+13. Malformed Host/protocol metadata must reject, and `X-Forwarded-Host` must
+   not override the standard Host.
+14. GET routes and frontend build behavior must remain unchanged.
+15. Missing `API_AUTH_KEY` on an allowed request must retain the existing 500
    response.
 
 **r) Tests added or updated.**
-
 | Test | Scenarios |
 |---|---|
 | Cross-site and same-site Fetch Metadata return JSON 403 | 1, 2, 9 |
@@ -195,11 +189,13 @@ additions.
 | Unknown Fetch Metadata falls back to Origin validation | 8 |
 | Same-origin POST forwards the backend response | 5, 11 |
 | Headerless POST forwards the backend response | 6, 11 |
-| Missing POST request fails before backend access | 10 |
-| Every POST route forwards its request object | 10 |
-| Allowed request without API key retains configuration error | 13 |
-| Existing frontend suite and production build | 11, 12 |
-| Existing Python frontend-contract tests | 12 |
+| Missing/mismatched POST metadata fails before backend access | 10 |
+| Every POST route forwards its request and POST method | 10 |
+| Standalone internal URL honors external Host/first protocol | 12 |
+| Malformed metadata and spoofed X-Forwarded-Host reject | 13 |
+| Allowed request without API key retains configuration error | 15 |
+| Existing frontend suite and production build | 11, 14 |
+| Existing Python frontend-contract tests | 14 |
 
 The test file is written and run red before proxy implementation.
 
@@ -214,9 +210,7 @@ and `docs/plans/**` change. Run the complete Python suite before handoff
 because this is a security-boundary change.
 
 ## 6. Execution, Rollback, Docs
-
 **u) Exact commands.**
-
 ```bash
 git fetch origin --prune
 git switch master
@@ -225,18 +219,32 @@ git switch -c codex/t-sec-5-proxy-origin-guard
 ```
 
 Tests-first red evidence:
-
 ```bash
 cd frontend
 node --test components/__tests__/BackendProxy.origin.test.js
 ```
 
 Final local verification:
-
 ```bash
 cd frontend
 npm test
 npm run build -- --webpack
+STANDALONE_SERVER=$(find .next/standalone -path '*/frontend/server.js' -print -quit)
+test -n "$STANDALONE_SERVER"
+HOSTNAME=0.0.0.0 PORT=3124 APP_ENV=dev \
+  API_AUTH_KEY=frontend-proxy-test-key \
+  INTERNAL_API_BASE_URL=http://127.0.0.1:9999 \
+  node "$STANDALONE_SERVER" >/tmp/t-sec-5-next.log 2>&1 &
+SERVER_PID=$!
+trap 'kill "$SERVER_PID" 2>/dev/null || true' EXIT
+until curl -fsS http://localhost:3124 >/dev/null; do sleep 1; done
+STATUS=$(curl -sS -o /tmp/t-sec-5-response.json -w '%{http_code}' \
+  -X POST -H 'Origin: http://localhost:3124' \
+  -H 'Sec-Fetch-Site: same-origin' \
+  http://localhost:3124/api/summarize/42)
+test "$STATUS" != 403
+kill "$SERVER_PID"
+trap - EXIT
 cd ..
 
 PYTHONPATH=. .venv/bin/pytest -q tests/test_frontend_pages_config.py
@@ -250,7 +258,6 @@ git status --short
 ```
 
 Delivery uses two atomic commits:
-
 1. `docs(remediation): authorize the proxy origin guard`
 2. `fix(frontend): reject non-same-origin proxy mutations`
 
@@ -262,13 +269,12 @@ close T-SEC-5 in a separate evidence-only ledger change.
 `git revert -m 1 <t-sec-5-closure-merge-sha>`, then run
 `git revert -m 1 <t-sec-5-implementation-merge-sha>`. Rerun frontend tests and
 build, the four Python frontend-contract tests, docs links, and the complete
-Python suite. The closure reversal reopens the `SECURITY.md` checklist and
-ledger status before implementation is removed. No migration, secret
-rotation, environment restore, or data repair is required. Rollback restores
-the known non-same-origin mutation gap.
+Python suite. The closure reversal reopens the ledger status; the
+implementation reversal reopens the `SECURITY.md` checklist. No migration,
+secret rotation, environment restore, or data repair is required. Rollback
+restores the known non-same-origin mutation gap.
 
 **w) Docs sync.**
-
 - `SECURITY.md` "Trust boundaries" and hardening checklist: record active
   same-origin mutation enforcement.
 - Remediation plan: version, active status, corrected ownership, acceptance,
@@ -278,7 +284,6 @@ the known non-same-origin mutation gap.
   and data-governance docs: no change.
 
 ## 7. Delivery Self-Audit
-
 **x) Antipattern scan, diff pass.** Re-run A-F and H. Reject a new middleware
 layer, duplicate route checks, user-auth behavior, test-only production
 exports, swallowed errors, source-only assertions, unrelated formatting, or

--- a/docs/plans/T_SEC_5_PROXY_ORIGIN_GUARD_PLAN.md
+++ b/docs/plans/T_SEC_5_PROXY_ORIGIN_GUARD_PLAN.md
@@ -59,8 +59,8 @@ blocked on G3.
    `X-Forwarded-Proto` value after the edge proxy overwrites it, and the
    request URL as fallback; it never trusts `X-Forwarded-Host`.
 5. Require each existing POST route to pass its incoming request to
-   `proxyBackendJson` and keep method metadata aligned. The guard activates
-   when either method is POST, so a wiring mismatch fails closed.
+   `proxyBackendJson` and keep method metadata aligned. The guard rejects a
+   method disagreement before applying POST origin policy.
 6. Return a JSON 403 before reading the API key or calling the backend when
    `Sec-Fetch-Site` is `cross-site` or `same-site`, or when a present `Origin`
    differs from that external target origin. Town Council defines no trusted

--- a/frontend/app/api/_lib/backend.js
+++ b/frontend/app/api/_lib/backend.js
@@ -91,7 +91,11 @@ function getExternalRequestOrigin(request) {
 }
 
 function isNonSameOriginMutation(request, method) {
-  if (method !== MUTATION_METHOD && request?.method !== MUTATION_METHOD) {
+  const requestMethod = request?.method;
+  if (requestMethod !== undefined && requestMethod !== method) {
+    return true;
+  }
+  if (method !== MUTATION_METHOD) {
     return false;
   }
 

--- a/frontend/app/api/_lib/backend.js
+++ b/frontend/app/api/_lib/backend.js
@@ -1,4 +1,13 @@
-import { NextResponse } from "next/server";
+const BLOCKED_FETCH_SITES = new Set(["cross-site", "same-site"]);
+const CROSS_SITE_DETAIL = "Cross-site mutation requests are not allowed.";
+const FETCH_SITE_HEADER = "sec-fetch-site";
+const FORBIDDEN_STATUS = 403;
+const FORWARDED_PROTOCOL_HEADER = "x-forwarded-proto";
+const HOST_HEADER = "host";
+const INVALID_HOST_AUTHORITY = /[/\\?#]/;
+const MUTATION_METHOD = "POST";
+const ORIGIN_HEADER = "origin";
+const WEB_PROTOCOLS = new Set(["http", "https"]);
 
 function getInternalApiBaseUrl() {
   return process.env.INTERNAL_API_BASE_URL || "http://api:8000";
@@ -12,6 +21,96 @@ function getApiAuthKey() {
   return apiAuthKey;
 }
 
+function parseUrl(urlValue) {
+  try {
+    return new URL(urlValue);
+  } catch (error) {
+    if (!(error instanceof TypeError)) {
+      throw error;
+    }
+    return null;
+  }
+}
+
+function parseWebOrigin(originValue) {
+  const parsedOrigin = parseUrl(originValue);
+  const protocol = parsedOrigin?.protocol.slice(0, -1);
+  return parsedOrigin && WEB_PROTOCOLS.has(protocol)
+    ? parsedOrigin.origin
+    : null;
+}
+
+function parseSerializedOrigin(originValue) {
+  const parsedOrigin = parseWebOrigin(originValue);
+  return parsedOrigin === originValue ? parsedOrigin : null;
+}
+
+function parseHostAuthority(hostValue, protocol) {
+  if (
+    hostValue !== hostValue.trim() ||
+    INVALID_HOST_AUTHORITY.test(hostValue)
+  ) {
+    return null;
+  }
+
+  const parsedHost = parseUrl(`${protocol}://${hostValue}`);
+  if (
+    !parsedHost ||
+    parsedHost.username ||
+    parsedHost.password ||
+    parsedHost.pathname !== "/" ||
+    parsedHost.search ||
+    parsedHost.hash
+  ) {
+    return null;
+  }
+  return parsedHost.host;
+}
+
+function getExternalRequestOrigin(request) {
+  const requestUrl = new URL(request.url);
+  const forwardedProtocolHeader = request.headers.get(
+    FORWARDED_PROTOCOL_HEADER,
+  );
+  const protocol =
+    forwardedProtocolHeader === null
+      ? requestUrl.protocol.slice(0, -1)
+      : forwardedProtocolHeader.split(",", 1)[0].trim().toLowerCase();
+  if (!WEB_PROTOCOLS.has(protocol)) {
+    return null;
+  }
+  const hostHeader = request.headers.get(HOST_HEADER);
+  const host =
+    hostHeader === null
+      ? requestUrl.host
+      : parseHostAuthority(hostHeader, protocol);
+  if (host === null) {
+    return null;
+  }
+  return parseWebOrigin(`${protocol}://${host}`);
+}
+
+function isNonSameOriginMutation(request, method) {
+  if (method !== MUTATION_METHOD && request?.method !== MUTATION_METHOD) {
+    return false;
+  }
+
+  if (BLOCKED_FETCH_SITES.has(request.headers.get(FETCH_SITE_HEADER))) {
+    return true;
+  }
+
+  const externalRequestOrigin = getExternalRequestOrigin(request);
+  if (externalRequestOrigin === null) {
+    return true;
+  }
+
+  const origin = request.headers.get(ORIGIN_HEADER);
+  return (
+    origin !== null &&
+    parseSerializedOrigin(origin) !== externalRequestOrigin
+  );
+}
+
 export function buildBackendUrl(path, searchParams) {
   const url = new URL(path, getInternalApiBaseUrl());
   if (searchParams) {
@@ -21,17 +120,25 @@ export function buildBackendUrl(path, searchParams) {
 }
 
 export async function proxyBackendJson({
+  request,
   method,
   path,
   searchParams,
   body,
 }) {
+  if (isNonSameOriginMutation(request, method)) {
+    return Response.json(
+      { detail: CROSS_SITE_DETAIL },
+      { status: FORBIDDEN_STATUS },
+    );
+  }
+
   let apiAuthKey;
   try {
     apiAuthKey = getApiAuthKey();
   } catch (error) {
     console.error("frontend_backend_proxy.missing_auth_env", error);
-    return NextResponse.json(
+    return Response.json(
       { detail: "Frontend backend proxy is not configured." },
       { status: 500 },
     );

--- a/frontend/app/api/extract/[catalogId]/route.js
+++ b/frontend/app/api/extract/[catalogId]/route.js
@@ -3,6 +3,7 @@ import { proxyBackendJson } from "../../_lib/backend";
 export async function POST(request, { params }) {
   const { catalogId } = await params;
   return proxyBackendJson({
+    request,
     method: "POST",
     path: `/extract/${catalogId}`,
     searchParams: request.nextUrl.searchParams,

--- a/frontend/app/api/report-issue/route.js
+++ b/frontend/app/api/report-issue/route.js
@@ -2,6 +2,7 @@ import { proxyBackendJson } from "../_lib/backend";
 
 export async function POST(request) {
   return proxyBackendJson({
+    request,
     method: "POST",
     path: "/report-issue",
     body: await request.text(),

--- a/frontend/app/api/segment/[catalogId]/route.js
+++ b/frontend/app/api/segment/[catalogId]/route.js
@@ -3,6 +3,7 @@ import { proxyBackendJson } from "../../_lib/backend";
 export async function POST(request, { params }) {
   const { catalogId } = await params;
   return proxyBackendJson({
+    request,
     method: "POST",
     path: `/segment/${catalogId}`,
     searchParams: request.nextUrl.searchParams,

--- a/frontend/app/api/summarize/[catalogId]/route.js
+++ b/frontend/app/api/summarize/[catalogId]/route.js
@@ -3,6 +3,7 @@ import { proxyBackendJson } from "../../_lib/backend";
 export async function POST(request, { params }) {
   const { catalogId } = await params;
   return proxyBackendJson({
+    request,
     method: "POST",
     path: `/summarize/${catalogId}`,
     searchParams: request.nextUrl.searchParams,

--- a/frontend/app/api/topics/[catalogId]/route.js
+++ b/frontend/app/api/topics/[catalogId]/route.js
@@ -3,6 +3,7 @@ import { proxyBackendJson } from "../../_lib/backend";
 export async function POST(request, { params }) {
   const { catalogId } = await params;
   return proxyBackendJson({
+    request,
     method: "POST",
     path: `/topics/${catalogId}`,
     searchParams: request.nextUrl.searchParams,

--- a/frontend/components/__tests__/BackendProxy.origin.test.js
+++ b/frontend/components/__tests__/BackendProxy.origin.test.js
@@ -1,0 +1,267 @@
+import test, { afterEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+import { proxyBackendJson } from "../../app/api/_lib/backend.js";
+
+const API_AUTH_KEY = "frontend-proxy-test-key";
+const BLOCKED_DETAIL = "Cross-site mutation requests are not allowed.";
+const FRONTEND_ORIGIN = "https://town-council.example";
+const INTERNAL_ORIGIN = "http://0.0.0.0:3000";
+const ROUTE_ROOT = path.resolve(process.cwd(), "app/api");
+const originalApiAuthKey = process.env.API_AUTH_KEY;
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalApiAuthKey === undefined) {
+    delete process.env.API_AUTH_KEY;
+  } else {
+    process.env.API_AUTH_KEY = originalApiAuthKey;
+  }
+});
+
+function makePostRequest(headers = {}, requestOrigin = FRONTEND_ORIGIN) {
+  return new Request(`${requestOrigin}/api/summarize/42`, {
+    method: "POST",
+    headers,
+  });
+}
+
+function makeStandalonePost(headers) {
+  return makePostRequest(headers, INTERNAL_ORIGIN);
+}
+
+function rejectUnexpectedBackendAccess() {
+  globalThis.fetch = async () => {
+    throw new Error("Blocked mutation reached the backend.");
+  };
+}
+
+function installBackendResponse() {
+  process.env.API_AUTH_KEY = API_AUTH_KEY;
+  globalThis.fetch = async (_backendUrl, backendOptions) => {
+    assert.equal(backendOptions.headers.get("X-API-Key"), API_AUTH_KEY);
+    return Response.json({ status: "queued" }, { status: 202 });
+  };
+}
+
+async function assertBlocked(request, method = "POST") {
+  rejectUnexpectedBackendAccess();
+  delete process.env.API_AUTH_KEY;
+
+  const proxyResponse = await proxyBackendJson({
+    request,
+    method,
+    path: "/summarize/42",
+  });
+
+  assert.equal(proxyResponse.status, 403);
+  assert.match(proxyResponse.headers.get("content-type"), /application\/json/);
+  assert.deepEqual(await proxyResponse.json(), { detail: BLOCKED_DETAIL });
+}
+
+function findRouteFiles(directory) {
+  return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      return findRouteFiles(entryPath);
+    }
+    return entry.name === "route.js" ? [entryPath] : [];
+  });
+}
+
+test("rejects cross-site and same-site Fetch Metadata", async () => {
+  for (const fetchSite of ["cross-site", "same-site"]) {
+    await assertBlocked(makePostRequest({ "Sec-Fetch-Site": fetchSite }));
+  }
+});
+test("rejects Origin mismatches by scheme, host, and port", async () => {
+  const mismatchedOrigins = [
+    "http://town-council.example",
+    "https://admin.town-council.example",
+    "https://town-council.example:8443",
+  ];
+
+  for (const origin of mismatchedOrigins) {
+    await assertBlocked(makePostRequest({ Origin: origin }));
+  }
+});
+test("rejects null and malformed Origin values", async () => {
+  for (const origin of [
+    "null",
+    "not-an-origin",
+    "https://town-council.example/not-an-origin-component",
+  ]) {
+    await assertBlocked(makePostRequest({ Origin: origin }));
+  }
+});
+test("blocked Fetch Metadata overrides a matching Origin", async () => {
+  await assertBlocked(
+    makePostRequest({
+      Origin: FRONTEND_ORIGIN,
+      "Sec-Fetch-Site": "cross-site",
+    }),
+  );
+});
+test("unknown Fetch Metadata falls back to Origin validation", async () => {
+  await assertBlocked(
+    makePostRequest({
+      Origin: "https://other.example",
+      "Sec-Fetch-Site": "future-value",
+    }),
+  );
+});
+test("same-origin POST forwards the backend response", async () => {
+  installBackendResponse();
+
+  const proxyResponse = await proxyBackendJson({
+    request: makePostRequest({
+      Origin: FRONTEND_ORIGIN,
+      "Sec-Fetch-Site": "same-origin",
+    }),
+    method: "POST",
+    path: "/summarize/42",
+  });
+
+  assert.equal(proxyResponse.status, 202);
+  assert.deepEqual(await proxyResponse.json(), { status: "queued" });
+});
+test("headerless POST preserves non-browser callers", async () => {
+  installBackendResponse();
+
+  const proxyResponse = await proxyBackendJson({
+    request: makePostRequest(),
+    method: "POST",
+    path: "/summarize/42",
+  });
+
+  assert.equal(proxyResponse.status, 202);
+  assert.deepEqual(await proxyResponse.json(), { status: "queued" });
+});
+
+test("standalone internal URL honors external Host and protocol", async () => {
+  const externalRequests = [
+    makeStandalonePost({
+      Host: "localhost:3124",
+      Origin: "http://localhost:3124",
+      "Sec-Fetch-Site": "same-origin",
+    }),
+    makeStandalonePost({
+      Host: "town-council.example",
+      Origin: FRONTEND_ORIGIN,
+      "Sec-Fetch-Site": "same-origin",
+      "X-Forwarded-Proto": "https, http",
+    }),
+    makeStandalonePost({
+      Host: "town-council.example:80",
+      Origin: "https://town-council.example:80",
+      "X-Forwarded-Proto": "https",
+    }),
+  ];
+
+  for (const request of externalRequests) {
+    installBackendResponse();
+    const proxyResponse = await proxyBackendJson({
+      request,
+      method: "POST",
+      path: "/summarize/42",
+    });
+    assert.equal(proxyResponse.status, 202);
+  }
+});
+
+test("rejects malformed proxy metadata and forwarded-port mismatches", async () => {
+  const malformedHeaders = [
+    { Host: "[invalid", Origin: FRONTEND_ORIGIN, "X-Forwarded-Proto": "https" },
+    { Host: "town-council.example@attacker.example", Origin: "https://attacker.example", "X-Forwarded-Proto": "https" },
+    { Host: "town-council.example/path", Origin: FRONTEND_ORIGIN, "X-Forwarded-Proto": "https" },
+    { Host: "town-council.example/", Origin: FRONTEND_ORIGIN, "X-Forwarded-Proto": "https" },
+    { Host: "town-council.example?", Origin: FRONTEND_ORIGIN, "X-Forwarded-Proto": "https" },
+    { Host: "town-council.example#", Origin: FRONTEND_ORIGIN, "X-Forwarded-Proto": "https" },
+    { Host: "town-council.example\\", Origin: FRONTEND_ORIGIN, "X-Forwarded-Proto": "https" },
+    { Host: "town-council.example", Origin: FRONTEND_ORIGIN, "X-Forwarded-Proto": "javascript" },
+    { Host: "town-council.example", Origin: "https://attacker.example", "X-Forwarded-Proto": "https://attacker.example/path?" },
+    { Host: "town-council.example", Origin: "http://town-council.example", "X-Forwarded-Proto": "   " },
+    { Host: "town-council.example", Origin: "http://town-council.example", "X-Forwarded-Proto": ", https" },
+    { Host: "town-council.example:80", Origin: FRONTEND_ORIGIN, "X-Forwarded-Proto": "https" },
+  ];
+
+  for (const headers of malformedHeaders) {
+    await assertBlocked(makeStandalonePost(headers));
+  }
+});
+
+test("does not trust X-Forwarded-Host over the standard Host", async () => {
+  await assertBlocked(
+    makePostRequest(
+      {
+        Host: "town-council.example",
+        Origin: "https://attacker.example",
+        "Sec-Fetch-Site": "future-value",
+        "X-Forwarded-Host": "attacker.example",
+        "X-Forwarded-Proto": "https",
+      },
+      "http://0.0.0.0:3000",
+    ),
+  );
+});
+
+test("POST without its request fails before backend access", async () => {
+  rejectUnexpectedBackendAccess();
+  process.env.API_AUTH_KEY = API_AUTH_KEY;
+
+  await assert.rejects(
+    proxyBackendJson({
+      method: "POST",
+      path: "/summarize/42",
+    }),
+    TypeError,
+  );
+});
+test("cross-site POST cannot bypass the guard through proxy method metadata", async () => {
+  await assertBlocked(
+    makePostRequest({ "Sec-Fetch-Site": "cross-site" }),
+    "GET",
+  );
+});
+
+test("allowed POST without API_AUTH_KEY keeps the configuration error", async () => {
+  rejectUnexpectedBackendAccess();
+  delete process.env.API_AUTH_KEY;
+
+  const proxyResponse = await proxyBackendJson({
+    request: makePostRequest({ Origin: FRONTEND_ORIGIN }),
+    method: "POST",
+    path: "/summarize/42",
+  });
+
+  assert.equal(proxyResponse.status, 500);
+  assert.deepEqual(await proxyResponse.json(), {
+    detail: "Frontend backend proxy is not configured.",
+  });
+});
+
+test("every POST route passes its request to the shared proxy", () => {
+  const postRouteSources = findRouteFiles(ROUTE_ROOT)
+    .map((routePath) => ({
+      routePath,
+      source: fs.readFileSync(routePath, "utf8"),
+    }))
+    .filter(({ source }) => /export async function POST/.test(source));
+
+  assert.ok(postRouteSources.length > 0);
+  for (const { routePath, source } of postRouteSources) {
+    const proxyOptions = source.match(
+      /proxyBackendJson\(\{(?<options>[\s\S]*?)\}\)/,
+    )?.groups?.options;
+    assert.ok(proxyOptions, `${routePath} must call proxyBackendJson`);
+    assert.match(
+      proxyOptions,
+      /\brequest\s*,/,
+      `${routePath} must pass request to proxyBackendJson`,
+    );
+    assert.match(proxyOptions, /method:\s*"POST"/, `${routePath} must use POST`);
+  }
+});

--- a/frontend/components/__tests__/BackendProxy.origin.test.js
+++ b/frontend/components/__tests__/BackendProxy.origin.test.js
@@ -220,10 +220,11 @@ test("POST without its request fails before backend access", async () => {
     TypeError,
   );
 });
-test("cross-site POST cannot bypass the guard through proxy method metadata", async () => {
+test("request and proxy method mismatches fail closed", async () => {
+  await assertBlocked(makePostRequest(), "GET");
   await assertBlocked(
-    makePostRequest({ "Sec-Fetch-Site": "cross-site" }),
-    "GET",
+    new Request(`${FRONTEND_ORIGIN}/api/summarize/42`, { method: "GET" }),
+    "POST",
   );
 });
 


### PR DESCRIPTION
## What changed

- Add a shared same-origin guard before frontend proxy POSTs read or forward the server-side API key.
- Reject `same-site` and `cross-site` Fetch Metadata, mismatched or malformed `Origin`, invalid `Host`/`X-Forwarded-Proto` metadata, explicit-port mismatches, and POST method wiring mismatches.
- Preserve exact same-origin requests and headerless non-browser callers.
- Pass the incoming request through all five mutation routes and document the reverse-proxy trust contract in `SECURITY.md`.
- Add tests for the shared boundary, every POST route, Next standalone URL behavior, explicit ports, malformed authorities, and existing forwarding/configuration behavior.

## Why

The frontend proxy injects `API_AUTH_KEY`, which authenticates the frontend deployment rather than the visitor. Without an origin check, a hostile site could cause a browser to submit mutation requests through that trusted frontend boundary.

## Trust-boundary impact

This changes the Internet-to-Frontend boundary documented in `SECURITY.md`. Cross-site browser requests lose access to proxy mutation routes before the API key is read. Reverse proxies must preserve the public `Host` and overwrite incoming `X-Forwarded-Proto`; `X-Forwarded-Host` is deliberately ignored. No secret, permission, application API, runtime default, or person-data behavior changes.

## Risk and compatibility

Headerless non-browser POSTs remain allowed for existing server-side callers. That is an explicit compatibility exception and is not complete protection for legacy browsers that omit both `Origin` and Fetch Metadata.

## Verification

- PASS: `cd frontend && npm test` (27 tests)
- PASS: `cd frontend && npm run build -- --webpack`
- PASS: production standalone smoke for direct, reverse-proxy, explicit-port, port-mismatch, cross-site, protocol-injection, and malformed-Host cases
- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_frontend_pages_config.py tests/test_resultcard_agenda_status_refresh.py tests/test_search_sort_ui_guardrails.py tests/test_semantic_search_ui_guardrails.py` (14 tests)
- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py` (2 tests)
- PASS: `PYTHONPATH=. .venv/bin/pytest -q` (1,190 tests)
- PASS: `git diff --check origin/master`
- PASS: independent pre-commit review, no remaining P1/P2 findings

## Remaining work

T-SEC-5 stays in progress until this PR merges and an evidence-only ledger closure records the merged checks. G2 still gates T-SEC-4, and G3 still gates Phase 2 architecture work.