### PR TITLE
T-GOV-4: Close the revised AGENTS policy task

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 This file is the AI collaboration contract for this repository.
 
 <project_identity>
-Town Council is a local-first civic data platform for crawling, extracting, indexing, and analyzing local government meeting records. Treat `README.md`, `ARCHITECTURE.md`, `SECURITY.md`, `docs/OPERATIONS.md`, `docs/PERFORMANCE.md`, `docs/ENGINEERING_GUARDRAILS.md`, `docs/TESTING.md`, `docs/DATA_GOVERNANCE.md`, and `ROADMAP.md` as canonical references.
+Town Council is a local-first civic data platform for crawling, extracting, indexing, and analyzing local government meeting records. Treat `README.md`, `ARCHITECTURE.md`, `SECURITY.md`, `docs/OPERATIONS.md`, `docs/PERFORMANCE.md`, `docs/ENGINEERING_GUARDRAILS.md`, `docs/TESTING.MD`, `docs/DATA_GOVERNANCE.md`, and `ROADMAP.md` as canonical references.
 
 Keep this file focused on repo-applicable operating policy: project constraints, commands, verification, quality rules, and reporting expectations. Do not use it for agent persona, chat-style output templates, session notes, or implementation logs.
 </project_identity>
@@ -43,7 +43,7 @@ authorizes their removal.
 - Test-seam re-exports: `from module import name as name` blocks or facade
   wrapper functions whose only purpose is to preserve historical monkeypatch
   targets. If a test breaks because a symbol moved, repoint the test at the
-  implementation module instead (`docs/TESTING.md`).
+  implementation module instead (`docs/TESTING.MD`).
 - Patchability parameters: adding injectable-callable parameters to a
   function signature so tests can substitute internals. Fake at approved
   boundaries (DB session factory, Celery dispatch, inference provider,

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,6 +1,6 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 3.24
+version: 3.25
 generated: 2026-07-24
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
@@ -10,6 +10,9 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v3.25:** Activates the T-GOV-4 closure audit for the revised `AGENTS.md`
+  policy that landed in commit `453c386`; adds plan, ledger, guardrail, and
+  two testing-policy path-casing corrections without re-authoring policy.
 - **v3.24:** Marks T-SEC-6 complete after PR #138 merged as `1805acd`.
   Public stats now expose only document count, credentialed CORS is disabled,
   stale browser-key guidance is removed, and two broad S105 exceptions are
@@ -142,7 +145,8 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 | State | Tasks |
 |---|---|
 | **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2, T-SEC-3, T-SEC-3C, T-SEC-4, T-SEC-4A, T-SEC-5, T-SEC-6, T-TIME-3, T-CRAWL-1, T-CRAWL-2, T-PLAT-2A, T-GOV-1 |
-| **Partially landed; acceptance incomplete** | T-GOV-4, T-GOV-5, T-GOV-6 |
+| **In progress** | T-GOV-4 |
+| **Partially landed; acceptance incomplete** | T-GOV-5, T-GOV-6 |
 | **Pending** | T-TIME-1..2, T-DA-1, T-DB-1, T-DC-1, T-DD-1, T-DE-1, T-PLAT-1, T-PLAT-2, T-PLAT-3, T-PLAT-4, T-GOV-2..3 |
 
 ---
@@ -981,18 +985,22 @@ files (GED-5 grant).
 
 ### T-GOV-4: Land the revised AGENTS.md
 - priority: P1
-- files_owned: AGENTS.md
-- depends_on: none for the antipatterns/security/hierarchy edits; the
-  verification-matrix and action-permission edits carry [transition]
-  markers tied to T-CI-1/T-CI-2.
-- do: Merge the provided draft (drafts/AGENTS.md). Verify every section not
-  named in the draft changelog is byte-identical to master (the revision is
-  surgical: canonical-doc list, hierarchy #1 clarification, new
+- status: in progress
+- implementation_plan: `docs/plans/T_GOV_4_AGENTS_POLICY_CLOSURE_PLAN.md`
+- files_owned: AGENTS.md (two `docs/TESTING.md` casing corrections only),
+  docs/plans/T_GOV_4_AGENTS_POLICY_CLOSURE_PLAN.md,
+  docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md,
+  tests/test_repository_guardrails.py
+- depends_on: none. The former T-CI-1/T-CI-2 transition conditions are
+  satisfied, and their markers have been removed from `AGENTS.md`.
+- landed_evidence: commit `453c386` changed only `AGENTS.md`.
+- do: Verify every section not named in the landed revision is byte-identical
+  to its parent and correct two testing-policy links to tracked-path casing.
+  The revision is surgical: canonical-doc list, hierarchy #1 clarification, new
   <known_antipatterns>, full-pytest permission move, matrix scope preamble +
   frontend npm row + mandatory cross-cutting sweep, new
   <security_sensitive_paths>, docs enumeration rule, checklist line,
-  maintenance triggers). When T-CI-1 and T-CI-2 merge, remove the two
-  [transition] markers in a follow-up commit.
+  maintenance triggers.
 - forbidden: Re-authoring policy text; reflowing unchanged sections.
 - accept: Diff against master touches only the enumerated sections;
   docs-link test green.

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,6 +1,6 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 3.25
+version: 3.26
 generated: 2026-07-24
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
@@ -10,6 +10,9 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v3.26:** Marks T-GOV-4 complete after auditing policy commit `453c386`,
+  correcting two testing-policy path references, and adding a durable
+  completion guardrail.
 - **v3.25:** Activates the T-GOV-4 closure audit for the revised `AGENTS.md`
   policy that landed in commit `453c386`; adds plan, ledger, guardrail, and
   two testing-policy path-casing corrections without re-authoring policy.
@@ -144,8 +147,7 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 | State | Tasks |
 |---|---|
-| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2, T-SEC-3, T-SEC-3C, T-SEC-4, T-SEC-4A, T-SEC-5, T-SEC-6, T-TIME-3, T-CRAWL-1, T-CRAWL-2, T-PLAT-2A, T-GOV-1 |
-| **In progress** | T-GOV-4 |
+| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2, T-SEC-3, T-SEC-3C, T-SEC-4, T-SEC-4A, T-SEC-5, T-SEC-6, T-TIME-3, T-CRAWL-1, T-CRAWL-2, T-PLAT-2A, T-GOV-1, T-GOV-4 |
 | **Partially landed; acceptance incomplete** | T-GOV-5, T-GOV-6 |
 | **Pending** | T-TIME-1..2, T-DA-1, T-DB-1, T-DC-1, T-DD-1, T-DE-1, T-PLAT-1, T-PLAT-2, T-PLAT-3, T-PLAT-4, T-GOV-2..3 |
 
@@ -985,7 +987,7 @@ files (GED-5 grant).
 
 ### T-GOV-4: Land the revised AGENTS.md
 - priority: P1
-- status: in progress
+- status: complete and verified 2026-07-24
 - implementation_plan: `docs/plans/T_GOV_4_AGENTS_POLICY_CLOSURE_PLAN.md`
 - files_owned: AGENTS.md (two `docs/TESTING.md` casing corrections only),
   docs/plans/T_GOV_4_AGENTS_POLICY_CLOSURE_PLAN.md,

--- a/docs/plans/T_GOV_4_AGENTS_POLICY_CLOSURE_PLAN.md
+++ b/docs/plans/T_GOV_4_AGENTS_POLICY_CLOSURE_PLAN.md
@@ -1,0 +1,232 @@
+# T-GOV-4: Close the Revised AGENTS Policy Task
+
+`artifact_contract: ce-unified-plan/v1`
+`artifact_readiness: implementation-ready`
+`execution: code`
+
+## 1. Context & Alignment
+
+**a) Driver.** The revised `AGENTS.md` landed in commit `453c386`, and the
+CI transitions it anticipated are complete. The active remediation ledger
+still classifies T-GOV-4 as partially landed, and two links use
+`docs/TESTING.md` instead of the tracked `docs/TESTING.MD` casing. This task
+corrects those links and adds durable completion evidence without
+re-authoring the policy.
+
+**b) Canonical documents consulted.**
+
+- `AGENTS.md` hierarchy, workflow contract, verification matrix, and
+  maintenance rules define the policy being verified.
+- `docs/ENGINEERING_GUARDRAILS.md` remains canonical for guardrail scope;
+  this task must not duplicate its machine-readable inventories.
+- `docs/TESTING.MD` permits tracked-filesystem policy tests and requires
+  observable contracts.
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md` defines T-GOV-4 acceptance
+  and currently records it as partially landed.
+- `docs/reviews/architecture-review-2026-07-19.html` identifies T-GOV-4 as
+  partial, but that implementation-state claim predates commit `453c386`.
+
+**c) Remediation alignment.** T-GOV-4 remains in the GOV lane. Expand its
+exclusive ownership to:
+
+- `AGENTS.md`, the two `docs/TESTING.md` casing corrections only
+- `docs/plans/T_GOV_4_AGENTS_POLICY_CLOSURE_PLAN.md`
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`
+- `tests/test_repository_guardrails.py`
+
+No other tracked file may change.
+
+**d) Decision-gate check.** T-GOV-4 depends on no G1-G5 decision. T-CI-1
+and T-CI-2 are complete, so their former transition conditions are
+satisfied. G4 and G5 remain open and unaffected.
+
+## 2. Design
+
+**e) Step-by-step approach.**
+
+1. Register this plan and expanded ownership before changing the closure
+   contract.
+2. Audit `git diff --unified=0 453c386^ 453c386 -- AGENTS.md`. Record every
+   changed hunk and verify each maps to the task's enumerated policy sections;
+   this proves sections outside those hunks remained byte-identical.
+3. Add a failing repository guardrail that expects T-GOV-4 to be uniquely
+   complete, this artifact to be complete, and no completed CI transition
+   marker or wrong-case testing-policy link to remain in `AGENTS.md`. The
+   task entry must also describe the transitions as completed history.
+4. Run the test red while the ledger and artifact still say in progress and
+   implementation-ready.
+5. Mark T-GOV-4 complete in the task table and task entry, record the landed
+   commit evidence, and mark this artifact complete.
+6. Correct only the two `docs/TESTING.md` references to the tracked
+   `docs/TESTING.MD` casing.
+7. Run the guardrail/tooling and docs verification rows plus the complete
+   Python suite.
+8. Obtain an independent pre-commit review, resolve every eligible P1/P2,
+   and rerun affected verification.
+9. Commit, push one PR, request Codex review, resolve feedback, and merge
+   only after all required checks pass.
+
+The only new function is the test
+`test_t_gov_4_agents_policy_is_complete`. Its responsibility is to enforce
+agreement among the live policy, task ledger, and closure artifact.
+
+**f) Reuse audit.** Reuse `_required_markdown_section` and
+`_remediation_task_states` in `tests/test_repository_guardrails.py`. No new
+parser, policy registry, wrapper, compatibility alias, or duplicated
+source inventory is introduced. No older implementation is retained or
+superseded.
+
+**g) Data contracts.** No application payload changes. The policy contract
+is repository text: T-GOV-4 appears in exactly one task-table state, its
+task entry has exactly one status, and `AGENTS.md` contains the required
+policy sections without stale T-CI-1/T-CI-2 transition language or
+wrong-case canonical paths.
+
+**h) Schema/migration impact.** None.
+
+## 3. Security & Data Governance
+
+**i) Security-sensitive paths.** None under `AGENTS.md`. The test verifies
+that `<security_sensitive_paths>` remains present but does not change any
+runtime trust boundary or security control.
+
+**j) Secrets.** No credential, key, environment variable, or default
+changes.
+
+**k) Person data.** No person-level data is created, linked, aggregated, or
+exposed. G4 is unaffected.
+
+**l) Untrusted input.** The test reads tracked Markdown policy files only.
+No scraped content, provider response, HTML, or user input is parsed.
+
+## 4. Code Health
+
+**m) GED conformance sweep.** The new test uses repository-domain names,
+existing helpers, no exception handler, no timestamp generation, no
+environment read, and no nesting beyond the existing comprehensions in
+the shared task-state parser. No production function changes.
+
+**n) Antipattern scan, plan pass.**
+
+- A1/H1: no external API or dependency-facing call is introduced.
+- A3: commit, test, and CI claims must be backed by commands or GitHub
+  evidence recorded in this artifact.
+- B1/F1: existing Markdown and task-state helpers are reused.
+- D1-D3: the test strengthens the state contract and checks public policy
+  text; no assertion is weakened or skipped.
+- E1-E3: edits are limited to the four owned paths; `AGENTS.md` changes only
+  the two proven wrong-case paths.
+- A2, A4, B2-B3, C1-C2, F2, H2-H4: no planned violations.
+
+**o) Ratchet interaction.** Ruff selectors, BLE001 boundaries, formatter
+scope, Mypy scope, coverage threshold, and verification commands remain
+unchanged. This task removes only stale remediation status.
+
+**p) Dead code and duplication audit.** No production code is deleted or
+added. The guardrail reuses the shared task-state parser. Expected net
+growth is one focused policy test and one implementation plan.
+
+## 5. Testing
+
+**q) Edge cases and failure scenarios.**
+
+1. T-GOV-4 appears as Complete and another state.
+2. The task entry remains partial, pending, or has multiple status lines.
+3. The artifact remains implementation-ready after ledger closure.
+4. A required `AGENTS.md` policy section is deleted or links the wrong path.
+5. A stale T-CI-1/T-CI-2 transition marker is reintroduced.
+6. Completion evidence names the wrong landed commit.
+7. The T-GOV-4 ledger entry says transition markers still remain.
+8. Historical commit `453c386` changed a section outside its enumerated
+   acceptance list.
+9. An unrelated current policy section is rewritten during closure.
+
+**r) Tests.**
+
+| Test | Scenarios |
+|---|---|
+| New `test_t_gov_4_agents_policy_is_complete` | 1-7 |
+| `git diff --unified=0 453c386^ 453c386 -- AGENTS.md` | 8 |
+| Current `git diff -- AGENTS.md` scope audit | 9 |
+| Existing repository guardrails | 1-9 |
+| Existing docs-link tests | policy-link integrity |
+| Complete Python suite | cross-cutting regression check |
+
+The closure test is written and run red before completion markers change.
+
+**s) Fakes and mocks.** None. The test uses the approved tracked-filesystem
+boundary and patches no production symbol.
+
+**t) Verification rows.** Apply the guardrail/tooling row because
+`tests/test_repository_guardrails.py` changes and the docs-only row because
+`AGENTS.md` policy status is being closed. Run the complete Python suite
+before handoff.
+
+## 6. Execution, Rollback, Docs
+
+**u) Exact commands.**
+
+```bash
+git fetch origin --prune
+git switch master
+git merge --ff-only origin/master
+git switch -c codex/t-gov-4-close-agents-policy
+
+git show --name-only --format= 453c386
+git diff --unified=0 453c386^ 453c386 -- AGENTS.md
+rg -n "<known_antipatterns>|<security_sensitive_paths>|authoritative CI verification|\\[transition" AGENTS.md
+
+PYTHONPATH=. .venv/bin/pytest -q \
+  tests/test_repository_guardrails.py::test_t_gov_4_agents_policy_is_complete
+
+./.venv/bin/ruff check .
+./.venv/bin/mypy
+PYTHONPATH=. .venv/bin/pytest -q tests/test_repository_guardrails.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py
+PYTHONPATH=. .venv/bin/pytest -q
+git diff --check
+git status --short
+```
+
+Delivery:
+
+```bash
+git push -u origin codex/t-gov-4-close-agents-policy
+gh pr create \
+  --base master \
+  --head codex/t-gov-4-close-agents-policy \
+  --title "T-GOV-4: Close the revised AGENTS policy task"
+```
+
+**v) Rollback.** Revert the T-GOV-4 closure merge commit, rerun Ruff, Mypy,
+repository guardrails, docs links, and the complete suite. No migration,
+configuration restoration, data repair, or external-state cleanup exists.
+Rollback restores the stale partial status but does not revert the already
+active `AGENTS.md` policy.
+
+**w) Docs sync.**
+
+- Remediation ledger: ownership, implementation-plan link, unique completed
+  state, landed commit, and changelog evidence.
+- This plan: implementation and delivery evidence.
+- `AGENTS.md`: correct the two canonical testing-policy path references;
+  leave all policy language unchanged.
+- README, ADR, architecture review, operations, security, testing,
+  engineering guardrails, and data-governance docs: no changes.
+
+## 7. Delivery Self-Audit
+
+**x) Antipattern scan, diff pass.** Re-run A-F/H. Reject any `AGENTS.md`
+policy rewrite, duplicated task-state parser, weakened guardrail, unrelated
+formatting, invented evidence, or change outside the four owned paths.
+
+**y) Evidence.** Record the tests-first red result, commit `453c386`
+verification, Ruff, Mypy, guardrail, docs-link, and complete-suite outcomes,
+independent review findings, commits, PR URL, unresolved-thread count, and
+final CI state. Anything unrun is `NOT VERIFIED`.
+
+**z) Deviations.** Expected authorized changes: ownership expands from one
+file to four closure paths, two testing-policy links receive case-only
+corrections, and the ledger moves T-GOV-4 from partial to complete. Any
+other `AGENTS.md` content edit, new dependency, runtime change, skipped
+review, unresolved P1/P2, or unrun required check is a blocker.

--- a/docs/plans/T_GOV_4_AGENTS_POLICY_CLOSURE_PLAN.md
+++ b/docs/plans/T_GOV_4_AGENTS_POLICY_CLOSURE_PLAN.md
@@ -1,7 +1,7 @@
 # T-GOV-4: Close the Revised AGENTS Policy Task
 
 `artifact_contract: ce-unified-plan/v1`
-`artifact_readiness: implementation-ready`
+`artifact_readiness: complete`
 `execution: code`
 
 ## 1. Context & Alignment
@@ -220,10 +220,18 @@ active `AGENTS.md` policy.
 policy rewrite, duplicated task-state parser, weakened guardrail, unrelated
 formatting, invented evidence, or change outside the four owned paths.
 
-**y) Evidence.** Record the tests-first red result, commit `453c386`
-verification, Ruff, Mypy, guardrail, docs-link, and complete-suite outcomes,
-independent review findings, commits, PR URL, unresolved-thread count, and
-final CI state. Anything unrun is `NOT VERIFIED`.
+**y) Evidence.** Tests-first closure verification failed as expected because
+T-GOV-4 was still In progress. The historical diff audit found 12 hunks, all
+within the enumerated `project_identity`, hierarchy, antipattern,
+action-permission, security-sensitive-path, verification-matrix, completion,
+docs-sync, and maintenance sections; commit `453c386` changed no other file.
+The two wrong-case testing-policy links were the only current `AGENTS.md`
+deficit. Planning review found three P2s and rereview found none. Ruff passed;
+Mypy passed 68 files; repository guardrail and docs-link tests passed 389;
+the complete Python suite passed 1,477; and `git diff --check` passed.
+Pre-commit review found three P2s in assertion scope and evidence reporting;
+the fixes passed targeted verification and rereview found no remaining P1/P2.
+Commit, PR, unresolved-thread, and CI evidence is `NOT VERIFIED`.
 
 **z) Deviations.** Expected authorized changes: ownership expands from one
 file to four closure paths, two testing-policy links receive case-only

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -3053,6 +3053,49 @@ def test_test_patch_points_policy_has_accepted_adr_and_effective_runbook():
         assert owned_path in dedup_b_row
 
 
+def test_t_gov_4_agents_policy_is_complete():
+    agent_policy = (ROOT / "AGENTS.md").read_text(encoding="utf-8")
+    remediation_ledger = (
+        ROOT / "docs" / "plans" / "TOWN_COUNCIL_REMEDIATION_PLAN.md"
+    ).read_text(encoding="utf-8")
+    implementation_plan = (
+        ROOT / "docs" / "plans" / "T_GOV_4_AGENTS_POLICY_CLOSURE_PLAN.md"
+    ).read_text(encoding="utf-8")
+    t_gov_4_entry = _required_markdown_section(
+        remediation_ledger,
+        "### T-GOV-4: Land the revised AGENTS.md",
+        "\n### T-GOV-5:",
+    )
+    project_identity = _required_markdown_section(
+        agent_policy,
+        "<project_identity>",
+        "\n</project_identity>",
+    )
+    known_antipatterns = _required_markdown_section(
+        agent_policy,
+        "<known_antipatterns>",
+        "\n</known_antipatterns>",
+    )
+
+    assert _remediation_task_states(remediation_ledger, "T-GOV-4") == ["Complete"]
+    assert "status: complete and verified 2026-07-24" in t_gov_4_entry
+    assert t_gov_4_entry.count("- status:") == 1
+    assert "commit `453c386` changed only `AGENTS.md`" in t_gov_4_entry
+    assert "carry [transition] markers" not in t_gov_4_entry
+    assert "`artifact_readiness: complete`" in implementation_plan
+
+    assert "<known_antipatterns>" in agent_policy
+    assert "<security_sensitive_paths>" in agent_policy
+    assert "authoritative CI verification is the full test suite" in agent_policy
+    assert "Both jobs are mandatory under the active" in agent_policy
+    assert "File-set enumerations" in agent_policy
+    assert "the CI full-suite and frontend jobs are delivered by remediation" not in agent_policy
+    assert "effective when the frontend test runner lands" not in agent_policy
+    assert "docs/TESTING.md" not in agent_policy
+    assert "docs/TESTING.MD" in project_identity
+    assert "docs/TESTING.MD" in known_antipatterns
+
+
 def test_test_patch_point_adr_boundary_uses_the_next_decision_heading():
     architecture_decisions = """
 ## 2026-07-24: Test patch points are not a public API


### PR DESCRIPTION
## What changed
- correct two `docs/TESTING.MD` path references in `AGENTS.md`
- record the 12-hunk audit of policy commit `453c386`
- move T-GOV-4 from partial to complete
- add a durable policy and remediation-state guardrail

## Why
The revised policy was already active, but the ledger remained partial and two canonical links used the wrong tracked-path casing. This closes the governance task without re-authoring policy.

## Historical evidence
`git diff --unified=0 453c386^ 453c386 -- AGENTS.md` shows 12 hunks, all confined to the task's enumerated policy sections. Commit `453c386` changed no other file.

## Verification
- Tests-first closure test: FAIL as expected on In-progress status
- PASS: `./.venv/bin/ruff check .`
- PASS: `./.venv/bin/mypy`, 68 files
- PASS: repository guardrails and docs links, 389 passed
- PASS: complete Python suite, 1,477 passed
- PASS: `git diff --check`
- PASS: independent planning and pre-commit rereviews, no remaining P1/P2

## Scope and risk
Four authorized paths only. No runtime, API, schema, dependency, secret, or security-boundary behavior changes.
