### PR TITLE
T-SEC-4A: Close the durable G2 policy record

### DIFF
--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,6 +1,6 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 3.18
+version: 3.19
 generated: 2026-07-24
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
@@ -10,6 +10,9 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v3.19:** Marks T-SEC-4A complete after PR #133 merged the durable G2
+  visitor-access policy record with required checks green. T-SEC-4 remains
+  pending as the authorized runtime control.
 - **v3.18:** Accepts the G3 ADR, activates the testing policy, removes the stale
   live G3 deferral, completes T-GOV-1, and unblocks Phase 2. T-GOV-6 remains
   partial because its README Documentation Map links are still missing.
@@ -119,8 +122,7 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 | State | Tasks |
 |---|---|
-| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2, T-SEC-3, T-SEC-3C, T-SEC-5, T-TIME-3, T-CRAWL-1, T-CRAWL-2, T-PLAT-2A, T-GOV-1 |
-| **In progress** | T-SEC-4A |
+| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2, T-SEC-3, T-SEC-3C, T-SEC-4A, T-SEC-5, T-TIME-3, T-CRAWL-1, T-CRAWL-2, T-PLAT-2A, T-GOV-1 |
 | **Partially landed; acceptance incomplete** | T-GOV-4, T-GOV-5, T-GOV-6 |
 | **Pending** | T-SEC-4, T-SEC-6, T-TIME-1..2, T-DA-1, T-DB-1, T-DC-1, T-DD-1, T-DE-1, T-PLAT-1, T-PLAT-2, T-PLAT-3, T-PLAT-4, T-GOV-2..3 |
 
@@ -563,9 +565,8 @@ in `AGENTS.md`, `docs/TESTING.MD`, and
 
 ### T-SEC-4A: Record the approved G2 visitor-access policy
 - priority: P0
-- status: in progress
-- decision_gate: G2 operator approval received 2026-07-24; durable record
-  pending this task
+- status: complete and verified 2026-07-24 (PR #133)
+- decision_gate: G2 operator approval received 2026-07-24; durable record satisfied by PR #133
 - implementation_plan: `docs/plans/T_SEC_4A_G2_VISITOR_ACCESS_POLICY_PLAN.md`
 - files_owned: docs/plans/T_SEC_4A_G2_VISITOR_ACCESS_POLICY_PLAN.md,
   docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md, SECURITY.md,

--- a/docs/plans/T_SEC_4A_G2_VISITOR_ACCESS_POLICY_PLAN.md
+++ b/docs/plans/T_SEC_4A_G2_VISITOR_ACCESS_POLICY_PLAN.md
@@ -244,6 +244,12 @@ green. The durable G2 record now exists in `SECURITY.md`, the remediation
 ledger, and repository guardrail tests. A closure-only follow-up must correct
 the stale task status without reopening policy or runtime work.
 
+This addendum supersedes the branch, tests-first baseline, implementation
+steps, delivery commits, rollback, self-audit, and documentation edits in
+Sections 1-7 above. Those sections remain the historical execution record for
+PR #133. Their ownership, security analysis, and no-runtime-change constraints
+still apply.
+
 ### Closure Scope
 
 1. Add the status expectation first and confirm it fails while T-SEC-4A remains
@@ -267,3 +273,18 @@ git diff --check
 
 No `SECURITY.md`, runtime, API, schema, environment, or dependency change is
 authorized by this addendum.
+
+### Closure Rollback
+
+Revert only the closure commit. Do not revert PR #133: its G2 policy remains
+approved and durable. Rerun the closure verification commands after the
+revert. No migration, data repair, configuration restore, or external-state
+cleanup is required.
+
+### Closure Self-Audit
+
+Before delivery, verify T-SEC-4A appears exactly once in the status table,
+under Complete; its task entry contains one completed status and no pending
+durable-record wording; T-SEC-4 remains pending; and no file outside the
+existing four-file ownership set changed. Report every command outcome,
+review finding, commit, PR, unresolved thread, and CI state.

--- a/docs/plans/T_SEC_4A_G2_VISITOR_ACCESS_POLICY_PLAN.md
+++ b/docs/plans/T_SEC_4A_G2_VISITOR_ACCESS_POLICY_PLAN.md
@@ -236,3 +236,34 @@ Mark anything unrun as `NOT VERIFIED`.
 **z) Deviations.** Expected: none. The superseded
 `codex/t-sec-5-closure` branch is wording reference only and must not enter this
 branch's history.
+
+## Closure Addendum
+
+PR #133 merged the authorized policy record on 2026-07-24 with required checks
+green. The durable G2 record now exists in `SECURITY.md`, the remediation
+ledger, and repository guardrail tests. A closure-only follow-up must correct
+the stale task status without reopening policy or runtime work.
+
+### Closure Scope
+
+1. Add the status expectation first and confirm it fails while T-SEC-4A remains
+   listed as in progress.
+2. Mark T-SEC-4A complete and verified by PR #133.
+3. Move T-SEC-4A from the in-progress row to the complete row. Remove the
+   in-progress row if no task remains in that state.
+4. Mark the durable-record decision-gate condition satisfied.
+5. Preserve T-SEC-4 as pending and preserve every G2 policy statement.
+
+### Closure Verification
+
+```bash
+./.venv/bin/ruff check .
+./.venv/bin/mypy
+PYTHONPATH=. .venv/bin/pytest -q tests/test_repository_guardrails.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py
+PYTHONPATH=. .venv/bin/pytest -q
+git diff --check
+```
+
+No `SECURITY.md`, runtime, API, schema, environment, or dependency change is
+authorized by this addendum.

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2899,7 +2899,8 @@ def test_t_sec_4a_is_complete_after_g2_policy_record_merged():
     t_sec_4a_states = [
         row.split("|")[1].strip().strip("*")
         for row in status_rows
-        if "T-SEC-4A" in {task.strip() for task in row.split("|")[2].split(",")}
+        for task in row.split("|")[2].split(",")
+        if task.strip() == "T-SEC-4A"
     ]
     normalized_t_sec_4a_entry = " ".join(t_sec_4a_entry.lower().split())
 

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2882,6 +2882,34 @@ def test_g2_accepted_risk_is_bounded_without_overclaiming_t_sec_4():
     assert "- [ ] Client IP forwarded from proxy" in security_policy
 
 
+def test_t_sec_4a_is_complete_after_g2_policy_record_merged():
+    remediation_ledger = (
+        ROOT / "docs" / "plans" / "TOWN_COUNCIL_REMEDIATION_PLAN.md"
+    ).read_text(encoding="utf-8")
+    t_sec_4a_entry = _required_markdown_section(
+        remediation_ledger,
+        "### T-SEC-4A: Record the approved G2 visitor-access policy",
+        "\n### T-SEC-4:",
+    )
+    status_rows = [
+        line
+        for line in remediation_ledger.splitlines()
+        if line.startswith("| **") and " |" in line
+    ]
+    t_sec_4a_states = [
+        row.split("|")[1].strip().strip("*")
+        for row in status_rows
+        if "T-SEC-4A" in {task.strip() for task in row.split("|")[2].split(",")}
+    ]
+    normalized_t_sec_4a_entry = " ".join(t_sec_4a_entry.lower().split())
+
+    assert "status: complete and verified 2026-07-24 (PR #133)" in t_sec_4a_entry
+    assert t_sec_4a_entry.count("- status:") == 1
+    assert "durable record satisfied by PR #133" in t_sec_4a_entry
+    assert "durable record pending" not in normalized_t_sec_4a_entry
+    assert t_sec_4a_states == ["Complete"]
+
+
 def test_test_patch_points_policy_has_accepted_adr_and_effective_runbook():
     architecture_decisions = (ROOT / "docs" / "ADR.md").read_text(encoding="utf-8")
     testing_policy = (ROOT / "docs" / "TESTING.MD").read_text(encoding="utf-8")
@@ -2923,11 +2951,6 @@ def test_test_patch_points_policy_has_accepted_adr_and_effective_runbook():
     complete_row = next(
         line for line in remediation_ledger.splitlines() if line.startswith("| **Complete** |")
     )
-    in_progress_row = next(
-        line
-        for line in remediation_ledger.splitlines()
-        if line.startswith("| **In progress** |")
-    )
     partial_row = next(
         line
         for line in remediation_ledger.splitlines()
@@ -2958,8 +2981,6 @@ def test_test_patch_points_policy_has_accepted_adr_and_effective_runbook():
     )
     assert "T-GOV-1" in complete_row
     assert "T-GOV-1" not in pending_row
-    assert "T-SEC-4A" not in complete_row
-    assert "T-SEC-4A" in in_progress_row
     assert "T-GOV-6" in partial_row
     assert (
         "remains partially landed until its three canonical documents are linked from the README "


### PR DESCRIPTION
## What changed
- records PR #133 as the completed durable G2 visitor-access policy work
- moves T-SEC-4A from in progress to complete while leaving T-SEC-4 pending
- adds a guardrail requiring exclusive completed status and rejecting stale pending metadata
- documents closure-only rollback and self-audit rules

## Why
PR #133 merged the approved policy and tests, but the remediation ledger still described T-SEC-4A as in progress.

## Risk
Docs and policy-test only. No runtime, API, schema, environment, dependency, or security-boundary behavior changes.

## Verification
- PASS `./.venv/bin/ruff check .`
- PASS `./.venv/bin/mypy`
- PASS `PYTHONPATH=. .venv/bin/pytest -q tests/test_repository_guardrails.py` (385)
- PASS `PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py` (2)
- PASS `PYTHONPATH=. .venv/bin/pytest -q` (1462)
- PASS `git diff --check`
- PASS independent pre-commit review after P1/P2 fixes

## Remaining deficit
T-SEC-4 remains pending and owns trusted proxy identity plus per-client rate buckets.
