### PR TITLE
T-SEC-4: Enforce trusted per-client rate limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This project ingests agendas/minutes, extracts text, indexes search content, and
 ```bash
 test -f .env || cp .env.example .env
 docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build \
-  postgres redis meilisearch tika inference semantic semantic-worker api worker enrichment-worker monitor frontend
+  postgres redis meilisearch tika inference semantic semantic-worker api worker enrichment-worker monitor frontend ingress
 bash ./scripts/bootstrap_local_models.sh
 docker compose -f docker-compose.yml -f docker-compose.dev.yml run --rm \
   pipeline python db_init.py
@@ -229,13 +229,13 @@ docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build \
   postgres redis meilisearch tika semantic semantic-worker
 docker compose --env-file .env --env-file env/profiles/m5_mlx_conservative.env \
   -f docker-compose.yml -f docker-compose.dev.yml up -d --build --no-deps \
-  worker api pipeline frontend
+  worker api pipeline frontend ingress
 docker compose --env-file .env --env-file env/profiles/m5_conservative.env \
   -f docker-compose.yml -f docker-compose.dev.yml up -d --build \
-  inference worker api pipeline frontend
+  inference worker api pipeline frontend ingress
 docker compose --env-file .env --env-file env/profiles/desktop_balanced.env \
   -f docker-compose.yml -f docker-compose.dev.yml up -d --build \
-  inference worker api pipeline frontend
+  inference worker api pipeline frontend ingress
 ```
 
 Model policy:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,15 +26,17 @@ engineering decisions is `reachable`).
 
 ## Trust boundaries
 
-1. Internet -> Frontend (Next.js): untrusted browsers. CSP (nonce +
+1. Internet -> Caddy -> Frontend (Next.js): untrusted browsers. Caddy is the
+   only published frontend entry and replaces caller-supplied
+   `X-Forwarded-For` before requests reach Next.js. It is deliberately not
+   configured to trust an upstream proxy. CSP (nonce +
    strict-dynamic), security headers, and same-origin checks on mutation
    routes apply here. The mutation guard rejects `same-site` and `cross-site`
    Fetch Metadata plus mismatched `Origin` values; requests with neither
    browser signal remain compatible for non-browser callers
    `[remediation: T-SEC-5]`.
-   Reverse proxies must preserve the public `Host` header and overwrite any
-   incoming `X-Forwarded-Proto`; the guard deliberately ignores
-   `X-Forwarded-Host`.
+   Caddy preserves the public `Host` header and writes `X-Forwarded-Proto`;
+   the guard deliberately ignores `X-Forwarded-Host`.
 2. Frontend server -> API: the proxy injects `X-API-Key` server-side
    (`frontend/app/api/_lib/backend.js`). Consequence: the API key does NOT
    authenticate end users; it only authenticates the frontend deployment.
@@ -45,10 +47,11 @@ engineering decisions is `reachable`).
    public read and task-status routes remain public. Town Council intentionally
    provides civic record analysis without end-user accounts. Adding operator
    authentication would change that access model. Per-client rate limits are
-   therefore the approved abuse control and depend on forwarding real client
-   identity `[remediation: T-SEC-4]`. Any future "operator only" action would
-   require a new policy decision and proxy authentication, not just the
-   deployment key.
+   therefore the approved abuse control. The frontend forwards one validated
+   client IP, and the API uses it only when `API_AUTH_KEY` authenticates the
+   deployment hop; otherwise the limiter uses the direct API peer
+   `[remediation: T-SEC-4]`. Any future "operator only" action would require a
+   new policy decision and proxy authentication, not just the deployment key.
 3. API and semantic service -> backing stores (Postgres, Redis, Meilisearch,
    inference): compose
    network only. No host port publication in the base compose file
@@ -96,12 +99,13 @@ engineering decisions is `reachable`).
 
 ## Hardening checklist (reachable posture)
 
-- [x] Base compose publishes only `api:8000` and `frontend:3000` (T-SEC-1)
+- [x] Base compose publishes only `api:8000` and Caddy ingress `3000`
+      (T-SEC-1, T-SEC-4)
 - [ ] Non-default values for every key in the inventory above
 - [x] API aborts on default key outside dev (T-SEC-2)
 - [x] Meilisearch search key enforced for API and semantic readers (T-SEC-3)
-- [ ] Client IP forwarded from proxy; limiter keys on it with trusted-proxy
-      allowlist (T-SEC-4)
+- [x] Caddy replaces caller forwarding metadata; frontend validates one IP;
+      API limiter trusts it only with the deployment key (T-SEC-4)
 - [x] Origin/Sec-Fetch-Site check on proxy mutation routes (T-SEC-5)
 - [ ] `NEXT_CSP_ENFORCE=true` after a report-only soak
 - [ ] `/stats` gated or minimized; CORS without `allow_credentials`
@@ -113,14 +117,14 @@ engineering decisions is `reachable`).
 Record deliberate acceptances here with rationale and revisit date, per the
 `AGENTS.md` status-reporting contract (old value, new value, rationale).
 
-- **Visitor-accessible AI actions before T-SEC-4.** G2 preserves account-free
-  public access to summarize, segment, extract, and topic-generation actions
-  through the Next.js proxy. Until trusted client identity reaches the API
-  limiter, visitors can share a rate bucket and unauthenticated proxy callers
-  can consume shared inference capacity. Direct calls to protected AI mutation
-  endpoints remain API-key protected. T-SEC-5 reduces cross-site browser abuse
-  but does not authenticate proxy callers. Revisit when T-SEC-4 merges or by
-  2026-08-31, whichever comes first.
+- **Deployment-key client identity trust.** G2 preserves account-free public
+  access through the frontend while protected direct API actions require
+  `API_AUTH_KEY`. The same deployment key authenticates forwarded client
+  identity at the API. A direct caller holding that secret can therefore
+  choose a forwarded limiter key, but already has authority to invoke the
+  protected actions. Visitors never receive the key. Revisit if the key is
+  delegated beyond trusted deployment operators or by 2026-10-31, whichever
+  comes first.
 
 ## Dependency and supply chain
 

--- a/api/app_setup.py
+++ b/api/app_setup.py
@@ -3,6 +3,7 @@ import logging
 import os
 from collections.abc import AsyncIterator, Iterator
 from contextlib import asynccontextmanager
+from ipaddress import ip_address
 from typing import Any
 
 from fastapi import FastAPI, Header, HTTPException, Request
@@ -28,9 +29,39 @@ HEADER_UNSAFE_API_AUTH_KEY_MESSAGE = (
 )
 DATABASE_UNAVAILABLE_DETAIL = "Database service is unavailable"
 SEMANTIC_SERVICE_URL = os.getenv("SEMANTIC_SERVICE_URL", "http://semantic:8010").rstrip("/")
+API_KEY_HEADER = "x-api-key"
+FORWARDED_CLIENT_HEADER = "x-forwarded-for"
+
+
+def _api_key_matches(candidate: str | None) -> bool:
+    expected_key = env_raw("API_AUTH_KEY", DEFAULT_API_AUTH_KEY)
+    return hmac.compare_digest(candidate or "", expected_key)
+
+
+def _forwarded_client_ip(request: Request) -> str | None:
+    forwarded_client = request.headers.get(FORWARDED_CLIENT_HEADER)
+    if (
+        forwarded_client is None
+        or forwarded_client != forwarded_client.strip()
+        or "," in forwarded_client
+    ):
+        return None
+    try:
+        return str(ip_address(forwarded_client))
+    except ValueError:
+        return None
+
+
+def rate_limit_client_key(request: Request) -> str:
+    if _api_key_matches(request.headers.get(API_KEY_HEADER)):
+        forwarded_client = _forwarded_client_ip(request)
+        if forwarded_client is not None:
+            return forwarded_client
+    return get_remote_address(request)
+
 
 # This protects the local API worker from expensive endpoint floods.
-limiter = Limiter(key_func=get_remote_address)
+limiter = Limiter(key_func=rate_limit_client_key)
 
 SessionLocal: Any = None
 _db_init_error: Exception | None = None
@@ -70,8 +101,7 @@ def get_db() -> Iterator[Any]:
 
 
 async def verify_api_key(request: Request, x_api_key: str = Header(None)) -> None:
-    expected_key = env_raw("API_AUTH_KEY", DEFAULT_API_AUTH_KEY)
-    if not hmac.compare_digest(x_api_key or "", expected_key):
+    if not _api_key_matches(x_api_key):
         client_ip = request.client.host if request and request.client else "unknown"
         logger.warning(
             "Unauthorized API access attempt: invalid or missing API key",

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -24,7 +24,7 @@ services:
       - "127.0.0.1:3001:3000"
 
   api:
-    command: uvicorn main:app --host 0.0.0.0 --port 8000 --reload
+    command: uvicorn main:app --host 0.0.0.0 --port 8000 --reload --no-proxy-headers
     volumes:
       - ./api:/app/api
       - ./pipeline:/app/pipeline

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -469,7 +469,7 @@ services:
       - data:/app/data
       - models_data:/models
     working_dir: /app/api
-    command: uvicorn main:app --host 0.0.0.0 --port 8000
+    command: uvicorn main:app --host 0.0.0.0 --port 8000 --no-proxy-headers
     ports:
       - "8000:8000"
     environment:
@@ -533,7 +533,25 @@ services:
       - models_data:/models
       - ollama_data:/root/.ollama
 
-  # Next.js Frontend: The user interface for searching and viewing results.
+  # Public ingress: Replaces caller-controlled forwarding headers before Next.js.
+  ingress:
+    image: caddy:2.11.4-alpine
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./docker/Caddyfile:/etc/caddy/Caddyfile:ro
+    depends_on:
+      frontend:
+        condition: service_healthy
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://127.0.0.1:3000/ || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
+
+  # Next.js Frontend: Internal UI and API proxy behind the public ingress.
   frontend:
     build:
       context: ./frontend
@@ -542,8 +560,8 @@ services:
         - NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL:-http://localhost:8000}
         - NEXT_PUBLIC_FEATURE_TRENDS_DASHBOARD=${NEXT_PUBLIC_FEATURE_TRENDS_DASHBOARD:-false}
         - APP_ENV=${APP_ENV:-dev}
-    ports:
-      - "3000:3000"
+    expose:
+      - "3000"
     environment:
       - NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL:-http://localhost:8000}
       - NEXT_PUBLIC_FEATURE_TRENDS_DASHBOARD=${NEXT_PUBLIC_FEATURE_TRENDS_DASHBOARD:-false}

--- a/docker/Caddyfile
+++ b/docker/Caddyfile
@@ -1,0 +1,7 @@
+{
+	auto_https off
+}
+
+:3000 {
+	reverse_proxy frontend:3000
+}

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,6 +1,6 @@
 # Operations Runbook
 
-Last updated: 2026-07-23
+Last updated: 2026-07-24
 
 ## Core workflow
 
@@ -18,7 +18,7 @@ cd "$REPO_ROOT"
 ```bash
 test -f .env || cp .env.example .env
 docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build \
-  postgres redis meilisearch tika inference semantic semantic-worker api worker enrichment-worker monitor frontend
+  postgres redis meilisearch tika inference semantic semantic-worker api worker enrichment-worker monitor frontend ingress
 bash ./scripts/bootstrap_local_models.sh
 docker compose -f docker-compose.yml -f docker-compose.dev.yml run --rm \
   pipeline python db_init.py
@@ -37,9 +37,9 @@ docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --force-rec
   postgres redis meilisearch prometheus grafana
 ```
 
-The base stack publishes only the API and frontend. For loopback-only access
-to backing and monitoring interfaces, start only those services with the
-development overlay:
+The base stack publishes only the API and Caddy ingress; Next.js stays
+internal. For loopback-only access to backing and monitoring interfaces, start
+only those services with the development overlay:
 
 ```bash
 docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d \
@@ -58,7 +58,7 @@ docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build \
   postgres redis meilisearch tika semantic semantic-worker
 docker compose --env-file .env --env-file env/profiles/m5_mlx_conservative.env \
   -f docker-compose.yml -f docker-compose.dev.yml up -d --build --no-deps \
-  worker api pipeline frontend
+  worker api pipeline frontend ingress
 docker compose exec -T worker python scripts/worker_healthcheck.py
 ```
 
@@ -67,6 +67,25 @@ What `scripts/dev_up.sh` does:
 - bootstraps the shared local model volume
 - initializes the DB schema
 - runs a small smoke check (`/health`)
+
+Public frontend traffic enters through Caddy on `http://localhost:3000`.
+Next.js is internal-only in base Compose. Caddy replaces caller-supplied
+`X-Forwarded-For`; the frontend validates one client IP and forwards it with
+the server-side API key. The API limiter trusts that identity only when the
+deployment key matches and otherwise uses the direct peer.
+
+Verify the ingress contract after Docker or proxy changes:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build \
+  ingress frontend api
+curl -fsS http://localhost:3000/
+docker compose ps ingress frontend api
+./scripts/verify_caddy_forwarded_for.sh
+```
+
+The final command sends a spoofed forwarding header through the pinned Caddy
+image and fails unless Caddy replaces it with the direct client address.
 
 What it does *not* do:
 - scrape any city data (no crawler runs)
@@ -1249,7 +1268,7 @@ docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build \
   postgres redis meilisearch tika semantic semantic-worker
 docker compose --env-file .env --env-file env/profiles/m5_mlx_conservative.env \
   -f docker-compose.yml -f docker-compose.dev.yml up -d --build --no-deps \
-  worker api pipeline frontend
+  worker api pipeline frontend ingress
 docker compose exec -T worker python scripts/worker_healthcheck.py
 ```
 
@@ -1263,7 +1282,7 @@ docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build \
   postgres redis meilisearch tika semantic semantic-worker
 docker compose --env-file .env --env-file env/profiles/m5_mlx_balanced.env \
   -f docker-compose.yml -f docker-compose.dev.yml up -d --build --no-deps \
-  worker api pipeline frontend
+  worker api pipeline frontend ingress
 docker compose exec -T worker python scripts/worker_healthcheck.py
 ```
 
@@ -1271,14 +1290,14 @@ M5 conservative baseline:
 ```bash
 docker compose --env-file .env --env-file env/profiles/m5_conservative.env \
   -f docker-compose.yml -f docker-compose.dev.yml up -d --build \
-  inference worker api pipeline frontend
+  inference worker api pipeline frontend ingress
 ```
 
 Desktop balanced:
 ```bash
 docker compose --env-file .env --env-file env/profiles/desktop_balanced.env \
   -f docker-compose.yml -f docker-compose.dev.yml up -d --build \
-  inference worker api pipeline frontend
+  inference worker api pipeline frontend ingress
 ```
 
 Interpretation rules:

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,6 +1,6 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 3.20
+version: 3.21
 generated: 2026-07-24
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
@@ -10,6 +10,10 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v3.21:** Starts T-SEC-4 implementation after tests-first evidence. Records
+  Caddy as sole public frontend entry, validated client forwarding, raw API
+  peer preservation, the deployment-key trust boundary, and the
+  operator-approved startup-path ownership found during pre-commit review.
 - **v3.20:** Authorizes T-SEC-4 after operator approval of a repository-owned
   Caddy ingress. Expands ownership for sole-entry topology, trusted
   frontend-to-API client identity, tests, security policy, and operations.
@@ -126,8 +130,9 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 | State | Tasks |
 |---|---|
 | **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2, T-SEC-3, T-SEC-3C, T-SEC-4A, T-SEC-5, T-TIME-3, T-CRAWL-1, T-CRAWL-2, T-PLAT-2A, T-GOV-1 |
+| **In progress** | T-SEC-4 |
 | **Partially landed; acceptance incomplete** | T-GOV-4, T-GOV-5, T-GOV-6 |
-| **Pending** | T-SEC-4, T-SEC-6, T-TIME-1..2, T-DA-1, T-DB-1, T-DC-1, T-DD-1, T-DE-1, T-PLAT-1, T-PLAT-2, T-PLAT-3, T-PLAT-4, T-GOV-2..3 |
+| **Pending** | T-SEC-6, T-TIME-1..2, T-DA-1, T-DB-1, T-DC-1, T-DD-1, T-DE-1, T-PLAT-1, T-PLAT-2, T-PLAT-3, T-PLAT-4, T-GOV-2..3 |
 
 ---
 
@@ -586,16 +591,17 @@ in `AGENTS.md`, `docs/TESTING.MD`, and
 
 ### T-SEC-4: Real client identity through the proxy; per-client rate limits
 - priority: P0
-- status: authorized
+- status: in progress
 - decision_gate: G2 approved 2026-07-24; repository-owned ingress approved 2026-07-24
 - implementation_plan: `docs/plans/T_SEC_4_TRUSTED_CLIENT_IDENTITY_PLAN.md`
 - files_owned: docs/plans/T_SEC_4_TRUSTED_CLIENT_IDENTITY_PLAN.md,
   docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md, docker-compose.yml,
-  docker/Caddyfile, frontend/app/api/_lib/backend.js,
+  docker-compose.dev.yml, docker/Caddyfile, frontend/app/api/_lib/backend.js,
   frontend/components/__tests__/BackendProxy.origin.test.js, api/app_setup.py,
   tests/test_api_client_identity.py, tests/test_docker_build_contracts.py,
   tests/test_repository_guardrails.py, scripts/verify_caddy_forwarded_for.sh,
-  SECURITY.md, docs/OPERATIONS.md
+  scripts/dev_up.sh, tests/test_startup_purge_gating.py, README.md,
+  env/profiles/README.md, SECURITY.md, docs/OPERATIONS.md
 - do: Make Caddy the sole public frontend entry so caller-supplied forwarded
   headers are replaced. Validate and forward one client IP from Next.js. Trust
   it at the API only when the deployment key authenticates the frontend;

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,6 +1,6 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 3.19
+version: 3.20
 generated: 2026-07-24
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
@@ -10,6 +10,9 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v3.20:** Authorizes T-SEC-4 after operator approval of a repository-owned
+  Caddy ingress. Expands ownership for sole-entry topology, trusted
+  frontend-to-API client identity, tests, security policy, and operations.
 - **v3.19:** Marks T-SEC-4A complete after PR #133 merged the durable G2
   visitor-access policy record with required checks green. T-SEC-4 remains
   pending as the authorized runtime control.
@@ -583,18 +586,33 @@ in `AGENTS.md`, `docs/TESTING.MD`, and
 
 ### T-SEC-4: Real client identity through the proxy; per-client rate limits
 - priority: P0
-- decision_gate: G2 approved 2026-07-24
-- files_owned: frontend/app/api/_lib/backend.js, api/app_setup.py
-- do: (a) backend.js forwards `X-Forwarded-For` (append client IP from
-  request) on proxied calls. (b) app_setup limiter key_func: trust XFF only
-  when the direct peer is in a configured internal CIDR/hostname allowlist
-  (env `TRUSTED_PROXY_CIDRS`, default the compose network); otherwise use
-  remote address.
-- accept: Two distinct simulated client IPs get independent rate buckets;
-  spoofed XFF from a non-trusted peer is ignored (tests for both).
-- forbidden: Global middleware rewrites; no new middleware class if a
-  key_func suffices.
-- verify: New targeted tests pass; suite green.
+- status: authorized
+- decision_gate: G2 approved 2026-07-24; repository-owned ingress approved 2026-07-24
+- implementation_plan: `docs/plans/T_SEC_4_TRUSTED_CLIENT_IDENTITY_PLAN.md`
+- files_owned: docs/plans/T_SEC_4_TRUSTED_CLIENT_IDENTITY_PLAN.md,
+  docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md, docker-compose.yml,
+  docker/Caddyfile, frontend/app/api/_lib/backend.js,
+  frontend/components/__tests__/BackendProxy.origin.test.js, api/app_setup.py,
+  tests/test_api_client_identity.py, tests/test_docker_build_contracts.py,
+  tests/test_repository_guardrails.py, scripts/verify_caddy_forwarded_for.sh,
+  SECURITY.md, docs/OPERATIONS.md
+- do: Make Caddy the sole public frontend entry so caller-supplied forwarded
+  headers are replaced. Validate and forward one client IP from Next.js. Trust
+  it at the API only when the deployment key authenticates the frontend;
+  otherwise use the direct peer. Disable Uvicorn proxy-header rewriting.
+- trust_assumption: Possession of `API_AUTH_KEY` is already the deployment
+  operator boundary. A direct API caller with that secret can choose forwarded
+  identity; this does not grant capability beyond the protected actions that
+  key already authorizes. Public visitors never receive the key.
+- accept: Direct frontend bypass is unavailable; spoofed ingress headers are
+  replaced; two trusted client IPs receive separate limiter keys; untrusted,
+  missing, malformed, and multi-value identity falls back to the direct peer.
+- forbidden: Trusted upstream-proxy configuration, fixed container IPs,
+  dynamic Compose CIDR trust, global middleware, new secrets, or direct
+  frontend publication.
+- verify: Follow the Full T-SEC-4 plan, including tests-first evidence,
+  security/frontend/API/Compose verification, runtime smoke, independent
+  review, complete suites, and decided CI.
 
 ### T-SEC-5: CSRF/origin check on proxy mutation routes
 - priority: P1

--- a/docs/plans/T_SEC_4_TRUSTED_CLIENT_IDENTITY_PLAN.md
+++ b/docs/plans/T_SEC_4_TRUSTED_CLIENT_IDENTITY_PLAN.md
@@ -1,0 +1,263 @@
+# T-SEC-4: Trusted Client Identity and Per-Client Rate Limits
+
+`artifact_contract: ce-unified-plan/v1`
+`artifact_readiness: implementation-ready`
+`execution: code`
+
+## 1. Context & Alignment
+
+**a) Driver.** G2 keeps account-free AI actions available through the public
+frontend, so rate limits need a client identity that visitors cannot choose.
+Next.js 16.2.11 preserves caller-supplied `X-Forwarded-For` and only inserts
+the socket peer when that header is absent. Forwarding the header directly
+would let non-browser callers select their own rate-limit bucket. The operator
+approved a repository-owned ingress that becomes the sole public frontend
+entry and overwrites forwarded identity before requests reach Next.js.
+
+**b) Canonical documents consulted.**
+
+- `AGENTS.md` security, workflow, verification, and runtime-default contracts
+  require a trust-boundary report, tests first, full verification, and explicit
+  approval for this topology change.
+- `SECURITY.md` defines the Internet-to-Frontend and Frontend-to-API boundaries
+  and records T-SEC-4 as the remaining G2 abuse control.
+- `docs/TESTING.MD` permits HTTP, filesystem, subprocess, and dependency
+  boundaries without production test seams.
+- `docs/ENGINEERING_GUARDRAILS.md` keeps Ruff and Mypy policy unchanged.
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md` owns G2, T-SEC-4 sequencing,
+  and exclusive paths.
+- `docs/reviews/architecture-review-2026-07-19.html` identifies shared
+  proxy-origin rate buckets as a P0 security defect.
+
+**c) Remediation alignment.** T-SEC-4 remains in the SEC lane. Expand
+`files_owned` to:
+
+- `docs/plans/T_SEC_4_TRUSTED_CLIENT_IDENTITY_PLAN.md`
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`
+- `docker-compose.yml`
+- `docker/Caddyfile`
+- `frontend/app/api/_lib/backend.js`
+- `frontend/components/__tests__/BackendProxy.origin.test.js`
+- `api/app_setup.py`
+- `tests/test_api_client_identity.py`
+- `tests/test_docker_build_contracts.py`
+- `tests/test_repository_guardrails.py`
+- `scripts/verify_caddy_forwarded_for.sh`
+- `SECURITY.md`
+- `docs/OPERATIONS.md`
+
+**d) Decision gates.** G2 is approved. On 2026-07-24 the operator also
+approved the repository-owned ingress and its runtime-topology change. G1's
+reachable posture is therefore handled, not assumed away. G3 is satisfied.
+G4 and G5 are unaffected.
+
+## 2. Design
+
+**e) Step-by-step approach.**
+
+1. Add failing tests for ingress isolation, Caddy configuration, Uvicorn raw
+   peer preservation, frontend IP validation, API trust, spoof rejection,
+   malformed input, and separate client keys.
+2. Add `ingress` using exact image `caddy:2.11.4-alpine`. Publish host port
+   `3000` only from ingress. Keep `frontend:3000` internal with `expose`.
+3. Add `docker/Caddyfile`. Caddy directly accepts public traffic and uses its
+   default reverse-proxy behavior, which ignores incoming spoofed forwarded
+   headers and writes the direct client identity for Next.js.
+4. Add `--no-proxy-headers` to Uvicorn so `request.client.host` remains the
+   actual API peer instead of being rewritten before application validation.
+5. In `backend.js`, accept exactly one valid IPv4 or IPv6 value from Caddy's
+   `X-Forwarded-For`; forward it to the API. Omit missing, malformed, or
+   multi-value input.
+6. In `app_setup.py`, reuse API-key comparison to authenticate the frontend
+   deployment. Trust one canonical forwarded IP only when the deployment key
+   matches. Otherwise use SlowAPI's direct remote address.
+7. Prove Caddy replaces a spoofed incoming header using a temporary echo
+   upstream during runtime verification.
+8. Update security and operations docs. Mark T-SEC-4 complete only after
+   runtime verification, independent review, and green PR checks.
+
+New functions:
+
+- `getForwardedClientIp(request)`: validate one ingress-provided IP for the
+  outgoing frontend-to-API request.
+- `_api_key_matches(candidate)`: own constant-time deployment-key comparison.
+- `_forwarded_client_ip(request)`: parse one canonical forwarded IP.
+- `rate_limit_client_key(request)`: choose trusted forwarded identity or the
+  direct API peer.
+
+No helper imports a route or facade. `app_setup.py` remains the limiter owner.
+
+**f) Reuse audit.** Reuse `proxyBackendJson`, `env_raw`,
+`get_remote_address`, the deployment API key, SlowAPI's custom `key_func`,
+existing frontend proxy tests, and Compose contract helpers. No middleware,
+proxy framework, identity registry, CIDR parser, fixed subnet, compatibility
+path, or duplicate limiter is added.
+
+Rejected alternatives:
+
+- Forward Next.js `X-Forwarded-For` directly: caller-spoofable.
+- `@vercel/functions.ipAddress()`: reads forwarded metadata and does not fix
+  the direct Docker deployment.
+- Dynamic Compose-network CIDR trust: no stable subnet and trusts unrelated
+  containers.
+- Fixed container IPs: collision-prone host networking and unnecessary config.
+- Visitor cookies: resettable and not a trustworthy abuse-control identity.
+
+**g) Contracts.**
+
+- Public port `3000` terminates at Caddy, not Next.js.
+- Caddy is not configured to trust an upstream proxy.
+- Frontend forwards only one syntactically valid IP.
+- API trusts forwarded identity only with the valid deployment key.
+- Invalid or untrusted identity falls back to the direct API peer.
+- Possession of `API_AUTH_KEY` remains the trusted deployment-operator
+  boundary. A direct caller with that secret can choose forwarded identity,
+  but already holds authority to invoke protected actions; visitors do not.
+- Runtime URLs, public access policy, API routes, task signatures, and rate
+  thresholds remain unchanged.
+
+**h) Schema/migrations.** None.
+
+## 3. Security & Data Governance
+
+**i) Trust-boundary impact.** Internet traffic loses direct access to Next.js.
+Caddy strips caller-controlled forwarded identity and establishes the client
+IP passed to Next.js. The deployment API key authenticates the frontend-to-API
+hop. Direct API callers cannot select forwarded rate buckets without that key;
+missing or malformed identity uses their socket peer. This implements
+`SECURITY.md` T-SEC-4 and reduces anonymous inference-capacity abuse.
+
+**j) Secrets.** No new secret or browser-visible variable. Existing
+`API_AUTH_KEY` remains server-side.
+
+**k) Person data.** Client IP is used transiently as a limiter key. It is not
+persisted, linked to civic records, returned, or added to person metadata.
+
+**l) Untrusted input.** Caddy owns the public header boundary. Frontend and API
+still validate the resulting header. Scraped content is unaffected.
+
+## 4. Code Health
+
+**m) GED conformance.** Functions stay focused, typed in Python, and under two
+nesting levels. IP literals live only in tests. Errors fall back to the direct
+peer rather than being swallowed. No timestamp or new environment read exists.
+
+**n) Antipattern scan, plan pass.**
+
+- A1/H1 corrected: verified installed Next.js 16.2.11 source, SlowAPI 0.1.9,
+  Node 20 `net.isIPv4`/`net.isIPv6`, Caddy reverse-proxy defaults, Compose
+  service isolation, and Caddy release 2.11.4.
+- A2/B1 corrected: no new env setting, middleware, registry, or fixed network.
+- B3 corrected: validation covers attacker-controlled headers at two trust
+  boundaries.
+- C1 corrected: direct frontend publication is removed.
+- D1-D3 corrected: tests assert externally visible forwarding, isolation, and
+  limiter keys without skips or private patch seams.
+- E1-E3/F1-F2/H2-H4: no planned violation.
+
+**o) Ratchets.** No Ruff, Mypy, BLE001, coverage, formatter, or workflow
+exception changes.
+
+**p) Dead code and duplication.** Remove direct frontend port publication and
+the limiter's direct-only key function. Reuse one API-key comparison. Expected
+net growth is one small ingress config, focused tests, and policy/runbook text.
+
+## 5. Testing
+
+**q) Edge and failure scenarios.**
+
+1. Caller supplies spoofed XFF to ingress.
+2. Frontend receives missing, malformed, whitespace-padded, or multi-value IP.
+3. Valid IPv4 and IPv6 identities reach API.
+4. API receives forwarded IP with missing or wrong deployment key.
+5. API receives malformed or multi-value forwarded identity with valid key.
+6. Two trusted clients must produce different limiter keys.
+7. Direct frontend publication or Uvicorn proxy rewriting returns.
+8. Caddy is configured to trust an upstream proxy, weakening the sole-ingress
+   invariant.
+9. Ingress or frontend health/dependency wiring breaks.
+10. Caddy validates but fails to replace spoofed forwarded identity at runtime.
+
+**r) Tests.**
+
+- Frontend Node tests cover 2-3 and outgoing headers.
+- `tests/test_api_client_identity.py` covers 3-6 with Starlette request scopes.
+- Docker contracts cover 1 and 7-9 by asserting sole publication, Caddy's
+  minimal configuration, read-only mount, dependency, and Uvicorn command.
+- Runtime verification covers 10 against a temporary echo upstream.
+- Repository guardrails cover T-SEC-4 status and remaining-policy alignment.
+- Existing API, frontend, security, and full suites cover regression.
+
+**s) Fakes/mocks.** Frontend tests fake outbound `fetch`, an approved HTTP
+boundary. API tests build Starlette requests and patch environment only.
+Compose tests use the existing filesystem/subprocess boundary. No facade is
+patched.
+
+**t) Verification rows.** Apply security-sensitive, frontend behavior,
+API/search, guardrail/tooling, and docs rows. Run frontend tests and the full
+Python suite.
+
+## 6. Execution, Rollback, Docs
+
+**u) Commands.**
+
+```bash
+./.venv/bin/ruff check .
+./.venv/bin/mypy
+PYTHONPATH=. .venv/bin/pytest -q tests/test_api_client_identity.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_docker_build_contracts.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_api.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_repository_guardrails.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py
+cd frontend && npm test
+docker compose config --quiet
+docker run --rm -v "$PWD/docker/Caddyfile:/etc/caddy/Caddyfile:ro" \
+  caddy:2.11.4-alpine caddy validate --config /etc/caddy/Caddyfile
+PYTHONPATH=. .venv/bin/pytest -q
+git diff --check
+```
+
+Runtime smoke:
+
+```bash
+docker compose up -d --build ingress frontend api
+curl -fsS http://localhost:3000/
+docker compose ps ingress frontend api
+```
+
+Spoof replacement proof uses the same pinned Caddy image with a temporary echo
+upstream. The response must contain the direct Docker client address and must
+not contain `198.51.100.77`:
+
+```bash
+./scripts/verify_caddy_forwarded_for.sh
+```
+
+**v) Rollback.** Revert the T-SEC-4 merge commit, remove the obsolete ingress
+container, recreate `api` and `frontend`, then verify the prior direct frontend
+port and direct-peer limiter behavior. This knowingly restores the accepted
+shared-bucket risk.
+No migration or data repair is required.
+
+**w) Docs sync.** Update `SECURITY.md` trust boundaries, checklist, and accepted
+risk; `docs/OPERATIONS.md` startup, ingress, verification, and rollback;
+remediation status and changelog; this plan. README, ADR, testing policy,
+architecture map, API contract, and data-governance docs remain unchanged.
+
+## 7. Delivery Self-Audit
+
+**x) Diff scan.** Re-run A-F/H. Reject trusted upstream proxies, direct
+frontend publication, XFF forwarding without validation and deployment-key
+trust, middleware, new secrets, fixed container IPs, broadened guardrails,
+unrelated formatting, and edits outside owned paths.
+
+**y) Evidence.** Report tests-first failures, every command outcome, exact
+counts, image/config validation, runtime smoke, planning and pre-commit review
+findings, commits, PR, unresolved threads, and final CI state. Mark unrun work
+`NOT VERIFIED`.
+
+**z) Deviations.** Expected: Caddy ingress, expanded ownership, explicit
+deployment-key trust instead of unstable CIDR trust, Uvicorn raw-peer
+preservation, and one owned verification script for the functional Caddy
+proof. Any other topology, dependency, config, policy, or file change is a
+blocker.

--- a/docs/plans/T_SEC_4_TRUSTED_CLIENT_IDENTITY_PLAN.md
+++ b/docs/plans/T_SEC_4_TRUSTED_CLIENT_IDENTITY_PLAN.md
@@ -35,6 +35,7 @@ entry and overwrites forwarded identity before requests reach Next.js.
 - `docs/plans/T_SEC_4_TRUSTED_CLIENT_IDENTITY_PLAN.md`
 - `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`
 - `docker-compose.yml`
+- `docker-compose.dev.yml`
 - `docker/Caddyfile`
 - `frontend/app/api/_lib/backend.js`
 - `frontend/components/__tests__/BackendProxy.origin.test.js`
@@ -43,8 +44,12 @@ entry and overwrites forwarded identity before requests reach Next.js.
 - `tests/test_docker_build_contracts.py`
 - `tests/test_repository_guardrails.py`
 - `scripts/verify_caddy_forwarded_for.sh`
+- `scripts/dev_up.sh`
+- `README.md`
+- `env/profiles/README.md`
 - `SECURITY.md`
 - `docs/OPERATIONS.md`
+- `tests/test_startup_purge_gating.py`
 
 **d) Decision gates.** G2 is approved. On 2026-07-24 the operator also
 approved the repository-owned ingress and its runtime-topology change. G1's
@@ -75,6 +80,8 @@ G4 and G5 are unaffected.
    upstream during runtime verification.
 8. Update security and operations docs. Mark T-SEC-4 complete only after
    runtime verification, independent review, and green PR checks.
+9. Keep the development overlay, standard helper, README quickstart, and
+   profile commands aligned with the ingress and raw-peer contracts.
 
 New functions:
 
@@ -220,9 +227,11 @@ git diff --check
 Runtime smoke:
 
 ```bash
-docker compose up -d --build ingress frontend api
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build \
+  ingress frontend api
 curl -fsS http://localhost:3000/
-docker compose ps ingress frontend api
+docker compose -f docker-compose.yml -f docker-compose.dev.yml ps \
+  ingress frontend api
 ```
 
 Spoof replacement proof uses the same pinned Caddy image with a temporary echo
@@ -258,6 +267,7 @@ findings, commits, PR, unresolved threads, and final CI state. Mark unrun work
 
 **z) Deviations.** Expected: Caddy ingress, expanded ownership, explicit
 deployment-key trust instead of unstable CIDR trust, Uvicorn raw-peer
-preservation, and one owned verification script for the functional Caddy
-proof. Any other topology, dependency, config, policy, or file change is a
+preservation, one owned verification script for the functional Caddy proof,
+and the operator-approved startup-path expansion found during pre-commit
+review. Any other topology, dependency, config, policy, or file change is a
 blocker.

--- a/env/profiles/README.md
+++ b/env/profiles/README.md
@@ -24,7 +24,7 @@ docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build \
   postgres redis meilisearch tika semantic semantic-worker
 docker compose --env-file .env --env-file env/profiles/m5_mlx_conservative.env \
   -f docker-compose.yml -f docker-compose.dev.yml up -d --build --no-deps \
-  worker api pipeline frontend
+  worker api pipeline frontend ingress
 docker compose exec -T worker python scripts/worker_healthcheck.py
 ```
 

--- a/frontend/app/api/_lib/backend.js
+++ b/frontend/app/api/_lib/backend.js
@@ -1,8 +1,11 @@
+import { isIPv4, isIPv6 } from "node:net";
+
 const BLOCKED_FETCH_SITES = new Set(["cross-site", "same-site"]);
 const CROSS_SITE_DETAIL = "Cross-site mutation requests are not allowed.";
 const FETCH_SITE_HEADER = "sec-fetch-site";
 const FORBIDDEN_STATUS = 403;
 const FORWARDED_PROTOCOL_HEADER = "x-forwarded-proto";
+const FORWARDED_CLIENT_HEADER = "x-forwarded-for";
 const HOST_HEADER = "host";
 const INVALID_HOST_AUTHORITY = /[/\\?#]/;
 const MUTATION_METHOD = "POST";
@@ -19,6 +22,21 @@ function getApiAuthKey() {
     throw new Error("API_AUTH_KEY is required for frontend backend proxy routes.");
   }
   return apiAuthKey;
+}
+
+function getForwardedClientIp(request) {
+  const forwardedClient =
+    request?.headers.get(FORWARDED_CLIENT_HEADER) ?? null;
+  if (
+    forwardedClient === null ||
+    forwardedClient !== forwardedClient.trim() ||
+    forwardedClient.includes(",")
+  ) {
+    return null;
+  }
+  return isIPv4(forwardedClient) || isIPv6(forwardedClient)
+    ? forwardedClient
+    : null;
 }
 
 function parseUrl(urlValue) {
@@ -151,6 +169,10 @@ export async function proxyBackendJson({
   const headers = new Headers({
     "X-API-Key": apiAuthKey,
   });
+  const forwardedClient = getForwardedClientIp(request);
+  if (forwardedClient !== null) {
+    headers.set("X-Forwarded-For", forwardedClient);
+  }
 
   if (body !== undefined) {
     headers.set("Content-Type", "application/json");

--- a/frontend/components/__tests__/BackendProxy.origin.test.js
+++ b/frontend/components/__tests__/BackendProxy.origin.test.js
@@ -29,6 +29,16 @@ function makePostRequest(headers = {}, requestOrigin = FRONTEND_ORIGIN) {
   });
 }
 
+function makeRawForwardedForRequest(forwardedFor) {
+  const request = makePostRequest();
+  const originalGet = request.headers.get.bind(request.headers);
+  request.headers.get = (name) =>
+    name.toLowerCase() === "x-forwarded-for"
+      ? forwardedFor
+      : originalGet(name);
+  return request;
+}
+
 function makeStandalonePost(headers) {
   return makePostRequest(headers, INTERNAL_ORIGIN);
 }
@@ -39,10 +49,11 @@ function rejectUnexpectedBackendAccess() {
   };
 }
 
-function installBackendResponse() {
+function installBackendResponse(onBackendRequest = () => {}) {
   process.env.API_AUTH_KEY = API_AUTH_KEY;
   globalThis.fetch = async (_backendUrl, backendOptions) => {
     assert.equal(backendOptions.headers.get("X-API-Key"), API_AUTH_KEY);
+    onBackendRequest(backendOptions.headers);
     return Response.json({ status: "queued" }, { status: 202 });
   };
 }
@@ -139,6 +150,64 @@ test("headerless POST preserves non-browser callers", async () => {
 
   assert.equal(proxyResponse.status, 202);
   assert.deepEqual(await proxyResponse.json(), { status: "queued" });
+});
+
+test("forwards exactly one valid IPv4 or IPv6 X-Forwarded-For", async () => {
+  for (const forwardedFor of ["203.0.113.42", "2001:db8::42"]) {
+    let backendHeaders;
+    installBackendResponse((headers) => {
+      backendHeaders = headers;
+    });
+
+    const proxyResponse = await proxyBackendJson({
+      request: makePostRequest({ "X-Forwarded-For": forwardedFor }),
+      method: "POST",
+      path: "/summarize/42",
+    });
+
+    assert.equal(proxyResponse.status, 202);
+    assert.equal(backendHeaders.get("X-Forwarded-For"), forwardedFor);
+  }
+});
+
+test("omits missing, malformed, whitespace-padded, and comma-separated X-Forwarded-For", async () => {
+  const requests = [
+    makePostRequest(),
+    makePostRequest({ "X-Forwarded-For": "not-an-ip" }),
+    makeRawForwardedForRequest(" 203.0.113.42 "),
+    makePostRequest({ "X-Forwarded-For": "203.0.113.42, 198.51.100.7" }),
+  ];
+
+  for (const request of requests) {
+    let backendHeaders;
+    installBackendResponse((headers) => {
+      backendHeaders = headers;
+    });
+
+    const proxyResponse = await proxyBackendJson({
+      request,
+      method: "POST",
+      path: "/summarize/42",
+    });
+
+    assert.equal(proxyResponse.status, 202);
+    assert.equal(backendHeaders.has("X-Forwarded-For"), false);
+  }
+});
+
+test("GET without its request preserves existing proxy callers", async () => {
+  let backendHeaders;
+  installBackendResponse((headers) => {
+    backendHeaders = headers;
+  });
+
+  const proxyResponse = await proxyBackendJson({
+    method: "GET",
+    path: "/catalog/42/content",
+  });
+
+  assert.equal(proxyResponse.status, 202);
+  assert.equal(backendHeaders.has("X-Forwarded-For"), false);
 });
 
 test("standalone internal URL honors external Host and protocol", async () => {

--- a/scripts/dev_up.sh
+++ b/scripts/dev_up.sh
@@ -14,7 +14,7 @@ if [[ ! -f .env ]]; then
   exit 1
 fi
 
-CORE_SERVICES=(postgres redis meilisearch tika inference semantic semantic-worker api worker enrichment-worker monitor frontend)
+CORE_SERVICES=(postgres redis meilisearch tika inference semantic semantic-worker api worker enrichment-worker monitor frontend ingress)
 COMPOSE=(docker compose -f docker-compose.yml -f docker-compose.dev.yml)
 
 echo "[dev_up] Building and starting core services..."

--- a/scripts/verify_caddy_forwarded_for.sh
+++ b/scripts/verify_caddy_forwarded_for.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CADDY_IMAGE="caddy:2.11.4-alpine"
+ECHO_IMAGE="python:3.12-slim-bookworm"
+SPOOFED_CLIENT_IP="198.51.100.77"
+RUN_ID="tc-caddy-xff-$$"
+NETWORK_NAME="${RUN_ID}-network"
+ECHO_CONTAINER="${RUN_ID}-echo"
+CADDY_CONTAINER="${RUN_ID}-caddy"
+SCRATCH_DIR="$(mktemp -d "${TMPDIR:-/tmp}/tc-caddy-xff.XXXXXX")"
+
+cleanup() {
+  docker rm -f "$CADDY_CONTAINER" "$ECHO_CONTAINER" >/dev/null 2>&1 || true
+  docker network rm "$NETWORK_NAME" >/dev/null 2>&1 || true
+  rm -rf "$SCRATCH_DIR"
+}
+trap cleanup EXIT
+
+cat >"$SCRATCH_DIR/echo_server.py" <<'PY'
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+
+class ForwardedForHandler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:
+        forwarded_for = self.headers.get("X-Forwarded-For", "")
+        response_body = forwarded_for.encode()
+        self.send_response(200)
+        self.send_header("Content-Length", str(len(response_body)))
+        self.end_headers()
+        self.wfile.write(response_body)
+
+    def log_message(self, format: str, *args: object) -> None:
+        return
+
+
+ThreadingHTTPServer(("0.0.0.0", 8080), ForwardedForHandler).serve_forever()
+PY
+
+cat >"$SCRATCH_DIR/Caddyfile" <<'CADDY'
+:8080 {
+	reverse_proxy echo:8080
+}
+CADDY
+
+docker network create "$NETWORK_NAME" >/dev/null
+docker run -d --rm \
+  --name "$ECHO_CONTAINER" \
+  --network "$NETWORK_NAME" \
+  --network-alias echo \
+  -v "$SCRATCH_DIR/echo_server.py:/echo_server.py:ro" \
+  "$ECHO_IMAGE" python /echo_server.py >/dev/null
+docker run -d --rm \
+  --name "$CADDY_CONTAINER" \
+  --network "$NETWORK_NAME" \
+  -p 127.0.0.1::8080 \
+  -v "$SCRATCH_DIR/Caddyfile:/etc/caddy/Caddyfile:ro" \
+  "$CADDY_IMAGE" >/dev/null
+
+HOST_PORT="$(docker port "$CADDY_CONTAINER" 8080/tcp | sed -n 's/.*://p')"
+for _ in {1..20}; do
+  forwarded_for="$(
+    curl -fsS \
+      -H "X-Forwarded-For: $SPOOFED_CLIENT_IP" \
+      "http://127.0.0.1:$HOST_PORT/" 2>/dev/null || true
+  )"
+  if [[ -n "$forwarded_for" ]]; then
+    break
+  fi
+  sleep 0.25
+done
+
+if [[ -z "${forwarded_for:-}" || "$forwarded_for" == *"$SPOOFED_CLIENT_IP"* ]]; then
+  printf 'Caddy did not replace spoofed X-Forwarded-For: %s\n' "${forwarded_for:-<empty>}" >&2
+  exit 1
+fi
+
+python3 -c 'import ipaddress, sys; ipaddress.ip_address(sys.argv[1])' "$forwarded_for"
+printf 'PASS: Caddy replaced spoofed X-Forwarded-For with %s\n' "$forwarded_for"

--- a/tests/test_api_client_identity.py
+++ b/tests/test_api_client_identity.py
@@ -1,0 +1,83 @@
+from collections.abc import Mapping
+
+import pytest
+from starlette.requests import Request
+
+from api import app_setup
+
+
+CONFIGURED_API_KEY = "configured-api-key-for-rate-limit-tests"
+CLIENT_HOST = "10.0.0.12"
+
+
+def _request(*, client_host: str, headers: Mapping[str, str]) -> Request:
+    scope = {
+        "type": "http",
+        "client": (client_host, 44321),
+        "headers": [(name.lower().encode(), value.encode()) for name, value in headers.items()],
+    }
+    return Request(scope)
+
+
+@pytest.mark.parametrize(
+    ("forwarded_ip", "expected_key"),
+    [
+        ("203.0.113.7", "203.0.113.7"),
+        ("2001:0db8:0000:0000:0000:ff00:0042:8329", "2001:db8::ff00:42:8329"),
+    ],
+)
+def test_valid_api_key_and_single_forwarded_ip_use_canonical_ip(
+    monkeypatch: pytest.MonkeyPatch,
+    forwarded_ip: str,
+    expected_key: str,
+) -> None:
+    monkeypatch.setenv("API_AUTH_KEY", CONFIGURED_API_KEY)
+    request = _request(
+        client_host=CLIENT_HOST,
+        headers={"X-API-Key": CONFIGURED_API_KEY, "X-Forwarded-For": forwarded_ip},
+    )
+
+    assert app_setup.rate_limit_client_key(request) == expected_key
+
+
+@pytest.mark.parametrize(
+    ("api_key", "forwarded_for"),
+    [
+        (None, "203.0.113.7"),
+        ("wrong-api-key", "203.0.113.7"),
+        (CONFIGURED_API_KEY, "not-an-ip"),
+        (CONFIGURED_API_KEY, " 203.0.113.7 "),
+        (CONFIGURED_API_KEY, "203.0.113.7, 198.51.100.4"),
+    ],
+)
+def test_untrusted_or_ambiguous_forwarding_falls_back_to_request_client(
+    monkeypatch: pytest.MonkeyPatch,
+    api_key: str | None,
+    forwarded_for: str,
+) -> None:
+    monkeypatch.setenv("API_AUTH_KEY", CONFIGURED_API_KEY)
+    headers = {"X-Forwarded-For": forwarded_for}
+    if api_key is not None:
+        headers["X-API-Key"] = api_key
+    request = _request(client_host=CLIENT_HOST, headers=headers)
+
+    assert app_setup.rate_limit_client_key(request) == CLIENT_HOST
+
+
+def test_two_trusted_forwarded_ips_produce_distinct_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("API_AUTH_KEY", CONFIGURED_API_KEY)
+    first_request = _request(
+        client_host=CLIENT_HOST,
+        headers={"X-API-Key": CONFIGURED_API_KEY, "X-Forwarded-For": "203.0.113.7"},
+    )
+    second_request = _request(
+        client_host=CLIENT_HOST,
+        headers={"X-API-Key": CONFIGURED_API_KEY, "X-Forwarded-For": "198.51.100.4"},
+    )
+
+    first_key = app_setup.rate_limit_client_key(first_request)
+    second_key = app_setup.rate_limit_client_key(second_request)
+
+    assert first_key == "203.0.113.7"
+    assert second_key == "198.51.100.4"
+    assert first_key != second_key

--- a/tests/test_docker_build_contracts.py
+++ b/tests/test_docker_build_contracts.py
@@ -85,7 +85,7 @@ def test_base_compose_publishes_only_application_interfaces():
 
     assert _published_port_bindings(compose_services) == {
         ("api", None, "8000", 8000),
-        ("frontend", None, "3000", 3000),
+        ("ingress", None, "3000", 3000),
     }
     assert all(service_config.get("network_mode") != "host" for service_config in compose_services.values())
 
@@ -96,7 +96,7 @@ def test_dev_overlay_publishes_operator_services_on_loopback_only():
 
     assert _published_port_bindings(development_services) == {
         ("api", None, "8000", 8000),
-        ("frontend", None, "3000", 3000),
+        ("ingress", None, "3000", 3000),
         ("grafana", "127.0.0.1", "3001", 3000),
         ("meilisearch", "127.0.0.1", "7700", 7700),
         ("postgres", "127.0.0.1", "5432", 5432),
@@ -105,6 +105,39 @@ def test_dev_overlay_publishes_operator_services_on_loopback_only():
     }
     assert _service_dependencies(development_services) == _service_dependencies(base_services)
     assert all(service_config.get("network_mode") != "host" for service_config in development_services.values())
+
+
+def test_ingress_is_the_only_public_frontend_boundary() -> None:
+    compose_services = _compose_services("docker-compose.yml")
+    development_services = _compose_services(
+        "docker-compose.yml",
+        "docker-compose.dev.yml",
+    )
+    ingress = compose_services["ingress"]
+    frontend = compose_services["frontend"]
+    api = compose_services["api"]
+
+    assert ingress["image"] == "caddy:2.11.4-alpine"
+    assert set(ingress["depends_on"]) == {"frontend"}
+    assert frontend.get("ports", []) == []
+    assert frontend["expose"] == ["3000"]
+    assert "--no-proxy-headers" in api["command"]
+    assert "--no-proxy-headers" in development_services["api"]["command"]
+
+    ingress_mounts = {
+        (volume["source"], volume["target"], volume["read_only"])
+        for volume in ingress["volumes"]
+    }
+    assert (
+        str((Path.cwd() / "docker" / "Caddyfile").resolve()),
+        "/etc/caddy/Caddyfile",
+        True,
+    ) in ingress_mounts
+
+    caddyfile = Path("docker/Caddyfile").read_text(encoding="utf-8")
+    assert "reverse_proxy frontend:3000" in caddyfile
+    assert "trusted_proxies" not in caddyfile
+    assert "header_up X-Forwarded-For" not in caddyfile
 
 
 def test_compose_separates_meilisearch_reader_and_writer_credentials(
@@ -225,11 +258,18 @@ def test_docker_build_context_excludes_local_environment_files() -> None:
 
 def test_dev_helper_requires_local_environment_file() -> None:
     dev_helper = Path("scripts/dev_up.sh").read_text(encoding="utf-8")
+    readme = Path("README.md").read_text(encoding="utf-8")
+    operations = Path("docs/OPERATIONS.md").read_text(encoding="utf-8")
+    profile_readme = Path("env/profiles/README.md").read_text(encoding="utf-8")
 
     assert 'if [[ ! -f .env ]]' in dev_helper
     assert "Create it from .env.example" in dev_helper
     assert "COMPOSE=(docker compose -f docker-compose.yml -f docker-compose.dev.yml)" in dev_helper
+    assert "monitor frontend ingress)" in dev_helper
     assert dev_helper.count('"${COMPOSE[@]}"') == 3
+    assert "monitor frontend ingress" in readme
+    assert "monitor frontend ingress" in operations
+    assert "worker api pipeline frontend ingress" in profile_readme
 
 
 def test_example_grafana_credentials_are_labeled_local_only():

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2835,7 +2835,15 @@ def test_g2_visitor_access_policy_is_aligned_between_security_and_remediation_le
     pending_row = next(
         line for line in remediation_ledger.splitlines() if line.startswith("| **Pending** |")
     )
+    in_progress_row = next(
+        line
+        for line in remediation_ledger.splitlines()
+        if line.startswith("| **In progress** |")
+    )
     pending_tasks = {task.strip() for task in pending_row.split("|")[2].split(",")}
+    in_progress_tasks = {
+        task.strip() for task in in_progress_row.split("|")[2].split(",")
+    }
 
     assert "Decision G2, approved 2026-07-24" in frontend_api_boundary
     assert (
@@ -2857,29 +2865,27 @@ def test_g2_visitor_access_policy_is_aligned_between_security_and_remediation_le
     assert "per-client rate limits" in frontend_api_boundary.lower()
     assert "per-client rate limits" in g2_entry.lower()
     assert "decision_gate: G2 approved 2026-07-24" in t_sec_4_entry
-    assert "T-SEC-4" in pending_tasks
+    assert "status: in progress" in t_sec_4_entry
+    assert "T-SEC-4" in in_progress_tasks
+    assert "T-SEC-4" not in pending_tasks
     canonical_g2_policy = f"{frontend_api_boundary} {g2_entry}".lower()
     assert not _g2_policy_has_contradiction(canonical_g2_policy)
 
 
-def test_g2_accepted_risk_is_bounded_without_overclaiming_t_sec_4():
+def test_g2_deployment_key_trust_is_bounded_after_t_sec_4_starts():
     security_policy = (ROOT / "SECURITY.md").read_text(encoding="utf-8")
     accepted_risk = _required_markdown_section(
         security_policy,
-        "**Visitor-accessible AI actions before T-SEC-4.**",
+        "**Deployment-key client identity trust.**",
         "\n## Dependency and supply chain",
     )
 
-    assert "unauthenticated proxy callers" in accepted_risk
-    assert "Direct calls to protected AI mutation endpoints remain API-key protected." in (
-        accepted_risk
-    )
-    assert "T-SEC-5 reduces cross-site browser abuse but does not authenticate" in accepted_risk
-    assert (
-        "Revisit when T-SEC-4 merges or by 2026-08-31, whichever comes first."
-        in accepted_risk
-    )
-    assert "- [ ] Client IP forwarded from proxy" in security_policy
+    assert "direct caller holding that secret" in accepted_risk
+    assert "already has authority to invoke the protected actions" in accepted_risk
+    assert "Visitors never receive the key." in accepted_risk
+    assert "Revisit if the key is delegated" in accepted_risk
+    assert "- [x] Caddy replaces caller forwarding metadata" in security_policy
+    assert "Visitor-accessible AI actions before T-SEC-4" not in security_policy
 
 
 def test_t_sec_4a_is_complete_after_g2_policy_record_merged():

--- a/tests/test_startup_purge_gating.py
+++ b/tests/test_startup_purge_gating.py
@@ -47,9 +47,16 @@ def test_base_compose_defaults_are_safe_and_dev_override_restores_convenience():
     dockerfile_source = Path("Dockerfile").read_text(encoding="utf-8")
 
     assert "${STARTUP_PURGE_DERIVED:-false}" in compose_source
-    assert "command: uvicorn main:app --host 0.0.0.0 --port 8000\n" in compose_source
+    assert (
+        "command: uvicorn main:app --host 0.0.0.0 --port 8000 --no-proxy-headers\n"
+        in compose_source
+    )
     assert "healthcheck:" in compose_source.split("redis:", 1)[1]
     assert "restart: unless-stopped" in compose_source.split("api:", 1)[1]
-    assert "--reload" in dev_compose_source
+    assert (
+        "command: uvicorn main:app --host 0.0.0.0 --port 8000 "
+        "--reload --no-proxy-headers"
+        in dev_compose_source
+    )
     assert "STARTUP_PURGE_DERIVED=${STARTUP_PURGE_DERIVED:-true}" in dev_compose_source
     assert "sys.exit(1)" in dockerfile_source


### PR DESCRIPTION
## What changed

- Put the Next.js frontend behind a pinned Caddy ingress and stop publishing the frontend container directly.
- Disable Uvicorn proxy-header trust, validate one forwarded client IP in Next.js, and accept that identity in the API only when the internal API key is valid.
- Key SlowAPI limits by authenticated forwarded identity while preserving the direct peer for untrusted requests.
- Align base/dev startup paths and profile guidance, document the trust boundary, and add API, frontend, Compose, startup, and runtime spoof tests.

## Why

The frontend proxy previously collapsed anonymous visitors onto one Docker peer, so rate limits were shared and spoofable forwarding headers could not safely identify clients. T-SEC-4 establishes one repository-owned ingress boundary and a fail-closed identity chain.

## Trust-boundary impact

Caddy is now the only public frontend listener. It replaces client-supplied `X-Forwarded-For` before requests reach Next.js. Next.js validates and forwards one IP while authenticating to the API. The API ignores forwarding headers without a valid internal API key. A holder of `API_AUTH_KEY` can still select a forwarded identity; this is accepted because that key already grants protected-action authority and must remain internal. No secret or public bind default is added.

## Risk and compatibility

- Startup commands must include the `ingress` service; checked-in helpers and profile docs are updated.
- Direct API clients continue to rate-limit by their socket peer unless they possess the internal API key.
- Rollback is a commit revert; no schema or data remediation is required.
- T-SEC-4 remains `In progress` until this PR is green and merged.

## Verification

- PASS: `./.venv/bin/ruff check .`
- PASS: `./.venv/bin/mypy` (68 source files)
- PASS: targeted Python union, 487 passed
- PASS: `npm test` in `frontend`, 30 passed
- PASS: Compose base/dev configuration validation
- PASS: pinned Caddy configuration validation
- PASS: `./scripts/verify_caddy_forwarded_for.sh`; spoofed `198.51.100.77` was replaced by the Docker peer
- PASS: `PYTHONPATH=. .venv/bin/pytest -q`; 1,471 passed
- PASS: bounded runtime smoke for API, frontend, and ingress; API health reported database connected
- PASS: `git diff --check`

## Remaining deficits

CI and review are pending. The ledger will be closed only after merge.