### PR TITLE
T-SEC-5: Close the proxy origin guard

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -38,10 +38,11 @@ engineering decisions is `reachable`).
 2. Frontend server -> API: the proxy injects `X-API-Key` server-side
    (`frontend/app/api/_lib/backend.js`). Consequence: the API key does NOT
    authenticate end users; it only authenticates the frontend deployment.
-   Every proxied route is effectively public. Per-client rate limiting
-   therefore depends on forwarding real client identity
-   `[remediation: T-SEC-4]`, and any "operator only" action requires auth at
-   the proxy, not just the key (decision G2, currently open).
+   Every proxied route is effectively public. Decision G2, approved
+   2026-07-24, keeps AI task endpoints available to any visitor with
+   per-client rate limits. That control depends on forwarding real client
+   identity `[remediation: T-SEC-4]`. Any future "operator only" action would
+   require a new policy decision and auth at the proxy, not just the key.
 3. API and semantic service -> backing stores (Postgres, Redis, Meilisearch,
    inference): compose
    network only. No host port publication in the base compose file

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -40,9 +40,13 @@ engineering decisions is `reachable`).
    authenticate end users; it only authenticates the frontend deployment.
    Every proxied route is effectively public. Decision G2, approved
    2026-07-24, keeps AI task endpoints available to any visitor with
-   per-client rate limits. That control depends on forwarding real client
-   identity `[remediation: T-SEC-4]`. Any future "operator only" action would
-   require a new policy decision and auth at the proxy, not just the key.
+   per-client rate limits. Town Council intentionally provides public civic
+   record analysis without end-user accounts; adding operator authentication
+   would change that access model, while the frontend key authenticates only
+   the deployment. Per-client limiting is therefore the approved abuse
+   control and depends on forwarding real client identity
+   `[remediation: T-SEC-4]`. Any future "operator only" action would require a
+   new policy decision and auth at the proxy, not just the key.
 3. API and semantic service -> backing stores (Postgres, Redis, Meilisearch,
    inference): compose
    network only. No host port publication in the base compose file
@@ -107,7 +111,13 @@ engineering decisions is `reachable`).
 Record deliberate acceptances here with rationale and revisit date, per the
 `AGENTS.md` status-reporting contract (old value, new value, rationale).
 
-- (none recorded yet)
+- **Visitor-accessible AI actions before T-SEC-4.** The approved G2 policy
+  accepts that, until real client identity reaches the API limiter, visitors
+  can share a rate bucket and a direct caller can consume shared inference
+  capacity. T-SEC-5 reduces cross-site browser abuse but does not authenticate
+  direct callers. This risk is accepted to preserve account-free public civic
+  access while T-SEC-4 delivers per-client limits. Revisit when T-SEC-4 merges
+  or by 2026-08-31, whichever comes first.
 
 ## Dependency and supply chain
 

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,6 +1,6 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 3.14
+version: 3.15
 generated: 2026-07-24
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
@@ -10,6 +10,9 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v3.15:** Records operator approval of G2 and G3: AI task endpoints remain
+  visitor-accessible with per-client rate limits, and the test-seam ADR
+  decision is ratified for an Accepted T-GOV-1 record.
 - **v3.14:** Marks T-SEC-5 complete after PR #130 merged with all required
   checks green, its P2 review finding resolved, and final Codex review clean.
 - **v3.13:** Activates T-SEC-5 with a Full implementation plan and expands
@@ -141,12 +144,13 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 - G1 deployment_posture: Is any instance ever network-reachable beyond
   localhost? Default assumption for this plan: YES (harden accordingly).
   Affects severity of SEC lane; does not block it.
-- G2 protected_action_policy: Are AI task endpoints (summarize/segment/
-  extract/topics) "any visitor" or "operator only"? Default: any visitor,
-  with per-client rate limits (T-SEC-4). If "operator only", add auth to the
-  Next proxy in a follow-up task (out of scope here).
-- G3 test_seam_adr: Ratify ADR "Test patch points are not a public API"
-  (T-GOV-1). BLOCKS all Phase 2 tasks.
+- G2 protected_action_policy: **Approved 2026-07-24.** AI task endpoints
+  (summarize/segment/extract/topics) remain available to any visitor with
+  per-client rate limits. T-SEC-4 is authorized; operator-only proxy
+  authentication is not part of the approved policy.
+- G3 test_seam_adr: **Approved 2026-07-24.** Ratify "Test patch points are not
+  a public API." T-GOV-1 must record the decision as an Accepted ADR before
+  Phase 2 implementation begins.
 - G4 pii_policy: Ratify ADR on person-entity minimization for non-officials
   (T-GOV-2). BLOCKS nothing in this plan, but blocks City Coverage Expansion.
 - G5 migration_tooling: Alembic adoption approved? Default: yes (T-PLAT-1).
@@ -542,6 +546,7 @@ in `AGENTS.md`, `docs/TESTING.MD`, and
 
 ### T-SEC-4: Real client identity through the proxy; per-client rate limits
 - priority: P0
+- decision_gate: G2 approved 2026-07-24
 - files_owned: frontend/app/api/_lib/backend.js, api/app_setup.py
 - do: (a) backend.js forwards `X-Forwarded-For` (append client IP from
   request) on proxied calls. (b) app_setup limiter key_func: trust XFF only
@@ -689,7 +694,7 @@ in `AGENTS.md`, `docs/TESTING.MD`, and
 
 ---
 
-## 5. PHASE 2 — DEDUPLICATION & DE-FACADING (blocked by G3)
+## 5. PHASE 2 — DEDUPLICATION & DE-FACADING (starts after T-GOV-1)
 
 Shared directive for all Phase 2 tasks: when a test patches a facade symbol,
 repoint the test at the implementation module. Delete the facade seam. Never
@@ -833,12 +838,13 @@ files (GED-5 grant).
 
 ### T-GOV-1: ADR — "Test patch points are not a public API" (gate G3)
 - priority: P0 (unblocks Phase 2)
+- decision_gate: G3 approved 2026-07-24
 - files_owned: docs/ADR.md
-- do: Draft entry per existing ADR format: decision (tests patch
+- do: Record the approved entry per existing ADR format: decision (tests patch
   implementation modules or fake at boundaries: DB session, Celery, LLM
   provider, Meilisearch client), rationale (cites the facade/sync findings),
   affected boundaries (tests/, all facade families), consequence (Phase 2
-  deletions authorized). Users ratifies before merge.
+  deletions authorized).
 - accept: ADR entry merged with Status: Accepted.
 
 ### T-GOV-2: ADR — Person-entity minimization & takedown (gate G4)
@@ -943,7 +949,7 @@ files (GED-5 grant).
 Phase 0: agent-ci  [T-CI-0, then T-CI-5 (allowlist snapshot freshness), then T-CI-1 .. T-CI-4]
 Docs-0:  agent-gov [T-GOV-6: SECURITY.md] + [T-GOV-4: AGENTS.md]   (with/just after Phase 0)
 Phase 1: agent-sec [T-SEC-1..6] || agent-time [T-TIME-1..3] || agent-crawl [T-CRAWL-1..2]
-Gate:    G3 ratified (T-GOV-1 + docs/TESTING.md via T-GOV-6)
+Gate:    T-GOV-1 ADR merged with Status: Accepted (G3 approved)
 Phase 2: agent-da || agent-db || agent-dd || agent-de ; then agent-dc (exclusive on api/*)
 Phase 3: agent-plat [T-PLAT-1..4] || agent-gov [T-GOV-2, T-GOV-3 + T-GOV-5]
 Anytime: T-GOV-6 DATA_GOVERNANCE.md (Section 3 pending G4)
@@ -957,7 +963,8 @@ its owned files reports and halts rather than widening scope.
 
 - Splitting frontend/components/ResultCard.js (needs a design pass, not a
   mechanical one; schedule after T-CI-2 provides a harness).
-- "Operator-only" auth on the Next proxy (pending G2).
+- "Operator-only" auth on the Next proxy (not approved by G2; requires a
+  future policy change).
 - Retiring generational strata (search_routes/search_read/api-search;
   migrate_v* files) beyond what Phase 2 tasks name.
 - env-access consolidation into config_env (low value until Phase 2 lands).

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,7 +1,7 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 3.13
-generated: 2026-07-23
+version: 3.14
+generated: 2026-07-24
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
 orchestrator_contract: Codex instantiates one agent per lane. Agents run in
@@ -10,6 +10,8 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v3.14:** Marks T-SEC-5 complete after PR #130 merged with all required
+  checks green, its P2 review finding resolved, and final Codex review clean.
 - **v3.13:** Activates T-SEC-5 with a Full implementation plan and expands
   ownership to its executable frontend test and canonical security checklist.
 - **v3.12:** Marks T-PLAT-2A complete after PR #128 merged with required
@@ -103,8 +105,8 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 | State | Tasks |
 |---|---|
-| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2, T-SEC-3, T-SEC-3C, T-TIME-3, T-CRAWL-1, T-CRAWL-2, T-PLAT-2A |
-| **In progress** | T-SEC-5 |
+| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2, T-SEC-3, T-SEC-3C, T-SEC-5, T-TIME-3, T-CRAWL-1, T-CRAWL-2, T-PLAT-2A |
+| **In progress** | None |
 | **Partially landed; acceptance incomplete** | T-GOV-4, T-GOV-5, T-GOV-6 |
 | **Pending** | T-SEC-4, T-SEC-6, T-TIME-1..2, T-DA-1, T-DB-1, T-DC-1, T-DD-1, T-DE-1, T-PLAT-1, T-PLAT-2, T-PLAT-3, T-PLAT-4, T-GOV-1..3 |
 
@@ -554,7 +556,7 @@ in `AGENTS.md`, `docs/TESTING.MD`, and
 
 ### T-SEC-5: CSRF/origin check on proxy mutation routes
 - priority: P1
-- status: in progress
+- status: complete and verified 2026-07-24 (PR #130)
 - implementation_plan: `docs/plans/T_SEC_5_PROXY_ORIGIN_GUARD_PLAN.md`
 - files_owned: docs/plans/T_SEC_5_PROXY_ORIGIN_GUARD_PLAN.md,
   docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md, SECURITY.md,

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,6 +1,6 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 3.16
+version: 3.17
 generated: 2026-07-24
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
@@ -10,6 +10,8 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v3.17:** Records G2's public-access rationale and the accepted interim
+  abuse/capacity risk pending T-SEC-4, with a review checkpoint.
 - **v3.16:** Synchronizes the approved G2 visitor-access policy with canonical
   `SECURITY.md`; T-SEC-4 remains the delivery task for per-client rate limits.
 - **v3.15:** Records operator approval of G2 and G3: AI task endpoints remain
@@ -149,7 +151,9 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 - G2 protected_action_policy: **Approved 2026-07-24.** AI task endpoints
   (summarize/segment/extract/topics) remain available to any visitor with
   per-client rate limits. T-SEC-4 is authorized; operator-only proxy
-  authentication is not part of the approved policy.
+  authentication is not part of the approved policy. Rationale: preserve
+  account-free public access to civic record analysis and use client-scoped
+  limiting, rather than end-user identity, as the abuse control.
 - G3 test_seam_adr: **Approved 2026-07-24.** Ratify "Test patch points are not
   a public API." T-GOV-1 must record the decision as an Accepted ADR before
   Phase 2 implementation begins.

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,6 +1,6 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 3.15
+version: 3.16
 generated: 2026-07-24
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
@@ -10,6 +10,8 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v3.16:** Synchronizes the approved G2 visitor-access policy with canonical
+  `SECURITY.md`; T-SEC-4 remains the delivery task for per-client rate limits.
 - **v3.15:** Records operator approval of G2 and G3: AI task endpoints remain
   visitor-accessible with per-client rate limits, and the test-seam ADR
   decision is ratified for an Accepted T-GOV-1 record.


### PR DESCRIPTION
## What changed

- Mark T-SEC-5 complete after PR #130 merged with all required checks green and final Codex review clean.
- Record the operator-approved G2 policy: AI task endpoints remain visitor-accessible with per-client rate limits, authorizing T-SEC-4.
- Record the operator-approved G3 decision: test patch points are not a public API, authorizing T-GOV-1.
- Keep Phase 2 blocked until T-GOV-1 merges the ADR with `Status: Accepted`.
- Clarify that operator-only proxy authentication is not approved and would require a future policy change.

## Why

The remediation ledger must reflect merged evidence and explicit human decisions before dependent work begins. This avoids treating approval alone as a substitute for the required Accepted ADR artifact.

## Risk and compatibility

Docs-only. No runtime, API, schema, security-control, default, or data change.

## Verification

- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py` (2 tests)
- PASS: exact T-SEC-5, G2, G3, T-SEC-4, T-GOV-1, Phase 2, and out-of-scope readbacks
- PASS: `git diff --check`
- PASS: independent review, no P1/P2 findings

## Evidence

PR #130 merged at `aba72a6` with Frontend Tests, Python Guardrails, CodeQL, and final Codex review clean. Its only P2 was fixed in `e951f9d` and the thread was resolved.