### PR TITLE
T-SEC-6: Record small security closure evidence

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -108,7 +108,7 @@ engineering decisions is `reachable`).
       API limiter trusts it only with the deployment key (T-SEC-4)
 - [x] Origin/Sec-Fetch-Site check on proxy mutation routes (T-SEC-5)
 - [ ] `NEXT_CSP_ENFORCE=true` after a report-only soak
-- [ ] `/stats` gated or minimized; CORS without `allow_credentials`
+- [x] `/stats` gated or minimized; CORS without `allow_credentials`
       (T-SEC-6)
 - [ ] Backups configured per `docs/OPERATIONS.md` (T-PLAT-3)
 

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,6 +1,6 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 3.23
+version: 3.24
 generated: 2026-07-24
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
@@ -10,6 +10,10 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v3.24:** Marks T-SEC-6 complete after PR #138 merged as `1805acd`.
+  Public stats now expose only document count, credentialed CORS is disabled,
+  stale browser-key guidance is removed, and two broad S105 exceptions are
+  replaced by ten explained line-level suppressions.
 - **v3.23:** Activates T-SEC-6 with tests-first ownership for public stats
   minimization, credential-free CORS, stale public-key guidance removal, and
   exact line-level S105 explanations.
@@ -137,8 +141,7 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 | State | Tasks |
 |---|---|
-| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2, T-SEC-3, T-SEC-3C, T-SEC-4, T-SEC-4A, T-SEC-5, T-TIME-3, T-CRAWL-1, T-CRAWL-2, T-PLAT-2A, T-GOV-1 |
-| **In progress** | T-SEC-6 |
+| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2, T-SEC-3, T-SEC-3C, T-SEC-4, T-SEC-4A, T-SEC-5, T-SEC-6, T-TIME-3, T-CRAWL-1, T-CRAWL-2, T-PLAT-2A, T-GOV-1 |
 | **Partially landed; acceptance incomplete** | T-GOV-4, T-GOV-5, T-GOV-6 |
 | **Pending** | T-TIME-1..2, T-DA-1, T-DB-1, T-DC-1, T-DD-1, T-DE-1, T-PLAT-1, T-PLAT-2, T-PLAT-3, T-PLAT-4, T-GOV-2..3 |
 
@@ -648,7 +651,7 @@ in `AGENTS.md`, `docs/TESTING.MD`, and
 
 ### T-SEC-6: Small closures
 - priority: P2
-- status: in progress
+- status: complete and verified 2026-07-24 (PR #138)
 - implementation_plan: `docs/plans/T_SEC_6_SMALL_SECURITY_CLOSURES_PLAN.md`
 - files_owned: .env.example, api/main.py (CORS and `/stats` only),
   pipeline/provider_telemetry.py (metric-key constants only),

--- a/docs/plans/T_SEC_6_SMALL_SECURITY_CLOSURES_PLAN.md
+++ b/docs/plans/T_SEC_6_SMALL_SECURITY_CLOSURES_PLAN.md
@@ -1,7 +1,7 @@
 # T-SEC-6: Small Security Closures
 
 `artifact_contract: ce-unified-plan/v1`
-`artifact_readiness: implementation-ready`
+`artifact_readiness: complete`
 `execution: code`
 
 ## 1. Context & Alignment
@@ -243,8 +243,9 @@ passed. Ruff passed; Mypy passed 68 files; API/reader-key tests passed 69;
 guardrail/docs tests passed 388; telemetry/topic/query tests passed 46; the
 complete Python suite passed 1,476 tests. Pre-commit review found one P2 in
 the S105 explanation ratchet; the test now requires each exact explanation,
-and rereview found no remaining P1/P2. PR CI and post-merge closure remain
-`NOT VERIFIED`.
+and rereview found no remaining P1/P2. PR #138 passed Frontend Tests, Python
+Guardrails, and CodeQL; Codex found no major issues on `d6ddc00`; the PR
+merged as `1805acd`. The post-merge closure test passed before delivery.
 
 **z) Deviations.** Expected: ownership expands from four to eleven files;
 `/stats` remains public under G2 but is minimized; ten current S105 false

--- a/docs/plans/T_SEC_6_SMALL_SECURITY_CLOSURES_PLAN.md
+++ b/docs/plans/T_SEC_6_SMALL_SECURITY_CLOSURES_PLAN.md
@@ -246,6 +246,9 @@ the S105 explanation ratchet; the test now requires each exact explanation,
 and rereview found no remaining P1/P2. PR #138 passed Frontend Tests, Python
 Guardrails, and CodeQL; Codex found no major issues on `d6ddc00`; the PR
 merged as `1805acd`. The post-merge closure test passed before delivery.
+Closure review found one P2 because the task-table assertion did not reject
+duplicate states; one shared parser now requires T-SEC-4, T-SEC-4A, and
+T-SEC-6 to each have exactly one completed state.
 
 **z) Deviations.** Expected: ownership expands from four to eleven files;
 `/stats` remains public under G2 but is minimized; ten current S105 false

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2919,14 +2919,19 @@ def test_t_sec_6_closures_are_scoped():
         assert source.count("# noqa: S105") == expected_explanations
         assert source.count(expected_explanation) == expected_explanations
 
-    assert "| **In progress** | T-SEC-6 |" in remediation_ledger
-    assert "- status: in progress" in _required_markdown_section(
+    assert "T-SEC-6" in _required_markdown_section(
+        remediation_ledger,
+        "| **Complete** |",
+        "\n| **Partially landed; acceptance incomplete** |",
+    )
+    assert "| **In progress** | T-SEC-6 |" not in remediation_ledger
+    assert "- status: complete and verified 2026-07-24 (PR #138)" in _required_markdown_section(
         remediation_ledger,
         "### T-SEC-6: Small closures",
         "\n### T-TIME-1:",
     )
-    assert "`artifact_readiness: implementation-ready`" in implementation_plan
-    assert "- [ ] `/stats` gated or minimized; CORS without `allow_credentials`" in security_policy
+    assert "`artifact_readiness: complete`" in implementation_plan
+    assert "- [x] `/stats` gated or minimized; CORS without `allow_credentials`" in security_policy
 
 
 def test_t_sec_4a_is_complete_after_g2_policy_record_merged():

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2059,6 +2059,20 @@ def _required_markdown_entry(markdown: str, heading: str) -> str:
     return " ".join(section_remainder[: next_heading.start()].split())
 
 
+def _remediation_task_states(remediation_ledger: str, task_id: str) -> list[str]:
+    status_rows = [
+        line
+        for line in remediation_ledger.splitlines()
+        if line.startswith("| **") and " |" in line
+    ]
+    return [
+        row.split("|")[1].strip().strip("*")
+        for row in status_rows
+        for listed_task_id in row.split("|")[2].split(",")
+        if listed_task_id.strip() == task_id
+    ]
+
+
 def _python_comment_blocks(source_path: Path) -> list[tuple[int, str]]:
     source_text = source_path.read_text(encoding="utf-8")
     source_lines = source_text.splitlines()
@@ -2832,17 +2846,7 @@ def test_g2_visitor_access_policy_is_aligned_after_t_sec_4_delivery():
         "### T-SEC-4: Real client identity through the proxy; per-client rate limits",
         "\n### T-SEC-5:",
     )
-    status_rows = [
-        line
-        for line in remediation_ledger.splitlines()
-        if line.startswith("| **") and " |" in line
-    ]
-    t_sec_4_states = [
-        row.split("|")[1].strip().strip("*")
-        for row in status_rows
-        for task in row.split("|")[2].split(",")
-        if task.strip() == "T-SEC-4"
-    ]
+    t_sec_4_states = _remediation_task_states(remediation_ledger, "T-SEC-4")
 
     assert "Decision G2, approved 2026-07-24" in frontend_api_boundary
     assert (
@@ -2919,12 +2923,7 @@ def test_t_sec_6_closures_are_scoped():
         assert source.count("# noqa: S105") == expected_explanations
         assert source.count(expected_explanation) == expected_explanations
 
-    assert "T-SEC-6" in _required_markdown_section(
-        remediation_ledger,
-        "| **Complete** |",
-        "\n| **Partially landed; acceptance incomplete** |",
-    )
-    assert "| **In progress** | T-SEC-6 |" not in remediation_ledger
+    assert _remediation_task_states(remediation_ledger, "T-SEC-6") == ["Complete"]
     assert "- status: complete and verified 2026-07-24 (PR #138)" in _required_markdown_section(
         remediation_ledger,
         "### T-SEC-6: Small closures",
@@ -2943,17 +2942,7 @@ def test_t_sec_4a_is_complete_after_g2_policy_record_merged():
         "### T-SEC-4A: Record the approved G2 visitor-access policy",
         "\n### T-SEC-4:",
     )
-    status_rows = [
-        line
-        for line in remediation_ledger.splitlines()
-        if line.startswith("| **") and " |" in line
-    ]
-    t_sec_4a_states = [
-        row.split("|")[1].strip().strip("*")
-        for row in status_rows
-        for task in row.split("|")[2].split(",")
-        if task.strip() == "T-SEC-4A"
-    ]
+    t_sec_4a_states = _remediation_task_states(remediation_ledger, "T-SEC-4A")
     normalized_t_sec_4a_entry = " ".join(t_sec_4a_entry.lower().split())
 
     assert "status: complete and verified 2026-07-24 (PR #133)" in t_sec_4a_entry


### PR DESCRIPTION
## What changed
- mark the T-SEC-6 hardening checklist item complete
- move T-SEC-6 from in progress to complete in the remediation ledger
- record PR #138's merge, CI, and review evidence
- ratchet the repository guardrail test to require completed state

## Why
PR #138 merged the implementation as `1805acd`. This narrow follow-up records durable completion evidence without mixing policy bookkeeping into the implementation PR.

## Verification
- Tests-first closure contract: FAIL as expected before docs alignment
- PASS: `./.venv/bin/ruff check .`
- PASS: `./.venv/bin/mypy`
- PASS: repository guardrails and docs links, 388 passed
- PASS: complete Python suite, 1,476 passed
- PASS: `git diff --check`
- PASS: independent pre-commit review, no P1/P2

## Scope
Four authorized closure files only. No runtime behavior, dependencies, secrets, or permissions change.
