### PR TITLE
T-GOV-1: Accept test patch points as non-public API

### DIFF
--- a/api/search/support_core.py
+++ b/api/search/support_core.py
@@ -10,7 +10,7 @@ from pipeline.meilisearch_credentials import DEVELOPMENT_APP_ENV, resolve_meilis
 MEILI_HOST = env_raw("MEILI_HOST", "http://meilisearch:7700")
 APP_ENV = env_lower("APP_ENV", DEVELOPMENT_APP_ENV)
 MEILI_SEARCH_KEY = env_raw("MEILI_SEARCH_KEY", "")
-# G3 defers facade removal; the legacy export now carries reader privilege only.
+# The legacy export preserves reader-only credential compatibility for runtime callers.
 MEILI_MASTER_KEY = resolve_meilisearch_reader_key(
     APP_ENV,
     MEILI_SEARCH_KEY,

--- a/docs/ADR.md
+++ b/docs/ADR.md
@@ -8,6 +8,50 @@ Use each entry to record:
 - the affected boundary or contract
 - links to the canonical docs that carry the ongoing operational or architecture detail
 
+## 2026-07-24: Test patch points are not a public API
+
+- Status: Accepted
+- Decision:
+  - Tests patch implementation modules where names are looked up or fake at
+    the approved architectural boundaries in `docs/TESTING.MD`.
+  - A test-only patch target is not a public API and does not require a
+    re-export, wrapper, synchronized global, injectable callable, or dependency
+    rebinding in production code.
+  - This decision supersedes earlier Accepted statements only to the extent that
+    they preserve a test-only patch target. Historical entries remain unchanged
+    as records of the decisions in force at that time.
+  - Runtime, import, CLI, API, task-identity, and operational contracts remain active
+    unless a separately owned remediation task changes them with behavior tests
+    and explicit compatibility reporting.
+  - Phase 2 tasks may delete test-only compatibility seams within their owned
+    facade families and must repoint affected tests in the same change.
+- Why:
+  - Test compatibility had become an accidental architecture constraint,
+    producing duplicated state, bidirectional synchronization, dependency
+    rebinding, and wrappers that obscured the real implementation owner.
+  - Preserving observable runtime contracts while moving tests to real
+    architectural boundaries allows focused de-facading without broad or
+    speculative breakage.
+- Affected boundaries:
+  - `tests/` follows the patch-target and approved-fake rules in
+    `docs/TESTING.MD`.
+  - Facade families remain runtime-compatible until their named remediation
+    tasks explicitly change them.
+  - T-DA-1, T-DB-1, T-DC-1, T-DD-1, and T-DE-1 are no longer blocked by G3;
+    their individual sequencing, ownership, and verification contracts still
+    apply.
+- Consequences:
+  - Production code is not modified solely to preserve a historical monkeypatch
+    path.
+  - Removing a test-only seam requires updating tests to patch the
+    implementation module or an approved fake boundary.
+  - This ADR does not authorize unowned facade removal or changes to runtime,
+    public import, API, CLI, Celery, inference, or operational behavior.
+- Canonical references:
+  - [docs/TESTING.MD](TESTING.MD)
+  - [AGENTS.md](../AGENTS.md)
+  - [Town Council remediation plan](plans/TOWN_COUNCIL_REMEDIATION_PLAN.md)
+
 ## 2026-05-17: Retire legacy runtime profiles behind a lifecycle manifest
 
 - Status: Accepted

--- a/docs/TESTING.MD
+++ b/docs/TESTING.MD
@@ -5,9 +5,8 @@ API" (`docs/ADR.md`, decision gate G3). `AGENTS.md` `<code_quality>` states
 the principle — tests assert observable behavior, not private implementation
 details — and this document says how to do that in this repository.
 
-Status: initial version, effective with the G3 ADR. During remediation
-Phase 2, tests are actively migrated to these rules; new tests must follow
-them immediately.
+Status: effective. During remediation Phase 2, tests are actively migrated to
+these rules; new tests must follow them immediately.
 
 ## The core rule
 

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,6 +1,6 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 3.16
+version: 3.17
 generated: 2026-07-24
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
@@ -10,6 +10,10 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v3.17:** Records operator approval of G3 and activates T-GOV-1 with
+  six-file ownership for the Accepted ADR, effective testing policy, policy
+  guardrails, remediation state, and one stale source comment. Phase 2 remains
+  blocked until the T-GOV-1 ADR merges.
 - **v3.16:** Records the operator-approved G2 policy: account-free summarize,
   segment, extract, and topic-generation actions remain available through the
   public Next.js proxy, direct calls to protected AI mutation endpoints remain
@@ -112,10 +116,10 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 | State | Tasks |
 |---|---|
-| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2, T-SEC-3, T-SEC-3C, T-SEC-5, T-TIME-3, T-CRAWL-1, T-CRAWL-2, T-PLAT-2A |
-| **In progress** | T-SEC-4A |
+| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2, T-SEC-3, T-SEC-3C, T-SEC-4A, T-SEC-5, T-TIME-3, T-CRAWL-1, T-CRAWL-2, T-PLAT-2A |
+| **In progress** | T-GOV-1 |
 | **Partially landed; acceptance incomplete** | T-GOV-4, T-GOV-5, T-GOV-6 |
-| **Pending** | T-SEC-4, T-SEC-6, T-TIME-1..2, T-DA-1, T-DB-1, T-DC-1, T-DD-1, T-DE-1, T-PLAT-1, T-PLAT-2, T-PLAT-3, T-PLAT-4, T-GOV-1..3 |
+| **Pending** | T-SEC-4, T-SEC-6, T-TIME-1..2, T-DA-1, T-DB-1, T-DC-1, T-DD-1, T-DE-1, T-PLAT-1, T-PLAT-2, T-PLAT-3, T-PLAT-4, T-GOV-2..3 |
 
 ---
 
@@ -156,8 +160,10 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
   proxy authentication is not approved. Rationale: preserve account-free
   public access to civic record analysis and use client-scoped limiting, rather
   than end-user identity, as the abuse control.
-- G3 test_seam_adr: Ratify ADR "Test patch points are not a public API"
-  (T-GOV-1). BLOCKS all Phase 2 tasks.
+- G3 test_seam_adr: **Approved 2026-07-24 for T-GOV-1 implementation.**
+  Tests patch implementation modules or fake at approved architectural
+  boundaries; historical test patch targets are not public API. Phase 2
+  remains blocked until the Accepted T-GOV-1 ADR merges.
 - G4 pii_policy: Ratify ADR on person-entity minimization for non-officials
   (T-GOV-2). BLOCKS nothing in this plan, but blocks City Coverage Expansion.
 - G5 migration_tooling: Alembic adoption approved? Default: yes (T-PLAT-1).
@@ -864,13 +870,31 @@ files (GED-5 grant).
 
 ### T-GOV-1: ADR — "Test patch points are not a public API" (gate G3)
 - priority: P0 (unblocks Phase 2)
-- files_owned: docs/ADR.md
-- do: Draft entry per existing ADR format: decision (tests patch
-  implementation modules or fake at boundaries: DB session, Celery, LLM
-  provider, Meilisearch client), rationale (cites the facade/sync findings),
-  affected boundaries (tests/, all facade families), consequence (Phase 2
-  deletions authorized). Users ratifies before merge.
-- accept: ADR entry merged with Status: Accepted.
+- status: in progress; operator approved G3 on 2026-07-24
+- implementation_plan:
+  `docs/plans/T_GOV_1_TEST_PATCH_POINTS_ADR_PLAN.md`
+- files_owned: api/search/support_core.py (comment only), docs/ADR.md,
+  docs/TESTING.MD, docs/plans/T_GOV_1_TEST_PATCH_POINTS_ADR_PLAN.md,
+  docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md,
+  tests/test_repository_guardrails.py
+- do: Add an Accepted entry per the existing ADR format. Tests patch
+  implementation modules or fake at the boundaries in docs/TESTING.MD.
+  Explicitly supersede prior statements only to the extent that they preserve
+  test-only patch targets; retain mixed runtime, import, CLI, API,
+  task-identity, and operational contracts without rewriting historical ADR
+  entries. Activate the testing policy, remove the stale live G3 deferral
+  comment, and enforce the decision with repository guardrails.
+- coordination: T-GOV-6 remains partially landed after this task because its
+  README Documentation Map links remain missing and are outside T-GOV-1
+  ownership.
+- accept: Accepted ADR merged; testing policy effective; no live source treats
+  G3 as a facade deferral; Phase 2 G3 blocker removed; runtime behavior and
+  public contracts unchanged.
+- forbidden: Facade removal, runtime/import/API changes, historical ADR
+  rewrites, new fake boundaries, or edits outside `files_owned`.
+- verify: Follow the Full T-GOV-1 implementation plan; Ruff, Mypy, repository
+  guardrails, docs links, Meilisearch key-security tests, and the complete
+  Python suite pass.
 
 ### T-GOV-2: ADR — Person-entity minimization & takedown (gate G4)
 - priority: P1

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,6 +1,6 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 3.17
+version: 3.18
 generated: 2026-07-24
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
@@ -10,6 +10,9 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v3.18:** Accepts the G3 ADR, activates the testing policy, removes the stale
+  live G3 deferral, completes T-GOV-1, and unblocks Phase 2. T-GOV-6 remains
+  partial because its README Documentation Map links are still missing.
 - **v3.17:** Records operator approval of G3 and activates T-GOV-1 with
   six-file ownership for the Accepted ADR, effective testing policy, policy
   guardrails, remediation state, and one stale source comment. Phase 2 remains
@@ -116,8 +119,8 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 | State | Tasks |
 |---|---|
-| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2, T-SEC-3, T-SEC-3C, T-SEC-4A, T-SEC-5, T-TIME-3, T-CRAWL-1, T-CRAWL-2, T-PLAT-2A |
-| **In progress** | T-GOV-1 |
+| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2, T-SEC-3, T-SEC-3C, T-SEC-4A, T-SEC-5, T-TIME-3, T-CRAWL-1, T-CRAWL-2, T-PLAT-2A, T-GOV-1 |
+| **In progress** | None |
 | **Partially landed; acceptance incomplete** | T-GOV-4, T-GOV-5, T-GOV-6 |
 | **Pending** | T-SEC-4, T-SEC-6, T-TIME-1..2, T-DA-1, T-DB-1, T-DC-1, T-DD-1, T-DE-1, T-PLAT-1, T-PLAT-2, T-PLAT-3, T-PLAT-4, T-GOV-2..3 |
 
@@ -160,10 +163,11 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
   proxy authentication is not approved. Rationale: preserve account-free
   public access to civic record analysis and use client-scoped limiting, rather
   than end-user identity, as the abuse control.
-- G3 test_seam_adr: **Approved 2026-07-24 for T-GOV-1 implementation.**
-  Tests patch implementation modules or fake at approved architectural
-  boundaries; historical test patch targets are not public API. Phase 2
-  remains blocked until the Accepted T-GOV-1 ADR merges.
+- G3 test_seam_adr: **Satisfied 2026-07-24.** The operator approved G3 and
+  T-GOV-1 records the Accepted ADR. Tests patch implementation modules or fake
+  at approved architectural boundaries; historical test patch targets are not
+  public API. Phase 2 is unblocked, subject to each task's own sequencing and
+  ownership.
 - G4 pii_policy: Ratify ADR on person-entity minimization for non-officials
   (T-GOV-2). BLOCKS nothing in this plan, but blocks City Coverage Expansion.
 - G5 migration_tooling: Alembic adoption approved? Default: yes (T-PLAT-1).
@@ -726,7 +730,7 @@ in `AGENTS.md`, `docs/TESTING.MD`, and
 
 ---
 
-## 5. PHASE 2 — DEDUPLICATION & DE-FACADING (blocked by G3)
+## 5. PHASE 2 — DEDUPLICATION & DE-FACADING
 
 Shared directive for all Phase 2 tasks: when a test patches a facade symbol,
 repoint the test at the implementation module. Delete the facade seam. Never
@@ -870,7 +874,7 @@ files (GED-5 grant).
 
 ### T-GOV-1: ADR — "Test patch points are not a public API" (gate G3)
 - priority: P0 (unblocks Phase 2)
-- status: in progress; operator approved G3 on 2026-07-24
+- status: complete and verified 2026-07-24
 - implementation_plan:
   `docs/plans/T_GOV_1_TEST_PATCH_POINTS_ADR_PLAN.md`
 - files_owned: api/search/support_core.py (comment only), docs/ADR.md,
@@ -976,10 +980,11 @@ files (GED-5 grant).
 - sequencing: SECURITY.md merges at Phase 1 start (it is the reference for
   SEC-lane PR impact statements; its checklist items cite T-SEC tasks as
   pending — that is intentional, update checkboxes as tasks merge).
-  TESTING.md merges with the G3 ADR (T-GOV-1) — it is the ADR's
-  operational companion. DATA_GOVERNANCE.md merges any time; its Section 3
-  stays in "options + working default" form until the user resolves G4, then
-  the G4 ADR task replaces Section 3 with the adopted policy.
+  TESTING.md is active with the G3 ADR (T-GOV-1) as its operational companion.
+  T-GOV-6 remains partially landed until its three canonical documents are
+  linked from the README Documentation Map. DATA_GOVERNANCE.md merges any time;
+  its Section 3 stays in "options + working default" form until the user
+  resolves G4, then the G4 ADR task replaces Section 3 with the adopted policy.
 - do: Merge the provided drafts. Add the three documents to the README
   Documentation Map. The user fills the deployment-posture blank in
   SECURITY.md (G1) before or at merge.
@@ -998,7 +1003,7 @@ files (GED-5 grant).
 Phase 0: agent-ci  [T-CI-0, then T-CI-5 (allowlist snapshot freshness), then T-CI-1 .. T-CI-4]
 Docs-0:  agent-gov [T-GOV-6: SECURITY.md] + [T-GOV-4: AGENTS.md]   (with/just after Phase 0)
 Phase 1: agent-sec [T-SEC-1..6] || agent-time [T-TIME-1..3] || agent-crawl [T-CRAWL-1..2]
-Gate:    G3 ratified (T-GOV-1 + docs/TESTING.md via T-GOV-6)
+Gate:    G3 satisfied (T-GOV-1 Accepted ADR + active docs/TESTING.MD)
 Phase 2: agent-da || agent-db || agent-dd || agent-de ; then agent-dc (exclusive on api/*)
 Phase 3: agent-plat [T-PLAT-1..4] || agent-gov [T-GOV-2, T-GOV-3 + T-GOV-5]
 Anytime: T-GOV-6 DATA_GOVERNANCE.md (Section 3 pending G4)

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -119,8 +119,8 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 | State | Tasks |
 |---|---|
-| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2, T-SEC-3, T-SEC-3C, T-SEC-4A, T-SEC-5, T-TIME-3, T-CRAWL-1, T-CRAWL-2, T-PLAT-2A, T-GOV-1 |
-| **In progress** | None |
+| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2, T-SEC-3, T-SEC-3C, T-SEC-5, T-TIME-3, T-CRAWL-1, T-CRAWL-2, T-PLAT-2A, T-GOV-1 |
+| **In progress** | T-SEC-4A |
 | **Partially landed; acceptance incomplete** | T-GOV-4, T-GOV-5, T-GOV-6 |
 | **Pending** | T-SEC-4, T-SEC-6, T-TIME-1..2, T-DA-1, T-DB-1, T-DC-1, T-DD-1, T-DE-1, T-PLAT-1, T-PLAT-2, T-PLAT-3, T-PLAT-4, T-GOV-2..3 |
 

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -184,7 +184,7 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 | TIME      | agent-time | pipeline/model_base.py, model_civic.py, model_events.py, model_records.py, model_runtime.py, models.py, db_migrate.py, migrate_v10.py (new), pipeline/summary_freshness.py (verify-only) |
 | CRAWL     | agent-crawl| council_crawler/**                                          |
 | DEDUP-A   | agent-da   | pipeline/metrics.py, pipeline/metrics_redis_backend.py, tests/test_*metrics* |
-| DEDUP-B   | agent-db   | pipeline/summary_backfill*.py, tests/test_*backfill*        |
+| DEDUP-B   | agent-db   | pipeline/summary_backfill*.py, pipeline/task_facade_helpers.py, pipeline/tasks.py, tests/test_*backfill*, tests/test_pipeline_batching.py, tests/test_run_pipeline_orchestration.py, tests/test_staged_hydrate_cities.py, tests/test_tasks_agenda_summary_format.py |
 | DEDUP-C   | agent-dc   | api/main.py, api/app_setup.py, tests/conftest.py, tests/test_*api* (Phase 2 only) |
 | DEDUP-D   | agent-dd   | scripts/flush_city_pipeline_state.py, scripts/reset_city_verification_state.py, scripts/*_healthcheck.py, tests for same |
 | DEDUP-E   | agent-de   | pipeline/http_inference_provider.py, pipeline/inprocess_inference_provider.py, pipeline/inference_provider_contract.py, tests for same |

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -755,14 +755,17 @@ files (GED-5 grant).
 
 ### T-DB-1: Collapse the summary_backfill facade
 - priority: P1
-- files_owned: pipeline/summary_backfill*.py, tests/test_*backfill*
+- files_owned: pipeline/summary_backfill*.py, pipeline/task_facade_helpers.py,
+  pipeline/tasks.py, tests/test_*backfill*, tests/test_pipeline_batching.py,
+  tests/test_run_pipeline_orchestration.py, tests/test_staged_hydrate_cities.py,
+  tests/test_tasks_agenda_summary_format.py
 - do: Callers import run_summary_hydration_backfill from
   summary_backfill_runner directly (or keep summary_backfill.py as a pure
   one-line re-import, no signature duplication, no conditional **splats).
-  Reduce injectable-callable params to the boundary fakes tests actually
-  need (DB session factory, summary callable); repoint tests for the rest.
-- accept: <= 8 params on the public signature; no conditional dict-splat
-  forwarding; backfill tests green.
+  Remove injectable-callable params. Repoint tests at implementation modules
+  and fake only the approved DB session factory or inference provider boundary.
+- accept: <= 8 params on the public signature; no injectable-callable params;
+  no conditional dict-splat forwarding; backfill tests green.
 - verify: Full suite green.
 
 ### T-DC-1: Remove the api.main <-> app_setup sync machinery

--- a/docs/plans/T_GOV_1_TEST_PATCH_POINTS_ADR_PLAN.md
+++ b/docs/plans/T_GOV_1_TEST_PATCH_POINTS_ADR_PLAN.md
@@ -1,0 +1,316 @@
+# T-GOV-1: Ratify Test Patch Points as Non-Public API
+
+`artifact_contract: ce-unified-plan/v1`  
+`artifact_readiness: implementation-ready`  
+`execution: code`
+
+## 1. Context & Alignment
+
+**a) Driver.** The operator approved G3 on 2026-07-24. Town Council has
+accumulated facade exports, synchronized globals, wrappers, and dependency
+rebindings whose only durable consumers are tests. Phase 2 cannot safely remove
+that debt until the architecture record makes the governing distinction
+explicit: runtime and public import contracts remain protected, but a test's
+historical monkeypatch target is not a public API.
+
+**b) Canonical documents consulted.**
+
+- `AGENTS.md` `<hierarchy_of_truth>`, `<known_antipatterns>`,
+  `<workflow_contract>`, and `<verification_matrix>` require an explicit
+  architecture decision, implementation-module patching, scoped ownership, and
+  complete verification.
+- `docs/ADR.md` is the accepted-decision log. Earlier entries preserve
+  test-only compatibility seams, so the new entry must explicitly supersede
+  those clauses without rewriting history or revoking runtime contracts.
+- `docs/TESTING.MD` already contains the approved fake boundaries and
+  implementation-module patching rules, but still says it becomes effective
+  with G3.
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md` makes T-GOV-1 the P0
+  governance task blocking every Phase 2 de-facading task.
+- `docs/reviews/architecture-review-2026-07-19.html` identifies facade
+  compatibility and test seams as material architecture debt.
+- `SECURITY.md` requires preserving the least-privilege Meilisearch reader-key
+  boundary touched by the comment-only source edit.
+- `docs/DATA_GOVERNANCE.md` adds no person-data constraint to this policy-only
+  task.
+
+**c) Remediation alignment.** This is T-GOV-1 in the GOV lane. Its exclusive
+`files_owned` set is:
+
+- `api/search/support_core.py`, comment only
+- `docs/ADR.md`
+- `docs/TESTING.MD`
+- `docs/plans/T_GOV_1_TEST_PATCH_POINTS_ADR_PLAN.md`
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`
+- `tests/test_repository_guardrails.py`
+
+The search module is coordinated with the SEC lane only to remove its stale
+statement that G3 defers facade removal. No runtime symbol, import, constant, or
+behavior may change.
+
+**d) Decision-gate check.** G3 was approved by the operator on 2026-07-24. The
+approval authorizes the Accepted ADR but does not unblock Phase 2 until this
+task merges. G1, G2, G4, and G5 are unchanged.
+
+## 2. Design
+
+**e) Step-by-step approach.**
+
+1. Register this Full Template plan, six-file ownership, operator approval, and
+   in-progress status in the remediation ledger.
+2. Commit the authorization record before changing policy, tests, or source
+   comments.
+3. Add failing repository guardrail tests before implementation:
+   - require a scoped Accepted ADR, effective testing policy, approved ledger
+     state, and removal of the Phase 2 G3 blocker after merge;
+   - reject live production Python comments that still treat G3 as a reason to
+     preserve a facade.
+4. Add a dated Accepted entry to `docs/ADR.md` with one responsibility:
+   distinguish protected runtime/public contracts from non-public test patch
+   targets.
+5. State that the new ADR supersedes prior accepted statements only to the
+   extent that they preserve monkeypatch paths, test-only re-exports,
+   synchronized globals, injectable callables, or dependency rebinding for test
+   compatibility. Runtime, import, CLI, API, task-identity, and operational
+   portions of mixed historical statements remain active. Leave all historical
+   entries unchanged.
+6. Preserve runtime behavior, supported import paths, CLI contracts, API
+   contracts, Celery signatures, provider boundaries, and operational
+   compatibility unless a separately owned remediation task explicitly
+   changes them.
+7. Activate `docs/TESTING.MD` by removing its G3 transition wording. Keep its
+   approved fake boundaries and implementation-module patching rules intact.
+8. Replace the stale G3 deferral comment in `api/search/support_core.py` with a
+   factual comment about current reader-key compatibility. Do not remove the
+   export in this task.
+9. Preserve the already-recorded operator approval of G3. In the implementation
+   commit, mark the T-GOV-1 ADR gate satisfied and the task complete, then
+   remove the Phase 2 G3 blocker while preserving each Phase 2 task's own
+   sequencing and ownership.
+10. Keep T-GOV-6 partially landed after T-GOV-1. This task activates its
+    testing-policy component, but the README Documentation Map still lacks the
+    three T-GOV-6 canonical links and is outside this task's ownership.
+11. Run the required gates, inspect the diff for generated antipatterns, obtain
+    a fresh subagent pre-commit review, and deliver one implementation commit
+    after the authorization commit.
+
+No new production function, helper module, facade, registry, wrapper, or
+configuration surface is introduced.
+
+**f) Reuse audit.** Extend the existing ADR format, testing policy,
+remediation ledger, and repository guardrail suite. The policy does not create
+a second fake-boundary list; `docs/TESTING.MD` remains the operational source.
+The new ADR supersedes older statements only to the extent that they preserve
+test-only patch targets; mixed runtime and operational contracts remain active.
+It does not duplicate or delete those historical records.
+
+Rejected alternatives:
+
+- Rewrite every historical ADR: rejected because architecture records must
+  preserve decision history and because broad edits would obscure the new
+  precedence rule.
+- Remove facade code in the ADR PR: rejected because Phase 2 tasks own those
+  runtime changes, tests, and rollback boundaries.
+- Treat all facades as immediately private: rejected because supported runtime
+  and public import contracts remain protected until an owned task changes
+  them.
+- Add a repository-wide monkeypatch scanner now: rejected because T-GOV-3 owns
+  the later guardrail redesign and this task needs only durable decision-state
+  checks.
+
+**g) Data contracts.** No application payload changes. The policy contract is:
+
+- Tests patch implementation modules or use approved architectural fakes.
+- Test-only patch locations do not block owned refactors.
+- Runtime behavior and public contracts remain protected.
+- A facade is removed only by its named remediation task with behavior tests.
+
+**h) Schema/migration impact.** None.
+
+## 3. Security & Data Governance
+
+**i) Security-sensitive paths.** `api/search/support_core.py` handles
+`MEILI_SEARCH_KEY` and `MEILI_MASTER_KEY`, so the required trust-boundary
+review applies even though the edit is comment-only. The API-to-Meilisearch
+reader boundary remains unchanged, an attacker gains no capability, and the
+`SECURITY.md` least-privilege reader-key control remains intact. No credential,
+authentication, rate-limit, CORS, proxy, client-construction, or key-resolution
+behavior changes.
+
+**j) Secrets.** No credential, key, environment variable, or default changes.
+
+**k) Person data.** No person-level data is created, linked, aggregated, or
+exposed. G4 remains open.
+
+**l) Untrusted input.** No scraped content, provider response, request body,
+HTML, JSON, or external artifact parsing changes.
+
+## 4. Code Health
+
+**m) GED conformance sweep.** The only production-file edit is a policy
+comment. New test helpers, if needed, remain test-local, typed, focused, and
+limited to exact Markdown sections or active Python roots. No exception
+handler, timestamp, environment read, runtime literal, or import-time side
+effect changes.
+
+**n) Antipattern scan, plan pass.**
+
+- A1/H1: no external library API or configuration call changes.
+- B1/F1: no parser framework, policy registry, wrapper, compatibility layer,
+  or duplicate fake-boundary inventory.
+- B2/C1: historical ADR text remains for audit history, but its test-only
+  compatibility clauses are explicitly superseded rather than kept active.
+- C2: tests are directed away from facade patch targets; no new seam preserves
+  an old target.
+- D1-D3: guardrails assert the observable policy state and active-code comment,
+  without skips, relaxed tolerances, or production mocks.
+- E1-E3: only six owned files may change; the source edit is comment-only.
+- A2-A4, B3, F2, and H2-H4: no planned violations.
+
+**o) Ratchet interaction.** No Ruff selector, BLE001 boundary, formatter
+scope, Mypy scope, coverage threshold, or CI gate changes. The task removes a
+policy blocker but does not remove any runtime allowlist entry.
+
+**p) Dead code and duplication audit.** Replace one stale G3-deferral comment
+and two transition statements. Reuse the existing approved-boundary table.
+Delete no runtime implementation. Expected production-code delta is zero.
+
+## 5. Testing
+
+**q) Edge and failure scenarios.**
+
+1. The ADR is present but not `Accepted`.
+2. The ADR fails to supersede prior test-only compatibility clauses.
+3. The ADR overreaches and treats runtime/API/import contracts as disposable.
+4. `docs/TESTING.MD` still says it becomes effective in the future.
+5. The ledger still describes G3 as open or Phase 2 as blocked by G3 after the
+   ADR implementation commit.
+6. The T-GOV-1 task is marked complete before the Accepted ADR exists.
+7. Live production Python still says G3 defers facade removal.
+8. Historical ADR text mentioning monkeypatch seams is incorrectly treated as
+   active production policy.
+9. The source comment edit changes executable behavior or imports.
+10. T-GOV-6 is incorrectly marked complete even though its README
+    Documentation Map acceptance deficit remains.
+
+**r) Tests.**
+
+| Test | Scenarios |
+|---|---|
+| `test_test_patch_points_policy_has_accepted_adr_and_effective_runbook` | 1-6, 8, 10 |
+| `test_live_python_does_not_treat_g3_as_a_facade_deferral` | 7, 9 |
+| Existing repository guardrail suite | 1-9 |
+| `tests/test_meilisearch_key_security.py` | 9 |
+| Complete Python suite | Runtime regression check |
+
+Both new tests are written and run red before the ADR, testing-policy, ledger,
+or source-comment implementation changes.
+
+**s) Fakes and mocks.** None. Tests use the approved filesystem boundary and
+read tracked policy/source files directly. No production facade, re-export, or
+implementation symbol is patched.
+
+**t) Verification rows.** Apply the guardrail/tooling row because
+`tests/test_repository_guardrails.py` changes, the docs-only row because
+canonical policy changes, and a focused search credential regression because
+`api/search/support_core.py` is touched. Run the complete Python suite before
+handoff.
+
+## 6. Execution, Rollback, Docs
+
+**u) Exact commands.**
+
+```bash
+git fetch origin --prune
+git switch master
+git merge --ff-only origin/master
+git switch -c codex/t-gov-1-test-patch-points-adr
+```
+
+Tests-first red evidence:
+
+```bash
+PYTHONPATH=. .venv/bin/pytest -q \
+  tests/test_repository_guardrails.py::test_test_patch_points_policy_has_accepted_adr_and_effective_runbook \
+  tests/test_repository_guardrails.py::test_live_python_does_not_treat_g3_as_a_facade_deferral
+```
+
+Final local verification:
+
+```bash
+./.venv/bin/ruff check .
+./.venv/bin/mypy
+PYTHONPATH=. .venv/bin/pytest -q tests/test_repository_guardrails.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_meilisearch_key_security.py
+PYTHONPATH=. .venv/bin/pytest -q
+git diff --check
+git status --short
+```
+
+Delivery uses two commits:
+
+1. `docs(remediation): authorize the G3 policy record`
+2. `docs(governance): accept test patch point policy`
+
+Push `codex/t-gov-1-test-patch-points-adr`, open one PR titled
+`T-GOV-1: Accept test patch points as non-public API`, request Codex review,
+and watch all checks to a decided state. Merge with a merge commit so the
+authorization and implementation commits remain independently reversible.
+Browser testing is not applicable.
+
+**v) Rollback.** Do not revert the PR merge commit because that would also
+erase the authorization record. Revert only the implementation commit retained
+by the required merge-commit strategy:
+
+```bash
+git switch master
+git pull --ff-only
+git revert <t_gov_1_implementation_commit_sha>
+./.venv/bin/ruff check .
+./.venv/bin/mypy
+PYTHONPATH=. .venv/bin/pytest -q tests/test_repository_guardrails.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_meilisearch_key_security.py
+PYTHONPATH=. .venv/bin/pytest -q
+git diff --check
+```
+
+No migration, data repair, configuration restore, or external-state cleanup is
+required. Reverting only the implementation restores the approval-only ledger
+state, makes the Accepted ADR gate unmet again, and re-blocks Phase 2.
+
+**w) Docs synchronization.**
+
+- `docs/ADR.md`: add the Accepted decision and scoped supersession rule.
+- `docs/TESTING.MD`: make the already-landed policy immediately effective.
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`: record approval, task
+  ownership/status, the satisfied ADR gate, and the Phase 2 gate transition.
+  T-GOV-6 remains partially landed because its README Documentation Map links
+  are still missing and outside this task.
+- `api/search/support_core.py`: update the stale policy comment only.
+- `AGENTS.md`, `SECURITY.md`, README, architecture review, operations,
+  performance, engineering guardrails, and data governance: no changes.
+
+## 7. Delivery Self-Audit
+
+**x) Antipattern scan, diff pass.** Re-run A-F and H. Reject facade removal,
+runtime/import changes, historical ADR rewrites, a second fake-boundary list,
+new test seams, policy registries, weakened tests, unrelated formatting, type
+suppression, or edits outside the six-file ownership set.
+
+**y) Evidence required at delivery.**
+
+- Tests-first red result.
+- Ruff, Mypy, repository guardrail, docs-link, Meilisearch key-security, and
+  complete-suite outcomes.
+- Planning-review and pre-commit-review findings with applied fixes.
+- Commit hashes, PR URL, unresolved-thread count, and final CI state.
+- Browser stage: `NOT APPLICABLE`.
+
+Anything unrun is reported as `NOT VERIFIED`.
+
+**z) Deviations.** Expected result is none. Any additional file, executable
+source change, facade removal, runtime/API/import contract change, new fake
+boundary, skipped review, unresolved P1/P2, or unrun required check is a
+blocker.

--- a/docs/plans/T_GOV_1_TEST_PATCH_POINTS_ADR_PLAN.md
+++ b/docs/plans/T_GOV_1_TEST_PATCH_POINTS_ADR_PLAN.md
@@ -1,7 +1,7 @@
 # T-GOV-1: Ratify Test Patch Points as Non-Public API
 
-`artifact_contract: ce-unified-plan/v1`  
-`artifact_readiness: implementation-ready`  
+`artifact_contract: ce-unified-plan/v1`
+`artifact_readiness: implementation-ready`
 `execution: code`
 
 ## 1. Context & Alignment

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2268,6 +2268,11 @@ def test_test_patch_points_policy_has_accepted_adr_and_effective_runbook():
     complete_row = next(
         line for line in remediation_ledger.splitlines() if line.startswith("| **Complete** |")
     )
+    in_progress_row = next(
+        line
+        for line in remediation_ledger.splitlines()
+        if line.startswith("| **In progress** |")
+    )
     partial_row = next(
         line
         for line in remediation_ledger.splitlines()
@@ -2298,6 +2303,8 @@ def test_test_patch_points_policy_has_accepted_adr_and_effective_runbook():
     )
     assert "T-GOV-1" in complete_row
     assert "T-GOV-1" not in pending_row
+    assert "T-SEC-4A" not in complete_row
+    assert "T-SEC-4A" in in_progress_row
     assert "T-GOV-6" in partial_row
     assert (
         "remains partially landed until its three canonical documents are linked from the README "

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2272,7 +2272,13 @@ def test_live_python_does_not_treat_g3_as_a_facade_deferral():
             source_path.read_text(encoding="utf-8").splitlines(),
             start=1,
         ):
-            if re.search(r"\bG3\b", source_line, re.IGNORECASE):
+            has_g3_reference = re.search(r"\bG3\b", source_line, re.IGNORECASE)
+            has_deferral_language = re.search(
+                r"\b(?:defer|block|preserv)\w*\b",
+                source_line,
+                re.IGNORECASE,
+            )
+            if has_g3_reference and has_deferral_language:
                 live_g3_references.append(
                     f"{relative_source_path}:{line_number}: {source_line.strip()}"
                 )

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2062,6 +2062,17 @@ OPERATOR_AUTH_APPROVAL_POLICY = re.compile(
     r"\boperator(?:-only)?(?: proxy)? authentication\s+(?:is\s+)?(?:approved|pending)\b",
     re.IGNORECASE,
 )
+G3_UNRESOLVED_POLICY = re.compile(
+    r"(?:\bg3\b\s+(?:is|remains)\s+(?:open|pending|unresolved)\b"
+    r"|\bg3\b\s*(?:status\s*)?:\s*(?:open|pending|unresolved)\b"
+    r"|\b(?:open|pending|unresolved)\s+g3\b)",
+    re.IGNORECASE,
+)
+PHASE_2_G3_BLOCKER_POLICY = re.compile(
+    r"(?:\bphase 2\b.{0,40}\bblock\w*\b.{0,20}\bg3\b"
+    r"|\bg3\b.{0,40}\bblock\w*\b.{0,20}\bphase 2\b)",
+    re.IGNORECASE,
+)
 
 
 def _g2_policy_has_contradiction(g2_policy: str) -> bool:
@@ -2168,3 +2179,102 @@ def test_g2_accepted_risk_is_bounded_without_overclaiming_t_sec_4():
         in accepted_risk
     )
     assert "- [ ] Client IP forwarded from proxy" in security_policy
+
+
+def test_test_patch_points_policy_has_accepted_adr_and_effective_runbook():
+    architecture_decisions = (ROOT / "docs" / "ADR.md").read_text(encoding="utf-8")
+    testing_policy = (ROOT / "docs" / "TESTING.MD").read_text(encoding="utf-8")
+    remediation_ledger = (
+        ROOT / "docs" / "plans" / "TOWN_COUNCIL_REMEDIATION_PLAN.md"
+    ).read_text(encoding="utf-8")
+    test_patch_point_decision = _required_markdown_section(
+        architecture_decisions,
+        "## 2026-07-24: Test patch points are not a public API",
+        "\n## 2026-05-17:",
+    )
+    g3_entry = _required_markdown_section(
+        remediation_ledger,
+        "- G3 test_seam_adr:",
+        "\n- G4 pii_policy:",
+    )
+    t_gov_1_entry = _required_markdown_section(
+        remediation_ledger,
+        '### T-GOV-1: ADR — "Test patch points are not a public API" (gate G3)',
+        "\n### T-GOV-2:",
+    )
+    t_gov_6_entry = _required_markdown_section(
+        remediation_ledger,
+        "### T-GOV-6: Introduce SECURITY.md, docs/TESTING.md, docs/DATA_GOVERNANCE.md",
+        "\n---\n\n## 7. EXECUTION ORDER SUMMARY",
+    )
+    phase_2_policy = _required_markdown_section(
+        remediation_ledger,
+        "## 5. PHASE 2 — DEDUPLICATION & DE-FACADING",
+        "\n### T-DA-1:",
+    )
+    complete_row = next(
+        line for line in remediation_ledger.splitlines() if line.startswith("| **Complete** |")
+    )
+    partial_row = next(
+        line
+        for line in remediation_ledger.splitlines()
+        if line.startswith("| **Partially landed; acceptance incomplete** |")
+    )
+    pending_row = next(
+        line for line in remediation_ledger.splitlines() if line.startswith("| **Pending** |")
+    )
+
+    assert "- Status: Accepted" in test_patch_point_decision
+    assert test_patch_point_decision.count("- Status:") == 1
+    assert "only to the extent that" in test_patch_point_decision
+    assert "test-only patch target" in test_patch_point_decision
+    assert "Runtime, import, CLI, API, task-identity, and operational contracts remain active" in (
+        test_patch_point_decision
+    )
+    assert "docs/TESTING.MD" in test_patch_point_decision
+    assert "Status: effective." in testing_policy
+    assert testing_policy.count("Status:") == 1
+    assert "effective with the G3 ADR" not in testing_policy
+    assert "**Satisfied 2026-07-24.**" in g3_entry
+    assert "status: complete and verified 2026-07-24" in t_gov_1_entry
+    assert t_gov_1_entry.count("- status:") == 1
+    assert not re.search(
+        r"\bstatus:\s*(?:draft|proposed|pending|in progress|incomplete)\b",
+        f"{test_patch_point_decision} {testing_policy} {t_gov_1_entry}",
+        re.IGNORECASE,
+    )
+    assert "T-GOV-1" in complete_row
+    assert "T-GOV-1" not in pending_row
+    assert "T-GOV-6" in partial_row
+    assert (
+        "remains partially landed until its three canonical documents are linked from the README "
+        "Documentation Map"
+        in t_gov_6_entry
+    )
+    assert "## 5. PHASE 2 — DEDUPLICATION & DE-FACADING\n" in remediation_ledger
+    assert "PHASE 2 — DEDUPLICATION & DE-FACADING (blocked by G3)" not in remediation_ledger
+    active_g3_policy = (
+        f"{test_patch_point_decision} {testing_policy} {g3_entry} "
+        f"{t_gov_1_entry} {phase_2_policy}"
+    )
+    assert not G3_UNRESOLVED_POLICY.search(active_g3_policy)
+    assert not PHASE_2_G3_BLOCKER_POLICY.search(active_g3_policy)
+
+
+def test_live_python_does_not_treat_g3_as_a_facade_deferral():
+    live_g3_references = []
+
+    for source_path in _broad_exception_scan_files():
+        relative_source_path = source_path.relative_to(ROOT)
+        if relative_source_path.parts[0] in {"archive", "tests"}:
+            continue
+        for line_number, source_line in enumerate(
+            source_path.read_text(encoding="utf-8").splitlines(),
+            start=1,
+        ):
+            if re.search(r"\bG3\b", source_line, re.IGNORECASE):
+                live_g3_references.append(
+                    f"{relative_source_path}:{line_number}: {source_line.strip()}"
+                )
+
+    assert live_g3_references == []

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2103,8 +2103,8 @@ G3_DEFERRAL_ACTION = re.compile(
     re.IGNORECASE,
 )
 G3_DEFERRED_WORK = re.compile(
-    r"(?:facade(?:\s+(?:removal|cleanup))?|test\s+(?:facade|seam)|patch\s+target|"
-    r"deduplicat\w*|de-fac\w*|removal)",
+    r"(?:facade\s+(?:removal|cleanup)|test\s+(?:facade|seam)|patch\s+target|"
+    r"deduplicat\w*|de-fac\w*)",
     re.IGNORECASE,
 )
 G3_NEGATION_GAP = (
@@ -2121,7 +2121,7 @@ G3_NEGATED_DEFERRAL_ACTION = re.compile(
     rf"{G3_NEGATION_GAP}\s+{G3_DEFERRAL_ACTION_PATTERN}\b",
     re.IGNORECASE,
 )
-G3_POLICY_SENTENCE_BOUNDARY = re.compile(r"\.")
+G3_POLICY_SENTENCE_BOUNDARY = re.compile(r"\.(?=\s|$)")
 G3_POLICY_CLAUSE_BOUNDARY = re.compile(
     r"(;|,|\b(?:and|but|however|while|yet)\b)",
     re.IGNORECASE,
@@ -2486,6 +2486,10 @@ def test_g3_deferral_scan_groups_wrapped_comment_blocks(tmp_path: Path):
         "# G3 preserves no test facade.",
         "# G3 is not expected to block facade removal.",
         "# G3 proceeds without blocking facade removal.",
+        "# G3 preserves the public facade.",
+        "# G3 preserves facade runtime compatibility.",
+        "# G3 blocks cache removal.",
+        "# G3 blocks temporary-file removal.",
     ),
 )
 def test_g3_deferral_scan_allows_non_deferral_policy(accepted_policy: str):
@@ -2506,6 +2510,7 @@ def test_g3_deferral_scan_allows_non_deferral_policy(accepted_policy: str):
         "# G3 blockers are blocking facade removal.",
         "# G3 blocks are blocking facade removal.",
         "# G3 blocks are preserving the test facade.",
+        "# G3 blocks api.main facade removal.",
         "# G3 blocks not only facade removal but also the test seam.",
         "# G3 not only blocks facade removal but also preserves the test seam.",
         "# G3 is not resolved, so preserve the test facade.",

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2094,14 +2094,125 @@ def _python_comment_blocks(source_path: Path) -> list[tuple[int, str]]:
     ]
 
 
-def _comment_block_defers_g3(comment_block: str) -> bool:
-    has_g3_reference = re.search(r"\bG3\b", comment_block, re.IGNORECASE)
-    has_deferral_language = re.search(
-        r"\b(?:defer|block|preserv)\w*\b",
-        comment_block,
-        re.IGNORECASE,
+G3_REFERENCE = re.compile(r"\bG3\b", re.IGNORECASE)
+G3_DEFERRAL_ACTION_PATTERN = (
+    r"(?:defer(?:s|red|ring)?|block(?:s|ed|ing)?|preserv(?:e|es|ed|ing))"
+)
+G3_DEFERRAL_ACTION = re.compile(
+    rf"\b{G3_DEFERRAL_ACTION_PATTERN}\b",
+    re.IGNORECASE,
+)
+G3_DEFERRED_WORK = re.compile(
+    r"(?:facade(?:\s+(?:removal|cleanup))?|test\s+(?:facade|seam)|patch\s+target|"
+    r"deduplicat\w*|de-fac\w*|removal)",
+    re.IGNORECASE,
+)
+G3_NEGATION_GAP = (
+    r"(?:\s+(?!(?:so|therefore|thus|hence|then)\b)[a-z][\w'-]*){0,4}"
+)
+G3_NEGATED_DEFERRED_WORK = re.compile(
+    rf"\b(?:neither|nor|no|not(?!\s+(?:only|just|merely)\b)){G3_NEGATION_GAP}\s+"
+    rf"{G3_DEFERRED_WORK.pattern}",
+    re.IGNORECASE,
+)
+G3_NEGATED_DEFERRAL_ACTION = re.compile(
+    r"\b(?:no\s+longer|never|cannot|can't|does\s+not|doesn't|is\s+not|isn't|"
+    r"not|without)(?!\s+(?:only|just|merely)\b)"
+    rf"{G3_NEGATION_GAP}\s+{G3_DEFERRAL_ACTION_PATTERN}\b",
+    re.IGNORECASE,
+)
+G3_POLICY_SENTENCE_BOUNDARY = re.compile(r"\.")
+G3_POLICY_CLAUSE_BOUNDARY = re.compile(
+    r"(;|,|\b(?:and|but|however|while|yet)\b)",
+    re.IGNORECASE,
+)
+G3_NOUN_ACTION_CONTINUATION = re.compile(
+    r"^\s+(?:are|is|was|were|exist|exists|listed|documented)\b",
+    re.IGNORECASE,
+)
+G3_BLOCKER_POLICY = re.compile(r"\bG3\b\s+remains\s+a\s+blocker\b", re.IGNORECASE)
+
+
+def _positive_g3_deferral_action(policy_clause: str) -> str | None:
+    negated_action_spans = [
+        negated_action.span()
+        for negated_action in G3_NEGATED_DEFERRAL_ACTION.finditer(policy_clause)
+    ]
+    for deferral_action in G3_DEFERRAL_ACTION.finditer(policy_clause):
+        if any(
+            start <= deferral_action.start() < end
+            for start, end in negated_action_spans
+        ):
+            continue
+        if G3_NOUN_ACTION_CONTINUATION.search(
+            policy_clause[deferral_action.end() :]
+        ):
+            continue
+        return deferral_action.group(0)
+    return None
+
+
+def _has_positive_g3_deferred_work(policy_clause: str) -> bool:
+    negated_work_spans = [
+        negated_work.span()
+        for negated_work in G3_NEGATED_DEFERRED_WORK.finditer(policy_clause)
+    ]
+    return any(
+        not any(start <= deferred_work.start() < end for start, end in negated_work_spans)
+        for deferred_work in G3_DEFERRED_WORK.finditer(policy_clause)
     )
-    return bool(has_g3_reference and has_deferral_language)
+
+
+def _g3_clause_defers_work(policy_clause: str) -> bool:
+    return bool(
+        G3_REFERENCE.search(policy_clause)
+        and _has_positive_g3_deferred_work(policy_clause)
+        and (
+            _positive_g3_deferral_action(policy_clause)
+            or G3_BLOCKER_POLICY.search(policy_clause)
+        )
+    )
+
+
+def _g3_sentence_defers_work(policy_sentence: str) -> bool:
+    has_g3_context = False
+    inherited_deferral_action: str | None = None
+    preceding_boundary = ""
+    policy_parts = G3_POLICY_CLAUSE_BOUNDARY.split(policy_sentence)
+    for part_index in range(0, len(policy_parts), 2):
+        policy_clause = policy_parts[part_index]
+        if preceding_boundary in {",", ";", "but", "however", "while", "yet"}:
+            inherited_deferral_action = None
+        clause_has_g3 = bool(G3_REFERENCE.search(policy_clause))
+        if clause_has_g3:
+            has_g3_context = True
+        positive_deferral_action = _positive_g3_deferral_action(policy_clause)
+        if positive_deferral_action:
+            inherited_deferral_action = positive_deferral_action
+        elif G3_DEFERRAL_ACTION.search(policy_clause):
+            inherited_deferral_action = None
+        inherited_policy = ""
+        if has_g3_context and not clause_has_g3:
+            inherited_policy = "G3 "
+        if (
+            inherited_deferral_action
+            and not G3_DEFERRAL_ACTION.search(policy_clause)
+        ):
+            inherited_policy = f"{inherited_policy}{inherited_deferral_action} "
+        scoped_clause = f"{inherited_policy}{policy_clause}"
+        if _g3_clause_defers_work(scoped_clause):
+            return True
+        if part_index + 1 < len(policy_parts):
+            preceding_boundary = policy_parts[part_index + 1].lower()
+    return False
+
+
+def _comment_block_defers_g3(comment_block: str) -> bool:
+    normalized_comment = " ".join(comment_block.replace("#", " ").split())
+    return any(
+        _g3_sentence_defers_work(policy_sentence)
+        for policy_sentence in G3_POLICY_SENTENCE_BOUNDARY.split(normalized_comment)
+    )
 
 
 G2_OPEN_POLICY = re.compile(
@@ -2351,6 +2462,64 @@ def test_g3_deferral_scan_groups_wrapped_comment_blocks(tmp_path: Path):
     ]
     assert _comment_block_defers_g3(comment_blocks[0][1])
     assert not _comment_block_defers_g3(comment_blocks[1][1])
+
+
+@pytest.mark.parametrize(
+    "accepted_policy",
+    (
+        "# G3 no longer blocks facade removal while preserving the runtime API.",
+        "# G3 blocks are listed in the report.",
+        "# G3 preserves runtime API compatibility.",
+        "# Facade removal is not blocked by G3.",
+        "# Facade removal is not being blocked by G3.",
+        "# G3 is pending for historical reference; facade removal is no longer blocked.",
+        "# G3 remains open for discussion. The facade documentation is current.",
+        "# G3 blocks migration and does not block facade removal and the test seam.",
+        "# G3 blocks are documented and facade removal status is current.",
+        "# G3 blocks are documented; facade removal status is current.",
+        "# G3 block is documented and facade removal status is current.",
+        "# G3 blocker is documented and facade removal status is current.",
+        "# G3 preservation is documented and facade removal status is current.",
+        "# G3 blocks migration, not facade removal.",
+        "# G3 no longer blocks facade removal, preserving the runtime API.",
+        "# G3 blocks neither facade removal nor test seams.",
+        "# G3 preserves no test facade.",
+        "# G3 is not expected to block facade removal.",
+        "# G3 proceeds without blocking facade removal.",
+    ),
+)
+def test_g3_deferral_scan_allows_non_deferral_policy(accepted_policy: str):
+    assert not _comment_block_defers_g3(accepted_policy)
+
+
+@pytest.mark.parametrize(
+    "deferred_policy",
+    (
+        "# G3 no longer blocks one cleanup, but G3 still preserves the test facade.",
+        "# G3 no longer blocks one cleanup. # G3 still preserves the test facade.",
+        "# G3 no longer blocks one cleanup, and G3 still preserves the test facade.",
+        "# G3 no longer blocks one cleanup, yet G3 still preserves the test facade.",
+        "# G3 no longer blocks facade removal and still preserves the test seam.",
+        "# G3 blocks migration and facade removal.",
+        "# G3 preserves runtime compatibility and the test facade.",
+        "# G3 remains pending; therefore preserve the test facade.",
+        "# G3 blockers are blocking facade removal.",
+        "# G3 blocks are blocking facade removal.",
+        "# G3 blocks are preserving the test facade.",
+        "# G3 blocks not only facade removal but also the test seam.",
+        "# G3 not only blocks facade removal but also preserves the test seam.",
+        "# G3 is not resolved, so preserve the test facade.",
+        "# G3 is not resolved so preserve the test facade.",
+        "# G3 is pending, so preserve the test facade.",
+        "# G3 is still pending, so preserve the test facade.",
+        "# G3 is unresolved, therefore block facade removal.",
+        "# G3 remains a blocker for facade removal.",
+    ),
+)
+def test_g3_deferral_scan_detects_positive_policy_after_other_negation(
+    deferred_policy: str,
+):
+    assert _comment_block_defers_g3(deferred_policy)
 
 
 def test_g3_deferral_scan_keeps_adjacent_inline_comments_separate(tmp_path: Path):

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2051,6 +2051,59 @@ def _required_markdown_section(markdown: str, heading: str, next_heading: str) -
     return " ".join(section.split())
 
 
+def _python_comment_blocks(source_path: Path) -> list[tuple[int, str]]:
+    source_text = source_path.read_text(encoding="utf-8")
+    source_lines = source_text.splitlines()
+    comment_tokens = [
+        (
+            python_token.start[0],
+            python_token.start[1],
+            not source_lines[python_token.start[0] - 1][: python_token.start[1]].strip(),
+            python_token.string,
+        )
+        for python_token in tokenize.generate_tokens(StringIO(source_text).readline)
+        if python_token.type == tokenize.COMMENT
+    ]
+    grouped_comments: list[tuple[int, int, int, bool, str]] = []
+
+    for line_number, column, is_full_line, comment_text in comment_tokens:
+        previous_comment = grouped_comments[-1] if grouped_comments else None
+        if (
+            previous_comment
+            and is_full_line
+            and previous_comment[3]
+            and line_number == previous_comment[1] + 1
+            and column == previous_comment[2]
+        ):
+            start_line, _, _, _, previous_text = previous_comment
+            grouped_comments[-1] = (
+                start_line,
+                line_number,
+                column,
+                is_full_line,
+                f"{previous_text} {comment_text}",
+            )
+        else:
+            grouped_comments.append(
+                (line_number, line_number, column, is_full_line, comment_text)
+            )
+
+    return [
+        (start_line, comment_text)
+        for start_line, _, _, _, comment_text in grouped_comments
+    ]
+
+
+def _comment_block_defers_g3(comment_block: str) -> bool:
+    has_g3_reference = re.search(r"\bG3\b", comment_block, re.IGNORECASE)
+    has_deferral_language = re.search(
+        r"\b(?:defer|block|preserv)\w*\b",
+        comment_block,
+        re.IGNORECASE,
+    )
+    return bool(has_g3_reference and has_deferral_language)
+
+
 G2_OPEN_POLICY = re.compile(
     r"(?:\bg2\b\s+(?:is|remains)\s+(?:open|pending|unresolved)\b"
     r"|\bg2\b\s*(?:status\s*)?:\s*(?:open|pending|unresolved)\b"
@@ -2268,19 +2321,49 @@ def test_live_python_does_not_treat_g3_as_a_facade_deferral():
         relative_source_path = source_path.relative_to(ROOT)
         if relative_source_path.parts[0] in {"archive", "tests"}:
             continue
-        for line_number, source_line in enumerate(
-            source_path.read_text(encoding="utf-8").splitlines(),
-            start=1,
-        ):
-            has_g3_reference = re.search(r"\bG3\b", source_line, re.IGNORECASE)
-            has_deferral_language = re.search(
-                r"\b(?:defer|block|preserv)\w*\b",
-                source_line,
-                re.IGNORECASE,
-            )
-            if has_g3_reference and has_deferral_language:
+        for line_number, comment_block in _python_comment_blocks(source_path):
+            if _comment_block_defers_g3(comment_block):
                 live_g3_references.append(
-                    f"{relative_source_path}:{line_number}: {source_line.strip()}"
+                    f"{relative_source_path}:{line_number}: {comment_block}"
                 )
 
     assert live_g3_references == []
+
+
+def test_g3_deferral_scan_groups_wrapped_comment_blocks(tmp_path: Path):
+    wrapped_policy = tmp_path / "wrapped_policy.py"
+    wrapped_policy.write_text(
+        "# G3 still\n# blocks facade removal.\n\n# An unrelated comment.\n",
+        encoding="utf-8",
+    )
+    comment_blocks = _python_comment_blocks(wrapped_policy)
+
+    assert comment_blocks == [
+        (1, "# G3 still # blocks facade removal."),
+        (4, "# An unrelated comment."),
+    ]
+    assert _comment_block_defers_g3(comment_blocks[0][1])
+    assert not _comment_block_defers_g3(comment_blocks[1][1])
+
+
+def test_g3_deferral_scan_keeps_adjacent_inline_comments_separate(tmp_path: Path):
+    unrelated_comments = tmp_path / "unrelated_comments.py"
+    unrelated_comments.write_text(
+        "first = 1  # G3 marker\n"
+        "second = 2  # preserves runtime behavior\n"
+        "# G3 standalone\n"
+        "third = 3  # blocks invalid input\n",
+        encoding="utf-8",
+    )
+    comment_blocks = _python_comment_blocks(unrelated_comments)
+
+    assert comment_blocks == [
+        (1, "# G3 marker"),
+        (2, "# preserves runtime behavior"),
+        (3, "# G3 standalone"),
+        (4, "# blocks invalid input"),
+    ]
+    assert not any(
+        _comment_block_defers_g3(comment_text)
+        for _, comment_text in comment_blocks
+    )

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2096,7 +2096,8 @@ def _python_comment_blocks(source_path: Path) -> list[tuple[int, str]]:
 
 G3_REFERENCE = re.compile(r"\bG3\b", re.IGNORECASE)
 G3_DEFERRAL_ACTION_PATTERN = (
-    r"(?:defer(?:s|red|ring)?|block(?:s|ed|ing)?|preserv(?:e|es|ed|ing))"
+    r"(?:defer(?:s|red|ring)?|block(?:s|ed|ing)?|preserv(?:e|es|ed|ing)|"
+    r"prevent(?:s|ed|ing)?|retain(?:s|ed)?|retaining)"
 )
 G3_DEFERRAL_ACTION = re.compile(
     rf"\b{G3_DEFERRAL_ACTION_PATTERN}\b",
@@ -2123,7 +2124,7 @@ G3_NEGATED_DEFERRAL_ACTION = re.compile(
 )
 G3_POLICY_SENTENCE_BOUNDARY = re.compile(r"\.(?=\s|$)")
 G3_POLICY_CLAUSE_BOUNDARY = re.compile(
-    r"(;|,|\b(?:and|but|however|while|yet)\b)",
+    r"(;|,|\b(?:and|but|however|while|yet|so|therefore|thus|hence|then)\b)",
     re.IGNORECASE,
 )
 G3_NOUN_ACTION_CONTINUATION = re.compile(
@@ -2131,6 +2132,14 @@ G3_NOUN_ACTION_CONTINUATION = re.compile(
     re.IGNORECASE,
 )
 G3_BLOCKER_POLICY = re.compile(r"\bG3\b\s+remains\s+a\s+blocker\b", re.IGNORECASE)
+G3_PREREQUISITE_POLICY = re.compile(
+    r"\bG3\b.{0,40}\b(?:is|remains)\s+(?:a\s+)?prerequisite\b",
+    re.IGNORECASE,
+)
+G3_NEGATED_PREREQUISITE_POLICY = re.compile(
+    r"\bG3\b.{0,40}\b(?:no\s+longer|not|never)\b.{0,30}\bprerequisite\b",
+    re.IGNORECASE,
+)
 
 
 def _positive_g3_deferral_action(policy_clause: str) -> str | None:
@@ -2170,6 +2179,10 @@ def _g3_clause_defers_work(policy_clause: str) -> bool:
         and (
             _positive_g3_deferral_action(policy_clause)
             or G3_BLOCKER_POLICY.search(policy_clause)
+            or (
+                G3_PREREQUISITE_POLICY.search(policy_clause)
+                and not G3_NEGATED_PREREQUISITE_POLICY.search(policy_clause)
+            )
         )
     )
 
@@ -2181,7 +2194,7 @@ def _g3_sentence_defers_work(policy_sentence: str) -> bool:
     policy_parts = G3_POLICY_CLAUSE_BOUNDARY.split(policy_sentence)
     for part_index in range(0, len(policy_parts), 2):
         policy_clause = policy_parts[part_index]
-        if preceding_boundary in {",", ";", "but", "however", "while", "yet"}:
+        if preceding_boundary and preceding_boundary != "and":
             inherited_deferral_action = None
         clause_has_g3 = bool(G3_REFERENCE.search(policy_clause))
         if clause_has_g3:
@@ -2490,6 +2503,9 @@ def test_g3_deferral_scan_groups_wrapped_comment_blocks(tmp_path: Path):
         "# G3 preserves facade runtime compatibility.",
         "# G3 blocks cache removal.",
         "# G3 blocks temporary-file removal.",
+        "# G3 no longer remains a prerequisite for facade removal.",
+        "# G3 no longer is a prerequisite for facade removal.",
+        "# G3 is no longer a prerequisite for facade removal.",
     ),
 )
 def test_g3_deferral_scan_allows_non_deferral_policy(accepted_policy: str):
@@ -2519,6 +2535,10 @@ def test_g3_deferral_scan_allows_non_deferral_policy(accepted_policy: str):
         "# G3 is still pending, so preserve the test facade.",
         "# G3 is unresolved, therefore block facade removal.",
         "# G3 remains a blocker for facade removal.",
+        "# G3 prevents facade removal.",
+        "# Until G3 is resolved, retain the test seam.",
+        "# G3 remains a prerequisite for facade removal.",
+        "# G3 is not resolved so remains a prerequisite for facade removal.",
     ),
 )
 def test_g3_deferral_scan_detects_positive_policy_after_other_negation(

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2081,7 +2081,7 @@ def _python_comment_blocks(source_path: Path) -> list[tuple[int, str]]:
                 line_number,
                 column,
                 is_full_line,
-                f"{previous_text} {comment_text}",
+                f"{previous_text}\n{comment_text}",
             )
         else:
             grouped_comments.append(
@@ -2096,6 +2096,11 @@ def _python_comment_blocks(source_path: Path) -> list[tuple[int, str]]:
 
 G3_REFERENCE = re.compile(r"\bG3\b", re.IGNORECASE)
 REMEDIATION_TASK_REFERENCE = re.compile(r"\bT-[A-Z]+-\d+[A-Z]?\b", re.IGNORECASE)
+REMEDIATION_TASK_LINE_REFERENCE = re.compile(
+    r"^\s*(?:(?:[-*+]|\d+\.)\s+)?T-[A-Z]+-\d+[A-Z]?\b",
+    re.IGNORECASE,
+)
+G3_COORDINATED_SUBJECT = re.compile(r"^\s*(?:both\s+)?G3\s*$", re.IGNORECASE)
 G3_DEFERRAL_ACTION_PATTERN = (
     r"(?:defer(?:s|red|ring)?|block(?:s|ed|ing)?|preserv(?:e|es|ed|ing)|"
     r"prevent(?:s|ed|ing)?|retain(?:s|ed)?|retaining|delay(?:s|ed|ing)?|"
@@ -2111,10 +2116,13 @@ G3_LEGACY_SEAM_OBJECT_PATTERN = (
     r"(?:bidirectional(?:ly)?\s+)?synchronized\s+globals?|"
     r"injectable(?:-|\s+)callables?(?:\s+(?:parameters?|seams?))?)"
 )
-G3_REMOVAL_OBJECT_PATTERN = (
-    r"(?:facades?|test\s+(?:facades?|seams?)|"
+G3_TEST_ONLY_OBJECT_PATTERN = (
+    r"(?:test\s+(?:facades?|seams?)|"
     r"(?:test(?:-only|\s+only)?\s+)?patch\s+(?:points?|targets?)|"
     rf"{G3_LEGACY_SEAM_OBJECT_PATTERN})"
+)
+G3_REMOVAL_OBJECT_PATTERN = (
+    rf"(?:facades?|{G3_TEST_ONLY_OBJECT_PATTERN})"
 )
 G3_REMOVAL_OBJECT_MODIFIER_PATTERN = r"(?:a|an|existing|legacy|temporary|that|the|this)"
 G3_MUST_PRECEDE_ACTION_PATTERN = (
@@ -2180,6 +2188,7 @@ G3_PERMISSIVE_ACTION_PATTERN = (
 G3_KEEP_HOLD_ACTION_PATTERN = r"(?:keep(?:s|ing)?|kept|hold(?:s|ing)?|held)"
 G3_REQUIREMENT_ACTION_PATTERN = r"requir(?:e|es|ed|ing)"
 G3_REQUIREMENT_MODIFIER_PATTERN = r"(?:a|an|continued|existing|temporary|the)"
+G3_RUNTIME_FACADE_PREFIX_PATTERN = r"(?:(?:public|runtime)\s+facades?\s+and\s+)?"
 G3_CONTRASTIVE_DEFERRED_WORK = re.compile(
     rf"\b(?:instead\s+of|rather\s+than)\s+"
     rf"(?:(?:{G3_DEFERRAL_ACTION_PATTERN}|{G3_PERMISSIVE_ACTION_PATTERN}|"
@@ -2280,10 +2289,24 @@ G3_REQUIREMENT_POLICY = re.compile(
     rf"{G3_DEFERRED_WORK.pattern}(?=\s*{G3_CONTROLLED_WORK_TAIL_PATTERN})",
     re.IGNORECASE,
 )
+G3_SUBJECT_FIRST_REQUIREMENT_POLICY = re.compile(
+    rf"\b{G3_REQUIREMENT_ACTION_PATTERN}\s+"
+    rf"(?:{G3_REQUIREMENT_MODIFIER_PATTERN}\s+){{0,3}}"
+    rf"{G3_RUNTIME_FACADE_PREFIX_PATTERN}"
+    rf"{G3_TEST_ONLY_OBJECT_PATTERN}\s+to\s+remain(?:\s+in\s+place)?"
+    rf"(?=\s*{G3_CONTROLLED_WORK_TAIL_PATTERN})",
+    re.IGNORECASE,
+)
 G3_NEGATED_REQUIREMENT_POLICY = re.compile(
     r"\b(?:no\s+longer|never|cannot|can't|does\s+not|doesn't|is\s+not|isn't|"
     r"not|without)(?!\s+(?:only|just|merely)\b)"
     rf"{G3_NEGATION_GAP}\s+requir(?:e|es|ed|ing)\b",
+    re.IGNORECASE,
+)
+G3_SUBJECT_NEGATED_REQUIREMENT_POLICY = re.compile(
+    rf"(?:\bno\s+G3\b(?:\s+[a-z-]+){{0,3}}|"
+    rf"\bneither\s+G3\s+nor\s+{REMEDIATION_TASK_REFERENCE.pattern})\s+"
+    rf"{G3_REQUIREMENT_ACTION_PATTERN}\b",
     re.IGNORECASE,
 )
 G3_TEMPORAL_REFERENCE_POLICY = re.compile(
@@ -2409,11 +2432,18 @@ def _g3_clause_defers_work(policy_clause: str) -> bool:
     if G3_NONASSERTIVE_POLICY_CONTEXT.search(policy_clause):
         return False
     negated_permission = G3_NEGATED_PERMISSIVE_ACTION.search(policy_clause)
-    has_deferred_work = (
-        G3_DEFERRED_WORK.search(policy_clause)
-        if negated_permission
-        else _has_positive_g3_deferred_work(policy_clause)
+    subject_first_requirement = G3_SUBJECT_FIRST_REQUIREMENT_POLICY.search(
+        policy_clause
     )
+    if negated_permission:
+        has_deferred_work = subject_first_requirement or G3_DEFERRED_WORK.search(
+            policy_clause
+        )
+    else:
+        has_deferred_work = (
+            subject_first_requirement
+            or _has_positive_g3_deferred_work(policy_clause)
+        )
     return bool(
         G3_REFERENCE.search(policy_clause)
         and has_deferred_work
@@ -2423,8 +2453,14 @@ def _g3_clause_defers_work(policy_clause: str) -> bool:
             or negated_permission
             or _g3_keep_hold_defers_work(policy_clause)
             or (
-                G3_REQUIREMENT_POLICY.search(policy_clause)
-                and not G3_NEGATED_REQUIREMENT_POLICY.search(policy_clause)
+                (
+                    G3_REQUIREMENT_POLICY.search(policy_clause)
+                    or subject_first_requirement
+                )
+                and not (
+                    G3_NEGATED_REQUIREMENT_POLICY.search(policy_clause)
+                    or G3_SUBJECT_NEGATED_REQUIREMENT_POLICY.search(policy_clause)
+                )
             )
             or (
                 G3_PREREQUISITE_POLICY.search(policy_clause)
@@ -2441,12 +2477,18 @@ def _g3_clause_defers_work(policy_clause: str) -> bool:
 
 
 def _g3_sentence_defers_work(policy_sentence: str) -> bool:
-    if (
-        not REMEDIATION_TASK_REFERENCE.search(policy_sentence)
-        and G3_REFERENCE.search(policy_sentence)
-        and _g3_keep_hold_defers_work(policy_sentence)
-    ):
-        return True
+    sentence_has_other_task = bool(
+        REMEDIATION_TASK_REFERENCE.search(policy_sentence)
+    )
+    if not sentence_has_other_task and G3_REFERENCE.search(policy_sentence):
+        if _g3_keep_hold_defers_work(policy_sentence):
+            return True
+        if (
+            G3_SUBJECT_FIRST_REQUIREMENT_POLICY.search(policy_sentence)
+            and not G3_NEGATED_REQUIREMENT_POLICY.search(policy_sentence)
+            and not G3_SUBJECT_NEGATED_REQUIREMENT_POLICY.search(policy_sentence)
+        ):
+            return True
     has_g3_context = False
     inherited_deferral_action: str | None = None
     inherited_removal_guard = False
@@ -2468,7 +2510,9 @@ def _g3_sentence_defers_work(policy_sentence: str) -> bool:
         coordinates_g3_subject = bool(
             part_index >= 2
             and preceding_boundary == "and"
-            and G3_REFERENCE.fullmatch(policy_parts[part_index - 2].strip())
+            and G3_COORDINATED_SUBJECT.fullmatch(
+                policy_parts[part_index - 2].strip()
+            )
         )
         coordinates_g3_prerequisite = bool(
             preceding_boundary == "and"
@@ -2523,7 +2567,19 @@ def _g3_sentence_defers_work(policy_sentence: str) -> bool:
 
 
 def _comment_block_defers_g3(comment_block: str) -> bool:
-    normalized_comment = " ".join(comment_block.replace("#", " ").split())
+    normalized_comment = ""
+    previous_comment_line = ""
+    for raw_comment_line in comment_block.splitlines():
+        comment_line = " ".join(raw_comment_line.replace("#", " ").split())
+        separator = " "
+        if (
+            normalized_comment
+            and REMEDIATION_TASK_LINE_REFERENCE.match(comment_line)
+            and not re.search(r"\b(?:and|or)\s*$", previous_comment_line, re.IGNORECASE)
+        ):
+            separator = ". "
+        normalized_comment = f"{normalized_comment}{separator}{comment_line}".strip()
+        previous_comment_line = comment_line
     has_g3_context = False
     for policy_sentence in G3_POLICY_SENTENCE_BOUNDARY.split(normalized_comment):
         sentence_has_g3 = bool(G3_REFERENCE.search(policy_sentence))
@@ -2818,7 +2874,7 @@ def test_g3_deferral_scan_groups_wrapped_comment_blocks(tmp_path: Path):
     comment_blocks = _python_comment_blocks(wrapped_policy)
 
     assert comment_blocks == [
-        (1, "# G3 still # blocks facade removal."),
+        (1, "# G3 still\n# blocks facade removal."),
         (4, "# An unrelated comment."),
     ]
     assert _comment_block_defers_g3(comment_blocks[0][1])
@@ -2858,6 +2914,7 @@ def test_g3_deferral_scan_groups_wrapped_comment_blocks(tmp_path: Path):
         "# G3 is not expected to block facade removal.",
         "# G3 proceeds without blocking facade removal.",
         "# G3 preserves the public facade.",
+        "# G3 requires the public facade to remain.",
         "# G3 preserves facade runtime compatibility.",
         "# G3 blocks cache removal.",
         "# G3 blocks temporary-file removal.",
@@ -2878,6 +2935,9 @@ def test_g3_deferral_scan_groups_wrapped_comment_blocks(tmp_path: Path):
         "# None of the facade removals are blocked by G3.",
         "# None of the test seams remain blocked by G3.",
         "# G3 no longer requires preservation of the test facade.",
+        "# G3 does not require the test facade to remain.",
+        "# No G3 policy requires the test facade to remain.",
+        "# Neither G3 nor T-SEC-4 requires the test facade to remain.",
         "# G3 requires the test facade documentation.",
         "# G3 requires the test seam status.",
         "# G3 allows removing the public facade.",
@@ -2893,6 +2953,8 @@ def test_g3_deferral_scan_groups_wrapped_comment_blocks(tmp_path: Path):
         "# G3 blocks migration and T-SEC-4 blocks facade removal.",
         "# G3 is accepted, but T-SEC-4 keeps the test facade until its work lands.",
         "# G3 is accepted, but T-SEC-4 is pending, so do not remove the test facade until T-SEC-4 lands.",
+        "# G3 is satisfied\n# T-SEC-4 blocks facade removal until its work lands.",
+        "# G3 is satisfied\n# - T-SEC-4 blocks facade removal until its work lands.",
         "# G3 need not land before facade removal.",
         "# Facade removal must not wait for G3.",
         "# Facade removal must land before G3.",
@@ -2950,6 +3012,9 @@ def test_g3_deferral_scan_allows_non_deferral_policy(accepted_policy: str):
         "# G3 and T-SEC-4 block facade removal.",
         "# G3 and T-SEC-4 preserve the test seam.",
         "# G3 and T-SEC-4 keep the test facade until Phase 2.",
+        "# G3 and\n# T-SEC-4 block facade removal.",
+        "# Both G3 and T-SEC-4 block facade removal.",
+        "# Both G3 and\n# T-SEC-4 block facade removal.",
         "# G3 preserves runtime compatibility and the test facade.",
         "# G3 remains pending; therefore preserve the test facade.",
         "# G3 blockers are blocking facade removal.",
@@ -3006,6 +3071,8 @@ def test_g3_deferral_scan_allows_non_deferral_policy(accepted_policy: str):
         "# G3 remains unresolved, requiring preservation of the test facade.",
         "# G3 requires continued preservation of the test facade.",
         "# G3 requires temporary preservation of the test seam.",
+        "# G3 requires the test facade to remain.",
+        "# G3 requires the public facade and test facade to remain.",
         "# G3 still blocks removal of the facade.",
         "# G3 defers removing the facade.",
         "# Until G3 lands, do not remove this facade.",

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2363,6 +2363,10 @@ G3_NEGATED_REMOVAL_DIRECTIVE = re.compile(
     rf"(?=\s*{G3_CONTROLLED_WORK_TAIL_PATTERN})",
     re.IGNORECASE,
 )
+G3_DECLARATIVE_REMOVAL_POLICY = re.compile(
+    rf"\bG3\b\s+means\s+(?:that\s+)?{G3_NEGATED_REMOVAL_DIRECTIVE_PATTERN}",
+    re.IGNORECASE,
+)
 G3_BEFORE_REMOVAL_DIRECTIVE_POLICY = re.compile(
     rf"(?:{G3_NEGATED_REMOVAL_DIRECTIVE_PATTERN}\s+before\s+\bG3\b|"
     rf"\bbefore\s+\bG3\b.{{0,80}}{G3_NEGATED_REMOVAL_DIRECTIVE_PATTERN})",
@@ -2372,7 +2376,7 @@ G3_BEFORE_REFERENCE_POLICY = re.compile(
     r"(?:\bbefore\b.*\bG3\b|\bG3\b.*\bbefore\b)",
     re.IGNORECASE,
 )
-G3_POLICY_SENTENCE_BOUNDARY = re.compile(r"[.?](?=\s|$)")
+G3_POLICY_SENTENCE_BOUNDARY = re.compile(r"([.?])(?=\s|$)")
 G3_POLICY_CLAUSE_BOUNDARY = re.compile(
     r"(;|,|\b(?:and|but|however|while|yet|so|therefore|thus|hence|then)\b)",
     re.IGNORECASE,
@@ -2471,6 +2475,8 @@ def _g3_clause_defers_work(policy_clause: str) -> bool:
         policy_clause
     ) or G3_HISTORICAL_POLICY_CONTEXT.search(policy_clause):
         return False
+    if G3_DECLARATIVE_REMOVAL_POLICY.search(policy_clause):
+        return True
     negated_permission = G3_NEGATED_PERMISSIVE_ACTION.search(policy_clause)
     subject_first_requirement = G3_SUBJECT_FIRST_REQUIREMENT_POLICY.search(
         policy_clause
@@ -2563,6 +2569,7 @@ def _g3_sentence_defers_work(policy_sentence: str) -> bool:
             has_historical_context
             and clause_has_g3
             and G3_ACTIVE_POLICY_CONTEXT.search(policy_clause)
+            and not G3_DECLARATIVE_REMOVAL_POLICY.search(policy_clause)
         ):
             has_historical_context = False
         if preceding_boundary and preceding_boundary != "and":
@@ -2653,7 +2660,11 @@ def _comment_block_defers_g3(comment_block: str) -> bool:
         normalized_comment = f"{normalized_comment}{separator}{comment_line}".strip()
         previous_comment_line = comment_line
     has_g3_context = False
-    for policy_sentence in G3_POLICY_SENTENCE_BOUNDARY.split(normalized_comment):
+    policy_parts = G3_POLICY_SENTENCE_BOUNDARY.split(normalized_comment)
+    for part_index in range(0, len(policy_parts), 2):
+        policy_sentence = policy_parts[part_index]
+        if part_index + 1 < len(policy_parts) and policy_parts[part_index + 1] == "?":
+            policy_sentence = f"{policy_sentence}?"
         sentence_has_g3 = bool(G3_REFERENCE.search(policy_sentence))
         sentence_has_other_task = bool(
             REMEDIATION_TASK_REFERENCE.search(policy_sentence)
@@ -3064,6 +3075,10 @@ def test_g3_deferral_scan_groups_wrapped_comment_blocks(tmp_path: Path):
         "# G3 prohibits blocking facade removal.",
         "# G3 forbids keeping the test facade.",
         "# G3 prohibits T-SEC-4 from blocking facade removal.",
+        "# G3 means facade removal can proceed.",
+        "# Historically, G3 means the facade cannot be removed.",
+        "# Does G3 mean the facade cannot be removed?",
+        "# G3 means the facade cannot be removed?",
         "# G3 preserves the HTTP response wrapper.",
         "# G3 blocks removal of the crawler request wrapper.",
         "# G3 preserves the public API re-export.",
@@ -3121,6 +3136,7 @@ def test_g3_deferral_scan_allows_non_deferral_policy(accepted_policy: str):
         "# G3 and\n# T-SEC-4 must land before facade removal.",
         "# Both G3 and T-SEC-4 must land before facade removal.",
         "# Historically, G3 required the test facade to remain, but G3 still blocks facade removal.",
+        "# Historically, G3 means the facade cannot be removed, but G3 still blocks facade removal.",
         "# Historically, G3 required the test facade to remain, and G3 still blocks facade removal.",
         "# Previously G3 blocked facade removal; G3 still preserves the test seam.",
         "# Historically, the test facade remained in place; G3 still blocks facade removal.",
@@ -3221,6 +3237,7 @@ def test_g3_deferral_scan_allows_non_deferral_policy(accepted_policy: str):
         "# G3 must land. Facade removal remains blocked until then.",
         "# Do not remove the test facade before G3 is accepted.",
         "# The test facade cannot be removed until G3 lands.",
+        "# G3 means the facade cannot be removed.",
     ),
 )
 def test_g3_deferral_scan_detects_positive_policy_after_other_negation(

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2407,9 +2407,17 @@ G3_NEGATED_PREREQUISITE_POLICY = re.compile(
     r"\bG3\b.{0,40}\b(?:no\s+longer|not|never)\b.{0,30}\bprerequisite\b",
     re.IGNORECASE,
 )
+G3_POLICY_RECORD_BRIDGE = re.compile(
+    r"\b(?:adr|decision|documentation|history|note|record|report|status)\b",
+    re.IGNORECASE,
+)
+G3_PASSIVE_ACTION_BRIDGE = re.compile(
+    r"^\s+(?:are|is|remain(?:s)?|was|were)\s+$",
+    re.IGNORECASE,
+)
 
 
-def _positive_g3_deferral_action(policy_clause: str) -> str | None:
+def _positive_g3_deferral_action(policy_clause: str) -> re.Match[str] | None:
     negated_action_spans = [
         negated_action.span()
         for negated_action in G3_NEGATED_DEFERRAL_ACTION.finditer(policy_clause)
@@ -2432,11 +2440,13 @@ def _positive_g3_deferral_action(policy_clause: str) -> str | None:
             policy_clause[deferral_action.end() :]
         ):
             continue
-        return deferral_action.group(0)
+        return deferral_action
     return None
 
 
-def _has_positive_g3_deferred_work(policy_clause: str) -> bool:
+def _positive_g3_deferred_work_matches(
+    policy_clause: str,
+) -> list[re.Match[str]]:
     negated_work_spans = [
         negated_work.span()
         for negated_work in G3_NEGATED_DEFERRED_WORK.finditer(policy_clause)
@@ -2444,10 +2454,34 @@ def _has_positive_g3_deferred_work(policy_clause: str) -> bool:
         contrastive_work.span()
         for contrastive_work in G3_CONTRASTIVE_DEFERRED_WORK.finditer(policy_clause)
     ]
-    return any(
-        not any(start <= deferred_work.start() < end for start, end in negated_work_spans)
+    return [
+        deferred_work
         for deferred_work in G3_DEFERRED_WORK.finditer(policy_clause)
-    )
+        if not any(
+            start <= deferred_work.start() < end
+            for start, end in negated_work_spans
+        )
+    ]
+
+
+def _g3_deferral_action_governs_work(
+    policy_clause: str,
+    deferral_action: re.Match[str],
+) -> bool:
+    for deferred_work in _positive_g3_deferred_work_matches(policy_clause):
+        if deferred_work.start() >= deferral_action.end():
+            action_bridge = policy_clause[
+                deferral_action.end() : deferred_work.start()
+            ]
+            if not G3_POLICY_RECORD_BRIDGE.search(action_bridge):
+                return True
+        if deferral_action.start() >= deferred_work.end() and (
+            G3_PASSIVE_ACTION_BRIDGE.fullmatch(
+                policy_clause[deferred_work.end() : deferral_action.start()]
+            )
+        ):
+            return True
+    return False
 
 
 def _g3_keep_hold_defers_work(policy_text: str) -> bool:
@@ -2481,6 +2515,14 @@ def _g3_clause_defers_work(policy_clause: str) -> bool:
     subject_first_requirement = G3_SUBJECT_FIRST_REQUIREMENT_POLICY.search(
         policy_clause
     )
+    positive_deferral_action = _positive_g3_deferral_action(policy_clause)
+    action_defers_work = bool(
+        positive_deferral_action
+        and _g3_deferral_action_governs_work(
+            policy_clause,
+            positive_deferral_action,
+        )
+    )
     qualified_facade_temporal = G3_QUALIFIED_FACADE_TEMPORAL_POLICY.search(
         policy_clause
     )
@@ -2494,13 +2536,13 @@ def _g3_clause_defers_work(policy_clause: str) -> bool:
         has_deferred_work = (
             subject_first_requirement
             or qualified_facade_temporal
-            or _has_positive_g3_deferred_work(policy_clause)
+            or bool(_positive_g3_deferred_work_matches(policy_clause))
         )
     return bool(
         G3_REFERENCE.search(policy_clause)
         and has_deferred_work
         and (
-            _positive_g3_deferral_action(policy_clause)
+            action_defers_work
             or G3_BLOCKER_POLICY.search(policy_clause)
             or negated_permission
             or _g3_keep_hold_defers_work(policy_clause)
@@ -2612,7 +2654,7 @@ def _g3_sentence_defers_work(policy_sentence: str) -> bool:
             )
         positive_deferral_action = _positive_g3_deferral_action(policy_clause)
         if positive_deferral_action:
-            inherited_deferral_action = positive_deferral_action
+            inherited_deferral_action = positive_deferral_action.group(0)
         elif G3_DEFERRAL_ACTION.search(policy_clause):
             inherited_deferral_action = None
         inherited_policy = ""
@@ -2992,6 +3034,7 @@ def test_g3_deferral_scan_groups_wrapped_comment_blocks(tmp_path: Path):
         "# G3 no longer blocks facade removal while preserving the runtime API.",
         "# G3 blocks are listed in the report.",
         "# G3 preserves runtime API compatibility.",
+        "# G3 preserves the historical ADR about facade removal.",
         "# Facade removal is not blocked by G3.",
         "# Facade removal is not being blocked by G3.",
         "# G3 is pending for historical reference; facade removal is no longer blocked.",

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2131,6 +2131,19 @@ G3_NOUN_ACTION_CONTINUATION = re.compile(
     r"^\s+(?:are|is|was|were|exist|exists|listed|documented)\b",
     re.IGNORECASE,
 )
+G3_PERMISSIVE_ACTION_PATTERN = (
+    r"(?:permit(?:s|ted|ting)?|allow(?:s|ed|ing)?|enabl(?:e|es|ed|ing))"
+)
+G3_PERMISSIVE_ACTION = re.compile(
+    rf"\b{G3_PERMISSIVE_ACTION_PATTERN}\b",
+    re.IGNORECASE,
+)
+G3_NEGATED_PERMISSIVE_ACTION = re.compile(
+    r"\b(?:no\s+longer|never|cannot|can't|does\s+not|doesn't|is\s+not|isn't|"
+    r"not|without)(?!\s+(?:only|just|merely)\b)"
+    rf"{G3_NEGATION_GAP}\s+{G3_PERMISSIVE_ACTION_PATTERN}\b",
+    re.IGNORECASE,
+)
 G3_BLOCKER_POLICY = re.compile(r"\bG3\b\s+remains\s+a\s+blocker\b", re.IGNORECASE)
 G3_PREREQUISITE_POLICY = re.compile(
     r"\bG3\b.{0,40}\b(?:is|remains)\s+(?:a\s+)?prerequisite\b",
@@ -2173,12 +2186,19 @@ def _has_positive_g3_deferred_work(policy_clause: str) -> bool:
 
 
 def _g3_clause_defers_work(policy_clause: str) -> bool:
+    negated_permission = G3_NEGATED_PERMISSIVE_ACTION.search(policy_clause)
+    has_deferred_work = (
+        G3_DEFERRED_WORK.search(policy_clause)
+        if negated_permission
+        else _has_positive_g3_deferred_work(policy_clause)
+    )
     return bool(
         G3_REFERENCE.search(policy_clause)
-        and _has_positive_g3_deferred_work(policy_clause)
+        and has_deferred_work
         and (
             _positive_g3_deferral_action(policy_clause)
             or G3_BLOCKER_POLICY.search(policy_clause)
+            or negated_permission
             or (
                 G3_PREREQUISITE_POLICY.search(policy_clause)
                 and not G3_NEGATED_PREREQUISITE_POLICY.search(policy_clause)
@@ -2195,6 +2215,11 @@ def _g3_sentence_defers_work(policy_sentence: str) -> bool:
     for part_index in range(0, len(policy_parts), 2):
         policy_clause = policy_parts[part_index]
         if preceding_boundary and preceding_boundary != "and":
+            inherited_deferral_action = None
+        if (
+            G3_PERMISSIVE_ACTION.search(policy_clause)
+            and not G3_NEGATED_PERMISSIVE_ACTION.search(policy_clause)
+        ):
             inherited_deferral_action = None
         clause_has_g3 = bool(G3_REFERENCE.search(policy_clause))
         if clause_has_g3:
@@ -2222,10 +2247,17 @@ def _g3_sentence_defers_work(policy_sentence: str) -> bool:
 
 def _comment_block_defers_g3(comment_block: str) -> bool:
     normalized_comment = " ".join(comment_block.replace("#", " ").split())
-    return any(
-        _g3_sentence_defers_work(policy_sentence)
-        for policy_sentence in G3_POLICY_SENTENCE_BOUNDARY.split(normalized_comment)
-    )
+    has_g3_context = False
+    for policy_sentence in G3_POLICY_SENTENCE_BOUNDARY.split(normalized_comment):
+        sentence_has_g3 = bool(G3_REFERENCE.search(policy_sentence))
+        if sentence_has_g3:
+            has_g3_context = True
+        scoped_sentence = policy_sentence
+        if has_g3_context and not sentence_has_g3:
+            scoped_sentence = f"G3 {policy_sentence}"
+        if _g3_sentence_defers_work(scoped_sentence):
+            return True
+    return False
 
 
 G2_OPEN_POLICY = re.compile(
@@ -2506,6 +2538,7 @@ def test_g3_deferral_scan_groups_wrapped_comment_blocks(tmp_path: Path):
         "# G3 no longer remains a prerequisite for facade removal.",
         "# G3 no longer is a prerequisite for facade removal.",
         "# G3 is no longer a prerequisite for facade removal.",
+        "# G3 preserves runtime compatibility and permits test facade removal.",
     ),
 )
 def test_g3_deferral_scan_allows_non_deferral_policy(accepted_policy: str):
@@ -2539,6 +2572,9 @@ def test_g3_deferral_scan_allows_non_deferral_policy(accepted_policy: str):
         "# Until G3 is resolved, retain the test seam.",
         "# G3 remains a prerequisite for facade removal.",
         "# G3 is not resolved so remains a prerequisite for facade removal.",
+        "# G3 is unresolved. # Facade removal remains blocked.",
+        "# G3 does not permit facade removal.",
+        "# G3 does not allow the test seam.",
     ),
 )
 def test_g3_deferral_scan_detects_positive_policy_after_other_negation(

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2367,7 +2367,7 @@ def _comment_block_defers_g3(comment_block: str) -> bool:
     for policy_sentence in G3_POLICY_SENTENCE_BOUNDARY.split(normalized_comment):
         sentence_has_g3 = bool(G3_REFERENCE.search(policy_sentence))
         if sentence_has_g3:
-            has_g3_context = True
+            has_g3_context = bool(G3_UNRESOLVED_POLICY.search(policy_sentence))
         scoped_sentence = policy_sentence
         if has_g3_context and not sentence_has_g3:
             scoped_sentence = f"G3 {policy_sentence}"
@@ -2695,6 +2695,7 @@ def test_g3_deferral_scan_groups_wrapped_comment_blocks(tmp_path: Path):
         "# G3 defers deleting the test seam status.",
         "# G3 is not a blocker for facade removal.",
         "# G3 blocks cleanup of the facade documentation.",
+        "# G3 is satisfied. T-SEC-4 blocks facade removal until its work lands.",
     ),
 )
 def test_g3_deferral_scan_allows_non_deferral_policy(accepted_policy: str):

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2158,6 +2158,21 @@ G3_REJECTED_KEEP_HOLD_ACTION = re.compile(
     rf"{G3_NEGATION_GAP}\s+{G3_KEEP_HOLD_ACTION_PATTERN}\b",
     re.IGNORECASE,
 )
+G3_REQUIREMENT_MODIFIER_PATTERN = r"(?:a|an|continued|existing|temporary|the)"
+G3_REQUIREMENT_POLICY = re.compile(
+    r"\brequir(?:e|es|ed|ing)\s+"
+    rf"(?:{G3_REQUIREMENT_MODIFIER_PATTERN}\s+){{0,3}}"
+    rf"(?:preserv(?:ation|ing)\s+of\s+"
+    rf"(?:{G3_REQUIREMENT_MODIFIER_PATTERN}\s+){{0,3}})?"
+    rf"{G3_DEFERRED_WORK.pattern}(?=\s*{G3_KEEP_HOLD_TAIL_PATTERN})",
+    re.IGNORECASE,
+)
+G3_NEGATED_REQUIREMENT_POLICY = re.compile(
+    r"\b(?:no\s+longer|never|cannot|can't|does\s+not|doesn't|is\s+not|isn't|"
+    r"not|without)(?!\s+(?:only|just|merely)\b)"
+    rf"{G3_NEGATION_GAP}\s+requir(?:e|es|ed|ing)\b",
+    re.IGNORECASE,
+)
 G3_POLICY_SENTENCE_BOUNDARY = re.compile(r"\.(?=\s|$)")
 G3_POLICY_CLAUSE_BOUNDARY = re.compile(
     r"(;|,|\b(?:and|but|however|while|yet|so|therefore|thus|hence|then)\b)",
@@ -2252,6 +2267,10 @@ def _g3_clause_defers_work(policy_clause: str) -> bool:
             or G3_BLOCKER_POLICY.search(policy_clause)
             or negated_permission
             or _g3_keep_hold_defers_work(policy_clause)
+            or (
+                G3_REQUIREMENT_POLICY.search(policy_clause)
+                and not G3_NEGATED_REQUIREMENT_POLICY.search(policy_clause)
+            )
             or (
                 G3_PREREQUISITE_POLICY.search(policy_clause)
                 and not G3_NEGATED_PREREQUISITE_POLICY.search(policy_clause)
@@ -2608,6 +2627,9 @@ def test_g3_deferral_scan_groups_wrapped_comment_blocks(tmp_path: Path):
         "# G3 is satisfied, so nothing blocks facade removal.",
         "# None of the facade removals are blocked by G3.",
         "# None of the test seams remain blocked by G3.",
+        "# G3 no longer requires preservation of the test facade.",
+        "# G3 requires the test facade documentation.",
+        "# G3 requires the test seam status.",
     ),
 )
 def test_g3_deferral_scan_allows_non_deferral_policy(accepted_policy: str):
@@ -2656,6 +2678,9 @@ def test_g3_deferral_scan_allows_non_deferral_policy(accepted_policy: str):
         "# G3 delays facade removal.",
         "# G3 postpones test seam cleanup.",
         "# Nothing but G3 blocks facade removal.",
+        "# G3 remains unresolved, requiring preservation of the test facade.",
+        "# G3 requires continued preservation of the test facade.",
+        "# G3 requires temporary preservation of the test seam.",
     ),
 )
 def test_g3_deferral_scan_detects_positive_policy_after_other_negation(

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2114,7 +2114,7 @@ G3_CONTROLLED_WORK_TAIL_PATTERN = (
     rf"\b(?:are|is|remain(?:s)?|was|were)\s+{G3_DEFERRAL_ACTION_PATTERN}\b)"
 )
 G3_REMOVAL_FIRST_WORK_PATTERN = (
-    rf"(?:(?:removal|deletion)\s+of\s+"
+    rf"(?:(?:cleanup|deletion|removal)\s+of\s+"
     rf"(?:{G3_REMOVAL_OBJECT_MODIFIER_PATTERN}\s+){{0,3}}"
     rf"{G3_REMOVAL_OBJECT_PATTERN}|"
     rf"(?:remov|delet)(?:e|es|ed|ing)\s+"
@@ -2694,6 +2694,7 @@ def test_g3_deferral_scan_groups_wrapped_comment_blocks(tmp_path: Path):
         "# Until G3 lands, do not remove this facade documentation.",
         "# G3 defers deleting the test seam status.",
         "# G3 is not a blocker for facade removal.",
+        "# G3 blocks cleanup of the facade documentation.",
     ),
 )
 def test_g3_deferral_scan_allows_non_deferral_policy(accepted_policy: str):
@@ -2749,6 +2750,7 @@ def test_g3_deferral_scan_allows_non_deferral_policy(accepted_policy: str):
         "# G3 defers removing the facade.",
         "# Until G3 lands, do not remove this facade.",
         "# G3 is a blocker for facade removal.",
+        "# G3 blocks cleanup of the facade.",
     ),
 )
 def test_g3_deferral_scan_detects_positive_policy_after_other_negation(

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2112,9 +2112,23 @@ G3_REMOVAL_OBJECT_MODIFIER_PATTERN = r"(?:a|an|existing|legacy|temporary|that|th
 G3_ORDERED_PREREQUISITE_ACTION_PATTERN = (
     r"(?:must\s+land\s+before|must\s+wait\s+(?:for|until))"
 )
+G3_PROHIBITION_ACTION_PATTERN = (
+    r"(?:prohibit(?:s|ed|ing)?|forbid(?:s|ding)?|forbade|forbidden)"
+)
+G3_PASSIVE_PROHIBITION_ACTION_PATTERN = r"(?:prohibited|forbidden)"
+G3_PROHIBITION_EMPHASIS_PATTERN = r"(?:(?:[a-z]+ly|still)\s+){0,2}"
+G3_PROHIBITION_REJECTION_PATTERN = (
+    rf"(?:(?:are|is|was|were)\s+{G3_PROHIBITION_EMPHASIS_PATTERN}"
+    rf"{G3_PASSIVE_PROHIBITION_ACTION_PATTERN}\s+from|"
+    rf"{G3_PROHIBITION_EMPHASIS_PATTERN}{G3_PROHIBITION_ACTION_PATTERN}"
+    rf"(?:(?:\s+[a-z0-9-]+){{0,4}}\s+from)?)"
+)
 G3_CONTROLLED_WORK_TAIL_PATTERN = (
     r"(?:$|\b(?:because|pending|unless|until|while)\b|"
     rf"\b{G3_ORDERED_PREREQUISITE_ACTION_PATTERN}\b|"
+    rf"\b(?:are|is|remain(?:s)?|was|were)\s+"
+    rf"{G3_PROHIBITION_EMPHASIS_PATTERN}"
+    rf"{G3_PASSIVE_PROHIBITION_ACTION_PATTERN}\s+by\s+\bG3\b|"
     rf"\b(?:are|is|remain(?:s)?|was|were)\s+{G3_DEFERRAL_ACTION_PATTERN}\b)"
 )
 G3_REMOVAL_FIRST_WORK_PATTERN = (
@@ -2142,6 +2156,16 @@ G3_ORDERED_PREREQUISITE_POLICY = re.compile(
     rf"{G3_DEFERRED_WORK.pattern}\s+must\s+wait\s+(?:for|until)\s+\bG3\b)",
     re.IGNORECASE,
 )
+G3_PROHIBITION_POLICY = re.compile(
+    rf"(?:\bG3\b\s+{G3_PROHIBITION_EMPHASIS_PATTERN}"
+    rf"{G3_PROHIBITION_ACTION_PATTERN}\s+(?:(?:a|an|the)\s+)?"
+    rf"{G3_DEFERRED_WORK.pattern}|"
+    rf"{G3_DEFERRED_WORK.pattern}\s+"
+    rf"(?:are|is|remain(?:s)?|was|were)\s+"
+    rf"{G3_PROHIBITION_EMPHASIS_PATTERN}"
+    rf"{G3_PASSIVE_PROHIBITION_ACTION_PATTERN}\s+by\s+\bG3\b)",
+    re.IGNORECASE,
+)
 G3_NEGATION_GAP = (
     r"(?:\s+(?!(?:so|therefore|thus|hence|then)\b)[a-z][\w'-]*){0,4}"
 )
@@ -2160,6 +2184,11 @@ G3_NEGATED_DEFERRAL_ACTION = re.compile(
 G3_NEGATED_SUBJECT_DEFERRAL_ACTION = re.compile(
     rf"\bnone\s+of\s+(?:the\s+)?{G3_DEFERRED_WORK.pattern}\s+"
     rf"(?:are|is|remain(?:s)?|was|were)\s+{G3_DEFERRAL_ACTION_PATTERN}\b",
+    re.IGNORECASE,
+)
+G3_PROHIBITED_DEFERRAL_ACTION = re.compile(
+    rf"\b{G3_PROHIBITION_REJECTION_PATTERN}\s+"
+    rf"{G3_DEFERRAL_ACTION_PATTERN}\b",
     re.IGNORECASE,
 )
 G3_KEEP_HOLD_ACTION_PATTERN = r"(?:keep(?:s|ing)?|kept|hold(?:s|ing)?|held)"
@@ -2183,7 +2212,8 @@ G3_NEGATED_KEEP_HOLD_ACTION = re.compile(
     re.IGNORECASE,
 )
 G3_REJECTED_KEEP_HOLD_ACTION = re.compile(
-    r"\b(?:avoid(?:s|ed|ing)?|stop(?:s|ped|ping)?)"
+    rf"\b(?:avoid(?:s|ed|ing)?|stop(?:s|ped|ping)?|"
+    rf"{G3_PROHIBITION_REJECTION_PATTERN})"
     rf"{G3_NEGATION_GAP}\s+{G3_KEEP_HOLD_ACTION_PATTERN}\b",
     re.IGNORECASE,
 )
@@ -2260,6 +2290,9 @@ def _positive_g3_deferral_action(policy_clause: str) -> str | None:
         for negated_action in G3_NEGATED_SUBJECT_DEFERRAL_ACTION.finditer(
             policy_clause
         )
+    ] + [
+        negated_action.span()
+        for negated_action in G3_PROHIBITED_DEFERRAL_ACTION.finditer(policy_clause)
     ]
     for deferral_action in G3_DEFERRAL_ACTION.finditer(policy_clause):
         if any(
@@ -2321,6 +2354,7 @@ def _g3_clause_defers_work(policy_clause: str) -> bool:
                 and not G3_NEGATED_PREREQUISITE_POLICY.search(policy_clause)
             )
             or G3_ORDERED_PREREQUISITE_POLICY.search(policy_clause)
+            or G3_PROHIBITION_POLICY.search(policy_clause)
         )
     )
 
@@ -2711,6 +2745,13 @@ def test_g3_deferral_scan_groups_wrapped_comment_blocks(tmp_path: Path):
         "# Facade removal must land before G3.",
         "# G3 must wait for facade removal.",
         "# G3 is satisfied; T-SEC-4 must land before facade removal.",
+        "# G3 does not prohibit facade removal.",
+        "# G3 no longer forbids facade removal.",
+        "# G3 is prohibited from blocking facade removal.",
+        "# G3 is forbidden from blocking facade removal.",
+        "# G3 prohibits blocking facade removal.",
+        "# G3 forbids keeping the test facade.",
+        "# G3 prohibits T-SEC-4 from blocking facade removal.",
     ),
 )
 def test_g3_deferral_scan_allows_non_deferral_policy(accepted_policy: str):
@@ -2769,6 +2810,15 @@ def test_g3_deferral_scan_allows_non_deferral_policy(accepted_policy: str):
         "# G3 blocks cleanup of the facade.",
         "# G3 must land before facade removal.",
         "# Facade removal must wait for G3.",
+        "# G3 prohibits facade removal.",
+        "# G3 forbids facade removal.",
+        "# Facade removal is prohibited by G3.",
+        "# Facade removal is forbidden by G3.",
+        "# G3 still prohibits facade removal.",
+        "# G3 prohibits the removal of the facade.",
+        "# Facade removal is still prohibited by G3.",
+        "# G3 currently prohibits facade removal.",
+        "# Facade removal is explicitly prohibited by G3.",
     ),
 )
 def test_g3_deferral_scan_detects_positive_policy_after_other_negation(

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2097,14 +2097,15 @@ def _python_comment_blocks(source_path: Path) -> list[tuple[int, str]]:
 G3_REFERENCE = re.compile(r"\bG3\b", re.IGNORECASE)
 G3_DEFERRAL_ACTION_PATTERN = (
     r"(?:defer(?:s|red|ring)?|block(?:s|ed|ing)?|preserv(?:e|es|ed|ing)|"
-    r"prevent(?:s|ed|ing)?|retain(?:s|ed)?|retaining)"
+    r"prevent(?:s|ed|ing)?|retain(?:s|ed)?|retaining|delay(?:s|ed|ing)?|"
+    r"postpon(?:e|es|ed|ing))"
 )
 G3_DEFERRAL_ACTION = re.compile(
     rf"\b{G3_DEFERRAL_ACTION_PATTERN}\b",
     re.IGNORECASE,
 )
 G3_DEFERRED_WORK = re.compile(
-    r"(?:facade\s+(?:removal|cleanup)|test\s+(?:facades?|seams?)|"
+    r"(?:facade\s+(?:removals?|cleanups?)|test\s+(?:facades?|seams?)|"
     r"test(?:-only|\s+only)?\s+patch\s+(?:points?|targets?)|patch\s+targets?|"
     r"deduplicat\w*|de-fac\w*)",
     re.IGNORECASE,
@@ -2118,9 +2119,15 @@ G3_NEGATED_DEFERRED_WORK = re.compile(
     re.IGNORECASE,
 )
 G3_NEGATED_DEFERRAL_ACTION = re.compile(
-    r"\b(?:no\s+longer|never|cannot|can't|does\s+not|doesn't|is\s+not|isn't|"
-    r"not|without)(?!\s+(?:only|just|merely)\b)"
+    r"\b(?:(?:nothing|nobody|none)(?!\s+(?:but|other\s+than)\b)|"
+    r"(?:no\s+longer|never|cannot|can't|does\s+not|doesn't|is\s+not|isn't|"
+    r"not|without)(?!\s+(?:only|just|merely)\b))"
     rf"{G3_NEGATION_GAP}\s+{G3_DEFERRAL_ACTION_PATTERN}\b",
+    re.IGNORECASE,
+)
+G3_NEGATED_SUBJECT_DEFERRAL_ACTION = re.compile(
+    rf"\bnone\s+of\s+(?:the\s+)?{G3_DEFERRED_WORK.pattern}\s+"
+    rf"(?:are|is|remain(?:s)?|was|were)\s+{G3_DEFERRAL_ACTION_PATTERN}\b",
     re.IGNORECASE,
 )
 G3_KEEP_HOLD_ACTION_PATTERN = r"(?:keep(?:s|ing)?|kept|hold(?:s|ing)?|held)"
@@ -2188,6 +2195,11 @@ def _positive_g3_deferral_action(policy_clause: str) -> str | None:
     negated_action_spans = [
         negated_action.span()
         for negated_action in G3_NEGATED_DEFERRAL_ACTION.finditer(policy_clause)
+    ] + [
+        negated_action.span()
+        for negated_action in G3_NEGATED_SUBJECT_DEFERRAL_ACTION.finditer(
+            policy_clause
+        )
     ]
     for deferral_action in G3_DEFERRAL_ACTION.finditer(policy_clause):
         if any(
@@ -2593,6 +2605,9 @@ def test_g3_deferral_scan_groups_wrapped_comment_blocks(tmp_path: Path):
         "# The G3 hold note documents facade removal progress.",
         "# Avoid keeping the test facade until G3 is resolved.",
         "# Stop keeping the test seam until G3 is resolved.",
+        "# G3 is satisfied, so nothing blocks facade removal.",
+        "# None of the facade removals are blocked by G3.",
+        "# None of the test seams remain blocked by G3.",
     ),
 )
 def test_g3_deferral_scan_allows_non_deferral_policy(accepted_policy: str):
@@ -2638,6 +2653,9 @@ def test_g3_deferral_scan_allows_non_deferral_policy(accepted_policy: str):
         "# Keep these test patch points until G3 is resolved.",
         "# Keep the test facades until G3 is resolved.",
         "# Keep the test facade while G3 remains unresolved.",
+        "# G3 delays facade removal.",
+        "# G3 postpones test seam cleanup.",
+        "# Nothing but G3 blocks facade removal.",
     ),
 )
 def test_g3_deferral_scan_detects_positive_policy_after_other_negation(

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2109,8 +2109,12 @@ G3_REMOVAL_OBJECT_PATTERN = (
     r"(?:test(?:-only|\s+only)?\s+)?patch\s+(?:points?|targets?))"
 )
 G3_REMOVAL_OBJECT_MODIFIER_PATTERN = r"(?:a|an|existing|legacy|temporary|that|the|this)"
+G3_ORDERED_PREREQUISITE_ACTION_PATTERN = (
+    r"(?:must\s+land\s+before|must\s+wait\s+(?:for|until))"
+)
 G3_CONTROLLED_WORK_TAIL_PATTERN = (
     r"(?:$|\b(?:because|pending|unless|until|while)\b|"
+    rf"\b{G3_ORDERED_PREREQUISITE_ACTION_PATTERN}\b|"
     rf"\b(?:are|is|remain(?:s)?|was|were)\s+{G3_DEFERRAL_ACTION_PATTERN}\b)"
 )
 G3_REMOVAL_FIRST_WORK_PATTERN = (
@@ -2131,6 +2135,11 @@ G3_DIRECT_DEFERRED_WORK_PATTERN = (
 G3_DEFERRED_WORK = re.compile(
     rf"(?:{G3_DIRECT_DEFERRED_WORK_PATTERN}|deduplicat\w*|de-fac\w*|"
     rf"{G3_REMOVAL_FIRST_WORK_PATTERN})",
+    re.IGNORECASE,
+)
+G3_ORDERED_PREREQUISITE_POLICY = re.compile(
+    rf"(?:\bG3\b\s+must\s+land\s+before\s+{G3_DEFERRED_WORK.pattern}|"
+    rf"{G3_DEFERRED_WORK.pattern}\s+must\s+wait\s+(?:for|until)\s+\bG3\b)",
     re.IGNORECASE,
 )
 G3_NEGATION_GAP = (
@@ -2311,6 +2320,7 @@ def _g3_clause_defers_work(policy_clause: str) -> bool:
                 G3_PREREQUISITE_POLICY.search(policy_clause)
                 and not G3_NEGATED_PREREQUISITE_POLICY.search(policy_clause)
             )
+            or G3_ORDERED_PREREQUISITE_POLICY.search(policy_clause)
         )
     )
 
@@ -2696,6 +2706,11 @@ def test_g3_deferral_scan_groups_wrapped_comment_blocks(tmp_path: Path):
         "# G3 is not a blocker for facade removal.",
         "# G3 blocks cleanup of the facade documentation.",
         "# G3 is satisfied. T-SEC-4 blocks facade removal until its work lands.",
+        "# G3 need not land before facade removal.",
+        "# Facade removal must not wait for G3.",
+        "# Facade removal must land before G3.",
+        "# G3 must wait for facade removal.",
+        "# G3 is satisfied; T-SEC-4 must land before facade removal.",
     ),
 )
 def test_g3_deferral_scan_allows_non_deferral_policy(accepted_policy: str):
@@ -2752,6 +2767,8 @@ def test_g3_deferral_scan_allows_non_deferral_policy(accepted_policy: str):
         "# Until G3 lands, do not remove this facade.",
         "# G3 is a blocker for facade removal.",
         "# G3 blocks cleanup of the facade.",
+        "# G3 must land before facade removal.",
+        "# Facade removal must wait for G3.",
     ),
 )
 def test_g3_deferral_scan_detects_positive_policy_after_other_negation(

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2317,11 +2317,13 @@ G3_REQUIREMENT_POLICY = re.compile(
     re.IGNORECASE,
 )
 G3_SUBJECT_FIRST_REQUIREMENT_POLICY = re.compile(
-    rf"\b{G3_REQUIREMENT_ACTION_PATTERN}\s+"
+    rf"(?:\b{G3_REQUIREMENT_ACTION_PATTERN}\s+"
     rf"(?:{G3_REQUIREMENT_MODIFIER_PATTERN}\s+){{0,3}}"
     rf"{G3_RUNTIME_FACADE_PREFIX_PATTERN}"
     rf"{G3_TEST_ONLY_OBJECT_PATTERN}\s+to\s+remain(?:\s+in\s+place)?"
-    rf"(?=\s*{G3_CONTROLLED_WORK_TAIL_PATTERN})",
+    rf"(?=\s*{G3_CONTROLLED_WORK_TAIL_PATTERN})|"
+    rf"\b{G3_RUNTIME_FACADE_PREFIX_PATTERN}{G3_TEST_ONLY_OBJECT_PATTERN}\s+"
+    r"must\s+remain(?:\s+in\s+place)?(?=\s*(?:$|[.,;])))",
     re.IGNORECASE,
 )
 G3_NEGATED_REQUIREMENT_POLICY = re.compile(
@@ -2334,6 +2336,12 @@ G3_SUBJECT_NEGATED_REQUIREMENT_POLICY = re.compile(
     rf"(?:\bno\s+G3\b(?:\s+[a-z-]+){{0,3}}|"
     rf"\bneither\s+G3\s+nor\s+{REMEDIATION_TASK_REFERENCE.pattern})\s+"
     rf"{G3_REQUIREMENT_ACTION_PATTERN}\b",
+    re.IGNORECASE,
+)
+G3_NEGATED_SUBJECT_MUST_REMAIN_POLICY = re.compile(
+    rf"\b(?:no\s+(?:the\s+)?{G3_TEST_ONLY_OBJECT_PATTERN}|"
+    rf"neither\s+(?:the\s+)?{G3_TEST_ONLY_OBJECT_PATTERN}\s+nor\s+"
+    rf"(?:the\s+)?{G3_TEST_ONLY_OBJECT_PATTERN})\s+must\s+remain\b",
     re.IGNORECASE,
 )
 G3_TEMPORAL_REFERENCE_POLICY = re.compile(
@@ -2498,6 +2506,7 @@ def _g3_clause_defers_work(policy_clause: str) -> bool:
                 and not (
                     G3_NEGATED_REQUIREMENT_POLICY.search(policy_clause)
                     or G3_SUBJECT_NEGATED_REQUIREMENT_POLICY.search(policy_clause)
+                    or G3_NEGATED_SUBJECT_MUST_REMAIN_POLICY.search(policy_clause)
                 )
             )
             or (
@@ -2533,6 +2542,7 @@ def _g3_sentence_defers_work(policy_sentence: str) -> bool:
             G3_SUBJECT_FIRST_REQUIREMENT_POLICY.search(policy_sentence)
             and not G3_NEGATED_REQUIREMENT_POLICY.search(policy_sentence)
             and not G3_SUBJECT_NEGATED_REQUIREMENT_POLICY.search(policy_sentence)
+            and not G3_NEGATED_SUBJECT_MUST_REMAIN_POLICY.search(policy_sentence)
         ):
             return True
     has_g3_context = False
@@ -3083,6 +3093,8 @@ def test_g3_deferral_scan_groups_wrapped_comment_blocks(tmp_path: Path):
         "# G3 once blocked facade removal.",
         "# Historically, G3 required the test facade to remain, and G3 preserved the test seam.",
         "# G3 prevents retaining the test facade.",
+        "# G3: no test facade must remain.",
+        "# G3: neither the test facade nor the test seam must remain.",
     ),
 )
 def test_g3_deferral_scan_allows_non_deferral_policy(accepted_policy: str):
@@ -3153,6 +3165,7 @@ def test_g3_deferral_scan_allows_non_deferral_policy(accepted_policy: str):
         "# The test patch point remains until G3 lands.",
         "# The test seam will remain until G3 is accepted.",
         "# The test facades must remain in place until G3 lands.",
+        "# G3: the test facade must remain.",
         "# The test patch point should remain until G3 is resolved.",
         "# The test seam has to remain until G3 is accepted.",
         "# The test seam is required to remain until G3 is accepted.",

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2713,8 +2713,14 @@ def _comment_block_defers_g3(comment_block: str) -> bool:
         )
         if sentence_has_g3:
             has_g3_context = bool(
-                G3_UNRESOLVED_POLICY.search(policy_sentence)
-                or G3_PENDING_PREREQUISITE_POLICY.search(policy_sentence)
+                not G3_NONASSERTIVE_POLICY_CONTEXT.search(policy_sentence)
+                and not G3_HISTORICAL_POLICY_CONTEXT.search(policy_sentence)
+                and (
+                    G3_UNRESOLVED_POLICY.search(policy_sentence)
+                    or G3_PENDING_PREREQUISITE_POLICY.search(policy_sentence)
+                    or G3_TEMPORAL_REFERENCE_POLICY.search(policy_sentence)
+                    or G3_BEFORE_REFERENCE_POLICY.search(policy_sentence)
+                )
             )
         elif sentence_has_other_task:
             has_g3_context = False
@@ -3122,6 +3128,8 @@ def test_g3_deferral_scan_groups_wrapped_comment_blocks(tmp_path: Path):
         "# Historically, G3 means the facade cannot be removed.",
         "# Does G3 mean the facade cannot be removed?",
         "# G3 means the facade cannot be removed?",
+        "# Until G3 lands? Keep the test facade.",
+        "# Historically, before G3 landed. Keep the test facade.",
         "# G3 preserves the HTTP response wrapper.",
         "# G3 blocks removal of the crawler request wrapper.",
         "# G3 preserves the public API re-export.",
@@ -3279,6 +3287,7 @@ def test_g3_deferral_scan_allows_non_deferral_policy(accepted_policy: str):
         "# G3 preserves synchronized globals.",
         "# G3 delays removal of injectable callables.",
         "# G3 must land. Facade removal remains blocked until then.",
+        "# Until G3 lands. Keep the test facade.",
         "# Do not remove the test facade before G3 is accepted.",
         "# The test facade cannot be removed until G3 lands.",
         "# The test facade stays until G3 lands.",

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2095,6 +2095,7 @@ def _python_comment_blocks(source_path: Path) -> list[tuple[int, str]]:
 
 
 G3_REFERENCE = re.compile(r"\bG3\b", re.IGNORECASE)
+REMEDIATION_TASK_REFERENCE = re.compile(r"\bT-[A-Z]+-\d+[A-Z]?\b", re.IGNORECASE)
 G3_DEFERRAL_ACTION_PATTERN = (
     r"(?:defer(?:s|red|ring)?|block(?:s|ed|ing)?|preserv(?:e|es|ed|ing)|"
     r"prevent(?:s|ed|ing)?|retain(?:s|ed)?|retaining|delay(?:s|ed|ing)?|"
@@ -2418,10 +2419,22 @@ def _comment_block_defers_g3(comment_block: str) -> bool:
     has_g3_context = False
     for policy_sentence in G3_POLICY_SENTENCE_BOUNDARY.split(normalized_comment):
         sentence_has_g3 = bool(G3_REFERENCE.search(policy_sentence))
+        sentence_has_other_task = bool(
+            REMEDIATION_TASK_REFERENCE.search(policy_sentence)
+        )
         if sentence_has_g3:
-            has_g3_context = bool(G3_UNRESOLVED_POLICY.search(policy_sentence))
+            has_g3_context = bool(
+                G3_UNRESOLVED_POLICY.search(policy_sentence)
+                or G3_PENDING_PREREQUISITE_POLICY.search(policy_sentence)
+            )
+        elif sentence_has_other_task:
+            has_g3_context = False
         scoped_sentence = policy_sentence
-        if has_g3_context and not sentence_has_g3:
+        if (
+            has_g3_context
+            and not sentence_has_g3
+            and not sentence_has_other_task
+        ):
             scoped_sentence = f"G3 {policy_sentence}"
         if _g3_sentence_defers_work(scoped_sentence):
             return True
@@ -2443,6 +2456,11 @@ G3_UNRESOLVED_POLICY = re.compile(
     r"(?:\bg3\b\s+(?:is|remains)\s+(?:open|pending|unresolved)\b"
     r"|\bg3\b\s*(?:status\s*)?:\s*(?:open|pending|unresolved)\b"
     r"|\b(?:open|pending|unresolved)\s+g3\b)",
+    re.IGNORECASE,
+)
+G3_PENDING_PREREQUISITE_POLICY = re.compile(
+    r"\bG3\b\s+(?:still\s+)?must\s+"
+    r"(?:land|be\s+(?:accepted|completed?|resolved))\s*$",
     re.IGNORECASE,
 )
 PHASE_2_G3_BLOCKER_POLICY = re.compile(
@@ -2767,6 +2785,9 @@ def test_g3_deferral_scan_groups_wrapped_comment_blocks(tmp_path: Path):
         "# G3 preserves the HTTP response wrapper.",
         "# G3 blocks removal of the crawler request wrapper.",
         "# G3 preserves the public API re-export.",
+        "# G3 must land for audit documentation. T-SEC-4 blocks facade removal until its work lands.",
+        "# G3 must land. T-SEC-4 blocks facade removal until its work lands.",
+        "# G3 must land. T-SEC-4 blocks migration until its work lands. Facade removal remains blocked until then.",
     ),
 )
 def test_g3_deferral_scan_allows_non_deferral_policy(accepted_policy: str):
@@ -2839,6 +2860,7 @@ def test_g3_deferral_scan_allows_non_deferral_policy(accepted_policy: str):
         "# G3 blocks removal of the test wrapper.",
         "# G3 preserves synchronized globals.",
         "# G3 delays removal of injectable callables.",
+        "# G3 must land. Facade removal remains blocked until then.",
     ),
 )
 def test_g3_deferral_scan_detects_positive_policy_after_other_negation(

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2228,7 +2228,10 @@ G3_NEGATED_PERMISSIVE_ACTION = re.compile(
     rf"{G3_NEGATION_GAP}\s+{G3_PERMISSIVE_ACTION_PATTERN}\b",
     re.IGNORECASE,
 )
-G3_BLOCKER_POLICY = re.compile(r"\bG3\b\s+remains\s+a\s+blocker\b", re.IGNORECASE)
+G3_BLOCKER_POLICY = re.compile(
+    r"\bG3\b\s+(?:is|remains)\s+a\s+blocker\b",
+    re.IGNORECASE,
+)
 G3_PREREQUISITE_POLICY = re.compile(
     r"\bG3\b.{0,40}\b(?:is|remains)\s+(?:a\s+)?prerequisite\b",
     re.IGNORECASE,
@@ -2690,6 +2693,7 @@ def test_g3_deferral_scan_groups_wrapped_comment_blocks(tmp_path: Path):
         "# G3 blocks removal of the facade documentation.",
         "# Until G3 lands, do not remove this facade documentation.",
         "# G3 defers deleting the test seam status.",
+        "# G3 is not a blocker for facade removal.",
     ),
 )
 def test_g3_deferral_scan_allows_non_deferral_policy(accepted_policy: str):
@@ -2744,6 +2748,7 @@ def test_g3_deferral_scan_allows_non_deferral_policy(accepted_policy: str):
         "# G3 still blocks removal of the facade.",
         "# G3 defers removing the facade.",
         "# Until G3 lands, do not remove this facade.",
+        "# G3 is a blocker for facade removal.",
     ),
 )
 def test_g3_deferral_scan_detects_positive_policy_after_other_negation(

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2159,7 +2159,7 @@ G3_COPULAR_TEMPORAL_ACTION_PATTERN = (
     r"(?:(?:must|shall|should|will)\s+(?:(?:continue\s+to|still)\s+)?|"
     r"(?:has|have|needs?)\s+to\s+|"
     r"(?:are|is)\s+(?:still\s+)?required\s+to\s+)?"
-    r"remain(?:s)?\s+(?:in\s+place\s+)?until\s+\bG3\b"
+    r"(?:remain(?:s)?|stay(?:s)?)\s+(?:in\s+place\s+)?until\s+\bG3\b"
 )
 G3_CONTROLLED_WORK_TAIL_PATTERN = (
     rf"(?:$|\b{G3_CONTROLLED_WORK_CONTINUATION_PATTERN}\b|"
@@ -3088,6 +3088,7 @@ def test_g3_deferral_scan_groups_wrapped_comment_blocks(tmp_path: Path):
         "# Do not remove the test facade before T-SEC-4 lands; G3 is accepted.",
         "# G3 is accepted; do not remove the test facade before T-SEC-4 lands.",
         "# G3 records whether the test seam remains until G3 is accepted.",
+        "# G3 asks whether the test facade stays until G3 lands.",
         "# G3 asks whether the test seam remains until G3 is accepted.",
         "# G3 checks whether the test seam remains until G3 is accepted.",
         "# Does the test seam remain until G3 is accepted?",
@@ -3237,6 +3238,7 @@ def test_g3_deferral_scan_allows_non_deferral_policy(accepted_policy: str):
         "# G3 must land. Facade removal remains blocked until then.",
         "# Do not remove the test facade before G3 is accepted.",
         "# The test facade cannot be removed until G3 lands.",
+        "# The test facade stays until G3 lands.",
         "# G3 means the facade cannot be removed.",
     ),
 )

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2104,10 +2104,33 @@ G3_DEFERRAL_ACTION = re.compile(
     rf"\b{G3_DEFERRAL_ACTION_PATTERN}\b",
     re.IGNORECASE,
 )
+G3_REMOVAL_OBJECT_PATTERN = (
+    r"(?:facades?|test\s+(?:facades?|seams?)|"
+    r"(?:test(?:-only|\s+only)?\s+)?patch\s+(?:points?|targets?))"
+)
+G3_REMOVAL_OBJECT_MODIFIER_PATTERN = r"(?:a|an|existing|legacy|temporary|that|the|this)"
+G3_CONTROLLED_WORK_TAIL_PATTERN = (
+    r"(?:$|\b(?:because|pending|unless|until|while)\b|"
+    rf"\b(?:are|is|remain(?:s)?|was|were)\s+{G3_DEFERRAL_ACTION_PATTERN}\b)"
+)
+G3_REMOVAL_FIRST_WORK_PATTERN = (
+    rf"(?:(?:removal|deletion)\s+of\s+"
+    rf"(?:{G3_REMOVAL_OBJECT_MODIFIER_PATTERN}\s+){{0,3}}"
+    rf"{G3_REMOVAL_OBJECT_PATTERN}|"
+    rf"(?:remov|delet)(?:e|es|ed|ing)\s+"
+    rf"(?:{G3_REMOVAL_OBJECT_MODIFIER_PATTERN}\s+){{0,3}}"
+    rf"{G3_REMOVAL_OBJECT_PATTERN})"
+    rf"(?=\s*{G3_CONTROLLED_WORK_TAIL_PATTERN})"
+)
+G3_DIRECT_DEFERRED_WORK_PATTERN = (
+    r"(?:facade\s+(?:removals?|cleanups?)|"
+    r"test\s+(?:facades?|seams?)(?:\s+(?:removals?|cleanups?))?|"
+    r"test(?:-only|\s+only)?\s+patch\s+(?:points?|targets?)|patch\s+targets?)"
+    rf"(?=\s*{G3_CONTROLLED_WORK_TAIL_PATTERN})"
+)
 G3_DEFERRED_WORK = re.compile(
-    r"(?:facade\s+(?:removals?|cleanups?)|test\s+(?:facades?|seams?)|"
-    r"test(?:-only|\s+only)?\s+patch\s+(?:points?|targets?)|patch\s+targets?|"
-    r"deduplicat\w*|de-fac\w*)",
+    rf"(?:{G3_DIRECT_DEFERRED_WORK_PATTERN}|deduplicat\w*|de-fac\w*|"
+    rf"{G3_REMOVAL_FIRST_WORK_PATTERN})",
     re.IGNORECASE,
 )
 G3_NEGATION_GAP = (
@@ -2138,13 +2161,10 @@ G3_KEEP_HOLD_NON_OBJECT_PATTERN = (
 G3_KEEP_HOLD_OBJECT_MODIFIER_PATTERN = (
     rf"(?!(?:{G3_KEEP_HOLD_NON_OBJECT_PATTERN})\b)[a-z][\w'-]*"
 )
-G3_KEEP_HOLD_TAIL_PATTERN = (
-    r"(?:$|\b(?:because|pending|unless|until|while)\b)"
-)
 G3_KEEP_HOLD_POLICY = re.compile(
     rf"\b{G3_KEEP_HOLD_ACTION_PATTERN}\b"
     rf"(?:\s+{G3_KEEP_HOLD_OBJECT_MODIFIER_PATTERN}){{0,4}}\s+"
-    rf"{G3_DEFERRED_WORK.pattern}(?=\s*{G3_KEEP_HOLD_TAIL_PATTERN})",
+    rf"{G3_DEFERRED_WORK.pattern}(?=\s*{G3_CONTROLLED_WORK_TAIL_PATTERN})",
     re.IGNORECASE,
 )
 G3_NEGATED_KEEP_HOLD_ACTION = re.compile(
@@ -2164,13 +2184,26 @@ G3_REQUIREMENT_POLICY = re.compile(
     rf"(?:{G3_REQUIREMENT_MODIFIER_PATTERN}\s+){{0,3}}"
     rf"(?:preserv(?:ation|ing)\s+of\s+"
     rf"(?:{G3_REQUIREMENT_MODIFIER_PATTERN}\s+){{0,3}})?"
-    rf"{G3_DEFERRED_WORK.pattern}(?=\s*{G3_KEEP_HOLD_TAIL_PATTERN})",
+    rf"{G3_DEFERRED_WORK.pattern}(?=\s*{G3_CONTROLLED_WORK_TAIL_PATTERN})",
     re.IGNORECASE,
 )
 G3_NEGATED_REQUIREMENT_POLICY = re.compile(
     r"\b(?:no\s+longer|never|cannot|can't|does\s+not|doesn't|is\s+not|isn't|"
     r"not|without)(?!\s+(?:only|just|merely)\b)"
     rf"{G3_NEGATION_GAP}\s+requir(?:e|es|ed|ing)\b",
+    re.IGNORECASE,
+)
+G3_TEMPORAL_REFERENCE_POLICY = re.compile(
+    r"(?:\b(?:pending|unless|until|while)\b.*\bG3\b|"
+    r"\bG3\b.*\b(?:pending|unless|until|while)\b)",
+    re.IGNORECASE,
+)
+G3_NEGATED_REMOVAL_DIRECTIVE = re.compile(
+    r"\b(?:cannot|can't|do\s+not|don't|never)\s+"
+    rf"(?:remov|delet)(?:e|es|ed|ing)\s+"
+    rf"(?:{G3_REMOVAL_OBJECT_MODIFIER_PATTERN}\s+){{0,3}}"
+    rf"{G3_REMOVAL_OBJECT_PATTERN}"
+    rf"(?=\s*{G3_CONTROLLED_WORK_TAIL_PATTERN})",
     re.IGNORECASE,
 )
 G3_POLICY_SENTENCE_BOUNDARY = re.compile(r"\.(?=\s|$)")
@@ -2280,6 +2313,10 @@ def _g3_clause_defers_work(policy_clause: str) -> bool:
 
 
 def _g3_sentence_defers_work(policy_sentence: str) -> bool:
+    if G3_TEMPORAL_REFERENCE_POLICY.search(
+        policy_sentence
+    ) and G3_NEGATED_REMOVAL_DIRECTIVE.search(policy_sentence):
+        return True
     if G3_REFERENCE.search(policy_sentence) and _g3_keep_hold_defers_work(
         policy_sentence
     ):
@@ -2497,6 +2534,11 @@ def test_test_patch_points_policy_has_accepted_adr_and_effective_runbook():
         "## 5. PHASE 2 — DEDUPLICATION & DE-FACADING",
         "\n### T-DA-1:",
     )
+    t_db_1_entry = _required_markdown_section(
+        remediation_ledger,
+        "### T-DB-1: Collapse the summary_backfill facade",
+        "\n### T-DC-1:",
+    )
     complete_row = next(
         line for line in remediation_ledger.splitlines() if line.startswith("| **Complete** |")
     )
@@ -2551,6 +2593,19 @@ def test_test_patch_points_policy_has_accepted_adr_and_effective_runbook():
     )
     assert not G3_UNRESOLVED_POLICY.search(active_g3_policy)
     assert not PHASE_2_G3_BLOCKER_POLICY.search(active_g3_policy)
+    assert "Reduce injectable-callable" not in t_db_1_entry
+    assert "summary callable" not in t_db_1_entry
+    assert "no injectable-callable params" in t_db_1_entry
+    assert "inference provider" in t_db_1_entry
+    for owned_path in (
+        "pipeline/task_facade_helpers.py",
+        "pipeline/tasks.py",
+        "tests/test_pipeline_batching.py",
+        "tests/test_run_pipeline_orchestration.py",
+        "tests/test_staged_hydrate_cities.py",
+        "tests/test_tasks_agenda_summary_format.py",
+    ):
+        assert owned_path in t_db_1_entry
 
 
 def test_live_python_does_not_treat_g3_as_a_facade_deferral():
@@ -2630,6 +2685,11 @@ def test_g3_deferral_scan_groups_wrapped_comment_blocks(tmp_path: Path):
         "# G3 no longer requires preservation of the test facade.",
         "# G3 requires the test facade documentation.",
         "# G3 requires the test seam status.",
+        "# G3 allows removing the public facade.",
+        "# G3 does not remove the public facade.",
+        "# G3 blocks removal of the facade documentation.",
+        "# Until G3 lands, do not remove this facade documentation.",
+        "# G3 defers deleting the test seam status.",
     ),
 )
 def test_g3_deferral_scan_allows_non_deferral_policy(accepted_policy: str):
@@ -2681,6 +2741,9 @@ def test_g3_deferral_scan_allows_non_deferral_policy(accepted_policy: str):
         "# G3 remains unresolved, requiring preservation of the test facade.",
         "# G3 requires continued preservation of the test facade.",
         "# G3 requires temporary preservation of the test seam.",
+        "# G3 still blocks removal of the facade.",
+        "# G3 defers removing the facade.",
+        "# Until G3 lands, do not remove this facade.",
     ),
 )
 def test_g3_deferral_scan_detects_positive_policy_after_other_negation(

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2104,9 +2104,16 @@ G3_DEFERRAL_ACTION = re.compile(
     rf"\b{G3_DEFERRAL_ACTION_PATTERN}\b",
     re.IGNORECASE,
 )
+G3_LEGACY_SEAM_OBJECT_PATTERN = (
+    r"(?:(?:compatibility|monkeypatch|test)\s+(?:re-exports?|wrappers?)|"
+    r"(?:monkeypatch\s+)?compatibility\s+shims?|"
+    r"(?:bidirectional(?:ly)?\s+)?synchronized\s+globals?|"
+    r"injectable(?:-|\s+)callables?(?:\s+(?:parameters?|seams?))?)"
+)
 G3_REMOVAL_OBJECT_PATTERN = (
     r"(?:facades?|test\s+(?:facades?|seams?)|"
-    r"(?:test(?:-only|\s+only)?\s+)?patch\s+(?:points?|targets?))"
+    r"(?:test(?:-only|\s+only)?\s+)?patch\s+(?:points?|targets?)|"
+    rf"{G3_LEGACY_SEAM_OBJECT_PATTERN})"
 )
 G3_REMOVAL_OBJECT_MODIFIER_PATTERN = r"(?:a|an|existing|legacy|temporary|that|the|this)"
 G3_ORDERED_PREREQUISITE_ACTION_PATTERN = (
@@ -2143,7 +2150,8 @@ G3_REMOVAL_FIRST_WORK_PATTERN = (
 G3_DIRECT_DEFERRED_WORK_PATTERN = (
     r"(?:facade\s+(?:removals?|cleanups?)|"
     r"test\s+(?:facades?|seams?)(?:\s+(?:removals?|cleanups?))?|"
-    r"test(?:-only|\s+only)?\s+patch\s+(?:points?|targets?)|patch\s+targets?)"
+    r"test(?:-only|\s+only)?\s+patch\s+(?:points?|targets?)|patch\s+targets?|"
+    rf"{G3_LEGACY_SEAM_OBJECT_PATTERN})"
     rf"(?=\s*{G3_CONTROLLED_WORK_TAIL_PATTERN})"
 )
 G3_DEFERRED_WORK = re.compile(
@@ -2752,6 +2760,9 @@ def test_g3_deferral_scan_groups_wrapped_comment_blocks(tmp_path: Path):
         "# G3 prohibits blocking facade removal.",
         "# G3 forbids keeping the test facade.",
         "# G3 prohibits T-SEC-4 from blocking facade removal.",
+        "# G3 preserves the HTTP response wrapper.",
+        "# G3 blocks removal of the crawler request wrapper.",
+        "# G3 preserves the public API re-export.",
     ),
 )
 def test_g3_deferral_scan_allows_non_deferral_policy(accepted_policy: str):
@@ -2819,6 +2830,11 @@ def test_g3_deferral_scan_allows_non_deferral_policy(accepted_policy: str):
         "# Facade removal is still prohibited by G3.",
         "# G3 currently prohibits facade removal.",
         "# Facade removal is explicitly prohibited by G3.",
+        "# G3 remains pending, so preserve the monkeypatch compatibility shim.",
+        "# G3 preserves the test re-export until Phase 2.",
+        "# G3 blocks removal of the test wrapper.",
+        "# G3 preserves synchronized globals.",
+        "# G3 delays removal of injectable callables.",
     ),
 )
 def test_g3_deferral_scan_detects_positive_policy_after_other_negation(

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2051,6 +2051,14 @@ def _required_markdown_section(markdown: str, heading: str, next_heading: str) -
     return " ".join(section.split())
 
 
+def _required_markdown_entry(markdown: str, heading: str) -> str:
+    _, heading_separator, section_remainder = markdown.partition(heading)
+    assert heading_separator, f"Missing required Markdown heading: {heading}"
+    next_heading = re.search(r"\n## ", section_remainder)
+    assert next_heading, f"Missing Markdown boundary after: {heading}"
+    return " ".join(section_remainder[: next_heading.start()].split())
+
+
 def _python_comment_blocks(source_path: Path) -> list[tuple[int, str]]:
     source_text = source_path.read_text(encoding="utf-8")
     source_lines = source_text.splitlines()
@@ -2217,6 +2225,17 @@ G3_NONASSERTIVE_POLICY_CONTEXT = re.compile(
     r"record(?:s|ed|ing)?|report(?:s|ed|ing)?|track(?:s|ed|ing)?)\s*"
     rf"(?:(?:if|whether)\b|:\s*{G3_INTERROGATIVE_OPENING_PATTERN}\b)|"
     rf"^\s*{G3_INTERROGATIVE_OPENING_PATTERN}\b|\?\s*$)",
+    re.IGNORECASE,
+)
+G3_HISTORICAL_POLICY_CONTEXT = re.compile(
+    r"(?:^\s*(?:historically|previously|formerly|in\s+the\s+past)\b"
+    r"|\bG3\b(?:\s+[a-z][\w'-]*){0,3}\s+once(?!\s+again\b))",
+    re.IGNORECASE,
+)
+G3_ACTIVE_POLICY_CONTEXT = re.compile(
+    r"\b(?:are|is|has|have|must|shall|should|will|cannot|can't|currently|now|still|"
+    r"defers|blocks|preserves|prevents|retains|delays|postpones|keeps|holds|"
+    r"requires|prohibits|forbids)\b",
     re.IGNORECASE,
 )
 G3_ORDERED_PREREQUISITE_POLICY = re.compile(
@@ -2435,7 +2454,9 @@ def _g3_keep_hold_defers_work(policy_text: str) -> bool:
 
 
 def _g3_clause_defers_work(policy_clause: str) -> bool:
-    if G3_NONASSERTIVE_POLICY_CONTEXT.search(policy_clause):
+    if G3_NONASSERTIVE_POLICY_CONTEXT.search(
+        policy_clause
+    ) or G3_HISTORICAL_POLICY_CONTEXT.search(policy_clause):
         return False
     negated_permission = G3_NEGATED_PERMISSIVE_ACTION.search(policy_clause)
     subject_first_requirement = G3_SUBJECT_FIRST_REQUIREMENT_POLICY.search(
@@ -2493,7 +2514,14 @@ def _g3_sentence_defers_work(policy_sentence: str) -> bool:
     sentence_has_other_task = bool(
         REMEDIATION_TASK_REFERENCE.search(policy_sentence)
     )
-    if not sentence_has_other_task and G3_REFERENCE.search(policy_sentence):
+    sentence_is_historical = bool(
+        G3_HISTORICAL_POLICY_CONTEXT.search(policy_sentence)
+    )
+    if (
+        not sentence_has_other_task
+        and not sentence_is_historical
+        and G3_REFERENCE.search(policy_sentence)
+    ):
         if _g3_keep_hold_defers_work(policy_sentence):
             return True
         if (
@@ -2503,12 +2531,25 @@ def _g3_sentence_defers_work(policy_sentence: str) -> bool:
         ):
             return True
     has_g3_context = False
+    has_historical_context = False
     inherited_deferral_action: str | None = None
     inherited_removal_guard = False
     preceding_boundary = ""
     policy_parts = G3_POLICY_CLAUSE_BOUNDARY.split(policy_sentence)
     for part_index in range(0, len(policy_parts), 2):
         policy_clause = policy_parts[part_index]
+        clause_has_g3 = bool(G3_REFERENCE.search(policy_clause))
+        clause_is_historical = bool(
+            G3_HISTORICAL_POLICY_CONTEXT.search(policy_clause)
+        )
+        if clause_is_historical:
+            has_historical_context = True
+        elif (
+            has_historical_context
+            and clause_has_g3
+            and G3_ACTIVE_POLICY_CONTEXT.search(policy_clause)
+        ):
+            has_historical_context = False
         if preceding_boundary and preceding_boundary != "and":
             inherited_deferral_action = None
         if (
@@ -2516,7 +2557,6 @@ def _g3_sentence_defers_work(policy_sentence: str) -> bool:
             and not G3_NEGATED_PERMISSIVE_ACTION.search(policy_clause)
         ):
             inherited_deferral_action = None
-        clause_has_g3 = bool(G3_REFERENCE.search(policy_clause))
         clause_has_other_task = bool(
             REMEDIATION_TASK_REFERENCE.search(policy_clause)
         )
@@ -2562,6 +2602,10 @@ def _g3_sentence_defers_work(policy_sentence: str) -> bool:
         ):
             inherited_policy = f"{inherited_policy}{inherited_deferral_action} "
         scoped_clause = f"{inherited_policy}{policy_clause}"
+        if has_historical_context:
+            if part_index + 1 < len(policy_parts):
+                preceding_boundary = policy_parts[part_index + 1].lower()
+            continue
         if G3_BEFORE_REMOVAL_DIRECTIVE_POLICY.search(scoped_clause):
             return True
         if G3_TEMPORAL_REFERENCE_POLICY.search(
@@ -2759,10 +2803,9 @@ def test_test_patch_points_policy_has_accepted_adr_and_effective_runbook():
     remediation_ledger = (
         ROOT / "docs" / "plans" / "TOWN_COUNCIL_REMEDIATION_PLAN.md"
     ).read_text(encoding="utf-8")
-    test_patch_point_decision = _required_markdown_section(
+    test_patch_point_decision = _required_markdown_entry(
         architecture_decisions,
         "## 2026-07-24: Test patch points are not a public API",
-        "\n## 2026-05-17:",
     )
     g3_entry = _required_markdown_section(
         remediation_ledger,
@@ -2860,6 +2903,29 @@ def test_test_patch_points_policy_has_accepted_adr_and_effective_runbook():
     ):
         assert owned_path in t_db_1_entry
         assert owned_path in dedup_b_row
+
+
+def test_test_patch_point_adr_boundary_uses_the_next_decision_heading():
+    architecture_decisions = """
+## 2026-07-24: Test patch points are not a public API
+
+- Status: Accepted
+
+## 2026-07-23: Unrelated later decision
+
+- Status: Proposed
+
+## 2026-05-17: Older decision
+
+- Status: Accepted
+"""
+
+    test_patch_point_decision = _required_markdown_entry(
+        architecture_decisions,
+        "## 2026-07-24: Test patch points are not a public API",
+    )
+
+    assert test_patch_point_decision == "- Status: Accepted"
 
 
 def test_live_python_does_not_treat_g3_as_a_facade_deferral():
@@ -3008,6 +3074,9 @@ def test_g3_deferral_scan_groups_wrapped_comment_blocks(tmp_path: Path):
         "# Did G3 block facade removal until Phase 2?",
         "# Was G3 preserving the test seam until Phase 2?",
         "# Did G3 require preservation of the test facade until Phase 2?",
+        "# Historically, G3 required the test facade to remain.",
+        "# G3 once blocked facade removal.",
+        "# Historically, G3 required the test facade to remain, and G3 preserved the test seam.",
     ),
 )
 def test_g3_deferral_scan_allows_non_deferral_policy(accepted_policy: str):
@@ -3032,6 +3101,13 @@ def test_g3_deferral_scan_allows_non_deferral_policy(accepted_policy: str):
         "# G3 and T-SEC-4 must land before facade removal.",
         "# G3 and\n# T-SEC-4 must land before facade removal.",
         "# Both G3 and T-SEC-4 must land before facade removal.",
+        "# Historically, G3 required the test facade to remain, but G3 still blocks facade removal.",
+        "# Historically, G3 required the test facade to remain, and G3 still blocks facade removal.",
+        "# Previously G3 blocked facade removal; G3 still preserves the test seam.",
+        "# Historically, the test facade remained in place; G3 still blocks facade removal.",
+        "# Historically, the test facade remained in place, and G3 now preserves the test seam.",
+        "# Historically, the test facade remained in place, and G3 blocks facade removal.",
+        "# G3 once again blocks facade removal.",
         "# G3 preserves runtime compatibility and the test facade.",
         "# G3 remains pending; therefore preserve the test facade.",
         "# G3 blockers are blocking facade removal.",

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2119,7 +2119,8 @@ G3_DEFERRAL_ACTION = re.compile(
     re.IGNORECASE,
 )
 G3_LEGACY_SEAM_OBJECT_PATTERN = (
-    r"(?:(?:compatibility|monkeypatch|test)\s+(?:re-exports?|wrappers?)|"
+    r"(?:(?:compatibility|monkeypatch)\s+(?:re-exports?|wrappers?)|"
+    r"test(?:-only|\s+only)?\s+(?:re-exports?|wrappers?)|"
     r"(?:monkeypatch\s+)?compatibility\s+shims?|"
     r"(?:bidirectional(?:ly)?\s+)?synchronized\s+globals?|"
     r"injectable(?:-|\s+)callables?(?:\s+(?:parameters?|seams?))?)"
@@ -3191,6 +3192,7 @@ def test_g3_deferral_scan_allows_non_deferral_policy(accepted_policy: str):
         "# Facade removal is explicitly prohibited by G3.",
         "# G3 remains pending, so preserve the monkeypatch compatibility shim.",
         "# G3 preserves the test re-export until Phase 2.",
+        "# G3 still blocks removal of test-only re-exports.",
         "# G3 blocks removal of the test wrapper.",
         "# G3 preserves synchronized globals.",
         "# G3 delays removal of injectable callables.",

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2104,7 +2104,8 @@ G3_DEFERRAL_ACTION = re.compile(
     re.IGNORECASE,
 )
 G3_DEFERRED_WORK = re.compile(
-    r"(?:facade\s+(?:removal|cleanup)|test\s+(?:facade|seam)|patch\s+target|"
+    r"(?:facade\s+(?:removal|cleanup)|test\s+(?:facades?|seams?)|"
+    r"test(?:-only|\s+only)?\s+patch\s+(?:points?|targets?)|patch\s+targets?|"
     r"deduplicat\w*|de-fac\w*)",
     re.IGNORECASE,
 )
@@ -2120,6 +2121,34 @@ G3_NEGATED_DEFERRAL_ACTION = re.compile(
     r"\b(?:no\s+longer|never|cannot|can't|does\s+not|doesn't|is\s+not|isn't|"
     r"not|without)(?!\s+(?:only|just|merely)\b)"
     rf"{G3_NEGATION_GAP}\s+{G3_DEFERRAL_ACTION_PATTERN}\b",
+    re.IGNORECASE,
+)
+G3_KEEP_HOLD_ACTION_PATTERN = r"(?:keep(?:s|ing)?|kept|hold(?:s|ing)?|held)"
+G3_KEEP_HOLD_NON_OBJECT_PATTERN = (
+    r"(?:about|comment|discussion|documentation|for|note|of|on|policy|progress|"
+    r"record|regarding|report|status|tracking)"
+)
+G3_KEEP_HOLD_OBJECT_MODIFIER_PATTERN = (
+    rf"(?!(?:{G3_KEEP_HOLD_NON_OBJECT_PATTERN})\b)[a-z][\w'-]*"
+)
+G3_KEEP_HOLD_TAIL_PATTERN = (
+    r"(?:$|\b(?:because|pending|unless|until|while)\b)"
+)
+G3_KEEP_HOLD_POLICY = re.compile(
+    rf"\b{G3_KEEP_HOLD_ACTION_PATTERN}\b"
+    rf"(?:\s+{G3_KEEP_HOLD_OBJECT_MODIFIER_PATTERN}){{0,4}}\s+"
+    rf"{G3_DEFERRED_WORK.pattern}(?=\s*{G3_KEEP_HOLD_TAIL_PATTERN})",
+    re.IGNORECASE,
+)
+G3_NEGATED_KEEP_HOLD_ACTION = re.compile(
+    r"\b(?:no\s+longer|never|cannot|can't|does\s+not|doesn't|is\s+not|isn't|"
+    r"not|without)(?!\s+(?:only|just|merely)\b)"
+    rf"{G3_NEGATION_GAP}\s+{G3_KEEP_HOLD_ACTION_PATTERN}\b",
+    re.IGNORECASE,
+)
+G3_REJECTED_KEEP_HOLD_ACTION = re.compile(
+    r"\b(?:avoid(?:s|ed|ing)?|stop(?:s|ped|ping)?)"
+    rf"{G3_NEGATION_GAP}\s+{G3_KEEP_HOLD_ACTION_PATTERN}\b",
     re.IGNORECASE,
 )
 G3_POLICY_SENTENCE_BOUNDARY = re.compile(r"\.(?=\s|$)")
@@ -2185,6 +2214,17 @@ def _has_positive_g3_deferred_work(policy_clause: str) -> bool:
     )
 
 
+def _g3_keep_hold_defers_work(policy_text: str) -> bool:
+    negated_permission = G3_NEGATED_PERMISSIVE_ACTION.search(policy_text)
+    positive_permission = G3_PERMISSIVE_ACTION.search(policy_text)
+    return bool(
+        G3_KEEP_HOLD_POLICY.search(policy_text)
+        and not G3_NEGATED_KEEP_HOLD_ACTION.search(policy_text)
+        and not G3_REJECTED_KEEP_HOLD_ACTION.search(policy_text)
+        and not (positive_permission and not negated_permission)
+    )
+
+
 def _g3_clause_defers_work(policy_clause: str) -> bool:
     negated_permission = G3_NEGATED_PERMISSIVE_ACTION.search(policy_clause)
     has_deferred_work = (
@@ -2199,6 +2239,7 @@ def _g3_clause_defers_work(policy_clause: str) -> bool:
             _positive_g3_deferral_action(policy_clause)
             or G3_BLOCKER_POLICY.search(policy_clause)
             or negated_permission
+            or _g3_keep_hold_defers_work(policy_clause)
             or (
                 G3_PREREQUISITE_POLICY.search(policy_clause)
                 and not G3_NEGATED_PREREQUISITE_POLICY.search(policy_clause)
@@ -2208,6 +2249,10 @@ def _g3_clause_defers_work(policy_clause: str) -> bool:
 
 
 def _g3_sentence_defers_work(policy_sentence: str) -> bool:
+    if G3_REFERENCE.search(policy_sentence) and _g3_keep_hold_defers_work(
+        policy_sentence
+    ):
+        return True
     has_g3_context = False
     inherited_deferral_action: str | None = None
     preceding_boundary = ""
@@ -2539,6 +2584,15 @@ def test_g3_deferral_scan_groups_wrapped_comment_blocks(tmp_path: Path):
         "# G3 no longer is a prerequisite for facade removal.",
         "# G3 is no longer a prerequisite for facade removal.",
         "# G3 preserves runtime compatibility and permits test facade removal.",
+        "# G3 is on hold and facade removal continues.",
+        "# G3 permits keeping the test facade.",
+        "# G3 does not keep the test facade.",
+        "# Do not hold the test seam until G3 is resolved.",
+        "# G3 keeps documentation for the test facade current.",
+        "# G3 keeps the test facade documentation current.",
+        "# The G3 hold note documents facade removal progress.",
+        "# Avoid keeping the test facade until G3 is resolved.",
+        "# Stop keeping the test seam until G3 is resolved.",
     ),
 )
 def test_g3_deferral_scan_allows_non_deferral_policy(accepted_policy: str):
@@ -2575,6 +2629,15 @@ def test_g3_deferral_scan_allows_non_deferral_policy(accepted_policy: str):
         "# G3 is unresolved. # Facade removal remains blocked.",
         "# G3 does not permit facade removal.",
         "# G3 does not allow the test seam.",
+        "# Keep the test facade until G3 is resolved.",
+        "# Hold the test seam until G3 is resolved.",
+        "# Keep the test patch point until G3 is resolved.",
+        "# Keep this test-only patch point until G3 is resolved.",
+        "# Keep our test facade until G3 is resolved.",
+        "# Keep the compatibility-only test facade until G3 is resolved.",
+        "# Keep these test patch points until G3 is resolved.",
+        "# Keep the test facades until G3 is resolved.",
+        "# Keep the test facade while G3 remains unresolved.",
     ),
 )
 def test_g3_deferral_scan_detects_positive_policy_after_other_negation(

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2112,7 +2112,7 @@ G3_COORDINATED_SUBJECT = re.compile(r"^\s*(?:both\s+)?G3\s*$", re.IGNORECASE)
 G3_DEFERRAL_ACTION_PATTERN = (
     r"(?:defer(?:s|red|ring)?|block(?:s|ed|ing)?|preserv(?:e|es|ed|ing)|"
     r"prevent(?:s|ed|ing)?|retain(?:s|ed)?|retaining|delay(?:s|ed|ing)?|"
-    r"postpon(?:e|es|ed|ing)|gat(?:es|ed|ing))"
+    r"postpon(?:e|es|ed|ing)|stop(?:s|ped|ping)?|gat(?:es|ed|ing))"
 )
 G3_DEFERRAL_ACTION = re.compile(
     rf"\b{G3_DEFERRAL_ACTION_PATTERN}\b",
@@ -2159,10 +2159,11 @@ G3_CONTROLLED_WORK_CONTINUATION_PATTERN = (
     r"can\s+(?:proceed|be\s+(?:cleaned\s+up|deleted|removed))"
 )
 G3_COPULAR_TEMPORAL_ACTION_PATTERN = (
-    r"(?:(?:must|shall|should|will)\s+(?:(?:continue\s+to|still)\s+)?|"
+    r"(?:(?:(?:must|shall|should|will)\s+(?:(?:continue\s+to|still)\s+)?|"
     r"(?:has|have|needs?)\s+to\s+|"
     r"(?:are|is)\s+(?:still\s+)?required\s+to\s+)?"
-    r"(?:remain(?:s)?|stay(?:s)?)\s+(?:in\s+place\s+)?until\s+\bG3\b"
+    r"(?:remain(?:s)?|stay(?:s)?)\s+(?:in\s+place\s+)?until\s+\bG3\b|"
+    r"(?:cannot|can't)\s+begin\s+until\s+\bG3\b)"
 )
 G3_CONTROLLED_WORK_TAIL_PATTERN = (
     rf"(?:$|\b{G3_CONTROLLED_WORK_CONTINUATION_PATTERN}\b|"
@@ -2285,7 +2286,8 @@ G3_NEGATED_SUBJECT_DEFERRAL_ACTION = re.compile(
     re.IGNORECASE,
 )
 G3_PROHIBITED_DEFERRAL_ACTION = re.compile(
-    rf"\b(?:{G3_PROHIBITION_REJECTION_PATTERN}|prevent(?:s|ed|ing)?)\s+"
+    rf"\b(?:{G3_PROHIBITION_REJECTION_PATTERN}|prevent(?:s|ed|ing)?|"
+    rf"stop(?:s|ped|ping)?)\s+"
     rf"{G3_DEFERRAL_ACTION_PATTERN}\b",
     re.IGNORECASE,
 )
@@ -2435,6 +2437,9 @@ def _positive_g3_deferral_action(policy_clause: str) -> re.Match[str] | None:
     ] + [
         negated_action.span()
         for negated_action in G3_PROHIBITED_DEFERRAL_ACTION.finditer(policy_clause)
+    ] + [
+        rejected_action.span()
+        for rejected_action in G3_REJECTED_KEEP_HOLD_ACTION.finditer(policy_clause)
     ]
     for deferral_action in G3_DEFERRAL_ACTION.finditer(policy_clause):
         if any(
@@ -3170,6 +3175,8 @@ def test_g3_deferral_scan_groups_wrapped_comment_blocks(tmp_path: Path):
         "# G3 once blocked facade removal.",
         "# Historically, G3 required the test facade to remain, and G3 preserved the test seam.",
         "# G3 prevents retaining the test facade.",
+        "# G3 stops retaining the test facade.",
+        "# Phase 2 can begin after G3 lands.",
         "# G3: no test facade must remain.",
         "# G3: neither the test facade nor the test seam must remain.",
         "# G3 records the Phase 2 gate.",
@@ -3221,6 +3228,7 @@ def test_g3_deferral_scan_allows_non_deferral_policy(accepted_policy: str):
         "# G3 is unresolved, therefore block facade removal.",
         "# G3 remains a blocker for facade removal.",
         "# G3 prevents facade removal.",
+        "# G3 stops facade removal.",
         "# Until G3 is resolved, retain the test seam.",
         "# Until G3 lands, do not remove the test facade, but T-SEC-4 status is current.",
         "# T-SEC-4 status is current, but before G3 lands, do not remove the test facade.",
@@ -3259,6 +3267,7 @@ def test_g3_deferral_scan_allows_non_deferral_policy(accepted_policy: str):
         "# Does G3 block migration? G3 preserves the test seam.",
         "# G3 delays facade removal.",
         "# Facade removal is gated on G3.",
+        "# Phase 2 cannot begin until G3 lands.",
         "# G3 gates Phase 2.",
         "# G3 postpones test seam cleanup.",
         "# Nothing but G3 blocks facade removal.",

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2307,6 +2307,10 @@ G3_BEFORE_REMOVAL_DIRECTIVE_POLICY = re.compile(
     rf"\bbefore\s+\bG3\b.{{0,80}}{G3_NEGATED_REMOVAL_DIRECTIVE_PATTERN})",
     re.IGNORECASE,
 )
+G3_BEFORE_REFERENCE_POLICY = re.compile(
+    r"(?:\bbefore\b.*\bG3\b|\bG3\b.*\bbefore\b)",
+    re.IGNORECASE,
+)
 G3_POLICY_SENTENCE_BOUNDARY = re.compile(r"[.?](?=\s|$)")
 G3_POLICY_CLAUSE_BOUNDARY = re.compile(
     r"(;|,|\b(?:and|but|however|while|yet|so|therefore|thus|hence|then)\b)",
@@ -2437,18 +2441,15 @@ def _g3_clause_defers_work(policy_clause: str) -> bool:
 
 
 def _g3_sentence_defers_work(policy_sentence: str) -> bool:
-    if G3_BEFORE_REMOVAL_DIRECTIVE_POLICY.search(policy_sentence):
-        return True
-    if G3_TEMPORAL_REFERENCE_POLICY.search(
-        policy_sentence
-    ) and G3_NEGATED_REMOVAL_DIRECTIVE.search(policy_sentence):
-        return True
-    if G3_REFERENCE.search(policy_sentence) and _g3_keep_hold_defers_work(
-        policy_sentence
+    if (
+        not REMEDIATION_TASK_REFERENCE.search(policy_sentence)
+        and G3_REFERENCE.search(policy_sentence)
+        and _g3_keep_hold_defers_work(policy_sentence)
     ):
         return True
     has_g3_context = False
     inherited_deferral_action: str | None = None
+    inherited_removal_guard = False
     preceding_boundary = ""
     policy_parts = G3_POLICY_CLAUSE_BOUNDARY.split(policy_sentence)
     for part_index in range(0, len(policy_parts), 2):
@@ -2461,8 +2462,35 @@ def _g3_sentence_defers_work(policy_sentence: str) -> bool:
         ):
             inherited_deferral_action = None
         clause_has_g3 = bool(G3_REFERENCE.search(policy_clause))
+        clause_has_other_task = bool(
+            REMEDIATION_TASK_REFERENCE.search(policy_clause)
+        )
+        coordinates_g3_subject = bool(
+            part_index >= 2
+            and preceding_boundary == "and"
+            and G3_REFERENCE.fullmatch(policy_parts[part_index - 2].strip())
+        )
+        coordinates_g3_prerequisite = bool(
+            preceding_boundary == "and"
+            and inherited_removal_guard
+            and not G3_DEFERRAL_ACTION.search(policy_clause)
+            and not G3_DEFERRED_WORK.search(policy_clause)
+        )
+        if (
+            clause_has_other_task
+            and not clause_has_g3
+            and not coordinates_g3_subject
+            and not coordinates_g3_prerequisite
+        ):
+            has_g3_context = False
+            inherited_deferral_action = None
+            inherited_removal_guard = False
         if clause_has_g3:
             has_g3_context = True
+            inherited_removal_guard = bool(
+                G3_TEMPORAL_REFERENCE_POLICY.search(policy_clause)
+                or G3_BEFORE_REFERENCE_POLICY.search(policy_clause)
+            )
         positive_deferral_action = _positive_g3_deferral_action(policy_clause)
         if positive_deferral_action:
             inherited_deferral_action = positive_deferral_action
@@ -2477,6 +2505,16 @@ def _g3_sentence_defers_work(policy_sentence: str) -> bool:
         ):
             inherited_policy = f"{inherited_policy}{inherited_deferral_action} "
         scoped_clause = f"{inherited_policy}{policy_clause}"
+        if G3_BEFORE_REMOVAL_DIRECTIVE_POLICY.search(scoped_clause):
+            return True
+        if G3_TEMPORAL_REFERENCE_POLICY.search(
+            scoped_clause
+        ) and G3_NEGATED_REMOVAL_DIRECTIVE.search(scoped_clause):
+            return True
+        if inherited_removal_guard and G3_NEGATED_REMOVAL_DIRECTIVE.search(
+            policy_clause
+        ):
+            return True
         if _g3_clause_defers_work(scoped_clause):
             return True
         if part_index + 1 < len(policy_parts):
@@ -2850,6 +2888,11 @@ def test_g3_deferral_scan_groups_wrapped_comment_blocks(tmp_path: Path):
         "# G3 is not a blocker for facade removal.",
         "# G3 blocks cleanup of the facade documentation.",
         "# G3 is satisfied. T-SEC-4 blocks facade removal until its work lands.",
+        "# G3 is accepted, but T-SEC-4 blocks facade removal.",
+        "# G3 is accepted and T-SEC-4 blocks facade removal.",
+        "# G3 blocks migration and T-SEC-4 blocks facade removal.",
+        "# G3 is accepted, but T-SEC-4 keeps the test facade until its work lands.",
+        "# G3 is accepted, but T-SEC-4 is pending, so do not remove the test facade until T-SEC-4 lands.",
         "# G3 need not land before facade removal.",
         "# Facade removal must not wait for G3.",
         "# Facade removal must land before G3.",
@@ -2904,6 +2947,9 @@ def test_g3_deferral_scan_allows_non_deferral_policy(accepted_policy: str):
         "# G3 no longer blocks one cleanup, yet G3 still preserves the test facade.",
         "# G3 no longer blocks facade removal and still preserves the test seam.",
         "# G3 blocks migration and facade removal.",
+        "# G3 and T-SEC-4 block facade removal.",
+        "# G3 and T-SEC-4 preserve the test seam.",
+        "# G3 and T-SEC-4 keep the test facade until Phase 2.",
         "# G3 preserves runtime compatibility and the test facade.",
         "# G3 remains pending; therefore preserve the test facade.",
         "# G3 blockers are blocking facade removal.",
@@ -2920,6 +2966,10 @@ def test_g3_deferral_scan_allows_non_deferral_policy(accepted_policy: str):
         "# G3 remains a blocker for facade removal.",
         "# G3 prevents facade removal.",
         "# Until G3 is resolved, retain the test seam.",
+        "# Until G3 lands, do not remove the test facade, but T-SEC-4 status is current.",
+        "# T-SEC-4 status is current, but before G3 lands, do not remove the test facade.",
+        "# Until G3 lands and T-SEC-4 is complete, do not remove the test facade.",
+        "# Before G3 lands and T-SEC-4 is complete, do not remove the test facade.",
         "# G3 remains a prerequisite for facade removal.",
         "# G3 is not resolved so remains a prerequisite for facade removal.",
         "# G3 is unresolved. # Facade removal remains blocked.",

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2203,6 +2203,11 @@ G3_COPULAR_TEMPORAL_POLICY = re.compile(
     rf"{G3_DEFERRED_WORK.pattern}\s+{G3_COPULAR_TEMPORAL_ACTION_PATTERN}",
     re.IGNORECASE,
 )
+G3_QUALIFIED_FACADE_TEMPORAL_POLICY = re.compile(
+    rf"\b(?:the\s+)?[a-z_]\w*(?:\.[a-z_]\w*)+\s+facades?\s+"
+    rf"{G3_COPULAR_TEMPORAL_ACTION_PATTERN}",
+    re.IGNORECASE,
+)
 G3_INTERROGATIVE_OPENING_PATTERN = (
     r"(?:am|are|can|could|did|do|does|had|has|have|how|is|may|might|must|"
     r"shall|should|was|were|what|when|where|which|who|why|will|would)"
@@ -2215,7 +2220,8 @@ G3_NONASSERTIVE_POLICY_CONTEXT = re.compile(
     re.IGNORECASE,
 )
 G3_ORDERED_PREREQUISITE_POLICY = re.compile(
-    rf"(?:\bG3\b\s+{G3_MUST_PRECEDE_ACTION_PATTERN}\s+"
+    rf"(?:\bG3\b\s+(?:{REMEDIATION_TASK_REFERENCE.pattern}\s+)?"
+    rf"{G3_MUST_PRECEDE_ACTION_PATTERN}\s+"
     rf"(?:{G3_REMOVAL_OBJECT_MODIFIER_PATTERN}\s+){{0,2}}"
     rf"{G3_DEFERRED_WORK.pattern}|"
     rf"{G3_DEFERRED_WORK.pattern}\s+must\s+wait\s+(?:for|until)\s+\bG3\b)",
@@ -2435,13 +2441,19 @@ def _g3_clause_defers_work(policy_clause: str) -> bool:
     subject_first_requirement = G3_SUBJECT_FIRST_REQUIREMENT_POLICY.search(
         policy_clause
     )
+    qualified_facade_temporal = G3_QUALIFIED_FACADE_TEMPORAL_POLICY.search(
+        policy_clause
+    )
     if negated_permission:
-        has_deferred_work = subject_first_requirement or G3_DEFERRED_WORK.search(
-            policy_clause
+        has_deferred_work = (
+            subject_first_requirement
+            or qualified_facade_temporal
+            or G3_DEFERRED_WORK.search(policy_clause)
         )
     else:
         has_deferred_work = (
             subject_first_requirement
+            or qualified_facade_temporal
             or _has_positive_g3_deferred_work(policy_clause)
         )
     return bool(
@@ -2470,6 +2482,7 @@ def _g3_clause_defers_work(policy_clause: str) -> bool:
                 G3_COPULAR_TEMPORAL_POLICY.search(policy_clause)
                 and not G3_NONASSERTIVE_POLICY_CONTEXT.search(policy_clause)
             )
+            or qualified_facade_temporal
             or G3_ORDERED_PREREQUISITE_POLICY.search(policy_clause)
             or G3_PROHIBITION_POLICY.search(policy_clause)
         )
@@ -2915,6 +2928,7 @@ def test_g3_deferral_scan_groups_wrapped_comment_blocks(tmp_path: Path):
         "# G3 proceeds without blocking facade removal.",
         "# G3 preserves the public facade.",
         "# G3 requires the public facade to remain.",
+        "# The api.main facade does not remain until G3 lands.",
         "# G3 preserves facade runtime compatibility.",
         "# G3 blocks cache removal.",
         "# G3 blocks temporary-file removal.",
@@ -3015,6 +3029,9 @@ def test_g3_deferral_scan_allows_non_deferral_policy(accepted_policy: str):
         "# G3 and\n# T-SEC-4 block facade removal.",
         "# Both G3 and T-SEC-4 block facade removal.",
         "# Both G3 and\n# T-SEC-4 block facade removal.",
+        "# G3 and T-SEC-4 must land before facade removal.",
+        "# G3 and\n# T-SEC-4 must land before facade removal.",
+        "# Both G3 and T-SEC-4 must land before facade removal.",
         "# G3 preserves runtime compatibility and the test facade.",
         "# G3 remains pending; therefore preserve the test facade.",
         "# G3 blockers are blocking facade removal.",
@@ -3073,6 +3090,7 @@ def test_g3_deferral_scan_allows_non_deferral_policy(accepted_policy: str):
         "# G3 requires temporary preservation of the test seam.",
         "# G3 requires the test facade to remain.",
         "# G3 requires the public facade and test facade to remain.",
+        "# The api.main facade remains until G3 lands.",
         "# G3 still blocks removal of the facade.",
         "# G3 defers removing the facade.",
         "# Until G3 lands, do not remove this facade.",

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2121,6 +2121,7 @@ G3_DEFERRAL_ACTION = re.compile(
 G3_LEGACY_SEAM_OBJECT_PATTERN = (
     r"(?:(?:compatibility|monkeypatch)\s+(?:re-exports?|wrappers?)|"
     r"test(?:-only|\s+only)?\s+(?:re-exports?|wrappers?)|"
+    r"test\s+facade\s+wrappers?|"
     r"(?:monkeypatch\s+)?compatibility\s+shims?|"
     r"(?:bidirectional(?:ly)?\s+)?synchronized\s+globals?|"
     r"injectable(?:-|\s+)callables?(?:\s+(?:parameters?|seams?))?)"
@@ -2278,7 +2279,7 @@ G3_NEGATED_SUBJECT_DEFERRAL_ACTION = re.compile(
     re.IGNORECASE,
 )
 G3_PROHIBITED_DEFERRAL_ACTION = re.compile(
-    rf"\b{G3_PROHIBITION_REJECTION_PATTERN}\s+"
+    rf"\b(?:{G3_PROHIBITION_REJECTION_PATTERN}|prevent(?:s|ed|ing)?)\s+"
     rf"{G3_DEFERRAL_ACTION_PATTERN}\b",
     re.IGNORECASE,
 )
@@ -2341,10 +2342,13 @@ G3_TEMPORAL_REFERENCE_POLICY = re.compile(
     re.IGNORECASE,
 )
 G3_NEGATED_REMOVAL_DIRECTIVE_PATTERN = (
-    r"\b(?:cannot|can't|do\s+not|don't|never)\s+"
+    r"(?:\b(?:cannot|can't|do\s+not|don't|never)\s+"
     rf"(?:remov|delet)(?:e|es|ed|ing)\s+"
     rf"(?:{G3_REMOVAL_OBJECT_MODIFIER_PATTERN}\s+){{0,3}}"
-    rf"{G3_REMOVAL_OBJECT_PATTERN}"
+    rf"{G3_REMOVAL_OBJECT_PATTERN}|"
+    rf"\b(?:{G3_REMOVAL_OBJECT_MODIFIER_PATTERN}\s+){{0,3}}"
+    rf"{G3_REMOVAL_OBJECT_PATTERN}\s+(?:cannot|can't)\s+be\s+"
+    r"(?:removed|deleted))"
 )
 G3_NEGATED_REMOVAL_DIRECTIVE = re.compile(
     rf"{G3_NEGATED_REMOVAL_DIRECTIVE_PATTERN}"
@@ -3078,6 +3082,7 @@ def test_g3_deferral_scan_groups_wrapped_comment_blocks(tmp_path: Path):
         "# Historically, G3 required the test facade to remain.",
         "# G3 once blocked facade removal.",
         "# Historically, G3 required the test facade to remain, and G3 preserved the test seam.",
+        "# G3 prevents retaining the test facade.",
     ),
 )
 def test_g3_deferral_scan_allows_non_deferral_policy(accepted_policy: str):
@@ -3193,11 +3198,13 @@ def test_g3_deferral_scan_allows_non_deferral_policy(accepted_policy: str):
         "# G3 remains pending, so preserve the monkeypatch compatibility shim.",
         "# G3 preserves the test re-export until Phase 2.",
         "# G3 still blocks removal of test-only re-exports.",
+        "# G3 blocks removal of test facade wrappers.",
         "# G3 blocks removal of the test wrapper.",
         "# G3 preserves synchronized globals.",
         "# G3 delays removal of injectable callables.",
         "# G3 must land. Facade removal remains blocked until then.",
         "# Do not remove the test facade before G3 is accepted.",
+        "# The test facade cannot be removed until G3 lands.",
     ),
 )
 def test_g3_deferral_scan_detects_positive_policy_after_other_negation(

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2137,8 +2137,15 @@ G3_PROHIBITION_REJECTION_PATTERN = (
 G3_CONTROLLED_WORK_CONTINUATION_PATTERN = (
     r"can\s+(?:proceed|be\s+(?:cleaned\s+up|deleted|removed))"
 )
+G3_COPULAR_TEMPORAL_ACTION_PATTERN = (
+    r"(?:(?:must|shall|should|will)\s+(?:(?:continue\s+to|still)\s+)?|"
+    r"(?:has|have|needs?)\s+to\s+|"
+    r"(?:are|is)\s+(?:still\s+)?required\s+to\s+)?"
+    r"remain(?:s)?\s+(?:in\s+place\s+)?until\s+\bG3\b"
+)
 G3_CONTROLLED_WORK_TAIL_PATTERN = (
     rf"(?:$|\b{G3_CONTROLLED_WORK_CONTINUATION_PATTERN}\b|"
+    rf"\b{G3_COPULAR_TEMPORAL_ACTION_PATTERN}|"
     r"\b(?:because|pending|unless|until|while)\b|"
     rf"\b{G3_ORDERED_PREREQUISITE_ACTION_PATTERN}\b|"
     rf"\b(?:are|is|remain(?:s)?|was|were)\s+"
@@ -2165,6 +2172,37 @@ G3_DIRECT_DEFERRED_WORK_PATTERN = (
 G3_DEFERRED_WORK = re.compile(
     rf"(?:{G3_DIRECT_DEFERRED_WORK_PATTERN}|deduplicat\w*|de-fac\w*|"
     rf"{G3_REMOVAL_FIRST_WORK_PATTERN})",
+    re.IGNORECASE,
+)
+G3_PERMISSIVE_ACTION_PATTERN = (
+    r"(?:permit(?:s|ted|ting)?|allow(?:s|ed|ing)?|enabl(?:e|es|ed|ing))"
+)
+G3_KEEP_HOLD_ACTION_PATTERN = r"(?:keep(?:s|ing)?|kept|hold(?:s|ing)?|held)"
+G3_REQUIREMENT_ACTION_PATTERN = r"requir(?:e|es|ed|ing)"
+G3_REQUIREMENT_MODIFIER_PATTERN = r"(?:a|an|continued|existing|temporary|the)"
+G3_CONTRASTIVE_DEFERRED_WORK = re.compile(
+    rf"\b(?:instead\s+of|rather\s+than)\s+"
+    rf"(?:(?:{G3_DEFERRAL_ACTION_PATTERN}|{G3_PERMISSIVE_ACTION_PATTERN}|"
+    rf"{G3_KEEP_HOLD_ACTION_PATTERN}|{G3_REQUIREMENT_ACTION_PATTERN}"
+    rf"(?:\s+(?:{G3_REQUIREMENT_MODIFIER_PATTERN}\s+){{0,3}}"
+    rf"preserv(?:ation|ing)\s+of)?)\s+)?"
+    rf"(?:{G3_REMOVAL_OBJECT_MODIFIER_PATTERN}\s+){{0,2}}"
+    rf"{G3_DEFERRED_WORK.pattern}",
+    re.IGNORECASE,
+)
+G3_COPULAR_TEMPORAL_POLICY = re.compile(
+    rf"{G3_DEFERRED_WORK.pattern}\s+{G3_COPULAR_TEMPORAL_ACTION_PATTERN}",
+    re.IGNORECASE,
+)
+G3_INTERROGATIVE_OPENING_PATTERN = (
+    r"(?:am|are|can|could|did|do|does|had|has|have|how|is|may|might|must|"
+    r"shall|should|was|were|what|when|where|which|who|why|will|would)"
+)
+G3_NONASSERTIVE_POLICY_CONTEXT = re.compile(
+    r"(?:\b(?:ask(?:s|ed|ing)?|check(?:s|ed|ing)?|document(?:s|ed|ing)?|"
+    r"record(?:s|ed|ing)?|report(?:s|ed|ing)?|track(?:s|ed|ing)?)\s*"
+    rf"(?:(?:if|whether)\b|:\s*{G3_INTERROGATIVE_OPENING_PATTERN}\b)|"
+    rf"^\s*{G3_INTERROGATIVE_OPENING_PATTERN}\b|\?\s*$)",
     re.IGNORECASE,
 )
 G3_ORDERED_PREREQUISITE_POLICY = re.compile(
@@ -2209,7 +2247,6 @@ G3_PROHIBITED_DEFERRAL_ACTION = re.compile(
     rf"{G3_DEFERRAL_ACTION_PATTERN}\b",
     re.IGNORECASE,
 )
-G3_KEEP_HOLD_ACTION_PATTERN = r"(?:keep(?:s|ing)?|kept|hold(?:s|ing)?|held)"
 G3_KEEP_HOLD_NON_OBJECT_PATTERN = (
     r"(?:about|comment|discussion|documentation|for|note|of|on|policy|progress|"
     r"record|regarding|report|status|tracking)"
@@ -2235,9 +2272,8 @@ G3_REJECTED_KEEP_HOLD_ACTION = re.compile(
     rf"{G3_NEGATION_GAP}\s+{G3_KEEP_HOLD_ACTION_PATTERN}\b",
     re.IGNORECASE,
 )
-G3_REQUIREMENT_MODIFIER_PATTERN = r"(?:a|an|continued|existing|temporary|the)"
 G3_REQUIREMENT_POLICY = re.compile(
-    r"\brequir(?:e|es|ed|ing)\s+"
+    rf"\b{G3_REQUIREMENT_ACTION_PATTERN}\s+"
     rf"(?:{G3_REQUIREMENT_MODIFIER_PATTERN}\s+){{0,3}}"
     rf"(?:preserv(?:ation|ing)\s+of\s+"
     rf"(?:{G3_REQUIREMENT_MODIFIER_PATTERN}\s+){{0,3}})?"
@@ -2271,7 +2307,7 @@ G3_BEFORE_REMOVAL_DIRECTIVE_POLICY = re.compile(
     rf"\bbefore\s+\bG3\b.{{0,80}}{G3_NEGATED_REMOVAL_DIRECTIVE_PATTERN})",
     re.IGNORECASE,
 )
-G3_POLICY_SENTENCE_BOUNDARY = re.compile(r"\.(?=\s|$)")
+G3_POLICY_SENTENCE_BOUNDARY = re.compile(r"[.?](?=\s|$)")
 G3_POLICY_CLAUSE_BOUNDARY = re.compile(
     r"(;|,|\b(?:and|but|however|while|yet|so|therefore|thus|hence|then)\b)",
     re.IGNORECASE,
@@ -2279,9 +2315,6 @@ G3_POLICY_CLAUSE_BOUNDARY = re.compile(
 G3_NOUN_ACTION_CONTINUATION = re.compile(
     r"^\s+(?:are|is|was|were|exist|exists|listed|documented)\b",
     re.IGNORECASE,
-)
-G3_PERMISSIVE_ACTION_PATTERN = (
-    r"(?:permit(?:s|ted|ting)?|allow(?:s|ed|ing)?|enabl(?:e|es|ed|ing))"
 )
 G3_PERMISSIVE_ACTION = re.compile(
     rf"\b{G3_PERMISSIVE_ACTION_PATTERN}\b",
@@ -2338,6 +2371,9 @@ def _has_positive_g3_deferred_work(policy_clause: str) -> bool:
     negated_work_spans = [
         negated_work.span()
         for negated_work in G3_NEGATED_DEFERRED_WORK.finditer(policy_clause)
+    ] + [
+        contrastive_work.span()
+        for contrastive_work in G3_CONTRASTIVE_DEFERRED_WORK.finditer(policy_clause)
     ]
     return any(
         not any(start <= deferred_work.start() < end for start, end in negated_work_spans)
@@ -2348,15 +2384,26 @@ def _has_positive_g3_deferred_work(policy_clause: str) -> bool:
 def _g3_keep_hold_defers_work(policy_text: str) -> bool:
     negated_permission = G3_NEGATED_PERMISSIVE_ACTION.search(policy_text)
     positive_permission = G3_PERMISSIVE_ACTION.search(policy_text)
+    contrastive_spans = [
+        contrastive_work.span()
+        for contrastive_work in G3_CONTRASTIVE_DEFERRED_WORK.finditer(policy_text)
+    ]
+    positive_keep_hold = any(
+        not any(start <= keep_hold.start() < end for start, end in contrastive_spans)
+        for keep_hold in G3_KEEP_HOLD_POLICY.finditer(policy_text)
+    )
     return bool(
-        G3_KEEP_HOLD_POLICY.search(policy_text)
+        positive_keep_hold
         and not G3_NEGATED_KEEP_HOLD_ACTION.search(policy_text)
         and not G3_REJECTED_KEEP_HOLD_ACTION.search(policy_text)
+        and not G3_NONASSERTIVE_POLICY_CONTEXT.search(policy_text)
         and not (positive_permission and not negated_permission)
     )
 
 
 def _g3_clause_defers_work(policy_clause: str) -> bool:
+    if G3_NONASSERTIVE_POLICY_CONTEXT.search(policy_clause):
+        return False
     negated_permission = G3_NEGATED_PERMISSIVE_ACTION.search(policy_clause)
     has_deferred_work = (
         G3_DEFERRED_WORK.search(policy_clause)
@@ -2378,6 +2425,10 @@ def _g3_clause_defers_work(policy_clause: str) -> bool:
             or (
                 G3_PREREQUISITE_POLICY.search(policy_clause)
                 and not G3_NEGATED_PREREQUISITE_POLICY.search(policy_clause)
+            )
+            or (
+                G3_COPULAR_TEMPORAL_POLICY.search(policy_clause)
+                and not G3_NONASSERTIVE_POLICY_CONTEXT.search(policy_clause)
             )
             or G3_ORDERED_PREREQUISITE_POLICY.search(policy_clause)
             or G3_PROHIBITION_POLICY.search(policy_clause)
@@ -2753,6 +2804,16 @@ def test_g3_deferral_scan_groups_wrapped_comment_blocks(tmp_path: Path):
         "# G3 blocker is documented and facade removal status is current.",
         "# G3 preservation is documented and facade removal status is current.",
         "# G3 blocks migration, not facade removal.",
+        "# G3 blocks migration rather than facade removal.",
+        "# G3 blocks migration instead of test seam cleanup.",
+        "# G3 blocks migration rather than blocking facade removal.",
+        "# G3 blocks migration instead of allowing facade removal.",
+        "# G3 delays migration rather than preserving the test seam.",
+        "# G3 blocks migration instead of keeping the test facade.",
+        "# G3 blocks migration rather than holding the test seam.",
+        "# G3 blocks migration instead of requiring preservation of the test facade.",
+        "# G3 blocks migration instead of requiring the preservation of the test facade.",
+        "# G3 blocks migration instead of requiring continued preservation of the test facade.",
         "# G3 no longer blocks facade removal, preserving the runtime API.",
         "# G3 blocks neither facade removal nor test seams.",
         "# G3 preserves no test facade.",
@@ -2811,6 +2872,23 @@ def test_g3_deferral_scan_groups_wrapped_comment_blocks(tmp_path: Path):
         "# G3 must land. T-SEC-4 blocks migration until its work lands. Facade removal remains blocked until then.",
         "# Do not remove the test facade before T-SEC-4 lands; G3 is accepted.",
         "# G3 is accepted; do not remove the test facade before T-SEC-4 lands.",
+        "# G3 records whether the test seam remains until G3 is accepted.",
+        "# G3 asks whether the test seam remains until G3 is accepted.",
+        "# G3 checks whether the test seam remains until G3 is accepted.",
+        "# Does the test seam remain until G3 is accepted?",
+        "# Why must the test seam remain until G3 is accepted?",
+        "# The G3 audit asks: does the test seam remain until G3 is accepted?",
+        "# G3 asks whether to keep the test facade until Phase 2.",
+        "# Does G3 block facade removal until G3 is accepted?",
+        "# Why does G3 preserve the test seam until Phase 2?",
+        "# Does G3 require preservation of the test facade until Phase 2?",
+        "# Does G3 prohibit facade removal until Phase 2?",
+        "# May G3 preserve the test seam until Phase 2?",
+        "# Might G3 block facade removal until Phase 2?",
+        "# Shall G3 keep the test facade until Phase 2?",
+        "# Did G3 block facade removal until Phase 2?",
+        "# Was G3 preserving the test seam until Phase 2?",
+        "# Did G3 require preservation of the test facade until Phase 2?",
     ),
 )
 def test_g3_deferral_scan_allows_non_deferral_policy(accepted_policy: str):
@@ -2856,6 +2934,22 @@ def test_g3_deferral_scan_allows_non_deferral_policy(accepted_policy: str):
         "# Keep these test patch points until G3 is resolved.",
         "# Keep the test facades until G3 is resolved.",
         "# Keep the test facade while G3 remains unresolved.",
+        "# The test seam remains until G3 is accepted.",
+        "# The test facade remains in place until G3 is resolved.",
+        "# The test patch point remains until G3 lands.",
+        "# The test seam will remain until G3 is accepted.",
+        "# The test facades must remain in place until G3 lands.",
+        "# The test patch point should remain until G3 is resolved.",
+        "# The test seam has to remain until G3 is accepted.",
+        "# The test seam is required to remain until G3 is accepted.",
+        "# The test seam needs to remain until G3 is accepted.",
+        "# The test seam is still required to remain until G3 is accepted.",
+        "# The test seam must continue to remain until G3 is accepted.",
+        "# G3 blocks migration rather than facade removal, but G3 preserves the test seam.",
+        "# G3 records whether migration is blocked, but the test seam remains until G3 is accepted.",
+        "# G3 asks whether migration is blocked, but the test seam remains until G3 is accepted.",
+        "# G3 asks whether to keep one test facade, but G3 preserves the test seam.",
+        "# Does G3 block migration? G3 preserves the test seam.",
         "# G3 delays facade removal.",
         "# G3 postpones test seam cleanup.",
         "# Nothing but G3 blocks facade removal.",

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2117,8 +2117,11 @@ G3_REMOVAL_OBJECT_PATTERN = (
     rf"{G3_LEGACY_SEAM_OBJECT_PATTERN})"
 )
 G3_REMOVAL_OBJECT_MODIFIER_PATTERN = r"(?:a|an|existing|legacy|temporary|that|the|this)"
+G3_MUST_PRECEDE_ACTION_PATTERN = (
+    r"must\s+(?:land|be\s+(?:accepted|completed?|resolved))\s+before"
+)
 G3_ORDERED_PREREQUISITE_ACTION_PATTERN = (
-    r"(?:must\s+land\s+before|must\s+wait\s+(?:for|until))"
+    rf"(?:{G3_MUST_PRECEDE_ACTION_PATTERN}|must\s+wait\s+(?:for|until))"
 )
 G3_PROHIBITION_ACTION_PATTERN = (
     r"(?:prohibit(?:s|ed|ing)?|forbid(?:s|ding)?|forbade|forbidden)"
@@ -2131,8 +2134,12 @@ G3_PROHIBITION_REJECTION_PATTERN = (
     rf"{G3_PROHIBITION_EMPHASIS_PATTERN}{G3_PROHIBITION_ACTION_PATTERN}"
     rf"(?:(?:\s+[a-z0-9-]+){{0,4}}\s+from)?)"
 )
+G3_CONTROLLED_WORK_CONTINUATION_PATTERN = (
+    r"can\s+(?:proceed|be\s+(?:cleaned\s+up|deleted|removed))"
+)
 G3_CONTROLLED_WORK_TAIL_PATTERN = (
-    r"(?:$|\b(?:because|pending|unless|until|while)\b|"
+    rf"(?:$|\b{G3_CONTROLLED_WORK_CONTINUATION_PATTERN}\b|"
+    r"\b(?:because|pending|unless|until|while)\b|"
     rf"\b{G3_ORDERED_PREREQUISITE_ACTION_PATTERN}\b|"
     rf"\b(?:are|is|remain(?:s)?|was|were)\s+"
     rf"{G3_PROHIBITION_EMPHASIS_PATTERN}"
@@ -2161,7 +2168,9 @@ G3_DEFERRED_WORK = re.compile(
     re.IGNORECASE,
 )
 G3_ORDERED_PREREQUISITE_POLICY = re.compile(
-    rf"(?:\bG3\b\s+must\s+land\s+before\s+{G3_DEFERRED_WORK.pattern}|"
+    rf"(?:\bG3\b\s+{G3_MUST_PRECEDE_ACTION_PATTERN}\s+"
+    rf"(?:{G3_REMOVAL_OBJECT_MODIFIER_PATTERN}\s+){{0,2}}"
+    rf"{G3_DEFERRED_WORK.pattern}|"
     rf"{G3_DEFERRED_WORK.pattern}\s+must\s+wait\s+(?:for|until)\s+\bG3\b)",
     re.IGNORECASE,
 )
@@ -2784,6 +2793,8 @@ def test_g3_deferral_scan_groups_wrapped_comment_blocks(tmp_path: Path):
         "# Facade removal must not wait for G3.",
         "# Facade removal must land before G3.",
         "# G3 must wait for facade removal.",
+        "# G3 must be accepted before facade removal documentation can proceed.",
+        "# G3 must be accepted before the test facade status can be removed.",
         "# G3 is satisfied; T-SEC-4 must land before facade removal.",
         "# G3 does not prohibit facade removal.",
         "# G3 no longer forbids facade removal.",
@@ -2857,6 +2868,12 @@ def test_g3_deferral_scan_allows_non_deferral_policy(accepted_policy: str):
         "# G3 is a blocker for facade removal.",
         "# G3 blocks cleanup of the facade.",
         "# G3 must land before facade removal.",
+        "# G3 must be accepted before facade removal.",
+        "# G3 must be complete before facade removal.",
+        "# G3 must be completed before test seam cleanup.",
+        "# G3 must be resolved before removing the test facade.",
+        "# G3 must be accepted before facade removal can proceed.",
+        "# G3 must be accepted before the test facade can be removed.",
         "# Facade removal must wait for G3.",
         "# G3 prohibits facade removal.",
         "# G3 forbids facade removal.",

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2138,6 +2138,9 @@ G3_REMOVAL_OBJECT_MODIFIER_PATTERN = r"(?:a|an|existing|legacy|temporary|that|th
 G3_MUST_PRECEDE_ACTION_PATTERN = (
     r"must\s+(?:land|be\s+(?:accepted|completed?|resolved))\s+before"
 )
+G3_PREREQUISITE_SUBJECT_PATTERN = (
+    r"(?:(?:contributors?|maintainers?|they|we|you)\s+)?"
+)
 G3_ORDERED_PREREQUISITE_ACTION_PATTERN = (
     rf"(?:{G3_MUST_PRECEDE_ACTION_PATTERN}|must\s+wait\s+(?:for|until))"
 )
@@ -2230,8 +2233,10 @@ G3_NONASSERTIVE_POLICY_CONTEXT = re.compile(
     re.IGNORECASE,
 )
 G3_HISTORICAL_POLICY_CONTEXT = re.compile(
-    r"(?:^\s*(?:historically|previously|formerly|in\s+the\s+past)\b"
-    r"|\bG3\b(?:\s+[a-z][\w'-]*){0,3}\s+once(?!\s+again\b))",
+    r"(?:^\s*(?:(?:historically|previously|formerly|in\s+the\s+past)\b|"
+    r"(?:the\s+)?(?:old|superseded)\b)"
+    r"|\bG3\b(?:\s+[a-z][\w'-]*){0,3}\s+once(?!\s+again\b)"
+    r"|\bG3\b(?:\s+[a-z][\w'-]*){0,3}\s+used\s+to\b)",
     re.IGNORECASE,
 )
 G3_ACTIVE_POLICY_CONTEXT = re.compile(
@@ -2243,6 +2248,7 @@ G3_ACTIVE_POLICY_CONTEXT = re.compile(
 G3_ORDERED_PREREQUISITE_POLICY = re.compile(
     rf"(?:\bG3\b\s+(?:{REMEDIATION_TASK_REFERENCE.pattern}\s+)?"
     rf"{G3_MUST_PRECEDE_ACTION_PATTERN}\s+"
+    rf"{G3_PREREQUISITE_SUBJECT_PATTERN}"
     rf"(?:{G3_REMOVAL_OBJECT_MODIFIER_PATTERN}\s+){{0,2}}"
     rf"{G3_DEFERRED_WORK.pattern}|"
     rf"{G3_DEFERRED_WORK.pattern}\s+must\s+wait\s+(?:for|until)\s+\bG3\b)",
@@ -3041,6 +3047,9 @@ def test_g3_deferral_scan_groups_wrapped_comment_blocks(tmp_path: Path):
         "# G3 blocks are listed in the report.",
         "# G3 preserves runtime API compatibility.",
         "# G3 preserves the historical ADR about facade removal.",
+        "# The old ADR says G3 blocks facade removal.",
+        "# The superseded decision says G3 preserves the test seam.",
+        "# G3 used to block facade removal.",
         "# Facade removal is not blocked by G3.",
         "# Facade removal is not being blocked by G3.",
         "# G3 is pending for historical reference; facade removal is no longer blocked.",
@@ -3115,6 +3124,7 @@ def test_g3_deferral_scan_groups_wrapped_comment_blocks(tmp_path: Path):
         "# Facade removal must land before G3.",
         "# G3 must wait for facade removal.",
         "# G3 must be accepted before facade removal documentation can proceed.",
+        "# G3 must land before we update facade documentation.",
         "# G3 must be accepted before the test facade status can be removed.",
         "# G3 is satisfied; T-SEC-4 must land before facade removal.",
         "# G3 does not prohibit facade removal.",
@@ -3188,6 +3198,7 @@ def test_g3_deferral_scan_allows_non_deferral_policy(accepted_policy: str):
         "# G3 and\n# T-SEC-4 must land before facade removal.",
         "# Both G3 and T-SEC-4 must land before facade removal.",
         "# Historically, G3 required the test facade to remain, but G3 still blocks facade removal.",
+        "# The old ADR says G3 blocks facade removal, but G3 still preserves the test facade.",
         "# Historically, G3 means the facade cannot be removed, but G3 still blocks facade removal.",
         "# Historically, G3 required the test facade to remain, and G3 still blocks facade removal.",
         "# Previously G3 blocked facade removal; G3 still preserves the test seam.",
@@ -3263,6 +3274,7 @@ def test_g3_deferral_scan_allows_non_deferral_policy(accepted_policy: str):
         "# G3 is a blocker for facade removal.",
         "# G3 blocks cleanup of the facade.",
         "# G3 must land before facade removal.",
+        "# G3 must land before we remove the facade.",
         "# G3 must be accepted before facade removal.",
         "# G3 must be complete before facade removal.",
         "# G3 must be completed before test seam cleanup.",

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2594,6 +2594,9 @@ def test_test_patch_points_policy_has_accepted_adr_and_effective_runbook():
         "### T-DB-1: Collapse the summary_backfill facade",
         "\n### T-DC-1:",
     )
+    dedup_b_row = next(
+        line for line in remediation_ledger.splitlines() if line.startswith("| DEDUP-B")
+    )
     complete_row = next(
         line for line in remediation_ledger.splitlines() if line.startswith("| **Complete** |")
     )
@@ -2661,6 +2664,7 @@ def test_test_patch_points_policy_has_accepted_adr_and_effective_runbook():
         "tests/test_tasks_agenda_summary_format.py",
     ):
         assert owned_path in t_db_1_entry
+        assert owned_path in dedup_b_row
 
 
 def test_live_python_does_not_treat_g3_as_a_facade_deferral():

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2246,12 +2246,20 @@ G3_TEMPORAL_REFERENCE_POLICY = re.compile(
     r"\bG3\b.*\b(?:pending|unless|until|while)\b)",
     re.IGNORECASE,
 )
-G3_NEGATED_REMOVAL_DIRECTIVE = re.compile(
+G3_NEGATED_REMOVAL_DIRECTIVE_PATTERN = (
     r"\b(?:cannot|can't|do\s+not|don't|never)\s+"
     rf"(?:remov|delet)(?:e|es|ed|ing)\s+"
     rf"(?:{G3_REMOVAL_OBJECT_MODIFIER_PATTERN}\s+){{0,3}}"
     rf"{G3_REMOVAL_OBJECT_PATTERN}"
+)
+G3_NEGATED_REMOVAL_DIRECTIVE = re.compile(
+    rf"{G3_NEGATED_REMOVAL_DIRECTIVE_PATTERN}"
     rf"(?=\s*{G3_CONTROLLED_WORK_TAIL_PATTERN})",
+    re.IGNORECASE,
+)
+G3_BEFORE_REMOVAL_DIRECTIVE_POLICY = re.compile(
+    rf"(?:{G3_NEGATED_REMOVAL_DIRECTIVE_PATTERN}\s+before\s+\bG3\b|"
+    rf"\bbefore\s+\bG3\b.{{0,80}}{G3_NEGATED_REMOVAL_DIRECTIVE_PATTERN})",
     re.IGNORECASE,
 )
 G3_POLICY_SENTENCE_BOUNDARY = re.compile(r"\.(?=\s|$)")
@@ -2369,6 +2377,8 @@ def _g3_clause_defers_work(policy_clause: str) -> bool:
 
 
 def _g3_sentence_defers_work(policy_sentence: str) -> bool:
+    if G3_BEFORE_REMOVAL_DIRECTIVE_POLICY.search(policy_sentence):
+        return True
     if G3_TEMPORAL_REFERENCE_POLICY.search(
         policy_sentence
     ) and G3_NEGATED_REMOVAL_DIRECTIVE.search(policy_sentence):
@@ -2788,6 +2798,8 @@ def test_g3_deferral_scan_groups_wrapped_comment_blocks(tmp_path: Path):
         "# G3 must land for audit documentation. T-SEC-4 blocks facade removal until its work lands.",
         "# G3 must land. T-SEC-4 blocks facade removal until its work lands.",
         "# G3 must land. T-SEC-4 blocks migration until its work lands. Facade removal remains blocked until then.",
+        "# Do not remove the test facade before T-SEC-4 lands; G3 is accepted.",
+        "# G3 is accepted; do not remove the test facade before T-SEC-4 lands.",
     ),
 )
 def test_g3_deferral_scan_allows_non_deferral_policy(accepted_policy: str):
@@ -2861,6 +2873,7 @@ def test_g3_deferral_scan_allows_non_deferral_policy(accepted_policy: str):
         "# G3 preserves synchronized globals.",
         "# G3 delays removal of injectable callables.",
         "# G3 must land. Facade removal remains blocked until then.",
+        "# Do not remove the test facade before G3 is accepted.",
     ),
 )
 def test_g3_deferral_scan_detects_positive_policy_after_other_negation(

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2112,7 +2112,7 @@ G3_COORDINATED_SUBJECT = re.compile(r"^\s*(?:both\s+)?G3\s*$", re.IGNORECASE)
 G3_DEFERRAL_ACTION_PATTERN = (
     r"(?:defer(?:s|red|ring)?|block(?:s|ed|ing)?|preserv(?:e|es|ed|ing)|"
     r"prevent(?:s|ed|ing)?|retain(?:s|ed)?|retaining|delay(?:s|ed|ing)?|"
-    r"postpon(?:e|es|ed|ing))"
+    r"postpon(?:e|es|ed|ing)|gat(?:es|ed|ing))"
 )
 G3_DEFERRAL_ACTION = re.compile(
     rf"\b{G3_DEFERRAL_ACTION_PATTERN}\b",
@@ -2189,7 +2189,7 @@ G3_DIRECT_DEFERRED_WORK_PATTERN = (
 )
 G3_DEFERRED_WORK = re.compile(
     rf"(?:{G3_DIRECT_DEFERRED_WORK_PATTERN}|deduplicat\w*|de-fac\w*|"
-    rf"{G3_REMOVAL_FIRST_WORK_PATTERN})",
+    rf"phase\s+2|{G3_REMOVAL_FIRST_WORK_PATTERN})",
     re.IGNORECASE,
 )
 G3_PERMISSIVE_ACTION_PATTERN = (
@@ -3095,6 +3095,7 @@ def test_g3_deferral_scan_groups_wrapped_comment_blocks(tmp_path: Path):
         "# G3 prevents retaining the test facade.",
         "# G3: no test facade must remain.",
         "# G3: neither the test facade nor the test seam must remain.",
+        "# G3 records the Phase 2 gate.",
     ),
 )
 def test_g3_deferral_scan_allows_non_deferral_policy(accepted_policy: str):
@@ -3178,6 +3179,8 @@ def test_g3_deferral_scan_allows_non_deferral_policy(accepted_policy: str):
         "# G3 asks whether to keep one test facade, but G3 preserves the test seam.",
         "# Does G3 block migration? G3 preserves the test seam.",
         "# G3 delays facade removal.",
+        "# Facade removal is gated on G3.",
+        "# G3 gates Phase 2.",
         "# G3 postpones test seam cleanup.",
         "# Nothing but G3 blocks facade removal.",
         "# G3 remains unresolved, requiring preservation of the test facade.",


### PR DESCRIPTION
## What changed
- added an Accepted ADR stating that test-only patch targets are not public API
- preserved runtime, import, CLI, API, task-identity, and operational contracts
- activated `docs/TESTING.MD`, satisfied G3, and unblocked Phase 2
- replaced the stale live G3 deferral comment without changing Meilisearch behavior
- added policy guardrails for contradictory status and live G3 dependencies

## Why
G3 was operator-approved, but Phase 2 de-facading remained blocked until an Accepted ADR distinguished test compatibility from supported runtime contracts.

## Risk and compatibility
Policy and tests only, plus one comment-only edit in a security-sensitive Meilisearch module. The API-to-Meilisearch reader-key boundary is unchanged; compiled executable behavior is unchanged. T-GOV-6 remains partial because its README Documentation Map links are still missing.

## Verification
- PASS: `./.venv/bin/ruff check .`
- PASS: `./.venv/bin/mypy`
- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_repository_guardrails.py` (125 passed)
- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py` (2 passed)
- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_meilisearch_key_security.py` (25 passed)
- PASS: `PYTHONPATH=. .venv/bin/pytest -q` (1,202 passed)
- PASS: `git diff --check`
- PASS: independent planning review after fixes
- PASS: independent pre-commit review after fixes
- NOT APPLICABLE: browser testing; no UI routes changed

## Tests-first evidence
The two new guardrails initially failed on the missing Accepted ADR and the live `api/search/support_core.py` G3 deferral comment before implementation.

## Rollback
Use merge-commit delivery. Revert only implementation commit `edeecf3` to restore the approval-only ledger state and re-block Phase 2 without erasing operator approval.