### PR TITLE
T-GOV-5: Close the engineering guardrails rewrite

### DIFF
--- a/docs/ENGINEERING_GUARDRAILS.md
+++ b/docs/ENGINEERING_GUARDRAILS.md
@@ -3,9 +3,9 @@
 Town Council uses a layered guardrail system to reduce low-signal code smells
 before they land in `master`.
 
-Status: this revision lands alongside remediation task T-GOV-3 (structural
-rules replace per-file line lists). Sections marked `[transition]` state which
-task activates them.
+Status: active. Config-owned lint, formatter, typing, coverage, smell-test,
+and CI scopes are live, including the C901 complexity ceiling. The structural
+rules header retains `[transition: T-GOV-3]` until its remaining rules land.
 
 ## Single-source rule for scopes
 
@@ -41,7 +41,7 @@ CI runs the static checks, fast-fail test subset, and complete Python suite
 under the `.coveragerc` production scope and coverage floor on every pull
 request and master push. The fast-fail subset provides earlier diagnostics;
 the coverage-enabled complete suite remains the Python merge gate (see
-`docs/TESTING.md`).
+`docs/TESTING.MD`).
 
 Run that gate locally when changing coverage policy:
 
@@ -72,11 +72,10 @@ worse than the length it removed. The replacement rules measure the thing we
 actually care about — cohesion and dependency direction — and files may be as
 long as their content is cohesive.
 
-1. Complexity ceiling: no function above radon grade C (CC > 10) in `api/`
-   or `pipeline/` without a documented exception. Enforcement mechanism and
-   rule selection are recorded in `ruff.toml` / the guardrail test when
-   adopted; per `AGENTS.md`, do not claim complexity enforcement before the
-   config selects it.
+1. Complexity ceiling: Ruff selects C901 across its configured repository
+   scope with `max-complexity = 10`. Existing offenders require narrow,
+   path-specific exceptions in `ruff.toml`; remove those exceptions when
+   current lint and guardrail checks prove them stale.
 2. Import direction: helper modules must not import their facade/route
    module. Generalized from the `semantic_service` rule to every
    facade+helpers family registered in the guardrail test constants.

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,6 +1,6 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 3.26
+version: 3.27
 generated: 2026-07-24
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
@@ -10,6 +10,10 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v3.27:** Activates T-GOV-5 closure for the rewritten engineering
+  guardrails policy. Expands ownership to its Full plan, durable completion
+  guardrail, and ledger state while preserving the pending T-GOV-3 structural
+  transition.
 - **v3.26:** Marks T-GOV-4 complete after auditing policy commit `453c386`,
   correcting two testing-policy path references, and adding a durable
   completion guardrail.
@@ -148,7 +152,8 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 | State | Tasks |
 |---|---|
 | **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2, T-SEC-3, T-SEC-3C, T-SEC-4, T-SEC-4A, T-SEC-5, T-SEC-6, T-TIME-3, T-CRAWL-1, T-CRAWL-2, T-PLAT-2A, T-GOV-1, T-GOV-4 |
-| **Partially landed; acceptance incomplete** | T-GOV-5, T-GOV-6 |
+| **In progress** | T-GOV-5 |
+| **Partially landed; acceptance incomplete** | T-GOV-6 |
 | **Pending** | T-TIME-1..2, T-DA-1, T-DB-1, T-DC-1, T-DD-1, T-DE-1, T-PLAT-1, T-PLAT-2, T-PLAT-3, T-PLAT-4, T-GOV-2..3 |
 
 ---
@@ -1010,19 +1015,26 @@ files (GED-5 grant).
 
 ### T-GOV-5: Land the rewritten ENGINEERING_GUARDRAILS.md
 - priority: P1
+- status: in progress
+- implementation_plan:
+  `docs/plans/T_GOV_5_ENGINEERING_GUARDRAILS_CLOSURE_PLAN.md`
 - depends_on: T-CI-4 (formatter scope in ruff-format.toml); coordinates with
   T-GOV-3 (structural rules).
-- files_owned: docs/ENGINEERING_GUARDRAILS.md
+- files_owned: docs/ENGINEERING_GUARDRAILS.md,
+  docs/plans/T_GOV_5_ENGINEERING_GUARDRAILS_CLOSURE_PLAN.md,
+  docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md,
+  tests/test_repository_guardrails.py
 - coordination: T-CI-0's narrow broad-handler structural-policy correction lands
   first. T-GOV-5 must carry the corrected policy into the rewritten document and
   must not restore final-statement or `sys.exit()` authorization.
-- do: Merge the provided draft (drafts/docs/ENGINEERING_GUARDRAILS.md) in
-  the same PR as T-CI-4 or immediately after. Reconcile [transition]
-  markers: T-CI-4 marker removed when the `ruff-format.toml` scope is live;
-  T-GOV-3
-  markers removed as each structural rule gains enforcement. The typed
-  subtree list must be confirmed present in mypy.ini before deleting the
-  doc enumeration (it already is — verify, don't assume).
+- do: Close the rewrite that landed in historical commit `c4a4a27` after
+  independently verifying current acceptance. Record that the original draft
+  is unavailable for exact identity comparison and that the rewrite landed
+  before T-CI-4 rather than alongside it. Reconcile [transition] markers:
+  retain T-GOV-3 markers until each structural rule gains enforcement; do not
+  restore a T-CI-4 marker now that `ruff-format.toml` scope is live. Confirm
+  the typed subtree remains in `mypy.ini` and C901 remains selected with
+  `max-complexity = 10`; do not duplicate either scope in prose.
 - forbidden: Reintroducing any file enumeration; deleting the boundary-
   handler or exception-process prose.
 - accept: No file-set enumerations remain in the doc; every scope statement

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,6 +1,6 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 3.27
+version: 3.28
 generated: 2026-07-24
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
@@ -10,6 +10,10 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v3.28:** Marks T-GOV-5 complete after independently verifying the landed
+  engineering guardrails rewrite, correcting three stale policy claims, and
+  adding a durable completion contract. Exact identity with the unavailable
+  original draft remains unverified.
 - **v3.27:** Activates T-GOV-5 closure for the rewritten engineering
   guardrails policy. Expands ownership to its Full plan, durable completion
   guardrail, and ledger state while preserving the pending T-GOV-3 structural
@@ -151,8 +155,7 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 | State | Tasks |
 |---|---|
-| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2, T-SEC-3, T-SEC-3C, T-SEC-4, T-SEC-4A, T-SEC-5, T-SEC-6, T-TIME-3, T-CRAWL-1, T-CRAWL-2, T-PLAT-2A, T-GOV-1, T-GOV-4 |
-| **In progress** | T-GOV-5 |
+| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2, T-SEC-3, T-SEC-3C, T-SEC-4, T-SEC-4A, T-SEC-5, T-SEC-6, T-TIME-3, T-CRAWL-1, T-CRAWL-2, T-PLAT-2A, T-GOV-1, T-GOV-4, T-GOV-5 |
 | **Partially landed; acceptance incomplete** | T-GOV-6 |
 | **Pending** | T-TIME-1..2, T-DA-1, T-DB-1, T-DC-1, T-DD-1, T-DE-1, T-PLAT-1, T-PLAT-2, T-PLAT-3, T-PLAT-4, T-GOV-2..3 |
 
@@ -1015,7 +1018,7 @@ files (GED-5 grant).
 
 ### T-GOV-5: Land the rewritten ENGINEERING_GUARDRAILS.md
 - priority: P1
-- status: in progress
+- status: complete and verified 2026-07-24
 - implementation_plan:
   `docs/plans/T_GOV_5_ENGINEERING_GUARDRAILS_CLOSURE_PLAN.md`
 - depends_on: T-CI-4 (formatter scope in ruff-format.toml); coordinates with
@@ -1027,6 +1030,10 @@ files (GED-5 grant).
 - coordination: T-CI-0's narrow broad-handler structural-policy correction lands
   first. T-GOV-5 must carry the corrected policy into the rewritten document and
   must not restore final-statement or `sys.exit()` authorization.
+- landed_evidence: commit `c4a4a27` changed only
+  `docs/ENGINEERING_GUARDRAILS.md`. The original draft is unavailable for
+  exact identity comparison; current acceptance was independently verified
+  after T-CI-4 completed.
 - do: Close the rewrite that landed in historical commit `c4a4a27` after
   independently verifying current acceptance. Record that the original draft
   is unavailable for exact identity comparison and that the rewrite landed

--- a/docs/plans/T_GOV_5_ENGINEERING_GUARDRAILS_CLOSURE_PLAN.md
+++ b/docs/plans/T_GOV_5_ENGINEERING_GUARDRAILS_CLOSURE_PLAN.md
@@ -1,0 +1,251 @@
+# T-GOV-5: Close the Engineering Guardrails Rewrite
+
+`artifact_contract: ce-unified-plan/v1`
+`artifact_readiness: implementation-ready`
+`execution: code`
+
+## 1. Context & Alignment
+
+**a) Driver.** The rewritten `docs/ENGINEERING_GUARDRAILS.md` landed in
+historical commit `c4a4a27`, and its T-CI-4 dependency is complete. The live
+document still says that the revision lands alongside T-GOV-3, uses the wrong
+case for the tracked testing-policy path, and describes C901 as not yet
+adopted. T-GOV-5 therefore remains partially landed even though its current
+acceptance criteria are independently verifiable. This closure corrects those
+claims and adds durable evidence without changing guardrail policy or removing
+the still-active T-GOV-3 transition.
+
+**b) Canonical documents consulted.**
+
+- `AGENTS.md` hierarchy, workflow contract, verification matrix, and docs-sync
+  rules require config-owned scope, exact verification, and current commands.
+- `docs/ENGINEERING_GUARDRAILS.md` is the guardrail-policy source being closed.
+- `docs/TESTING.MD` permits tracked-filesystem policy tests and requires
+  observable contracts.
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md` defines T-GOV-5 acceptance and
+  currently records it as partially landed.
+- `docs/reviews/architecture-review-2026-07-19.html` identifies the guardrail
+  rewrite as landed but awaiting its CI dependencies and closure.
+- `ruff.toml`, `ruff-format.toml`, `mypy.ini`, `.coveragerc`, and the Python and
+  frontend workflows are the machine-readable sources for current guardrail
+  scope and enforcement.
+
+**c) Remediation alignment.** T-GOV-5 remains in the GOV lane. Expand its
+exclusive ownership to:
+
+- `docs/ENGINEERING_GUARDRAILS.md`
+- `docs/plans/T_GOV_5_ENGINEERING_GUARDRAILS_CLOSURE_PLAN.md`
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`
+- `tests/test_repository_guardrails.py`
+
+The machine-readable guardrail configs and workflows are read-only evidence
+for this task.
+
+**d) Decision-gate check.** T-GOV-5 depends on no G1-G5 decision. T-CI-4 is
+complete. T-GOV-3 remains pending, so its structural-rules transition marker
+must remain.
+
+## 2. Design
+
+**e) Step-by-step approach.**
+
+1. Register this plan and expanded ownership before changing the closure
+   contract.
+2. Audit historical commit `c4a4a27` and current guardrail config. Record that
+   the rewrite changed only `docs/ENGINEERING_GUARDRAILS.md`, while the
+   original external draft is unavailable for exact identity verification.
+3. Obtain an independent planning review and correct every eligible P1/P2.
+4. Add a failing repository guardrail that expects T-GOV-5 to be uniquely
+   complete, this artifact to be complete, and the live guardrail document to
+   contain current testing-policy casing, current C901 enforcement, all
+   required exception prose, and the pending T-GOV-3 marker.
+5. Run the focused test red while the ledger and artifact remain incomplete
+   and the live document contains stale claims.
+6. Correct only three live-document claims: rewrite status, testing-policy
+   path casing, and C901 adoption/scope wording.
+7. Mark T-GOV-5 complete in the task table and task entry, record historical
+   and current acceptance evidence, and mark this artifact complete.
+8. Run guardrail/tooling, docs-link, and complete-suite verification.
+9. Obtain a fresh pre-commit review, resolve every eligible P1/P2, and rerun
+   affected verification.
+10. Commit, push one PR, request Codex review, resolve feedback, and merge only
+    after required checks pass.
+
+The only new function is
+`test_t_gov_5_engineering_guardrails_is_complete`. Its responsibility is to
+enforce agreement among the live guardrail policy, current C901 config, task
+ledger, and closure artifact.
+
+**f) Reuse audit.** Reuse `_required_markdown_section` and
+`_remediation_task_states` in `tests/test_repository_guardrails.py`, plus the
+existing Ruff, formatter, Mypy, coverage, workflow, exception, and
+suppression guardrails. No parser, policy registry, wrapper, compatibility
+alias, or duplicate source inventory is introduced.
+
+**g) Data contracts.** No application payload changes. The repository-policy
+contract is text: T-GOV-5 appears in exactly one task-table state; its task
+entry has exactly one status; scope remains config-owned; and the live
+document retains its boundary-handler, exception-process, flat re-raise, and
+`sys.exit()` prohibition contracts. The test parses `ruff.toml` with the
+existing `tomllib` dependency and requires C901 selection plus
+`max-complexity = 10`.
+
+**h) Schema/migration impact.** None.
+
+## 3. Security & Data Governance
+
+**i) Security-sensitive paths.** None under `AGENTS.md`. The guardrail prose
+describes exception policy but does not alter a runtime trust boundary or
+security control.
+
+**j) Secrets.** No credential, key, environment variable, or default changes.
+
+**k) Person data.** No person-level data is created, linked, aggregated, or
+exposed. G4 is unaffected.
+
+**l) Untrusted input.** The new test reads tracked Markdown and existing
+machine-readable configuration only. It does not parse scraped content,
+provider responses, HTML, or user input.
+
+## 4. Code Health
+
+**m) GED conformance sweep.** The new test uses repository-domain names,
+existing helpers, no exception handler, no timestamp generation, no
+environment read, and no additional nesting. No production function changes.
+
+**n) Antipattern scan, plan pass.**
+
+- A1/H1: no external API or dependency-facing call is introduced; enforcement
+  claims are checked against current repository config.
+- A3: historical identity is explicitly `NOT VERIFIED` because the original
+  draft is unavailable; current acceptance is verified independently.
+- B1/F1: existing Markdown and guardrail helpers are reused.
+- D1-D3: the test strengthens observable policy alignment without skips,
+  widened tolerances, or private production assertions.
+- E1-E3: edits are limited to the four owned paths and three named live-policy
+  corrections.
+- A2, A4, B2-B3, C1-C2, F2, H2-H4: no planned violations.
+
+**o) Ratchet interaction.** Ruff selectors, BLE001 boundaries, formatter
+scope, Mypy scope, coverage threshold, CI workflows, and runtime behavior
+remain unchanged. T-GOV-3's transition marker remains because its structural
+work is pending.
+
+**p) Dead code and duplication audit.** No production code is added or
+deleted. Stale status and adoption wording is replaced in place. The new test
+reuses shared task-state and Markdown helpers. Expected net growth is one
+focused policy test and this implementation plan.
+
+## 5. Testing
+
+**q) Edge cases and failure scenarios.**
+
+1. T-GOV-5 appears as Complete and another state.
+2. The task entry remains partial, pending, or has multiple status lines.
+3. The artifact remains implementation-ready after ledger closure.
+4. The live document restores stale “lands alongside T-GOV-3” wording.
+5. The tracked testing-policy path regresses to `docs/TESTING.md`.
+6. C901 is described as pending or limited to a duplicated path list.
+7. The pending T-GOV-3 transition marker is removed prematurely.
+8. Boundary-handler, exception-process, or flat re-raise prose is deleted.
+9. `sys.exit()` becomes authorized inside unlisted broad handlers.
+10. A scope inventory is duplicated into prose instead of remaining in config.
+    The test splits the document into Markdown blocks and rejects any block
+    containing more than one distinct backticked `.py` path, while allowing an
+    isolated illustrative path or config-location reference.
+11. Closure claims exact draft identity despite the original draft being
+    unavailable.
+
+**r) Tests.**
+
+| Test | Scenarios |
+|---|---|
+| New `test_t_gov_5_engineering_guardrails_is_complete` | 1-11 |
+| Existing Ruff, formatter, Mypy, coverage, and workflow guardrails | 6, 10 |
+| Existing broad-handler and suppression guardrails | 8, 9 |
+| Existing docs-link tests | 5 |
+| Complete Python suite | cross-cutting regression check |
+
+The closure test is written and run red before completion markers and live
+policy claims change.
+
+**s) Fakes and mocks.** None. The test uses the approved tracked-filesystem
+boundary and patches no production symbol.
+
+**t) Verification rows.** Apply the guardrail/tooling row because
+`tests/test_repository_guardrails.py` changes and the docs-only row because
+canonical guardrail policy changes. Run the complete Python suite before
+handoff.
+
+## 6. Execution, Rollback, Docs
+
+**u) Exact commands.**
+
+```bash
+git fetch origin --prune
+git switch master
+git merge --ff-only origin/master
+git switch -c codex/t-gov-5-close-engineering-guardrails
+
+git show --name-only --format= c4a4a27
+rg -n "C901|max-complexity|src =" ruff.toml
+rg -n "include =" ruff-format.toml
+rg -n "^files =" mypy.ini
+rg -n "^source =" .coveragerc
+rg -n '`[^`]*\.py`' docs/ENGINEERING_GUARDRAILS.md
+
+PYTHONPATH=. .venv/bin/pytest -q \
+  tests/test_repository_guardrails.py::test_t_gov_5_engineering_guardrails_is_complete
+
+./.venv/bin/ruff check .
+./.venv/bin/mypy
+PYTHONPATH=. .venv/bin/pytest -q tests/test_repository_guardrails.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py
+PYTHONPATH=. .venv/bin/pytest -q
+git diff --check
+git status --short
+```
+
+Delivery:
+
+```bash
+git push -u origin codex/t-gov-5-close-engineering-guardrails
+gh pr create \
+  --base master \
+  --head codex/t-gov-5-close-engineering-guardrails \
+  --title "T-GOV-5: Close the engineering guardrails rewrite"
+```
+
+**v) Rollback.** Revert the T-GOV-5 closure merge commit, rerun Ruff, Mypy,
+repository guardrails, docs links, and the complete suite. No migration,
+configuration restoration, data repair, or external-state cleanup exists.
+Rollback restores stale partial status but does not revert active guardrail
+enforcement.
+
+**w) Docs sync.**
+
+- `docs/ENGINEERING_GUARDRAILS.md`: current rewrite status, tracked testing
+  path casing, and active C901 enforcement without a duplicated file list.
+- Remediation ledger: ownership, implementation-plan link, unique completed
+  state, historical caveat, and acceptance evidence.
+- This plan: implementation, review, verification, and delivery evidence.
+- `AGENTS.md`, README, ADR, architecture review, operations, security, testing,
+  and data-governance docs: no changes.
+
+## 7. Delivery Self-Audit
+
+**x) Antipattern scan, diff pass.** Re-run A-F/H. Reject duplicated scope
+inventories, removal of the live T-GOV-3 transition, weakened exception
+policy, unrelated policy rewrites, new guardrail exceptions, type
+suppressions, or claims of exact draft identity.
+
+**y) Evidence.** Report each command from 6u with PASS or FAIL, including the
+tests-first red result, historical audit, planning-review findings,
+pre-commit-review findings, commit hashes, PR URL, unresolved-thread count,
+and final CI state. Record original-draft identity as `NOT VERIFIED`.
+
+**z) Deviations.** The authorized historical deviation is that commit
+`c4a4a27` landed before T-CI-4 rather than in the same PR or immediately
+after it. The dependency is now complete, so current acceptance can close.
+Any additional changed path, guardrail-policy change, removed T-GOV-3 marker,
+skipped review, unresolved P1/P2, or unrun required check is a blocker.

--- a/docs/plans/T_GOV_5_ENGINEERING_GUARDRAILS_CLOSURE_PLAN.md
+++ b/docs/plans/T_GOV_5_ENGINEERING_GUARDRAILS_CLOSURE_PLAN.md
@@ -1,7 +1,7 @@
 # T-GOV-5: Close the Engineering Guardrails Rewrite
 
 `artifact_contract: ce-unified-plan/v1`
-`artifact_readiness: implementation-ready`
+`artifact_readiness: complete`
 `execution: code`
 
 ## 1. Context & Alignment
@@ -150,9 +150,10 @@ focused policy test and this implementation plan.
 8. Boundary-handler, exception-process, or flat re-raise prose is deleted.
 9. `sys.exit()` becomes authorized inside unlisted broad handlers.
 10. A scope inventory is duplicated into prose instead of remaining in config.
-    The test splits the document into Markdown blocks and rejects any block
-    containing more than one distinct backticked `.py` path, while allowing an
-    isolated illustrative path or config-location reference.
+    The test extracts backticked and unbackticked Python path references,
+    rejects all Python glob paths, and rejects any Markdown section containing
+    more than one distinct Python path. Isolated config references and examples
+    remain allowed.
 11. Closure claims exact draft identity despite the original draft being
     unavailable.
 

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -3096,6 +3096,89 @@ def test_t_gov_4_agents_policy_is_complete():
     assert "docs/TESTING.MD" in known_antipatterns
 
 
+def test_t_gov_5_engineering_guardrails_is_complete():
+    guardrail_policy = (
+        ROOT / "docs" / "ENGINEERING_GUARDRAILS.md"
+    ).read_text(encoding="utf-8")
+    remediation_ledger = (
+        ROOT / "docs" / "plans" / "TOWN_COUNCIL_REMEDIATION_PLAN.md"
+    ).read_text(encoding="utf-8")
+    implementation_plan = (
+        ROOT / "docs" / "plans" / "T_GOV_5_ENGINEERING_GUARDRAILS_CLOSURE_PLAN.md"
+    ).read_text(encoding="utf-8")
+    ruff_config = tomllib.loads((ROOT / "ruff.toml").read_text(encoding="utf-8"))
+    t_gov_5_entry = _required_markdown_section(
+        remediation_ledger,
+        "### T-GOV-5: Land the rewritten ENGINEERING_GUARDRAILS.md",
+        "\n### T-GOV-6:",
+    )
+    structural_rules = _required_markdown_section(
+        guardrail_policy,
+        "## Structural rules `[transition: T-GOV-3]`",
+        "\n## Optional local dead-code and complexity audit",
+    )
+    exception_process = _required_markdown_section(
+        guardrail_policy,
+        "## How to request an exception",
+        "\n## Boundary exception handlers",
+    )
+    boundary_handlers = _required_markdown_section(
+        guardrail_policy,
+        "## Boundary exception handlers",
+        "\n## Flat re-raise contract",
+    )
+    flat_reraise_contract = _required_markdown_section(
+        guardrail_policy,
+        "## Flat re-raise contract",
+        "\n## Typed subtree",
+    )
+    python_path_pattern = re.compile(
+        r"(?<![\w./*?\[\]-])(?:[\w.*?\[\]-]+/)*[\w.*?\[\]-]+\.py\b"
+    )
+    python_path_references = python_path_pattern.findall(guardrail_policy)
+    python_path_globs = {
+        python_path
+        for python_path in python_path_references
+        if any(glob_marker in python_path for glob_marker in ("*", "?", "["))
+    }
+    python_path_enumerations = [
+        sorted(set(python_path_pattern.findall(markdown_section)))
+        for markdown_section in re.split(r"(?m)^## ", guardrail_policy)
+        if len(set(python_path_pattern.findall(markdown_section))) > 1
+    ]
+
+    assert _remediation_task_states(remediation_ledger, "T-GOV-5") == ["Complete"]
+    assert "status: complete and verified 2026-07-24" in t_gov_5_entry
+    assert t_gov_5_entry.count("- status:") == 1
+    assert "commit `c4a4a27` changed only `docs/ENGINEERING_GUARDRAILS.md`" in (
+        t_gov_5_entry
+    )
+    assert "original draft is unavailable for exact identity comparison" in (
+        t_gov_5_entry
+    )
+    assert "`artifact_readiness: complete`" in implementation_plan
+
+    assert "lands alongside remediation task T-GOV-3" not in guardrail_policy
+    assert "docs/TESTING.md" not in guardrail_policy
+    assert "docs/TESTING.MD" in guardrail_policy
+    assert "when adopted" not in structural_rules
+    assert "C901" in structural_rules
+    assert "configured repository scope" in structural_rules
+    assert "max-complexity = 10" in structural_rules
+    assert "C901" in ruff_config["lint"]["select"]
+    assert ruff_config["lint"]["mccabe"]["max-complexity"] == 10
+    assert "[transition: T-CI-4]" not in guardrail_policy
+    assert "Keep exceptions narrow and path-specific." in exception_process
+    assert "log with context and return a typed failure payload" in boundary_handlers
+    assert "must not contain conditional or loop flow" in flat_reraise_contract
+    assert re.search(
+        r"must not contain .*?`sys\.exit\(\)`\.",
+        flat_reraise_contract,
+    )
+    assert python_path_globs == set()
+    assert python_path_enumerations == []
+
+
 def test_test_patch_point_adr_boundary_uses_the_next_decision_heading():
     architecture_decisions = """
 ## 2026-07-24: Test patch points are not a public API


### PR DESCRIPTION
## What changed
- records the T-GOV-5 Full closure plan and evidence caveat
- corrects stale rewrite status, testing-policy casing, and C901 guidance
- adds a durable completion contract for config-owned scope and exception policy
- marks T-GOV-5 complete while retaining the pending T-GOV-3 transition

## Why
The rewritten guardrail policy was already active, but its ledger state and three claims no longer matched repository config. This closes that documentation task without changing lint rules, thresholds, workflows, or runtime behavior.

## Risk and compatibility
Docs and repository-contract tests only. No runtime, schema, API, dependency, or guardrail-policy change. Exact identity with the unavailable original draft remains not verified; current acceptance was independently verified.

## Verification
- PASS: `./.venv/bin/ruff check .`
- PASS: `./.venv/bin/mypy` (68 source files)
- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_repository_guardrails.py tests/test_docs_links.py` (390 passed)
- PASS: `PYTHONPATH=. .venv/bin/pytest -q` (1,478 passed)
- PASS: `git diff --check`

## Review
Planning review raised three P2 issues and pre-commit review raised five P2 issues. All were corrected; both final rereviews found no remaining P1/P2 issues.
