### PR TITLE
T-SEC-4A: Record the approved G2 visitor-access policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -40,9 +40,10 @@ engineering decisions is `reachable`).
    authenticate end users; it only authenticates the frontend deployment.
    Every proxied route is effectively public. Decision G2, approved 2026-07-24,
    keeps AI task endpoints available to visitors through the public Next.js
-   proxy. Direct API requests still require `X-API-Key`. Town Council
-   intentionally provides civic record analysis without end-user accounts;
-   adding operator authentication would change that access model. Per-client
+   proxy. Direct calls to these protected AI mutation endpoints still require
+   `X-API-Key`; public read and task-status routes remain public. Town Council
+   intentionally provides civic record analysis without end-user accounts.
+   Adding operator authentication would change that access model. Per-client
    rate limits are therefore the approved abuse control and depend on
    forwarding real client identity `[remediation: T-SEC-4]`. Any future
    "operator only" action would require a new policy decision and proxy
@@ -115,9 +116,10 @@ Record deliberate acceptances here with rationale and revisit date, per the
   public access to civic record analysis through the Next.js proxy. Until
   trusted client identity reaches the API limiter, visitors can share a rate
   bucket and unauthenticated proxy callers can consume shared inference
-  capacity. Direct API requests remain API-key protected. T-SEC-5 reduces
-  cross-site browser abuse but does not authenticate proxy callers. Revisit
-  when T-SEC-4 merges or by 2026-08-31, whichever comes first.
+  capacity. Direct calls to protected AI mutation endpoints remain API-key
+  protected. T-SEC-5 reduces cross-site browser abuse but does not authenticate
+  proxy callers. Revisit when T-SEC-4 merges or by 2026-08-31, whichever comes
+  first.
 
 ## Dependency and supply chain
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -38,10 +38,15 @@ engineering decisions is `reachable`).
 2. Frontend server -> API: the proxy injects `X-API-Key` server-side
    (`frontend/app/api/_lib/backend.js`). Consequence: the API key does NOT
    authenticate end users; it only authenticates the frontend deployment.
-   Every proxied route is effectively public. Per-client rate limiting
-   therefore depends on forwarding real client identity
-   `[remediation: T-SEC-4]`, and any "operator only" action requires auth at
-   the proxy, not just the key (decision G2, currently open).
+   Every proxied route is effectively public. Decision G2, approved 2026-07-24,
+   keeps AI task endpoints available to visitors through the public Next.js
+   proxy. Direct API requests still require `X-API-Key`. Town Council
+   intentionally provides civic record analysis without end-user accounts;
+   adding operator authentication would change that access model. Per-client
+   rate limits are therefore the approved abuse control and depend on
+   forwarding real client identity `[remediation: T-SEC-4]`. Any future
+   "operator only" action would require a new policy decision and proxy
+   authentication, not just the deployment key.
 3. API and semantic service -> backing stores (Postgres, Redis, Meilisearch,
    inference): compose
    network only. No host port publication in the base compose file
@@ -106,7 +111,13 @@ engineering decisions is `reachable`).
 Record deliberate acceptances here with rationale and revisit date, per the
 `AGENTS.md` status-reporting contract (old value, new value, rationale).
 
-- (none recorded yet)
+- **Visitor-accessible AI actions before T-SEC-4.** G2 preserves account-free
+  public access to civic record analysis through the Next.js proxy. Until
+  trusted client identity reaches the API limiter, visitors can share a rate
+  bucket and unauthenticated proxy callers can consume shared inference
+  capacity. Direct API requests remain API-key protected. T-SEC-5 reduces
+  cross-site browser abuse but does not authenticate proxy callers. Revisit
+  when T-SEC-4 merges or by 2026-08-31, whichever comes first.
 
 ## Dependency and supply chain
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,15 +39,16 @@ engineering decisions is `reachable`).
    (`frontend/app/api/_lib/backend.js`). Consequence: the API key does NOT
    authenticate end users; it only authenticates the frontend deployment.
    Every proxied route is effectively public. Decision G2, approved 2026-07-24,
-   keeps AI task endpoints available to visitors through the public Next.js
-   proxy. Direct calls to these protected AI mutation endpoints still require
-   `X-API-Key`; public read and task-status routes remain public. Town Council
-   intentionally provides civic record analysis without end-user accounts.
-   Adding operator authentication would change that access model. Per-client
-   rate limits are therefore the approved abuse control and depend on
-   forwarding real client identity `[remediation: T-SEC-4]`. Any future
-   "operator only" action would require a new policy decision and proxy
-   authentication, not just the deployment key.
+   keeps summarize, segment, extract, and topic-generation actions available to
+   visitors through the public Next.js proxy. Direct calls to protected AI
+   mutation endpoints, including vote extraction, still require `X-API-Key`;
+   public read and task-status routes remain public. Town Council intentionally
+   provides civic record analysis without end-user accounts. Adding operator
+   authentication would change that access model. Per-client rate limits are
+   therefore the approved abuse control and depend on forwarding real client
+   identity `[remediation: T-SEC-4]`. Any future "operator only" action would
+   require a new policy decision and proxy authentication, not just the
+   deployment key.
 3. API and semantic service -> backing stores (Postgres, Redis, Meilisearch,
    inference): compose
    network only. No host port publication in the base compose file
@@ -113,13 +114,13 @@ Record deliberate acceptances here with rationale and revisit date, per the
 `AGENTS.md` status-reporting contract (old value, new value, rationale).
 
 - **Visitor-accessible AI actions before T-SEC-4.** G2 preserves account-free
-  public access to civic record analysis through the Next.js proxy. Until
-  trusted client identity reaches the API limiter, visitors can share a rate
-  bucket and unauthenticated proxy callers can consume shared inference
-  capacity. Direct calls to protected AI mutation endpoints remain API-key
-  protected. T-SEC-5 reduces cross-site browser abuse but does not authenticate
-  proxy callers. Revisit when T-SEC-4 merges or by 2026-08-31, whichever comes
-  first.
+  public access to summarize, segment, extract, and topic-generation actions
+  through the Next.js proxy. Until trusted client identity reaches the API
+  limiter, visitors can share a rate bucket and unauthenticated proxy callers
+  can consume shared inference capacity. Direct calls to protected AI mutation
+  endpoints remain API-key protected. T-SEC-5 reduces cross-site browser abuse
+  but does not authenticate proxy callers. Revisit when T-SEC-4 merges or by
+  2026-08-31, whichever comes first.
 
 ## Dependency and supply chain
 

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,6 +1,6 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 3.14
+version: 3.15
 generated: 2026-07-24
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
@@ -10,6 +10,9 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v3.15:** Activates T-SEC-4A to record the operator-approved G2
+  visitor-access policy independently from T-SEC-5 closure and T-SEC-4
+  runtime implementation.
 - **v3.14:** Marks T-SEC-5 complete after PR #130 merged with all required
   checks green, its P2 review finding resolved, and final Codex review clean.
 - **v3.13:** Activates T-SEC-5 with a Full implementation plan and expands
@@ -106,7 +109,7 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 | State | Tasks |
 |---|---|
 | **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2, T-SEC-3, T-SEC-3C, T-SEC-5, T-TIME-3, T-CRAWL-1, T-CRAWL-2, T-PLAT-2A |
-| **In progress** | None |
+| **In progress** | T-SEC-4A |
 | **Partially landed; acceptance incomplete** | T-GOV-4, T-GOV-5, T-GOV-6 |
 | **Pending** | T-SEC-4, T-SEC-6, T-TIME-1..2, T-DA-1, T-DB-1, T-DC-1, T-DD-1, T-DE-1, T-PLAT-1, T-PLAT-2, T-PLAT-3, T-PLAT-4, T-GOV-1..3 |
 
@@ -539,6 +542,25 @@ in `AGENTS.md`, `docs/TESTING.MD`, and
   three owned files.
 - verify: Docs links, targeted contradiction checks, clean diff, current-head
   review, and green PR checks.
+
+### T-SEC-4A: Record the approved G2 visitor-access policy
+- priority: P0
+- status: in progress
+- decision_gate: G2 operator approval received 2026-07-24; durable record
+  pending this task
+- implementation_plan: `docs/plans/T_SEC_4A_G2_VISITOR_ACCESS_POLICY_PLAN.md`
+- files_owned: docs/plans/T_SEC_4A_G2_VISITOR_ACCESS_POLICY_PLAN.md,
+  docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md, SECURITY.md,
+  tests/test_repository_guardrails.py
+- do: Record the approved visitor-access policy, its rationale, the interim
+  accepted risk, and its dependency on T-SEC-4 without changing runtime code.
+- accept: `SECURITY.md` and the remediation ledger agree; policy tests prevent
+  status/risk drift; T-SEC-4 remains pending.
+- forbidden: Runtime changes, operator-auth implementation, G3 content, or
+  edits outside `files_owned`.
+- verify: Follow the Full T-SEC-4A plan, including tests-first evidence,
+  guardrail and docs verification, the complete Python suite, independent
+  review, and decided CI.
 
 ### T-SEC-4: Real client identity through the proxy; per-client rate limits
 - priority: P0

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,6 +1,6 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 3.15
+version: 3.16
 generated: 2026-07-24
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
@@ -10,6 +10,9 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v3.16:** Records the operator-approved G2 policy: account-free AI actions
+  remain available through the public Next.js proxy, direct API access remains
+  key-protected, and T-SEC-4 owns the pending per-client limiting control.
 - **v3.15:** Activates T-SEC-4A to record the operator-approved G2
   visitor-access policy independently from T-SEC-5 closure and T-SEC-4
   runtime implementation.
@@ -144,10 +147,13 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 - G1 deployment_posture: Is any instance ever network-reachable beyond
   localhost? Default assumption for this plan: YES (harden accordingly).
   Affects severity of SEC lane; does not block it.
-- G2 protected_action_policy: Are AI task endpoints (summarize/segment/
-  extract/topics) "any visitor" or "operator only"? Default: any visitor,
-  with per-client rate limits (T-SEC-4). If "operator only", add auth to the
-  Next proxy in a follow-up task (out of scope here).
+- G2 protected_action_policy: **Approved 2026-07-24.** AI task endpoints
+  (summarize/segment/extract/topics) remain available to visitors through the
+  public Next.js proxy with per-client rate limits. Direct API requests remain
+  deployment-key protected. T-SEC-4 is authorized; operator-only proxy
+  authentication is not approved. Rationale: preserve account-free public
+  access to civic record analysis and use client-scoped limiting, rather than
+  end-user identity, as the abuse control.
 - G3 test_seam_adr: Ratify ADR "Test patch points are not a public API"
   (T-GOV-1). BLOCKS all Phase 2 tasks.
 - G4 pii_policy: Ratify ADR on person-entity minimization for non-officials
@@ -564,6 +570,7 @@ in `AGENTS.md`, `docs/TESTING.MD`, and
 
 ### T-SEC-4: Real client identity through the proxy; per-client rate limits
 - priority: P0
+- decision_gate: G2 approved 2026-07-24
 - files_owned: frontend/app/api/_lib/backend.js, api/app_setup.py
 - do: (a) backend.js forwards `X-Forwarded-For` (append client IP from
   request) on proxied calls. (b) app_setup limiter key_func: trust XFF only
@@ -979,7 +986,8 @@ its owned files reports and halts rather than widening scope.
 
 - Splitting frontend/components/ResultCard.js (needs a design pass, not a
   mechanical one; schedule after T-CI-2 provides a harness).
-- "Operator-only" auth on the Next proxy (pending G2).
+- "Operator-only" auth on the Next proxy (not approved by G2; requires a
+  future policy change).
 - Retiring generational strata (search_routes/search_read/api-search;
   migrate_v* files) beyond what Phase 2 tasks name.
 - env-access consolidation into config_env (low value until Phase 2 lands).

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -10,10 +10,10 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
-- **v3.16:** Records the operator-approved G2 policy: account-free AI actions
-  remain available through the public Next.js proxy, direct calls to protected
-  AI mutation endpoints remain key-protected, and T-SEC-4 owns the pending
-  per-client limiting control.
+- **v3.16:** Records the operator-approved G2 policy: account-free summarize,
+  segment, extract, and topic-generation actions remain available through the
+  public Next.js proxy, direct calls to protected AI mutation endpoints remain
+  key-protected, and T-SEC-4 owns the pending per-client limiting control.
 - **v3.15:** Activates T-SEC-4A to record the operator-approved G2
   visitor-access policy independently from T-SEC-5 closure and T-SEC-4
   runtime implementation.

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -11,8 +11,9 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 ## Changelog
 
 - **v3.16:** Records the operator-approved G2 policy: account-free AI actions
-  remain available through the public Next.js proxy, direct API access remains
-  key-protected, and T-SEC-4 owns the pending per-client limiting control.
+  remain available through the public Next.js proxy, direct calls to protected
+  AI mutation endpoints remain key-protected, and T-SEC-4 owns the pending
+  per-client limiting control.
 - **v3.15:** Activates T-SEC-4A to record the operator-approved G2
   visitor-access policy independently from T-SEC-5 closure and T-SEC-4
   runtime implementation.
@@ -149,11 +150,12 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
   Affects severity of SEC lane; does not block it.
 - G2 protected_action_policy: **Approved 2026-07-24.** AI task endpoints
   (summarize/segment/extract/topics) remain available to visitors through the
-  public Next.js proxy with per-client rate limits. Direct API requests remain
-  deployment-key protected. T-SEC-4 is authorized; operator-only proxy
-  authentication is not approved. Rationale: preserve account-free public
-  access to civic record analysis and use client-scoped limiting, rather than
-  end-user identity, as the abuse control.
+  public Next.js proxy with per-client rate limits. Direct calls to these
+  protected AI mutation endpoints remain deployment-key protected; public read
+  and task-status routes remain public. T-SEC-4 is authorized; operator-only
+  proxy authentication is not approved. Rationale: preserve account-free
+  public access to civic record analysis and use client-scoped limiting, rather
+  than end-user identity, as the abuse control.
 - G3 test_seam_adr: Ratify ADR "Test patch points are not a public API"
   (T-GOV-1). BLOCKS all Phase 2 tasks.
 - G4 pii_policy: Ratify ADR on person-entity minimization for non-officials

--- a/docs/plans/T_SEC_4A_G2_VISITOR_ACCESS_POLICY_PLAN.md
+++ b/docs/plans/T_SEC_4A_G2_VISITOR_ACCESS_POLICY_PLAN.md
@@ -1,0 +1,230 @@
+# T-SEC-4A: Record the Approved G2 Visitor-Access Policy
+
+`artifact_contract: ce-unified-plan/v1`  
+`artifact_readiness: implementation-ready`  
+`execution: docs-and-policy-tests`
+
+## 1. Context & Alignment
+
+**a) Driver.** The operator approved account-free visitor access through the
+public Next.js proxy to summarize, segment, extract, and topic-generation
+actions, with per-client rate limits as the abuse control. Direct API requests
+still require the deployment API key. The repository must record that decision
+consistently without implying that T-SEC-4 has already delivered trustworthy
+client identity or separate rate buckets.
+
+**b) Canonical documents consulted.**
+
+- `AGENTS.md` `<hierarchy_of_truth>`, `<workflow_contract>`, and
+  `<status_reporting_contract>` require canonical policy alignment, tests-first
+  delivery, and explicit old/new values, rationale, and remaining deficits.
+- `SECURITY.md` is canonical for the frontend-to-API trust boundary and
+  deliberate accepted risks.
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md` owns G2 status, T-SEC-4
+  sequencing, and task ownership.
+- `docs/TESTING.MD` permits tracked-filesystem policy tests without a
+  production test seam.
+- `docs/reviews/architecture-review-2026-07-19.html` routes proxy identity and
+  limiting through T-SEC-4 without requiring operator authentication.
+
+**c) Remediation alignment.** Add T-SEC-4A to the SEC lane with exactly these
+owned files:
+
+- `docs/plans/T_SEC_4A_G2_VISITOR_ACCESS_POLICY_PLAN.md`
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`
+- `SECURITY.md`
+- `tests/test_repository_guardrails.py`
+
+T-SEC-4 retains exclusive ownership of its runtime implementation files.
+
+**d) Decision-gate check.** G2 was approved by the operator on 2026-07-24:
+AI task endpoints remain available to any visitor with per-client rate limits;
+operator-only authentication is not approved. No further operator decision is
+required. G1, G3, G4, and G5 are unaffected.
+
+## 2. Design
+
+**e) Step-by-step approach.**
+
+1. Branch from `master` after the T-SEC-5 closure merges.
+2. Add this plan and register T-SEC-4A ownership before policy or test edits.
+3. Add two failing policy-alignment tests and record the red result.
+4. Record G2 as approved in the remediation ledger, including its rationale.
+5. Update the `SECURITY.md` frontend-to-API boundary:
+   - AI task endpoints remain visitor-accessible through the public proxy.
+   - Direct API requests still require the deployment API key.
+   - The frontend API key authenticates the deployment, not proxy visitors.
+   - Per-client limiting is the approved abuse control.
+   - Operator-only proxy authentication is not approved.
+6. Add an accepted-risk entry for the period before T-SEC-4 merges, with a
+   review checkpoint at T-SEC-4 merge or 2026-08-31, whichever comes first.
+7. Replace stale "pending G2" text with the selected policy.
+8. Keep T-SEC-4 pending and explicitly dependent on G2.
+9. Run all required verification and obtain a fresh subagent pre-commit review.
+10. Commit the policy/test change separately from this authorization commit,
+    push, open one PR, resolve review findings, and wait for decided CI.
+
+No production function, helper, parser, registry, authentication layer, or
+runtime abstraction is added.
+
+**f) Reuse audit.** Extend the existing G2 gate, T-SEC-4 task, `SECURITY.md`
+trust-boundary and accepted-risk sections, and tracked-filesystem guardrail
+tests. Add no ADR, policy registry, Markdown parser, compatibility path, or
+duplicate security-policy source.
+
+**g) Contracts.**
+
+- Old policy: G2 is open and visitor access is only a default assumption.
+- New policy: AI task endpoints remain visitor-accessible through the public
+  Next.js proxy; direct API requests still require the deployment API key;
+  per-client limiting is the selected abuse control; operator-only proxy
+  authentication is not approved.
+- Remaining deficit: T-SEC-4 has not yet delivered trusted client identity or
+  independent rate buckets.
+
+No application API, schema, Celery signature, environment variable, runtime
+default, or soak policy changes.
+
+**h) Schema/migration impact.** None.
+
+## 3. Security & Data Governance
+
+**i) Trust-boundary impact.** This task records, but does not change, the
+Internet-to-Frontend-to-API boundary. It grants an attacker no new runtime
+capability. It documents the existing risk that unauthenticated proxy callers
+can consume shared inference capacity until T-SEC-4 lands. Direct API requests
+remain API-key protected. `SECURITY.md` remains the canonical control and risk
+record.
+
+**j) Secrets.** No credential, key, environment variable, or default changes.
+
+**k) Person data.** No person-level data is created, linked, aggregated, or
+exposed. G4 is unaffected.
+
+**l) Untrusted input.** No runtime input is parsed. Tests read tracked Markdown
+through the approved filesystem boundary.
+
+## 4. Code Health
+
+**m) GED conformance sweep.** No production logic, timestamp, environment read,
+error handler, dependency, or runtime literal changes. Test names use security
+and remediation domain vocabulary. Each test checks one policy contract.
+
+**n) Antipattern scan, plan pass.**
+
+- A1/H1: no dependency API or configuration call is introduced.
+- B1/F1: reuse tracked Markdown and existing guardrail tests; add no parser or
+  policy framework.
+- D1-D3: add positive and negative policy markers without weakening, skipping,
+  or mocking tests. Exact markers are the observable governance contract.
+- E1-E3: edit only the four owned files and remove only stale G2 claims.
+- A2-A4, B2-B3, C1-C2, F2, H2-H4: no planned violations.
+
+**o) Ratchet interaction.** Ruff selectors, BLE001 boundaries, Mypy scope,
+formatter scope, coverage threshold, and workflow behavior remain unchanged.
+
+**p) Dead code and duplication audit.** Remove stale "G2 open" and "pending
+G2" claims. Keep detailed rationale and accepted risk in `SECURITY.md`; keep
+only gate status, short rationale, dependency, and progress in the remediation
+ledger. Expected runtime-code delta is zero.
+
+## 5. Testing
+
+**q) Edge cases and failure scenarios.**
+
+1. `SECURITY.md` says G2 is approved while the ledger says open.
+2. Either document describes operator-only authentication as approved or
+   pending.
+3. Visitor access is documented without per-client rate limits.
+4. Documentation implies direct API access no longer requires the deployment
+   API key or that T-SEC-4 is already implemented.
+5. The accepted risk lacks both the T-SEC-4 merge event and the 2026-08-31
+   review deadline.
+6. T-SEC-5 is incorrectly described as visitor authentication.
+7. Future edits remove the policy rationale or T-SEC-4 dependency.
+
+**r) Tests added.**
+
+- `test_g2_visitor_access_policy_is_aligned_between_security_and_remediation_ledger`
+  covers scenarios 1, 2, 3, and 7.
+- `test_g2_accepted_risk_is_bounded_without_overclaiming_t_sec_4` covers
+  scenarios 4, 5, and 6 and requires both review checkpoints.
+- Existing repository guardrail and docs-link suites cover policy-file
+  readability and reference integrity.
+
+No edge case is deferred and no test is orphaned.
+
+**s) Fakes and mocks.** None. Tests use only the tracked-filesystem boundary
+approved by `docs/TESTING.MD`.
+
+**t) Verification rows.** Apply the guardrail/tooling and docs-only rows. Run
+the complete Python suite because the change adds cross-cutting policy
+enforcement tests.
+
+## 6. Execution, Rollback, Docs
+
+**u) Exact commands.**
+
+```bash
+git fetch origin --prune
+git switch master
+git merge --ff-only origin/master
+git switch -c codex/t-sec-4a-g2-policy-record
+```
+
+Tests-first red evidence:
+
+```bash
+PYTHONPATH=. .venv/bin/pytest -q \
+  tests/test_repository_guardrails.py::test_g2_visitor_access_policy_is_aligned_between_security_and_remediation_ledger \
+  tests/test_repository_guardrails.py::test_g2_accepted_risk_is_bounded_without_overclaiming_t_sec_4
+```
+
+Expected: both fail against the G2-open policy.
+
+Final verification:
+
+```bash
+./.venv/bin/ruff check .
+./.venv/bin/mypy
+PYTHONPATH=. .venv/bin/pytest -q tests/test_repository_guardrails.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py
+PYTHONPATH=. .venv/bin/pytest -q
+git diff --check
+git status --short
+```
+
+Delivery uses two commits:
+
+1. `docs(remediation): authorize the G2 policy record`
+2. `docs(security): record visitor access for AI actions`
+
+**v) Rollback.** Revert the T-SEC-4A merge commit and rerun the same checks.
+The operator approval remains valid, but T-SEC-4 pauses until a corrected
+durable policy record lands. No migration, data repair, configuration restore,
+or external-state cleanup is required.
+
+**w) Docs synchronization.**
+
+- `SECURITY.md`: trust-boundary rationale and accepted risk.
+- Remediation ledger: G2 approval, rationale, T-SEC-4A task, T-SEC-4
+  dependency, status table, changelog, and out-of-scope wording.
+- This Full Template plan.
+- `AGENTS.md`, ADR, architecture review, README, operations, testing policy,
+  and data-governance docs: no changes.
+
+## 7. Delivery Self-Audit
+
+**x) Antipattern scan, diff pass.** Re-run A-F and H. Reject runtime changes,
+operator-auth implementation, T-SEC-4 implementation, G3 content, an ADR,
+duplicated policy paragraphs, weakened tests, or files outside the four-file
+ownership set.
+
+**y) Evidence.** Report the tests-first failures and every command from 6u with
+`PASS` or `FAIL`, exact test counts, subagent planning and pre-commit review
+findings, commit hashes, PR URL, unresolved-thread count, and final CI state.
+Mark anything unrun as `NOT VERIFIED`.
+
+**z) Deviations.** Expected: none. The superseded
+`codex/t-sec-5-closure` branch is wording reference only and must not enter this
+branch's history.

--- a/docs/plans/T_SEC_4A_G2_VISITOR_ACCESS_POLICY_PLAN.md
+++ b/docs/plans/T_SEC_4A_G2_VISITOR_ACCESS_POLICY_PLAN.md
@@ -39,9 +39,10 @@ owned files:
 T-SEC-4 retains exclusive ownership of its runtime implementation files.
 
 **d) Decision-gate check.** G2 was approved by the operator on 2026-07-24:
-AI task endpoints remain available to any visitor with per-client rate limits;
-operator-only authentication is not approved. No further operator decision is
-required. G1, G3, G4, and G5 are unaffected.
+the proxied summarize, segment, extract, and topic-generation actions remain
+available to any visitor with per-client rate limits; operator-only
+authentication is not approved. Vote extraction is not visitor-proxied. No
+further operator decision is required. G1, G3, G4, and G5 are unaffected.
 
 ## 2. Design
 
@@ -52,9 +53,11 @@ required. G1, G3, G4, and G5 are unaffected.
 3. Add two failing policy-alignment tests and record the red result.
 4. Record G2 as approved in the remediation ledger, including its rationale.
 5. Update the `SECURITY.md` frontend-to-API boundary:
-   - AI task endpoints remain visitor-accessible through the public proxy.
-   - Direct calls to protected AI mutation endpoints still require the
-     deployment API key; public read and task-status routes remain public.
+   - Summarize, segment, extract, and topic-generation actions remain
+     visitor-accessible through the public proxy.
+   - Direct calls to protected AI mutation endpoints, including vote
+     extraction, still require the deployment API key; public read and
+     task-status routes remain public.
    - The frontend API key authenticates the deployment, not proxy visitors.
    - Per-client limiting is the approved abuse control.
    - Operator-only proxy authentication is not approved.
@@ -77,11 +80,12 @@ duplicate security-policy source.
 **g) Contracts.**
 
 - Old policy: G2 is open and visitor access is only a default assumption.
-- New policy: AI task endpoints remain visitor-accessible through the public
-  Next.js proxy; direct calls to protected AI mutation endpoints still require
-  the deployment API key; public read and task-status routes remain public;
-  per-client limiting is the selected abuse control; operator-only proxy
-  authentication is not approved.
+- New policy: summarize, segment, extract, and topic-generation actions remain
+  visitor-accessible through the public Next.js proxy; vote extraction is not
+  visitor-proxied; direct calls to protected AI mutation endpoints still
+  require the deployment API key; public read and task-status routes remain
+  public; per-client limiting is the selected abuse control; operator-only
+  proxy authentication is not approved.
 - Remaining deficit: T-SEC-4 has not yet delivered trusted client identity or
   independent rate buckets.
 

--- a/docs/plans/T_SEC_4A_G2_VISITOR_ACCESS_POLICY_PLAN.md
+++ b/docs/plans/T_SEC_4A_G2_VISITOR_ACCESS_POLICY_PLAN.md
@@ -9,9 +9,10 @@
 **a) Driver.** The operator approved account-free visitor access through the
 public Next.js proxy to summarize, segment, extract, and topic-generation
 actions, with per-client rate limits as the abuse control. Direct API requests
-still require the deployment API key. The repository must record that decision
-consistently without implying that T-SEC-4 has already delivered trustworthy
-client identity or separate rate buckets.
+to the protected AI mutation endpoints still require the deployment API key;
+public read and task-status routes remain public. The repository must record
+that decision consistently without implying that T-SEC-4 has already delivered
+trustworthy client identity or separate rate buckets.
 
 **b) Canonical documents consulted.**
 
@@ -52,7 +53,8 @@ required. G1, G3, G4, and G5 are unaffected.
 4. Record G2 as approved in the remediation ledger, including its rationale.
 5. Update the `SECURITY.md` frontend-to-API boundary:
    - AI task endpoints remain visitor-accessible through the public proxy.
-   - Direct API requests still require the deployment API key.
+   - Direct calls to protected AI mutation endpoints still require the
+     deployment API key; public read and task-status routes remain public.
    - The frontend API key authenticates the deployment, not proxy visitors.
    - Per-client limiting is the approved abuse control.
    - Operator-only proxy authentication is not approved.
@@ -76,7 +78,8 @@ duplicate security-policy source.
 
 - Old policy: G2 is open and visitor access is only a default assumption.
 - New policy: AI task endpoints remain visitor-accessible through the public
-  Next.js proxy; direct API requests still require the deployment API key;
+  Next.js proxy; direct calls to protected AI mutation endpoints still require
+  the deployment API key; public read and task-status routes remain public;
   per-client limiting is the selected abuse control; operator-only proxy
   authentication is not approved.
 - Remaining deficit: T-SEC-4 has not yet delivered trusted client identity or
@@ -92,9 +95,9 @@ default, or soak policy changes.
 **i) Trust-boundary impact.** This task records, but does not change, the
 Internet-to-Frontend-to-API boundary. It grants an attacker no new runtime
 capability. It documents the existing risk that unauthenticated proxy callers
-can consume shared inference capacity until T-SEC-4 lands. Direct API requests
-remain API-key protected. `SECURITY.md` remains the canonical control and risk
-record.
+can consume shared inference capacity until T-SEC-4 lands. Direct calls to
+protected AI mutation endpoints remain API-key protected. `SECURITY.md` remains
+the canonical control and risk record.
 
 **j) Secrets.** No credential, key, environment variable, or default changes.
 
@@ -136,8 +139,9 @@ ledger. Expected runtime-code delta is zero.
 2. Either document describes operator-only authentication as approved or
    pending.
 3. Visitor access is documented without per-client rate limits.
-4. Documentation implies direct API access no longer requires the deployment
-   API key or that T-SEC-4 is already implemented.
+4. Documentation implies protected AI mutation endpoints no longer require the
+   deployment API key, public read/status routes require it, or T-SEC-4 is
+   already implemented.
 5. The accepted risk lacks both the T-SEC-4 merge event and the 2026-08-31
    review deadline.
 6. T-SEC-5 is incorrectly described as visitor authentication.

--- a/docs/plans/T_SEC_4A_G2_VISITOR_ACCESS_POLICY_PLAN.md
+++ b/docs/plans/T_SEC_4A_G2_VISITOR_ACCESS_POLICY_PLAN.md
@@ -1,7 +1,7 @@
 # T-SEC-4A: Record the Approved G2 Visitor-Access Policy
 
-`artifact_contract: ce-unified-plan/v1`  
-`artifact_readiness: implementation-ready`  
+`artifact_contract: ce-unified-plan/v1`
+`artifact_readiness: implementation-ready`
 `execution: docs-and-policy-tests`
 
 ## 1. Context & Alignment

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2041,3 +2041,66 @@ def test_nlp_entity_cleanup_modules_stay_under_size_target():
     ]
 
     assert oversized_modules == []
+
+
+def _required_markdown_section(markdown: str, heading: str, next_heading: str) -> str:
+    _, heading_separator, section_remainder = markdown.partition(heading)
+    assert heading_separator, f"Missing required Markdown heading: {heading}"
+    section, next_separator, _ = section_remainder.partition(next_heading)
+    assert next_separator, f"Missing Markdown boundary after: {heading}"
+    return " ".join(section.split())
+
+
+def test_g2_visitor_access_policy_is_aligned_between_security_and_remediation_ledger():
+    security_policy = (ROOT / "SECURITY.md").read_text(encoding="utf-8")
+    remediation_ledger = (
+        ROOT / "docs" / "plans" / "TOWN_COUNCIL_REMEDIATION_PLAN.md"
+    ).read_text(encoding="utf-8")
+    frontend_api_boundary = _required_markdown_section(
+        security_policy,
+        "2. Frontend server -> API:",
+        "\n3. API and semantic service",
+    )
+    g2_entry = _required_markdown_section(
+        remediation_ledger,
+        "- G2 protected_action_policy:",
+        "\n- G3 test_seam_adr:",
+    )
+    t_sec_4_entry = _required_markdown_section(
+        remediation_ledger,
+        "### T-SEC-4: Real client identity through the proxy; per-client rate limits",
+        "\n### T-SEC-5:",
+    )
+    pending_row = next(
+        line for line in remediation_ledger.splitlines() if line.startswith("| **Pending** |")
+    )
+
+    assert "Decision G2, approved 2026-07-24" in frontend_api_boundary
+    assert "public Next.js proxy" in frontend_api_boundary
+    assert "Direct API requests still require `X-API-Key`" in frontend_api_boundary
+    assert "**Approved 2026-07-24.**" in g2_entry
+    assert "public Next.js proxy" in g2_entry
+    assert "T-SEC-4 is authorized" in g2_entry
+    assert "operator-only proxy authentication is not approved" in g2_entry
+    assert "per-client rate limits" in frontend_api_boundary.lower()
+    assert "per-client rate limits" in g2_entry.lower()
+    assert "decision_gate: G2 approved 2026-07-24" in t_sec_4_entry
+    assert "T-SEC-4" in pending_row
+
+
+def test_g2_accepted_risk_is_bounded_without_overclaiming_t_sec_4():
+    security_policy = (ROOT / "SECURITY.md").read_text(encoding="utf-8")
+    accepted_risk = _required_markdown_section(
+        security_policy,
+        "**Visitor-accessible AI actions before T-SEC-4.**",
+        "\n## Dependency and supply chain",
+    )
+
+    assert "unauthenticated proxy callers" in accepted_risk
+    assert "Direct API requests remain API-key protected." in accepted_risk
+    assert "T-SEC-5 reduces cross-site browser abuse but does not authenticate" in accepted_risk
+    assert (
+        "Revisit when T-SEC-4 merges or by 2026-08-31, whichever comes first."
+        in accepted_risk
+    )
+    assert "- [ ] Client IP forwarded from proxy" in security_policy

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2051,6 +2051,55 @@ def _required_markdown_section(markdown: str, heading: str, next_heading: str) -
     return " ".join(section.split())
 
 
+G2_OPEN_POLICY = re.compile(
+    r"(?:\bg2\b\s+(?:is|remains)\s+(?:open|pending|unresolved)\b"
+    r"|\bg2\b\s*(?:status\s*)?:\s*(?:open|pending|unresolved)\b"
+    r"|\bdecision\s+g2,\s+currently\s+(?:open|pending|unresolved)\b"
+    r"|\b(?:open|pending|unresolved)\s+g2\b)",
+    re.IGNORECASE,
+)
+OPERATOR_AUTH_APPROVAL_POLICY = re.compile(
+    r"\boperator(?:-only)?(?: proxy)? authentication\s+(?:is\s+)?(?:approved|pending)\b",
+    re.IGNORECASE,
+)
+
+
+def _g2_policy_has_contradiction(g2_policy: str) -> bool:
+    return bool(
+        G2_OPEN_POLICY.search(g2_policy) or OPERATOR_AUTH_APPROVAL_POLICY.search(g2_policy)
+    )
+
+
+@pytest.mark.parametrize(
+    "contradictory_policy",
+    (
+        "G2 is open.",
+        "G2 status: pending.",
+        "Pending G2.",
+        "Operator-only authentication is approved.",
+        "Operator authentication pending.",
+    ),
+)
+def test_g2_policy_contradiction_detection_covers_equivalent_wording(
+    contradictory_policy: str,
+) -> None:
+    assert _g2_policy_has_contradiction(contradictory_policy)
+
+
+@pytest.mark.parametrize(
+    "approved_policy",
+    (
+        "G2 is approved; T-SEC-4 remains pending.",
+        "G2 is not open.",
+        "Operator-only proxy authentication is not approved.",
+    ),
+)
+def test_g2_policy_contradiction_detection_allows_approved_wording(
+    approved_policy: str,
+) -> None:
+    assert not _g2_policy_has_contradiction(approved_policy)
+
+
 def test_g2_visitor_access_policy_is_aligned_between_security_and_remediation_ledger():
     security_policy = (ROOT / "SECURITY.md").read_text(encoding="utf-8")
     remediation_ledger = (
@@ -2074,10 +2123,15 @@ def test_g2_visitor_access_policy_is_aligned_between_security_and_remediation_le
     pending_row = next(
         line for line in remediation_ledger.splitlines() if line.startswith("| **Pending** |")
     )
+    pending_tasks = {task.strip() for task in pending_row.split("|")[2].split(",")}
 
     assert "Decision G2, approved 2026-07-24" in frontend_api_boundary
     assert "public Next.js proxy" in frontend_api_boundary
-    assert "Direct API requests still require `X-API-Key`" in frontend_api_boundary
+    assert (
+        "Direct calls to these protected AI mutation endpoints still require `X-API-Key`"
+        in frontend_api_boundary
+    )
+    assert "public read and task-status routes remain public" in frontend_api_boundary
     assert "**Approved 2026-07-24.**" in g2_entry
     assert "public Next.js proxy" in g2_entry
     assert "T-SEC-4 is authorized" in g2_entry
@@ -2085,7 +2139,9 @@ def test_g2_visitor_access_policy_is_aligned_between_security_and_remediation_le
     assert "per-client rate limits" in frontend_api_boundary.lower()
     assert "per-client rate limits" in g2_entry.lower()
     assert "decision_gate: G2 approved 2026-07-24" in t_sec_4_entry
-    assert "T-SEC-4" in pending_row
+    assert "T-SEC-4" in pending_tasks
+    canonical_g2_policy = f"{frontend_api_boundary} {g2_entry}".lower()
+    assert not _g2_policy_has_contradiction(canonical_g2_policy)
 
 
 def test_g2_accepted_risk_is_bounded_without_overclaiming_t_sec_4():
@@ -2097,7 +2153,9 @@ def test_g2_accepted_risk_is_bounded_without_overclaiming_t_sec_4():
     )
 
     assert "unauthenticated proxy callers" in accepted_risk
-    assert "Direct API requests remain API-key protected." in accepted_risk
+    assert "Direct calls to protected AI mutation endpoints remain API-key protected." in (
+        accepted_risk
+    )
     assert "T-SEC-5 reduces cross-site browser abuse but does not authenticate" in accepted_risk
     assert (
         "Revisit when T-SEC-4 merges or by 2026-08-31, whichever comes first."

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2126,13 +2126,19 @@ def test_g2_visitor_access_policy_is_aligned_between_security_and_remediation_le
     pending_tasks = {task.strip() for task in pending_row.split("|")[2].split(",")}
 
     assert "Decision G2, approved 2026-07-24" in frontend_api_boundary
+    assert (
+        "summarize, segment, extract, and topic-generation actions"
+        in frontend_api_boundary
+    )
     assert "public Next.js proxy" in frontend_api_boundary
     assert (
-        "Direct calls to these protected AI mutation endpoints still require `X-API-Key`"
+        "Direct calls to protected AI mutation endpoints, including vote extraction, still require "
+        "`X-API-Key`"
         in frontend_api_boundary
     )
     assert "public read and task-status routes remain public" in frontend_api_boundary
     assert "**Approved 2026-07-24.**" in g2_entry
+    assert "(summarize/segment/extract/topics)" in g2_entry
     assert "public Next.js proxy" in g2_entry
     assert "T-SEC-4 is authorized" in g2_entry
     assert "operator-only proxy authentication is not approved" in g2_entry


### PR DESCRIPTION
## What changed
- Registers T-SEC-4A with a reviewed Full implementation plan.
- Records G2 as approved for account-free AI actions through the public Next.js proxy.
- Confirms direct API requests remain protected by the deployment API key.
- Documents the accepted shared-capacity risk until T-SEC-4 and a bounded review checkpoint.
- Adds fail-closed guardrail tests scoped to the G2 entry, T-SEC-4 status, and accepted-risk section.

## Why
Town Council needs a durable, internally consistent security-policy record before implementing per-client rate limiting. This PR keeps the policy decision separate from T-SEC-5 closure and T-SEC-4 runtime code.

## Trust-boundary impact
This records existing behavior and grants no new attacker capability. Public proxy callers remain unauthenticated; direct API callers still need `X-API-Key`. T-SEC-4 remains pending to forward trusted client identity and create independent rate buckets.

## Risk and compatibility
No runtime, API, schema, configuration, environment, or soak-policy change. Interim risk: proxy visitors can share a rate bucket and consume shared inference capacity until T-SEC-4. Revisit at T-SEC-4 merge or 2026-08-31, whichever comes first.

## Verification
- PASS: `./.venv/bin/ruff check .`
- PASS: `./.venv/bin/mypy` (68 source files)
- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_repository_guardrails.py` (115 passed)
- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py` (2 passed)
- PASS: `PYTHONPATH=. .venv/bin/pytest -q` (1,192 passed)
- PASS: `git diff --check`
- PASS: final subagent review, no P1/P2/P3 findings

## Remaining deficits
- T-SEC-4 has not yet delivered trusted client identity or per-client rate buckets.
- G3 is intentionally excluded and will land through T-GOV-1.
