### PR TITLE
G5: Record Alembic adoption approval

### DIFF
--- a/docs/ADR.md
+++ b/docs/ADR.md
@@ -8,6 +8,32 @@ Use each entry to record:
 - the affected boundary or contract
 - links to the canonical docs that carry the ongoing operational or architecture detail
 
+## 2026-07-24: Adopt Alembic for schema migrations
+
+- Status: Accepted
+- Decision:
+  - Adopt Alembic as the schema-migration system through remediation task
+    T-PLAT-1.
+  - Apply migration work in this order: T-TIME-1 updates timezone-aware model
+    declarations, T-TIME-2 converts existing databases through the final
+    numbered migration, and T-PLAT-1 establishes the Alembic baseline.
+  - Keep the current `migrate_v*` chain readable but frozen after the baseline;
+    use Alembic for every later schema change.
+- Why:
+  - One revision graph gives future schema changes explicit upgrade and
+    downgrade contracts.
+  - Establishing the baseline after model and existing-database correction
+    avoids encoding known timestamp debt as the intended schema.
+  - A single ordered sequence preserves the current phase contract and removes
+    the prior conditional wording between T-PLAT-1 and T-TIME-2.
+- Affected boundaries:
+  - T-PLAT-1 owns Alembic setup, baseline parity, and operator documentation.
+  - T-TIME-2 owns the final numbered migration before the baseline.
+  - No migration or schema change occurs from this decision record alone.
+- Canonical references:
+  - [Town Council remediation plan](plans/TOWN_COUNCIL_REMEDIATION_PLAN.md)
+  - [G5 decision plan](plans/G5_ALEMBIC_ADOPTION_DECISION_PLAN.md)
+
 ## 2026-07-24: Test patch points are not a public API
 
 - Status: Accepted

--- a/docs/ADR.md
+++ b/docs/ADR.md
@@ -29,11 +29,16 @@ Use each entry to record:
 - Affected boundaries:
   - T-PLAT-1 owns Alembic setup, baseline parity, and operator documentation.
   - T-TIME-2 owns the final numbered migration before the baseline.
-  - The existing `run_migrations()` pipeline contract remains the canonical
-    entrypoint and hands off to Alembic after the frozen legacy chain.
-  - Existing databases must match current schema before baseline stamping;
-    `pipeline/db_migrate.py` must abort adoption on drift before it stamps the
-    baseline. Operator docs must not prescribe unguarded stamping.
+  - The existing `python db_migrate.py` subprocess remains the canonical
+    pipeline contract. Its `migrate()` function delegates through the frozen
+    legacy runner when needed and then hands off to Alembic.
+  - Existing databases must match the frozen baseline schema before baseline
+    stamping; delayed adopters use that same comparison even after newer
+    revisions exist. `pipeline/db_migrate.py` must abort adoption on drift
+    before it stamps the baseline. Operator docs must not prescribe unguarded
+    stamping.
+  - Fresh PostgreSQL upgrades create the pgvector extension before baseline
+    table DDL creates vector columns.
   - The baseline is the downgrade floor. Its downgrade path must fail before
     DDL so a stamped existing database cannot lose pre-existing tables or data.
     Post-baseline revisions may downgrade only to the baseline.

--- a/docs/ADR.md
+++ b/docs/ADR.md
@@ -34,6 +34,9 @@ Use each entry to record:
   - Existing databases must match current schema before baseline stamping;
     `pipeline/db_migrate.py` must abort adoption on drift before it stamps the
     baseline. Operator docs must not prescribe unguarded stamping.
+  - The baseline is the downgrade floor. Its downgrade path must fail before
+    DDL so a stamped existing database cannot lose pre-existing tables or data.
+    Post-baseline revisions may downgrade only to the baseline.
   - No migration or schema change occurs from this decision record alone.
 - Canonical references:
   - [Town Council remediation plan](plans/TOWN_COUNCIL_REMEDIATION_PLAN.md)

--- a/docs/ADR.md
+++ b/docs/ADR.md
@@ -29,6 +29,11 @@ Use each entry to record:
 - Affected boundaries:
   - T-PLAT-1 owns Alembic setup, baseline parity, and operator documentation.
   - T-TIME-2 owns the final numbered migration before the baseline.
+  - The existing `run_migrations()` pipeline contract remains the canonical
+    entrypoint and hands off to Alembic after the frozen legacy chain.
+  - Existing databases must match current schema before baseline stamping;
+    `pipeline/db_migrate.py` must abort adoption on drift before it stamps the
+    baseline. Operator docs must not prescribe unguarded stamping.
   - No migration or schema change occurs from this decision record alone.
 - Canonical references:
   - [Town Council remediation plan](plans/TOWN_COUNCIL_REMEDIATION_PLAN.md)

--- a/docs/plans/G5_ALEMBIC_ADOPTION_DECISION_PLAN.md
+++ b/docs/plans/G5_ALEMBIC_ADOPTION_DECISION_PLAN.md
@@ -95,7 +95,7 @@ change is one plan and short decision updates.
 3. Sequencing places T-PLAT-1 before the TIME migration work.
 4. T-PLAT-1 is incorrectly marked complete.
 5. ADR and remediation plan disagree.
-6. Added links are broken.
+6. Local links added by the G5 decision records are broken.
 7. Canonical `run_pipeline.py` migration flow bypasses Alembic after adoption.
 8. An existing database is stamped despite drift from the frozen baseline
    schema.
@@ -111,7 +111,8 @@ change is one plan and short decision updates.
 
 **r) Tests.**
 
-- Docs-link test covers scenario 6.
+- Explicit filesystem checks cover every local link added by the G5 decision
+  records in scenario 6. The existing docs-link test does not scan these files.
 - Separate positive and negative `rg` checks cover scenarios 1-5 and 7.
 - Manual diff review confirms T-PLAT-1 remains pending.
 - T-PLAT-1 contract tests must cover scenario 8 with both fresh and
@@ -133,6 +134,9 @@ change is one plan and short decision updates.
 
 ```bash
 PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py
+test -f docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+test -f docs/plans/G5_ALEMBIC_ADOPTION_DECISION_PLAN.md
+test -f docs/reviews/architecture-review-2026-07-19.html
 rg -n "G5 migration_tooling: \\*\\*Approved 2026-07-24" \
   docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
 rg -n "status: approved; implementation pending" \

--- a/docs/plans/G5_ALEMBIC_ADOPTION_DECISION_PLAN.md
+++ b/docs/plans/G5_ALEMBIC_ADOPTION_DECISION_PLAN.md
@@ -42,7 +42,8 @@ TIME migration work; it does not rewrite T-TIME-2 into an Alembic revision.
 4. Add an Accepted ADR that preserves the current migration chain as frozen
    history after the baseline and assigns post-baseline migrations to Alembic.
 5. Expand T-PLAT-1 ownership for root configuration, the pinned dependency,
-   canonical migration handoff, legacy parity repair, and schema-parity tests.
+   canonical migration handoff, legacy parity repair, affected legacy-runner
+   tests, and schema-parity tests.
 6. Run docs-link and contradiction checks.
 7. Obtain an independent pre-commit review and resolve all eligible P1/P2
    findings.
@@ -140,7 +141,7 @@ rg -n "Migration order is T-TIME-1, T-TIME-2, then T-PLAT-1" \
   docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
 rg -n "files_owned: alembic/\\*\\* \\(new\\), alembic.ini \\(new\\)" \
   docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
-rg -n "\\| PLAT.*alembic.ini.*pipeline/db_migrate.py.*docs/OPERATIONS.md.*tests/test_alembic_migrations.py" \
+rg -n "\\| PLAT.*alembic.ini.*pipeline/db_migrate.py.*docs/OPERATIONS.md.*tests/test_alembic_migrations.py.*tests/test_db_migrate.py" \
   docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
 rg -n "alembic upgrade head" docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
 rg -n "existing database" docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md

--- a/docs/plans/G5_ALEMBIC_ADOPTION_DECISION_PLAN.md
+++ b/docs/plans/G5_ALEMBIC_ADOPTION_DECISION_PLAN.md
@@ -96,10 +96,17 @@ change is one plan and short decision updates.
 5. ADR and remediation plan disagree.
 6. Added links are broken.
 7. Canonical `run_pipeline.py` migration flow bypasses Alembic after adoption.
-8. An existing database is stamped despite schema drift from current models.
+8. An existing database is stamped despite drift from the frozen baseline
+   schema.
 9. T-TIME-2 cannot wire v10 into the focused migration runner within ownership.
 10. Downgrading below a stamped baseline runs destructive baseline DDL against
     pre-existing tables.
+11. A delayed adopter is compared with newer models instead of the immutable
+    baseline schema and cannot reach post-baseline upgrades.
+12. A fresh PostgreSQL database lacks the pgvector extension when baseline
+    table DDL creates vector columns.
+13. Planning preserves an internal helper instead of the actual
+    `python db_migrate.py` pipeline subprocess contract.
 
 **r) Tests.**
 
@@ -111,6 +118,9 @@ change is one plan and short decision updates.
 - Ownership checks cover scenario 9.
 - A cross-baseline downgrade test covers scenario 10 and asserts schema and
   representative data remain unchanged.
+- Fresh, immediate-adoption, and delayed-adoption PostgreSQL tests cover
+  scenarios 11 and 12.
+- Pipeline orchestration contract tests cover scenario 13.
 
 **s) Fakes and mocks.** None.
 
@@ -132,20 +142,26 @@ rg -n "files_owned: alembic/\\*\\* \\(new\\), alembic.ini \\(new\\)" \
   docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
 rg -n "\\| PLAT.*alembic.ini.*pipeline/db_migrate.py.*docs/OPERATIONS.md.*tests/test_alembic_migrations.py" \
   docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
-rg -n "canonical migration entrypoint" \
-  docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
 rg -n "alembic upgrade head" docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
 rg -n "existing database" docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
-rg -n "schema diff is empty" \
-  docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
 rg -n "pipeline/db_migration_runner.py" \
   docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
 rg -n "only supported existing-database adoption" \
   docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
-rg -n "do not instruct operators to run an unguarded" \
+rg -n "unguarded" \
   docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
 rg -n "downgrade floor" \
   docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+rg -n "frozen baseline schema" \
+  docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+rg -n "adopters use that same frozen comparison" \
+  docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+rg -n "stamping aborts on nonempty baseline drift" \
+  docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+rg -n "pgvector extension before baseline table DDL" \
+  docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+rg -n "python db_migrate.py" \
+  docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md docs/ADR.md
 rg -n "Adopt Alembic for schema migrations" docs/ADR.md
 rg -n "T-TIME-1 updates timezone-aware model" docs/ADR.md
 rg -n "T-TIME-2 converts existing databases" docs/ADR.md

--- a/docs/plans/G5_ALEMBIC_ADOPTION_DECISION_PLAN.md
+++ b/docs/plans/G5_ALEMBIC_ADOPTION_DECISION_PLAN.md
@@ -108,6 +108,11 @@ change is one plan and short decision updates.
     table DDL creates vector columns.
 13. Planning preserves an internal helper instead of the actual
     `python db_migrate.py` pipeline subprocess contract.
+14. Legacy v8 reads newer mutable model metadata before delayed-adoption
+    baseline comparison.
+15. PostgreSQL-specific migration acceptance runs only against SQLite or is
+    optional in CI.
+16. Pipeline or city-contributor docs omit the migrate-before-seed contract.
 
 **r) Tests.**
 
@@ -123,6 +128,10 @@ change is one plan and short decision updates.
 - Fresh, immediate-adoption, and delayed-adoption PostgreSQL tests cover
   scenarios 11 and 12.
 - Pipeline orchestration contract tests cover scenario 13.
+- Frozen-metadata v8 tests cover scenario 14.
+- Python Guardrails workflow and guardrail contract tests cover scenario 15
+  with an isolated pgvector PostgreSQL service and no optional skips.
+- Explicit documentation ownership and link checks cover scenario 16.
 
 **s) Fakes and mocks.** None.
 
@@ -150,6 +159,8 @@ rg -n "\\| PLAT.*alembic.ini.*pipeline/db_migrate.py.*docs/OPERATIONS.md.*tests/
 rg -n "pipeline/db_init.py.*scripts/dev_up.sh.*README.md.*tests/test_db_init.py.*tests/test_docker_build_contracts.py" \
   docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
 rg -n "pipeline/seed_places.py.*pipeline/promote_stage.py.*tests/test_seed_places.py.*tests/test_pipeline_idempotency.py" \
+  docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+rg -n "pipeline/migrate_v8.py.*migration_pgvector_semantic_embeddings.py.*python-guardrails.yml.*docs/PIPELINE.md.*docs/CONTRIBUTING_CITIES.md" \
   docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
 rg -n "alembic upgrade head" docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
 rg -n "existing database" docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md

--- a/docs/plans/G5_ALEMBIC_ADOPTION_DECISION_PLAN.md
+++ b/docs/plans/G5_ALEMBIC_ADOPTION_DECISION_PLAN.md
@@ -115,6 +115,7 @@ change is one plan and short decision updates.
 16. Pipeline or city-contributor docs omit the migrate-before-seed contract.
 17. The canonical architecture map still describes only numbered migrations.
 18. Baseline autogeneration omits objects created only by legacy raw SQL.
+19. T-PLAT-1 and T-GOV-3 concurrently edit the shared guardrail contract.
 
 **r) Tests.**
 
@@ -137,6 +138,7 @@ change is one plan and short decision updates.
 - Architecture-map ownership and content checks cover scenario 17.
 - Legacy-object inventory and fresh-versus-v10 PostgreSQL parity tests cover
   scenario 18, including HNSW and lineage timestamp indexes.
+- Explicit task sequencing covers scenario 19.
 
 **s) Fakes and mocks.** None.
 
@@ -170,6 +172,8 @@ rg -n "pipeline/migrate_v8.py.*migration_pgvector_semantic_embeddings.py.*python
 rg -n "ARCHITECTURE.md \\(T-PLAT-1 migration map only\\)" \
   docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
 rg -n "ix_semantic_embedding_hnsw|ix_catalog_lineage_updated_at" \
+  docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+rg -n "T-PLAT-1 and T-GOV-3 MUST NOT run concurrently" \
   docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
 rg -n "alembic upgrade head" docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
 rg -n "existing database" docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md

--- a/docs/plans/G5_ALEMBIC_ADOPTION_DECISION_PLAN.md
+++ b/docs/plans/G5_ALEMBIC_ADOPTION_DECISION_PLAN.md
@@ -1,0 +1,158 @@
+# G5: Record Alembic Adoption
+
+## 1. Context & Alignment
+
+**a) Driver.** The operator approved G5 on 2026-07-24. The repository needs a
+durable decision record before T-PLAT-1 or T-TIME-2 starts so agents do not
+silently choose between Alembic and the existing `migrate_v*` chain.
+
+**b) Canonical documents consulted.**
+
+- `AGENTS.md`: decision gates require operator approval, exact scope, and docs
+  synchronization.
+- `docs/ADR.md`: accepted architecture decisions live in the indexed ADR log.
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`: G5 controls T-PLAT-1 and the
+  migration mechanism for T-TIME-2.
+- `docs/reviews/architecture-review-2026-07-19.html`: migration compatibility
+  strata should change only after the Alembic decision and PostgreSQL parity
+  evidence.
+
+**c) Remediation alignment.** This decision-only change owns:
+
+- `docs/plans/G5_ALEMBIC_ADOPTION_DECISION_PLAN.md`
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`
+- `docs/ADR.md`
+
+T-PLAT-1 remains pending and owns Alembic implementation. T-TIME-2 remains
+pending and owns the timezone-column migration.
+
+**d) Decision-gate check.** G5 is satisfied by explicit operator approval.
+G1-G4 remain unchanged. This record authorizes T-PLAT-1 after the existing
+TIME migration work; it does not rewrite T-TIME-2 into an Alembic revision.
+
+## 2. Design
+
+**e) Step-by-step approach.**
+
+1. Record G5 as approved with date and rationale.
+2. Preserve the migration sequence: T-TIME-1 updates model declarations,
+   T-TIME-2 migrates existing databases through `migrate_v10.py`, then
+   T-PLAT-1 establishes the Alembic baseline.
+3. Mark T-PLAT-1 as approved and pending, not complete.
+4. Add an Accepted ADR that preserves the current migration chain as frozen
+   history after the baseline and assigns post-baseline migrations to Alembic.
+5. Expand T-PLAT-1 ownership for root configuration, the pinned dependency,
+   and schema-parity tests.
+6. Run docs-link and contradiction checks.
+7. Obtain an independent pre-commit review and resolve all eligible P1/P2
+   findings.
+
+No function or module is added.
+
+**f) Reuse audit.** Extend the existing remediation gate, task, sequencing,
+and ADR sections. No second migration registry or implementation plan is
+created.
+
+**g) Data contracts.** None.
+
+**h) Schema and migrations.** None in this change. T-TIME-2 remains the final
+planned numbered migration. T-PLAT-1 will baseline the resulting schema.
+
+## 3. Security & Data Governance
+
+**i) Security boundary.** None. No runtime or credential path changes.
+
+**j) Secrets.** None.
+
+**k) Person data.** None.
+
+**l) Untrusted input.** None.
+
+## 4. Code Health
+
+**m) GED conformance sweep.** Docs-only, three-file scope. No code, error
+handling, timestamps, environment reads, or runtime defaults change.
+
+**n) Antipattern scan, plan pass.** A1/H1 do not apply because no Alembic API
+is called. A2-A4, B1-B3, C1-C2, D1-D3, E1-E3, F1-F2, and H2-H4 pass. The
+decision does not add compatibility code; it explicitly freezes the old chain
+after the future baseline.
+
+**o) Ratchet interaction.** None.
+
+**p) Dead code and duplication audit.** No code is deleted. Conflicting
+conditional migration wording is replaced by one sequence. Expected net
+change is one plan and short decision updates.
+
+## 5. Testing
+
+**q) Edge and failure scenarios.**
+
+1. G5 remains worded as open or defaulted rather than approved.
+2. T-TIME-2 is incorrectly rewritten as an Alembic revision or removed from
+   the numbered chain.
+3. Sequencing places T-PLAT-1 before the TIME migration work.
+4. T-PLAT-1 is incorrectly marked complete.
+5. ADR and remediation plan disagree.
+6. Added links are broken.
+
+**r) Tests.**
+
+- Docs-link test covers scenario 6.
+- Separate positive and negative `rg` checks cover scenarios 1-5.
+- Manual diff review confirms T-PLAT-1 remains pending.
+
+**s) Fakes and mocks.** None.
+
+**t) Verification rows.** Docs-only row.
+
+## 6. Execution, Rollback, Docs
+
+**u) Exact commands.**
+
+```bash
+PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py
+rg -n "G5 migration_tooling: \\*\\*Approved 2026-07-24" \
+  docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+rg -n "status: approved; implementation pending" \
+  docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+rg -n "Migration order is T-TIME-1, T-TIME-2, then T-PLAT-1" \
+  docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+rg -n "files_owned: alembic/\\*\\* \\(new\\), alembic.ini \\(new\\)" \
+  docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+rg -n "\\| PLAT.*alembic.ini.*pipeline/db_migrate.py.*docs/OPERATIONS.md.*tests/test_alembic_migrations.py" \
+  docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+rg -n "Adopt Alembic for schema migrations" docs/ADR.md
+rg -n "T-TIME-1 updates timezone-aware model" docs/ADR.md
+rg -n "T-TIME-2 converts existing databases" docs/ADR.md
+rg -n "T-PLAT-1 establishes the Alembic baseline" docs/ADR.md
+! rg -n "depends_on: T-TIME-2|T-TIME-1, T-PLAT-1, then T-TIME-2|T-TIME-2.*Alembic revision" \
+  docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md docs/ADR.md
+git diff --check
+git status --short
+```
+
+After these checks, an independent subagent reviews the complete diff before
+commit.
+
+**v) Rollback.** Revert the decision-record commit. No schema, data, runtime,
+or external-state remediation is required.
+
+**w) Docs synchronization.**
+
+- Remediation plan: gate, sequence, task status, and changelog.
+- ADR: accepted migration-tooling decision.
+- Architecture review: unchanged historical artifact.
+- Operations: deferred to T-PLAT-1 implementation.
+
+## 7. Delivery Self-Audit
+
+**x) Antipattern scan, diff pass.** Re-run A-F and H. Reject migration code,
+new dependencies, out-of-scope docs edits, or claims that Alembic is already
+implemented.
+
+**y) Evidence.** Report every command in 6u and the pre-commit review with
+`PASS` or `FAIL`. Mark anything unrun as `NOT VERIFIED`.
+
+**z) Deviations.** Expected result: none. Any fourth changed file or migration
+implementation is a blocker.

--- a/docs/plans/G5_ALEMBIC_ADOPTION_DECISION_PLAN.md
+++ b/docs/plans/G5_ALEMBIC_ADOPTION_DECISION_PLAN.md
@@ -113,6 +113,7 @@ change is one plan and short decision updates.
 15. PostgreSQL-specific migration acceptance runs only against SQLite or is
     optional in CI.
 16. Pipeline or city-contributor docs omit the migrate-before-seed contract.
+17. The canonical architecture map still describes only numbered migrations.
 
 **r) Tests.**
 
@@ -132,6 +133,7 @@ change is one plan and short decision updates.
 - Python Guardrails workflow and guardrail contract tests cover scenario 15
   with an isolated pgvector PostgreSQL service and no optional skips.
 - Explicit documentation ownership and link checks cover scenario 16.
+- Architecture-map ownership and content checks cover scenario 17.
 
 **s) Fakes and mocks.** None.
 
@@ -161,6 +163,8 @@ rg -n "pipeline/db_init.py.*scripts/dev_up.sh.*README.md.*tests/test_db_init.py.
 rg -n "pipeline/seed_places.py.*pipeline/promote_stage.py.*tests/test_seed_places.py.*tests/test_pipeline_idempotency.py" \
   docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
 rg -n "pipeline/migrate_v8.py.*migration_pgvector_semantic_embeddings.py.*python-guardrails.yml.*docs/PIPELINE.md.*docs/CONTRIBUTING_CITIES.md" \
+  docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+rg -n "ARCHITECTURE.md \\(T-PLAT-1 migration map only\\)" \
   docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
 rg -n "alembic upgrade head" docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
 rg -n "existing database" docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md

--- a/docs/plans/G5_ALEMBIC_ADOPTION_DECISION_PLAN.md
+++ b/docs/plans/G5_ALEMBIC_ADOPTION_DECISION_PLAN.md
@@ -98,6 +98,8 @@ change is one plan and short decision updates.
 7. Canonical `run_pipeline.py` migration flow bypasses Alembic after adoption.
 8. An existing database is stamped despite schema drift from current models.
 9. T-TIME-2 cannot wire v10 into the focused migration runner within ownership.
+10. Downgrading below a stamped baseline runs destructive baseline DDL against
+    pre-existing tables.
 
 **r) Tests.**
 
@@ -107,6 +109,8 @@ change is one plan and short decision updates.
 - T-PLAT-1 contract tests must cover scenario 8 with both fresh and
   legacy-migrated database paths.
 - Ownership checks cover scenario 9.
+- A cross-baseline downgrade test covers scenario 10 and asserts schema and
+  representative data remain unchanged.
 
 **s) Fakes and mocks.** None.
 
@@ -139,6 +143,8 @@ rg -n "pipeline/db_migration_runner.py" \
 rg -n "only supported existing-database adoption" \
   docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
 rg -n "do not instruct operators to run an unguarded" \
+  docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+rg -n "downgrade floor" \
   docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
 rg -n "Adopt Alembic for schema migrations" docs/ADR.md
 rg -n "T-TIME-1 updates timezone-aware model" docs/ADR.md

--- a/docs/plans/G5_ALEMBIC_ADOPTION_DECISION_PLAN.md
+++ b/docs/plans/G5_ALEMBIC_ADOPTION_DECISION_PLAN.md
@@ -42,8 +42,8 @@ TIME migration work; it does not rewrite T-TIME-2 into an Alembic revision.
 4. Add an Accepted ADR that preserves the current migration chain as frozen
    history after the baseline and assigns post-baseline migrations to Alembic.
 5. Expand T-PLAT-1 ownership for root configuration, the pinned dependency,
-   canonical migration handoff, legacy parity repair, affected legacy-runner
-   tests, and schema-parity tests.
+   canonical existing- and fresh-database handoffs, legacy parity repair,
+   affected setup and runner tests, and schema-parity tests.
 6. Run docs-link and contradiction checks.
 7. Obtain an independent pre-commit review and resolve all eligible P1/P2
    findings.
@@ -142,6 +142,8 @@ rg -n "Migration order is T-TIME-1, T-TIME-2, then T-PLAT-1" \
 rg -n "files_owned: alembic/\\*\\* \\(new\\), alembic.ini \\(new\\)" \
   docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
 rg -n "\\| PLAT.*alembic.ini.*pipeline/db_migrate.py.*docs/OPERATIONS.md.*tests/test_alembic_migrations.py.*tests/test_db_migrate.py" \
+  docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+rg -n "pipeline/db_init.py.*scripts/dev_up.sh.*README.md.*tests/test_db_init.py.*tests/test_docker_build_contracts.py" \
   docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
 rg -n "alembic upgrade head" docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
 rg -n "existing database" docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md

--- a/docs/plans/G5_ALEMBIC_ADOPTION_DECISION_PLAN.md
+++ b/docs/plans/G5_ALEMBIC_ADOPTION_DECISION_PLAN.md
@@ -43,7 +43,7 @@ TIME migration work; it does not rewrite T-TIME-2 into an Alembic revision.
    history after the baseline and assigns post-baseline migrations to Alembic.
 5. Expand T-PLAT-1 ownership for root configuration, the pinned dependency,
    canonical existing- and fresh-database handoffs, legacy parity repair,
-   affected setup and runner tests, and schema-parity tests.
+   affected setup, seed, promotion, and runner tests, and schema-parity tests.
 6. Run docs-link and contradiction checks.
 7. Obtain an independent pre-commit review and resolve all eligible P1/P2
    findings.
@@ -144,6 +144,8 @@ rg -n "files_owned: alembic/\\*\\* \\(new\\), alembic.ini \\(new\\)" \
 rg -n "\\| PLAT.*alembic.ini.*pipeline/db_migrate.py.*docs/OPERATIONS.md.*tests/test_alembic_migrations.py.*tests/test_db_migrate.py" \
   docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
 rg -n "pipeline/db_init.py.*scripts/dev_up.sh.*README.md.*tests/test_db_init.py.*tests/test_docker_build_contracts.py" \
+  docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+rg -n "pipeline/seed_places.py.*pipeline/promote_stage.py.*tests/test_seed_places.py.*tests/test_pipeline_idempotency.py" \
   docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
 rg -n "alembic upgrade head" docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
 rg -n "existing database" docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md

--- a/docs/plans/G5_ALEMBIC_ADOPTION_DECISION_PLAN.md
+++ b/docs/plans/G5_ALEMBIC_ADOPTION_DECISION_PLAN.md
@@ -114,6 +114,7 @@ change is one plan and short decision updates.
     optional in CI.
 16. Pipeline or city-contributor docs omit the migrate-before-seed contract.
 17. The canonical architecture map still describes only numbered migrations.
+18. Baseline autogeneration omits objects created only by legacy raw SQL.
 
 **r) Tests.**
 
@@ -134,6 +135,8 @@ change is one plan and short decision updates.
   with an isolated pgvector PostgreSQL service and no optional skips.
 - Explicit documentation ownership and link checks cover scenario 16.
 - Architecture-map ownership and content checks cover scenario 17.
+- Legacy-object inventory and fresh-versus-v10 PostgreSQL parity tests cover
+  scenario 18, including HNSW and lineage timestamp indexes.
 
 **s) Fakes and mocks.** None.
 
@@ -165,6 +168,8 @@ rg -n "pipeline/seed_places.py.*pipeline/promote_stage.py.*tests/test_seed_place
 rg -n "pipeline/migrate_v8.py.*migration_pgvector_semantic_embeddings.py.*python-guardrails.yml.*docs/PIPELINE.md.*docs/CONTRIBUTING_CITIES.md" \
   docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
 rg -n "ARCHITECTURE.md \\(T-PLAT-1 migration map only\\)" \
+  docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+rg -n "ix_semantic_embedding_hnsw|ix_catalog_lineage_updated_at" \
   docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
 rg -n "alembic upgrade head" docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
 rg -n "existing database" docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md

--- a/docs/plans/G5_ALEMBIC_ADOPTION_DECISION_PLAN.md
+++ b/docs/plans/G5_ALEMBIC_ADOPTION_DECISION_PLAN.md
@@ -42,7 +42,7 @@ TIME migration work; it does not rewrite T-TIME-2 into an Alembic revision.
 4. Add an Accepted ADR that preserves the current migration chain as frozen
    history after the baseline and assigns post-baseline migrations to Alembic.
 5. Expand T-PLAT-1 ownership for root configuration, the pinned dependency,
-   and schema-parity tests.
+   canonical migration handoff, legacy parity repair, and schema-parity tests.
 6. Run docs-link and contradiction checks.
 7. Obtain an independent pre-commit review and resolve all eligible P1/P2
    findings.
@@ -95,12 +95,18 @@ change is one plan and short decision updates.
 4. T-PLAT-1 is incorrectly marked complete.
 5. ADR and remediation plan disagree.
 6. Added links are broken.
+7. Canonical `run_pipeline.py` migration flow bypasses Alembic after adoption.
+8. An existing database is stamped despite schema drift from current models.
+9. T-TIME-2 cannot wire v10 into the focused migration runner within ownership.
 
 **r) Tests.**
 
 - Docs-link test covers scenario 6.
-- Separate positive and negative `rg` checks cover scenarios 1-5.
+- Separate positive and negative `rg` checks cover scenarios 1-5 and 7.
 - Manual diff review confirms T-PLAT-1 remains pending.
+- T-PLAT-1 contract tests must cover scenario 8 with both fresh and
+  legacy-migrated database paths.
+- Ownership checks cover scenario 9.
 
 **s) Fakes and mocks.** None.
 
@@ -121,6 +127,18 @@ rg -n "Migration order is T-TIME-1, T-TIME-2, then T-PLAT-1" \
 rg -n "files_owned: alembic/\\*\\* \\(new\\), alembic.ini \\(new\\)" \
   docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
 rg -n "\\| PLAT.*alembic.ini.*pipeline/db_migrate.py.*docs/OPERATIONS.md.*tests/test_alembic_migrations.py" \
+  docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+rg -n "canonical migration entrypoint" \
+  docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+rg -n "alembic upgrade head" docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+rg -n "existing database" docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+rg -n "schema diff is empty" \
+  docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+rg -n "pipeline/db_migration_runner.py" \
+  docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+rg -n "only supported existing-database adoption" \
+  docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+rg -n "do not instruct operators to run an unguarded" \
   docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
 rg -n "Adopt Alembic for schema migrations" docs/ADR.md
 rg -n "T-TIME-1 updates timezone-aware model" docs/ADR.md

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,6 +1,6 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 3.36
+version: 3.37
 generated: 2026-07-24
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
@@ -10,6 +10,9 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v3.37:** Gives T-TIME-2 ownership of focused v10 migration and ordering
+  tests so the final numbered migration cannot land unverified before the
+  Alembic baseline.
 - **v3.36:** Adds `seed_places.py` and `promote_stage.py` plus their affected
   tests to T-PLAT-1 ownership. Operational entrypoints may no longer call
   `create_tables()` outside the Alembic migration path.
@@ -249,7 +252,7 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 |-----------|-----------|------------------------------------------------------------|
 | CI        | agent-ci   | .github/workflows/**, ruff.toml, ruff-format.toml (new), .pre-commit-config.yaml, .coveragerc, frontend/package.json, frontend/jest.config.* (new) |
 | SEC       | agent-sec  | docker-compose.yml, docker-compose.dev.yml, .dockerignore, .env.example, api/app_setup.py, api/main.py (CORS+/stats sections only), api/search/support_core.py, pipeline/meilisearch_credentials.py, semantic_service/main.py, frontend/app/api/** |
-| TIME      | agent-time | pipeline/model_base.py, model_civic.py, model_events.py, model_records.py, model_runtime.py, models.py, db_migrate.py, db_migration_runner.py, migrate_v10.py (new), pipeline/summary_freshness.py (verify-only) |
+| TIME      | agent-time | pipeline/model_base.py, model_civic.py, model_events.py, model_records.py, model_runtime.py, models.py, db_migrate.py, db_migration_runner.py, migrate_v10.py (new), tests/test_migrate_v10.py (new), tests/test_db_migrate.py (T-TIME-2 v10 ordering only), pipeline/summary_freshness.py (verify-only) |
 | CRAWL     | agent-crawl| council_crawler/**                                          |
 | DEDUP-A   | agent-da   | pipeline/metrics.py, pipeline/metrics_redis_backend.py, tests/test_*metrics* |
 | DEDUP-B   | agent-db   | pipeline/summary_backfill*.py, pipeline/task_facade_helpers.py, pipeline/tasks.py, tests/test_*backfill*, tests/test_pipeline_batching.py, tests/test_run_pipeline_orchestration.py, tests/test_staged_hydrate_cities.py, tests/test_tasks_agenda_summary_format.py |
@@ -741,13 +744,15 @@ in `AGENTS.md`, `docs/TESTING.MD`, and
 ### T-TIME-2: Migration for timestamp columns
 - priority: P1
 - files_owned: pipeline/migrate_v10.py (new), pipeline/db_migrate.py,
-  pipeline/db_migration_runner.py
+  pipeline/db_migration_runner.py, tests/test_migrate_v10.py (new),
+  tests/test_db_migrate.py (v10 ordering only)
 - do: Additive migration converting existing columns to timestamptz
   (`ALTER ... TYPE timestamptz USING <col> AT TIME ZONE 'UTC'`). Wire into
   run_migrations after v9. This is the final numbered migration before the
   T-PLAT-1 Alembic baseline.
-- accept: Migration idempotent (safe re-run); documented in db_migrate
-  docstring.
+- accept: Migration idempotent (safe re-run); focused tests prove v10 runs
+  after v9, reruns safely, and leaves the final numbered version at v10;
+  documented in db_migrate docstring.
 - verify: Run against a dev DB snapshot; suite green.
 
 ### T-TIME-3: pool_pre_ping

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -930,12 +930,16 @@ files (GED-5 grant).
   in the existing column-migration owner, compare schema, abort on drift,
   stamp the baseline, then upgrade to head. Keep migrate_v* readable but
   frozen (no v11+). Document fresh, existing, upgrade, and downgrade workflows;
-  do not instruct operators to run an unguarded `alembic stamp`.
+  do not instruct operators to run an unguarded `alembic stamp`. The baseline
+  is the downgrade floor: its downgrade must fail before any DDL, while later
+  revisions may downgrade only as far as the baseline.
 - accept: Fresh DB via Alembic equals `create_all` schema; an existing database
   migrated through v10 has an empty schema diff before baseline stamping;
   stamping aborts on nonempty drift; the canonical pipeline migration call
-  applies post-baseline Alembic revisions; OPERATIONS documents
-  upgrade/downgrade.
+  applies post-baseline Alembic revisions; attempting to downgrade below the
+  baseline exits nonzero without changing schema or representative data;
+  OPERATIONS documents the baseline floor and supported upgrade/downgrade
+  range.
 - verify: Schema diff script output empty; suite green.
 
 ### T-PLAT-2A: Patch Next.js's transitive Sharp runtime

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,6 +1,6 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 3.37
+version: 3.38
 generated: 2026-07-24
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
@@ -10,6 +10,9 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v3.38:** Closes three T-PLAT-1 implementation gaps: frozen v8 metadata for
+  delayed adopters, mandatory PostgreSQL migration CI, and synchronized
+  pipeline and city-contributor migration guidance.
 - **v3.37:** Gives T-TIME-2 ownership of focused v10 migration and ordering
   tests so the final numbered migration cannot land unverified before the
   Alembic baseline.
@@ -259,7 +262,7 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 | DEDUP-C   | agent-dc   | api/main.py, api/app_setup.py, tests/conftest.py, tests/test_*api* (Phase 2 only) |
 | DEDUP-D   | agent-dd   | scripts/flush_city_pipeline_state.py, scripts/reset_city_verification_state.py, scripts/*_healthcheck.py, tests for same |
 | DEDUP-E   | agent-de   | pipeline/http_inference_provider.py, pipeline/inprocess_inference_provider.py, pipeline/inference_provider_contract.py, tests for same |
-| PLAT      | agent-plat | alembic/** (new), alembic.ini (new), pipeline/requirements*.txt, pipeline/db_init.py (T-PLAT-1 only), pipeline/db_migrate.py (T-PLAT-1 only, after TIME), pipeline/db_migration_columns.py (T-PLAT-1 legacy parity only), pipeline/seed_places.py (T-PLAT-1 schema handoff only), pipeline/promote_stage.py (T-PLAT-1 schema handoff only), scripts/dev_up.sh (T-PLAT-1 only), README.md (T-PLAT-1 setup section only), api/requirements.txt, semantic_service/requirements.txt, constraints.txt (new), .github/dependabot.yml (new), docs/OPERATIONS.md (migration and backup sections only), tests/test_alembic_migrations.py (new), tests/test_db_init.py (T-PLAT-1 only), tests/test_db_migrate.py (T-PLAT-1 only), tests/test_docker_build_contracts.py (T-PLAT-1 fresh-DB contract only), tests/test_seed_places.py (T-PLAT-1 schema handoff only), tests/test_seed_places_includes_cupertino.py (T-PLAT-1 schema handoff only), tests/test_database.py (T-PLAT-1 promotion schema handoff only), tests/test_pipeline_idempotency.py (T-PLAT-1 promotion schema handoff only), tests/test_pipeline_integration.py (T-PLAT-1 promotion schema handoff only), tests/test_run_pipeline_orchestration.py (T-PLAT-1 migration-prelude contract only), api/cache.py |
+| PLAT      | agent-plat | alembic/** (new), alembic.ini (new), pipeline/requirements*.txt, pipeline/db_init.py (T-PLAT-1 only), pipeline/db_migrate.py (T-PLAT-1 only, after TIME), pipeline/db_migration_columns.py (T-PLAT-1 legacy parity only), pipeline/migrate_v8.py (T-PLAT-1 frozen metadata only), pipeline/migration_pgvector_semantic_embeddings.py (T-PLAT-1 frozen metadata only), pipeline/seed_places.py (T-PLAT-1 schema handoff only), pipeline/promote_stage.py (T-PLAT-1 schema handoff only), scripts/dev_up.sh (T-PLAT-1 only), README.md (T-PLAT-1 setup section only), api/requirements.txt, semantic_service/requirements.txt, constraints.txt (new), .github/dependabot.yml (new), .github/workflows/python-guardrails.yml (T-PLAT-1 PostgreSQL migration service/step only), docs/OPERATIONS.md (migration and backup sections only), docs/PIPELINE.md (T-PLAT-1 migration section only), docs/CONTRIBUTING_CITIES.md (T-PLAT-1 seed prerequisite only), tests/test_alembic_migrations.py (new), tests/test_db_init.py (T-PLAT-1 only), tests/test_db_migrate.py (T-PLAT-1 only), tests/test_docker_build_contracts.py (T-PLAT-1 fresh-DB contract only), tests/test_migrate_v8_pgvector_order.py (T-PLAT-1 only), tests/test_seed_places.py (T-PLAT-1 schema handoff only), tests/test_seed_places_includes_cupertino.py (T-PLAT-1 schema handoff only), tests/test_database.py (T-PLAT-1 promotion schema handoff only), tests/test_pipeline_idempotency.py (T-PLAT-1 promotion schema handoff only), tests/test_pipeline_integration.py (T-PLAT-1 promotion schema handoff only), tests/test_repository_guardrails.py (T-PLAT-1 migration CI contract only), tests/test_run_pipeline_orchestration.py (T-PLAT-1 migration-prelude contract only), api/cache.py |
 | GOV       | agent-gov  | docs/ADR.md, docs/ENGINEERING_GUARDRAILS.md, AGENTS.md, SECURITY.md (new), docs/TESTING.md (new), docs/DATA_GOVERNANCE.md (new), tests/test_repository_guardrails.py (Phase 3 only) |
 
 Sequencing rule: SEC and DEDUP-C both own api/app_setup.py + api/main.py —
@@ -934,16 +937,23 @@ files (GED-5 grant).
   pipeline/requirements.txt, pipeline/db_init.py (fresh-DB handoff),
   pipeline/db_migrate.py (Alembic handoff),
   pipeline/db_migration_columns.py (legacy parity repair only),
+  pipeline/migrate_v8.py and
+  pipeline/migration_pgvector_semantic_embeddings.py (frozen metadata only),
   pipeline/seed_places.py (schema handoff only),
   pipeline/promote_stage.py (schema handoff only),
-  scripts/dev_up.sh, README.md (setup section), docs/OPERATIONS.md
-  (migration section), tests/test_alembic_migrations.py (new),
+  scripts/dev_up.sh, README.md (setup section), docs/OPERATIONS.md and
+  docs/PIPELINE.md (migration sections), docs/CONTRIBUTING_CITIES.md
+  (seed prerequisite), .github/workflows/python-guardrails.yml
+  (PostgreSQL migration service/step only),
+  tests/test_alembic_migrations.py (new),
   tests/test_db_init.py, tests/test_db_migrate.py,
   tests/test_docker_build_contracts.py (fresh-DB contract only),
+  tests/test_migrate_v8_pgvector_order.py,
   tests/test_seed_places.py and tests/test_seed_places_includes_cupertino.py
   (schema handoff only), tests/test_database.py,
   tests/test_pipeline_idempotency.py, and tests/test_pipeline_integration.py
   (promotion schema handoff only),
+  tests/test_repository_guardrails.py (migration CI contract only),
   tests/test_run_pipeline_orchestration.py (migration-prelude contract only)
 - do: `alembic init`; autogenerate a baseline revision from current models
   after T-TIME-2. Preserve the existing `python db_migrate.py` subprocess in
@@ -959,6 +969,9 @@ files (GED-5 grant).
   in the existing column-migration owner, compare against the frozen baseline
   schema, abort on drift, stamp the baseline, then upgrade to head. Delayed
   adopters use that same frozen comparison even when newer revisions exist.
+  Replace v8's mutable `Base.metadata.create_all()` dependency with frozen
+  baseline metadata so later models cannot mutate delayed adopters before the
+  parity check.
   Baseline upgrade creates the pgvector extension before baseline table DDL.
   Keep migrate_v* readable but frozen (no v11+). Document fresh, existing,
   delayed-adoption, upgrade, and downgrade workflows; do not instruct operators
@@ -973,7 +986,9 @@ files (GED-5 grant).
   `python db_migrate.py` subprocess remains unchanged and applies
   post-baseline revisions; attempting to downgrade below the baseline exits
   nonzero without changing schema or representative data; OPERATIONS documents
-  the baseline floor and supported workflows.
+  the baseline floor and supported workflows. Python Guardrails runs fresh,
+  existing, delayed-adoption, upgrade, and downgrade tests against an isolated
+  pgvector PostgreSQL service without optional skips.
 - verify: Schema diff script output empty; suite green.
 
 ### T-PLAT-2A: Patch Next.js's transitive Sharp runtime

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -247,7 +247,7 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 | DEDUP-C   | agent-dc   | api/main.py, api/app_setup.py, tests/conftest.py, tests/test_*api* (Phase 2 only) |
 | DEDUP-D   | agent-dd   | scripts/flush_city_pipeline_state.py, scripts/reset_city_verification_state.py, scripts/*_healthcheck.py, tests for same |
 | DEDUP-E   | agent-de   | pipeline/http_inference_provider.py, pipeline/inprocess_inference_provider.py, pipeline/inference_provider_contract.py, tests for same |
-| PLAT      | agent-plat | alembic/** (new), alembic.ini (new), pipeline/requirements*.txt, pipeline/db_migrate.py (T-PLAT-1 only, after TIME), pipeline/db_migration_columns.py (T-PLAT-1 legacy parity only), api/requirements.txt, semantic_service/requirements.txt, constraints.txt (new), .github/dependabot.yml (new), docs/OPERATIONS.md (migration and backup sections only), tests/test_alembic_migrations.py (new), api/cache.py |
+| PLAT      | agent-plat | alembic/** (new), alembic.ini (new), pipeline/requirements*.txt, pipeline/db_migrate.py (T-PLAT-1 only, after TIME), pipeline/db_migration_columns.py (T-PLAT-1 legacy parity only), api/requirements.txt, semantic_service/requirements.txt, constraints.txt (new), .github/dependabot.yml (new), docs/OPERATIONS.md (migration and backup sections only), tests/test_alembic_migrations.py (new), tests/test_run_pipeline_orchestration.py (T-PLAT-1 migration-prelude contract only), api/cache.py |
 | GOV       | agent-gov  | docs/ADR.md, docs/ENGINEERING_GUARDRAILS.md, AGENTS.md, SECURITY.md (new), docs/TESTING.md (new), docs/DATA_GOVERNANCE.md (new), tests/test_repository_guardrails.py (Phase 3 only) |
 
 Sequencing rule: SEC and DEDUP-C both own api/app_setup.py + api/main.py —
@@ -920,26 +920,32 @@ files (GED-5 grant).
   pipeline/requirements.txt, pipeline/db_migrate.py (Alembic handoff),
   pipeline/db_migration_columns.py (legacy parity repair only),
   docs/OPERATIONS.md (migration section), tests/test_alembic_migrations.py
-  (new)
+  (new), tests/test_run_pipeline_orchestration.py (migration-prelude contract
+  only)
 - do: `alembic init`; autogenerate a baseline revision from current models
-  after T-TIME-2. Keep `pipeline.run_pipeline` on its existing
-  `run_migrations()` call; make that canonical migration entrypoint run the
-  frozen legacy chain when needed and then `alembic upgrade head`.
+  after T-TIME-2. Preserve the existing `python db_migrate.py` subprocess in
+  `pipeline.run_pipeline`; make `db_migrate.migrate()` delegate through the
+  frozen legacy runner when needed and then run `alembic upgrade head`.
   `pipeline/db_migrate.py` owns the only supported existing-database adoption
   path: run the legacy chain through v10, repair the known missing-index drift
-  in the existing column-migration owner, compare schema, abort on drift,
-  stamp the baseline, then upgrade to head. Keep migrate_v* readable but
-  frozen (no v11+). Document fresh, existing, upgrade, and downgrade workflows;
-  do not instruct operators to run an unguarded `alembic stamp`. The baseline
-  is the downgrade floor: its downgrade must fail before any DDL, while later
-  revisions may downgrade only as far as the baseline.
-- accept: Fresh DB via Alembic equals `create_all` schema; an existing database
-  migrated through v10 has an empty schema diff before baseline stamping;
-  stamping aborts on nonempty drift; the canonical pipeline migration call
-  applies post-baseline Alembic revisions; attempting to downgrade below the
-  baseline exits nonzero without changing schema or representative data;
-  OPERATIONS documents the baseline floor and supported upgrade/downgrade
-  range.
+  in the existing column-migration owner, compare against the frozen baseline
+  schema, abort on drift, stamp the baseline, then upgrade to head. Delayed
+  adopters use that same frozen comparison even when newer revisions exist.
+  Baseline upgrade creates the pgvector extension before baseline table DDL.
+  Keep migrate_v* readable but frozen (no v11+). Document fresh, existing,
+  delayed-adoption, upgrade, and downgrade workflows; do not instruct operators
+  to run an unguarded `alembic stamp`. The baseline is the downgrade floor:
+  its downgrade must fail before any DDL, while later revisions may downgrade
+  only as far as the baseline.
+- accept: Fresh extension-free PostgreSQL via Alembic creates pgvector before
+  vector columns and equals the frozen baseline schema; an existing database
+  migrated through v10 has an empty diff against that baseline before
+  stamping; a delayed adopter stamps only after baseline parity and then
+  reaches head; stamping aborts on nonempty baseline drift; the canonical
+  `python db_migrate.py` subprocess remains unchanged and applies
+  post-baseline revisions; attempting to downgrade below the baseline exits
+  nonzero without changing schema or representative data; OPERATIONS documents
+  the baseline floor and supported workflows.
 - verify: Schema diff script output empty; suite green.
 
 ### T-PLAT-2A: Patch Next.js's transitive Sharp runtime

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,6 +1,6 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 3.38
+version: 3.39
 generated: 2026-07-24
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
@@ -10,6 +10,9 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v3.39:** Adds the canonical `ARCHITECTURE.md` migration map to T-PLAT-1
+  ownership so Alembic adoption cannot leave the system map on the retired
+  numbered-only design.
 - **v3.38:** Closes three T-PLAT-1 implementation gaps: frozen v8 metadata for
   delayed adopters, mandatory PostgreSQL migration CI, and synchronized
   pipeline and city-contributor migration guidance.
@@ -262,7 +265,7 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 | DEDUP-C   | agent-dc   | api/main.py, api/app_setup.py, tests/conftest.py, tests/test_*api* (Phase 2 only) |
 | DEDUP-D   | agent-dd   | scripts/flush_city_pipeline_state.py, scripts/reset_city_verification_state.py, scripts/*_healthcheck.py, tests for same |
 | DEDUP-E   | agent-de   | pipeline/http_inference_provider.py, pipeline/inprocess_inference_provider.py, pipeline/inference_provider_contract.py, tests for same |
-| PLAT      | agent-plat | alembic/** (new), alembic.ini (new), pipeline/requirements*.txt, pipeline/db_init.py (T-PLAT-1 only), pipeline/db_migrate.py (T-PLAT-1 only, after TIME), pipeline/db_migration_columns.py (T-PLAT-1 legacy parity only), pipeline/migrate_v8.py (T-PLAT-1 frozen metadata only), pipeline/migration_pgvector_semantic_embeddings.py (T-PLAT-1 frozen metadata only), pipeline/seed_places.py (T-PLAT-1 schema handoff only), pipeline/promote_stage.py (T-PLAT-1 schema handoff only), scripts/dev_up.sh (T-PLAT-1 only), README.md (T-PLAT-1 setup section only), api/requirements.txt, semantic_service/requirements.txt, constraints.txt (new), .github/dependabot.yml (new), .github/workflows/python-guardrails.yml (T-PLAT-1 PostgreSQL migration service/step only), docs/OPERATIONS.md (migration and backup sections only), docs/PIPELINE.md (T-PLAT-1 migration section only), docs/CONTRIBUTING_CITIES.md (T-PLAT-1 seed prerequisite only), tests/test_alembic_migrations.py (new), tests/test_db_init.py (T-PLAT-1 only), tests/test_db_migrate.py (T-PLAT-1 only), tests/test_docker_build_contracts.py (T-PLAT-1 fresh-DB contract only), tests/test_migrate_v8_pgvector_order.py (T-PLAT-1 only), tests/test_seed_places.py (T-PLAT-1 schema handoff only), tests/test_seed_places_includes_cupertino.py (T-PLAT-1 schema handoff only), tests/test_database.py (T-PLAT-1 promotion schema handoff only), tests/test_pipeline_idempotency.py (T-PLAT-1 promotion schema handoff only), tests/test_pipeline_integration.py (T-PLAT-1 promotion schema handoff only), tests/test_repository_guardrails.py (T-PLAT-1 migration CI contract only), tests/test_run_pipeline_orchestration.py (T-PLAT-1 migration-prelude contract only), api/cache.py |
+| PLAT      | agent-plat | alembic/** (new), alembic.ini (new), pipeline/requirements*.txt, pipeline/db_init.py (T-PLAT-1 only), pipeline/db_migrate.py (T-PLAT-1 only, after TIME), pipeline/db_migration_columns.py (T-PLAT-1 legacy parity only), pipeline/migrate_v8.py (T-PLAT-1 frozen metadata only), pipeline/migration_pgvector_semantic_embeddings.py (T-PLAT-1 frozen metadata only), pipeline/seed_places.py (T-PLAT-1 schema handoff only), pipeline/promote_stage.py (T-PLAT-1 schema handoff only), scripts/dev_up.sh (T-PLAT-1 only), README.md (T-PLAT-1 setup section only), ARCHITECTURE.md (T-PLAT-1 migration map only), api/requirements.txt, semantic_service/requirements.txt, constraints.txt (new), .github/dependabot.yml (new), .github/workflows/python-guardrails.yml (T-PLAT-1 PostgreSQL migration service/step only), docs/OPERATIONS.md (migration and backup sections only), docs/PIPELINE.md (T-PLAT-1 migration section only), docs/CONTRIBUTING_CITIES.md (T-PLAT-1 seed prerequisite only), tests/test_alembic_migrations.py (new), tests/test_db_init.py (T-PLAT-1 only), tests/test_db_migrate.py (T-PLAT-1 only), tests/test_docker_build_contracts.py (T-PLAT-1 fresh-DB contract only), tests/test_migrate_v8_pgvector_order.py (T-PLAT-1 only), tests/test_seed_places.py (T-PLAT-1 schema handoff only), tests/test_seed_places_includes_cupertino.py (T-PLAT-1 schema handoff only), tests/test_database.py (T-PLAT-1 promotion schema handoff only), tests/test_pipeline_idempotency.py (T-PLAT-1 promotion schema handoff only), tests/test_pipeline_integration.py (T-PLAT-1 promotion schema handoff only), tests/test_repository_guardrails.py (T-PLAT-1 migration CI contract only), tests/test_run_pipeline_orchestration.py (T-PLAT-1 migration-prelude contract only), api/cache.py |
 | GOV       | agent-gov  | docs/ADR.md, docs/ENGINEERING_GUARDRAILS.md, AGENTS.md, SECURITY.md (new), docs/TESTING.md (new), docs/DATA_GOVERNANCE.md (new), tests/test_repository_guardrails.py (Phase 3 only) |
 
 Sequencing rule: SEC and DEDUP-C both own api/app_setup.py + api/main.py —
@@ -941,9 +944,10 @@ files (GED-5 grant).
   pipeline/migration_pgvector_semantic_embeddings.py (frozen metadata only),
   pipeline/seed_places.py (schema handoff only),
   pipeline/promote_stage.py (schema handoff only),
-  scripts/dev_up.sh, README.md (setup section), docs/OPERATIONS.md and
-  docs/PIPELINE.md (migration sections), docs/CONTRIBUTING_CITIES.md
-  (seed prerequisite), .github/workflows/python-guardrails.yml
+  scripts/dev_up.sh, README.md (setup section), ARCHITECTURE.md (migration
+  map), docs/OPERATIONS.md and docs/PIPELINE.md (migration sections),
+  docs/CONTRIBUTING_CITIES.md (seed prerequisite),
+  .github/workflows/python-guardrails.yml
   (PostgreSQL migration service/step only),
   tests/test_alembic_migrations.py (new),
   tests/test_db_init.py, tests/test_db_migrate.py,
@@ -988,7 +992,8 @@ files (GED-5 grant).
   nonzero without changing schema or representative data; OPERATIONS documents
   the baseline floor and supported workflows. Python Guardrails runs fresh,
   existing, delayed-adoption, upgrade, and downgrade tests against an isolated
-  pgvector PostgreSQL service without optional skips.
+  pgvector PostgreSQL service without optional skips. ARCHITECTURE maps
+  Alembic as the authoritative post-baseline migration graph.
 - verify: Schema diff script output empty; suite green.
 
 ### T-PLAT-2A: Patch Next.js's transitive Sharp runtime

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,6 +1,6 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 3.33
+version: 3.34
 generated: 2026-07-24
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
@@ -10,6 +10,9 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v3.34:** Adds `tests/test_db_migrate.py` to T-PLAT-1 ownership so Alembic
+  adoption can replace obsolete legacy-runner assertions without preserving
+  compatibility seams solely for tests.
 - **v3.33:** Records operator approval of G5 and fixes migration sequencing:
   T-TIME-1 updates model declarations, T-TIME-2 converts existing databases
   through the final numbered migration, and T-PLAT-1 then establishes the
@@ -247,7 +250,7 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 | DEDUP-C   | agent-dc   | api/main.py, api/app_setup.py, tests/conftest.py, tests/test_*api* (Phase 2 only) |
 | DEDUP-D   | agent-dd   | scripts/flush_city_pipeline_state.py, scripts/reset_city_verification_state.py, scripts/*_healthcheck.py, tests for same |
 | DEDUP-E   | agent-de   | pipeline/http_inference_provider.py, pipeline/inprocess_inference_provider.py, pipeline/inference_provider_contract.py, tests for same |
-| PLAT      | agent-plat | alembic/** (new), alembic.ini (new), pipeline/requirements*.txt, pipeline/db_migrate.py (T-PLAT-1 only, after TIME), pipeline/db_migration_columns.py (T-PLAT-1 legacy parity only), api/requirements.txt, semantic_service/requirements.txt, constraints.txt (new), .github/dependabot.yml (new), docs/OPERATIONS.md (migration and backup sections only), tests/test_alembic_migrations.py (new), tests/test_run_pipeline_orchestration.py (T-PLAT-1 migration-prelude contract only), api/cache.py |
+| PLAT      | agent-plat | alembic/** (new), alembic.ini (new), pipeline/requirements*.txt, pipeline/db_migrate.py (T-PLAT-1 only, after TIME), pipeline/db_migration_columns.py (T-PLAT-1 legacy parity only), api/requirements.txt, semantic_service/requirements.txt, constraints.txt (new), .github/dependabot.yml (new), docs/OPERATIONS.md (migration and backup sections only), tests/test_alembic_migrations.py (new), tests/test_db_migrate.py (T-PLAT-1 only), tests/test_run_pipeline_orchestration.py (T-PLAT-1 migration-prelude contract only), api/cache.py |
 | GOV       | agent-gov  | docs/ADR.md, docs/ENGINEERING_GUARDRAILS.md, AGENTS.md, SECURITY.md (new), docs/TESTING.md (new), docs/DATA_GOVERNANCE.md (new), tests/test_repository_guardrails.py (Phase 3 only) |
 
 Sequencing rule: SEC and DEDUP-C both own api/app_setup.py + api/main.py —
@@ -920,8 +923,8 @@ files (GED-5 grant).
   pipeline/requirements.txt, pipeline/db_migrate.py (Alembic handoff),
   pipeline/db_migration_columns.py (legacy parity repair only),
   docs/OPERATIONS.md (migration section), tests/test_alembic_migrations.py
-  (new), tests/test_run_pipeline_orchestration.py (migration-prelude contract
-  only)
+  (new), tests/test_db_migrate.py, tests/test_run_pipeline_orchestration.py
+  (migration-prelude contract only)
 - do: `alembic init`; autogenerate a baseline revision from current models
   after T-TIME-2. Preserve the existing `python db_migrate.py` subprocess in
   `pipeline.run_pipeline`; make `db_migrate.migrate()` delegate through the

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,6 +1,6 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 3.39
+version: 3.40
 generated: 2026-07-24
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
@@ -10,6 +10,9 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v3.40:** Requires T-PLAT-1 to inventory and encode schema objects created
+  only by legacy raw SQL, preventing baseline autogeneration from omitting
+  indexes that current model metadata does not declare.
 - **v3.39:** Adds the canonical `ARCHITECTURE.md` migration map to T-PLAT-1
   ownership so Alembic adoption cannot leave the system map on the retired
   numbered-only design.
@@ -960,7 +963,11 @@ files (GED-5 grant).
   tests/test_repository_guardrails.py (migration CI contract only),
   tests/test_run_pipeline_orchestration.py (migration-prelude contract only)
 - do: `alembic init`; autogenerate a baseline revision from current models
-  after T-TIME-2. Preserve the existing `python db_migrate.py` subprocess in
+  after T-TIME-2, then reconcile it against an explicit inventory of every
+  schema object created by the frozen legacy migrations. This inventory must
+  include legacy-only objects absent from model metadata, including
+  `ix_semantic_embedding_hnsw` and `ix_catalog_lineage_updated_at`.
+  Preserve the existing `python db_migrate.py` subprocess in
   `pipeline.run_pipeline`; make `db_migrate.migrate()` delegate through the
   frozen legacy runner when needed and then run `alembic upgrade head`.
   Make `pipeline/db_init.py`, `scripts/dev_up.sh`, and README setup use the
@@ -983,9 +990,10 @@ files (GED-5 grant).
   its downgrade must fail before any DDL, while later revisions may downgrade
   only as far as the baseline.
 - accept: Fresh extension-free PostgreSQL via Alembic creates pgvector before
-  vector columns and equals the frozen baseline schema; an existing database
-  migrated through v10 has an empty diff against that baseline before
-  stamping; a delayed adopter stamps only after baseline parity and then
+  vector columns, contains every inventoried legacy-only object, and equals
+  the frozen baseline schema; an existing database migrated through v10 has
+  an empty object-level diff against that baseline before stamping; a delayed
+  adopter stamps only after baseline parity and then
   reaches head; stamping aborts on nonempty baseline drift; the canonical
   `python db_migrate.py` subprocess remains unchanged and applies
   post-baseline revisions; attempting to downgrade below the baseline exits

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,6 +1,6 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 3.40
+version: 3.41
 generated: 2026-07-24
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
@@ -10,6 +10,8 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v3.41:** Prevents T-PLAT-1 and T-GOV-3 from running concurrently while
+  both own focused changes in `tests/test_repository_guardrails.py`.
 - **v3.40:** Requires T-PLAT-1 to inventory and encode schema objects created
   only by legacy raw SQL, preventing baseline autogeneration from omitting
   indexes that current model metadata does not declare.
@@ -287,6 +289,9 @@ T-CI-3 receives a narrow temporary coordination grant for coverage scope
 references, verification commands, merge-gate prose, and transition markers
 in `AGENTS.md`, `docs/TESTING.MD`, and
 `docs/ENGINEERING_GUARDRAILS.md`; later GOV work retains all other ownership.
+T-PLAT-1 and T-GOV-3 MUST NOT run concurrently because both own focused
+changes in `tests/test_repository_guardrails.py`; whichever starts second
+must wait for the first PR to merge and rebase on `master`.
 
 ---
 
@@ -938,6 +943,7 @@ files (GED-5 grant).
 ### T-PLAT-1: Alembic baseline (gate G5)
 - priority: P1
 - status: approved; implementation pending
+- must_not_run_concurrently_with: T-GOV-3
 - decision_record: `docs/plans/G5_ALEMBIC_ADOPTION_DECISION_PLAN.md`
 - files_owned: alembic/** (new), alembic.ini (new),
   pipeline/requirements.txt, pipeline/db_init.py (fresh-DB handoff),

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,6 +1,6 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 3.34
+version: 3.35
 generated: 2026-07-24
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
@@ -10,6 +10,9 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v3.35:** Routes T-PLAT-1 through the canonical fresh-database contributor
+  workflow by adding `pipeline/db_init.py`, `scripts/dev_up.sh`, README setup
+  guidance, and their contract tests to task ownership.
 - **v3.34:** Adds `tests/test_db_migrate.py` to T-PLAT-1 ownership so Alembic
   adoption can replace obsolete legacy-runner assertions without preserving
   compatibility seams solely for tests.
@@ -250,7 +253,7 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 | DEDUP-C   | agent-dc   | api/main.py, api/app_setup.py, tests/conftest.py, tests/test_*api* (Phase 2 only) |
 | DEDUP-D   | agent-dd   | scripts/flush_city_pipeline_state.py, scripts/reset_city_verification_state.py, scripts/*_healthcheck.py, tests for same |
 | DEDUP-E   | agent-de   | pipeline/http_inference_provider.py, pipeline/inprocess_inference_provider.py, pipeline/inference_provider_contract.py, tests for same |
-| PLAT      | agent-plat | alembic/** (new), alembic.ini (new), pipeline/requirements*.txt, pipeline/db_migrate.py (T-PLAT-1 only, after TIME), pipeline/db_migration_columns.py (T-PLAT-1 legacy parity only), api/requirements.txt, semantic_service/requirements.txt, constraints.txt (new), .github/dependabot.yml (new), docs/OPERATIONS.md (migration and backup sections only), tests/test_alembic_migrations.py (new), tests/test_db_migrate.py (T-PLAT-1 only), tests/test_run_pipeline_orchestration.py (T-PLAT-1 migration-prelude contract only), api/cache.py |
+| PLAT      | agent-plat | alembic/** (new), alembic.ini (new), pipeline/requirements*.txt, pipeline/db_init.py (T-PLAT-1 only), pipeline/db_migrate.py (T-PLAT-1 only, after TIME), pipeline/db_migration_columns.py (T-PLAT-1 legacy parity only), scripts/dev_up.sh (T-PLAT-1 only), README.md (T-PLAT-1 setup section only), api/requirements.txt, semantic_service/requirements.txt, constraints.txt (new), .github/dependabot.yml (new), docs/OPERATIONS.md (migration and backup sections only), tests/test_alembic_migrations.py (new), tests/test_db_init.py (T-PLAT-1 only), tests/test_db_migrate.py (T-PLAT-1 only), tests/test_docker_build_contracts.py (T-PLAT-1 fresh-DB contract only), tests/test_run_pipeline_orchestration.py (T-PLAT-1 migration-prelude contract only), api/cache.py |
 | GOV       | agent-gov  | docs/ADR.md, docs/ENGINEERING_GUARDRAILS.md, AGENTS.md, SECURITY.md (new), docs/TESTING.md (new), docs/DATA_GOVERNANCE.md (new), tests/test_repository_guardrails.py (Phase 3 only) |
 
 Sequencing rule: SEC and DEDUP-C both own api/app_setup.py + api/main.py —
@@ -920,15 +923,21 @@ files (GED-5 grant).
 - status: approved; implementation pending
 - decision_record: `docs/plans/G5_ALEMBIC_ADOPTION_DECISION_PLAN.md`
 - files_owned: alembic/** (new), alembic.ini (new),
-  pipeline/requirements.txt, pipeline/db_migrate.py (Alembic handoff),
+  pipeline/requirements.txt, pipeline/db_init.py (fresh-DB handoff),
+  pipeline/db_migrate.py (Alembic handoff),
   pipeline/db_migration_columns.py (legacy parity repair only),
-  docs/OPERATIONS.md (migration section), tests/test_alembic_migrations.py
-  (new), tests/test_db_migrate.py, tests/test_run_pipeline_orchestration.py
-  (migration-prelude contract only)
+  scripts/dev_up.sh, README.md (setup section), docs/OPERATIONS.md
+  (migration section), tests/test_alembic_migrations.py (new),
+  tests/test_db_init.py, tests/test_db_migrate.py,
+  tests/test_docker_build_contracts.py (fresh-DB contract only),
+  tests/test_run_pipeline_orchestration.py (migration-prelude contract only)
 - do: `alembic init`; autogenerate a baseline revision from current models
   after T-TIME-2. Preserve the existing `python db_migrate.py` subprocess in
   `pipeline.run_pipeline`; make `db_migrate.migrate()` delegate through the
   frozen legacy runner when needed and then run `alembic upgrade head`.
+  Make `pipeline/db_init.py`, `scripts/dev_up.sh`, and README setup use the
+  same migration entrypoint so fresh contributor databases are Alembic-owned
+  immediately instead of being created through `Base.metadata.create_all()`.
   `pipeline/db_migrate.py` owns the only supported existing-database adoption
   path: run the legacy chain through v10, repair the known missing-index drift
   in the existing column-migration owner, compare against the frozen baseline

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,6 +1,6 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 3.35
+version: 3.36
 generated: 2026-07-24
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
@@ -10,6 +10,9 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v3.36:** Adds `seed_places.py` and `promote_stage.py` plus their affected
+  tests to T-PLAT-1 ownership. Operational entrypoints may no longer call
+  `create_tables()` outside the Alembic migration path.
 - **v3.35:** Routes T-PLAT-1 through the canonical fresh-database contributor
   workflow by adding `pipeline/db_init.py`, `scripts/dev_up.sh`, README setup
   guidance, and their contract tests to task ownership.
@@ -253,7 +256,7 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 | DEDUP-C   | agent-dc   | api/main.py, api/app_setup.py, tests/conftest.py, tests/test_*api* (Phase 2 only) |
 | DEDUP-D   | agent-dd   | scripts/flush_city_pipeline_state.py, scripts/reset_city_verification_state.py, scripts/*_healthcheck.py, tests for same |
 | DEDUP-E   | agent-de   | pipeline/http_inference_provider.py, pipeline/inprocess_inference_provider.py, pipeline/inference_provider_contract.py, tests for same |
-| PLAT      | agent-plat | alembic/** (new), alembic.ini (new), pipeline/requirements*.txt, pipeline/db_init.py (T-PLAT-1 only), pipeline/db_migrate.py (T-PLAT-1 only, after TIME), pipeline/db_migration_columns.py (T-PLAT-1 legacy parity only), scripts/dev_up.sh (T-PLAT-1 only), README.md (T-PLAT-1 setup section only), api/requirements.txt, semantic_service/requirements.txt, constraints.txt (new), .github/dependabot.yml (new), docs/OPERATIONS.md (migration and backup sections only), tests/test_alembic_migrations.py (new), tests/test_db_init.py (T-PLAT-1 only), tests/test_db_migrate.py (T-PLAT-1 only), tests/test_docker_build_contracts.py (T-PLAT-1 fresh-DB contract only), tests/test_run_pipeline_orchestration.py (T-PLAT-1 migration-prelude contract only), api/cache.py |
+| PLAT      | agent-plat | alembic/** (new), alembic.ini (new), pipeline/requirements*.txt, pipeline/db_init.py (T-PLAT-1 only), pipeline/db_migrate.py (T-PLAT-1 only, after TIME), pipeline/db_migration_columns.py (T-PLAT-1 legacy parity only), pipeline/seed_places.py (T-PLAT-1 schema handoff only), pipeline/promote_stage.py (T-PLAT-1 schema handoff only), scripts/dev_up.sh (T-PLAT-1 only), README.md (T-PLAT-1 setup section only), api/requirements.txt, semantic_service/requirements.txt, constraints.txt (new), .github/dependabot.yml (new), docs/OPERATIONS.md (migration and backup sections only), tests/test_alembic_migrations.py (new), tests/test_db_init.py (T-PLAT-1 only), tests/test_db_migrate.py (T-PLAT-1 only), tests/test_docker_build_contracts.py (T-PLAT-1 fresh-DB contract only), tests/test_seed_places.py (T-PLAT-1 schema handoff only), tests/test_seed_places_includes_cupertino.py (T-PLAT-1 schema handoff only), tests/test_database.py (T-PLAT-1 promotion schema handoff only), tests/test_pipeline_idempotency.py (T-PLAT-1 promotion schema handoff only), tests/test_pipeline_integration.py (T-PLAT-1 promotion schema handoff only), tests/test_run_pipeline_orchestration.py (T-PLAT-1 migration-prelude contract only), api/cache.py |
 | GOV       | agent-gov  | docs/ADR.md, docs/ENGINEERING_GUARDRAILS.md, AGENTS.md, SECURITY.md (new), docs/TESTING.md (new), docs/DATA_GOVERNANCE.md (new), tests/test_repository_guardrails.py (Phase 3 only) |
 
 Sequencing rule: SEC and DEDUP-C both own api/app_setup.py + api/main.py —
@@ -926,10 +929,16 @@ files (GED-5 grant).
   pipeline/requirements.txt, pipeline/db_init.py (fresh-DB handoff),
   pipeline/db_migrate.py (Alembic handoff),
   pipeline/db_migration_columns.py (legacy parity repair only),
+  pipeline/seed_places.py (schema handoff only),
+  pipeline/promote_stage.py (schema handoff only),
   scripts/dev_up.sh, README.md (setup section), docs/OPERATIONS.md
   (migration section), tests/test_alembic_migrations.py (new),
   tests/test_db_init.py, tests/test_db_migrate.py,
   tests/test_docker_build_contracts.py (fresh-DB contract only),
+  tests/test_seed_places.py and tests/test_seed_places_includes_cupertino.py
+  (schema handoff only), tests/test_database.py,
+  tests/test_pipeline_idempotency.py, and tests/test_pipeline_integration.py
+  (promotion schema handoff only),
   tests/test_run_pipeline_orchestration.py (migration-prelude contract only)
 - do: `alembic init`; autogenerate a baseline revision from current models
   after T-TIME-2. Preserve the existing `python db_migrate.py` subprocess in
@@ -938,6 +947,8 @@ files (GED-5 grant).
   Make `pipeline/db_init.py`, `scripts/dev_up.sh`, and README setup use the
   same migration entrypoint so fresh contributor databases are Alembic-owned
   immediately instead of being created through `Base.metadata.create_all()`.
+  Remove implicit schema creation from `seed_places.py` and
+  `promote_stage.py`; operators must migrate before seeding or promotion.
   `pipeline/db_migrate.py` owns the only supported existing-database adoption
   path: run the legacy chain through v10, repair the known missing-index drift
   in the existing column-migration owner, compare against the frozen baseline

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,6 +1,6 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 3.32
+version: 3.33
 generated: 2026-07-24
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
@@ -10,6 +10,10 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v3.33:** Records operator approval of G5 and fixes migration sequencing:
+  T-TIME-1 updates model declarations, T-TIME-2 converts existing databases
+  through the final numbered migration, and T-PLAT-1 then establishes the
+  Alembic baseline. Implementation remains pending.
 - **v3.32:** Marks T-DA-1 complete after removing duplicated Redis state,
   facade synchronization, dynamic metric lookups, and injected write
   callables. One collector now owns each provider series, preserves local
@@ -221,8 +225,10 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
   ownership.
 - G4 pii_policy: Ratify ADR on person-entity minimization for non-officials
   (T-GOV-2). BLOCKS nothing in this plan, but blocks City Coverage Expansion.
-- G5 migration_tooling: Alembic adoption approved? Default: yes (T-PLAT-1).
-  If no, T-TIME-2 ships via the existing migrate_v10 chain unchanged.
+- G5 migration_tooling: **Approved 2026-07-24.** Adopt Alembic through
+  T-PLAT-1 after T-TIME-1 and T-TIME-2. Freeze the readable `migrate_v*`
+  chain after the baseline; author all later schema changes as Alembic
+  revisions.
 
 ---
 
@@ -239,12 +245,13 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 | DEDUP-C   | agent-dc   | api/main.py, api/app_setup.py, tests/conftest.py, tests/test_*api* (Phase 2 only) |
 | DEDUP-D   | agent-dd   | scripts/flush_city_pipeline_state.py, scripts/reset_city_verification_state.py, scripts/*_healthcheck.py, tests for same |
 | DEDUP-E   | agent-de   | pipeline/http_inference_provider.py, pipeline/inprocess_inference_provider.py, pipeline/inference_provider_contract.py, tests for same |
-| PLAT      | agent-plat | alembic/** (new), pipeline/requirements*.txt, api/requirements.txt, semantic_service/requirements.txt, constraints.txt (new), .github/dependabot.yml (new), docs/OPERATIONS.md (backup section only), api/cache.py |
+| PLAT      | agent-plat | alembic/** (new), alembic.ini (new), pipeline/requirements*.txt, pipeline/db_migrate.py (T-PLAT-1 only, after TIME), api/requirements.txt, semantic_service/requirements.txt, constraints.txt (new), .github/dependabot.yml (new), docs/OPERATIONS.md (migration and backup sections only), tests/test_alembic_migrations.py (new), api/cache.py |
 | GOV       | agent-gov  | docs/ADR.md, docs/ENGINEERING_GUARDRAILS.md, AGENTS.md, SECURITY.md (new), docs/TESTING.md (new), docs/DATA_GOVERNANCE.md (new), tests/test_repository_guardrails.py (Phase 3 only) |
 
 Sequencing rule: SEC and DEDUP-C both own api/app_setup.py + api/main.py —
 they are in different phases and MUST NOT run concurrently. TIME owns
-model files; PLAT's Alembic baseline runs AFTER TIME merges. T-CI-0 temporarily
+model files. Migration order is T-TIME-1, T-TIME-2, then T-PLAT-1; other TIME
+and PLAT work may run independently when ownership permits. T-CI-0 temporarily
 coordinates `docs/ENGINEERING_GUARDRAILS.md` with T-GOV-3 and T-GOV-5 for the
 narrow broad-handler policy correction described below; the GOV lane retains
 ownership of the later redesign and rewrite. T-CI-5 temporarily coordinates
@@ -716,7 +723,8 @@ in `AGENTS.md`, `docs/TESTING.MD`, and
   calls only — column defaults reference callables, so also add a
   guardrail-test assertion that model files contain no naive default
   callables; suite green.
-- depends_on: T-TIME-2 for existing DBs.
+- sequencing: May merge before T-TIME-2, but must not deploy against an
+  existing database until T-TIME-2 has converted its timestamp columns.
 - verify: grep + full suite.
 
 ### T-TIME-2: Migration for timestamp columns
@@ -724,8 +732,8 @@ in `AGENTS.md`, `docs/TESTING.MD`, and
 - files_owned: pipeline/migrate_v10.py (new), pipeline/db_migrate.py
 - do: Additive migration converting existing columns to timestamptz
   (`ALTER ... TYPE timestamptz USING <col> AT TIME ZONE 'UTC'`). Wire into
-  run_migrations after v9. If G5=yes and T-PLAT-1 has merged first, author
-  as an Alembic revision instead.
+  run_migrations after v9. This is the final numbered migration before the
+  T-PLAT-1 Alembic baseline.
 - accept: Migration idempotent (safe re-run); documented in db_migrate
   docstring.
 - verify: Run against a dev DB snapshot; suite green.
@@ -903,8 +911,12 @@ files (GED-5 grant).
 
 ### T-PLAT-1: Alembic baseline (gate G5)
 - priority: P1
-- files_owned: alembic/** (new), pipeline/db_migrate.py (deprecation note),
-  docs/OPERATIONS.md (migration section)
+- status: approved; implementation pending
+- decision_record: `docs/plans/G5_ALEMBIC_ADOPTION_DECISION_PLAN.md`
+- files_owned: alembic/** (new), alembic.ini (new),
+  pipeline/requirements.txt, pipeline/db_migrate.py (deprecation note),
+  docs/OPERATIONS.md (migration section), tests/test_alembic_migrations.py
+  (new)
 - do: `alembic init`; autogenerate a baseline revision from current models
   (post T-TIME-1); stamp existing dev DBs; document the workflow. Keep
   migrate_v* chain readable but frozen (no v11+).
@@ -1113,7 +1125,8 @@ Docs-0:  agent-gov [T-GOV-6: SECURITY.md] + [T-GOV-4: AGENTS.md]   (with/just af
 Phase 1: agent-sec [T-SEC-1..6] || agent-time [T-TIME-1..3] || agent-crawl [T-CRAWL-1..2]
 Gate:    G3 satisfied (T-GOV-1 Accepted ADR + active docs/TESTING.MD)
 Phase 2: agent-da || agent-db || agent-dd || agent-de ; then agent-dc (exclusive on api/*)
-Phase 3: agent-plat [T-PLAT-1..4] || agent-gov [T-GOV-2, T-GOV-3 + T-GOV-5]
+Phase 3: agent-plat [T-PLAT-1 after T-TIME-1 and T-TIME-2, then T-PLAT-2..4]
+         || agent-gov [T-GOV-2, T-GOV-3 + T-GOV-5]
 Anytime: T-GOV-6 DATA_GOVERNANCE.md (Section 3 pending G4)
 ```
 

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -13,7 +13,9 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 - **v3.33:** Records operator approval of G5 and fixes migration sequencing:
   T-TIME-1 updates model declarations, T-TIME-2 converts existing databases
   through the final numbered migration, and T-PLAT-1 then establishes the
-  Alembic baseline. Implementation remains pending.
+  Alembic baseline. The baseline task must preserve the canonical pipeline
+  entrypoint and prove legacy-schema parity before stamping. Implementation
+  remains pending.
 - **v3.32:** Marks T-DA-1 complete after removing duplicated Redis state,
   facade synchronization, dynamic metric lookups, and injected write
   callables. One collector now owns each provider series, preserves local
@@ -238,14 +240,14 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 |-----------|-----------|------------------------------------------------------------|
 | CI        | agent-ci   | .github/workflows/**, ruff.toml, ruff-format.toml (new), .pre-commit-config.yaml, .coveragerc, frontend/package.json, frontend/jest.config.* (new) |
 | SEC       | agent-sec  | docker-compose.yml, docker-compose.dev.yml, .dockerignore, .env.example, api/app_setup.py, api/main.py (CORS+/stats sections only), api/search/support_core.py, pipeline/meilisearch_credentials.py, semantic_service/main.py, frontend/app/api/** |
-| TIME      | agent-time | pipeline/model_base.py, model_civic.py, model_events.py, model_records.py, model_runtime.py, models.py, db_migrate.py, migrate_v10.py (new), pipeline/summary_freshness.py (verify-only) |
+| TIME      | agent-time | pipeline/model_base.py, model_civic.py, model_events.py, model_records.py, model_runtime.py, models.py, db_migrate.py, db_migration_runner.py, migrate_v10.py (new), pipeline/summary_freshness.py (verify-only) |
 | CRAWL     | agent-crawl| council_crawler/**                                          |
 | DEDUP-A   | agent-da   | pipeline/metrics.py, pipeline/metrics_redis_backend.py, tests/test_*metrics* |
 | DEDUP-B   | agent-db   | pipeline/summary_backfill*.py, pipeline/task_facade_helpers.py, pipeline/tasks.py, tests/test_*backfill*, tests/test_pipeline_batching.py, tests/test_run_pipeline_orchestration.py, tests/test_staged_hydrate_cities.py, tests/test_tasks_agenda_summary_format.py |
 | DEDUP-C   | agent-dc   | api/main.py, api/app_setup.py, tests/conftest.py, tests/test_*api* (Phase 2 only) |
 | DEDUP-D   | agent-dd   | scripts/flush_city_pipeline_state.py, scripts/reset_city_verification_state.py, scripts/*_healthcheck.py, tests for same |
 | DEDUP-E   | agent-de   | pipeline/http_inference_provider.py, pipeline/inprocess_inference_provider.py, pipeline/inference_provider_contract.py, tests for same |
-| PLAT      | agent-plat | alembic/** (new), alembic.ini (new), pipeline/requirements*.txt, pipeline/db_migrate.py (T-PLAT-1 only, after TIME), api/requirements.txt, semantic_service/requirements.txt, constraints.txt (new), .github/dependabot.yml (new), docs/OPERATIONS.md (migration and backup sections only), tests/test_alembic_migrations.py (new), api/cache.py |
+| PLAT      | agent-plat | alembic/** (new), alembic.ini (new), pipeline/requirements*.txt, pipeline/db_migrate.py (T-PLAT-1 only, after TIME), pipeline/db_migration_columns.py (T-PLAT-1 legacy parity only), api/requirements.txt, semantic_service/requirements.txt, constraints.txt (new), .github/dependabot.yml (new), docs/OPERATIONS.md (migration and backup sections only), tests/test_alembic_migrations.py (new), api/cache.py |
 | GOV       | agent-gov  | docs/ADR.md, docs/ENGINEERING_GUARDRAILS.md, AGENTS.md, SECURITY.md (new), docs/TESTING.md (new), docs/DATA_GOVERNANCE.md (new), tests/test_repository_guardrails.py (Phase 3 only) |
 
 Sequencing rule: SEC and DEDUP-C both own api/app_setup.py + api/main.py —
@@ -729,7 +731,8 @@ in `AGENTS.md`, `docs/TESTING.MD`, and
 
 ### T-TIME-2: Migration for timestamp columns
 - priority: P1
-- files_owned: pipeline/migrate_v10.py (new), pipeline/db_migrate.py
+- files_owned: pipeline/migrate_v10.py (new), pipeline/db_migrate.py,
+  pipeline/db_migration_runner.py
 - do: Additive migration converting existing columns to timestamptz
   (`ALTER ... TYPE timestamptz USING <col> AT TIME ZONE 'UTC'`). Wire into
   run_migrations after v9. This is the final numbered migration before the
@@ -914,14 +917,25 @@ files (GED-5 grant).
 - status: approved; implementation pending
 - decision_record: `docs/plans/G5_ALEMBIC_ADOPTION_DECISION_PLAN.md`
 - files_owned: alembic/** (new), alembic.ini (new),
-  pipeline/requirements.txt, pipeline/db_migrate.py (deprecation note),
+  pipeline/requirements.txt, pipeline/db_migrate.py (Alembic handoff),
+  pipeline/db_migration_columns.py (legacy parity repair only),
   docs/OPERATIONS.md (migration section), tests/test_alembic_migrations.py
   (new)
 - do: `alembic init`; autogenerate a baseline revision from current models
-  (post T-TIME-1); stamp existing dev DBs; document the workflow. Keep
-  migrate_v* chain readable but frozen (no v11+).
-- accept: Fresh DB via alembic == create_all schema (diff empty);
-  OPERATIONS documents upgrade/downgrade.
+  after T-TIME-2. Keep `pipeline.run_pipeline` on its existing
+  `run_migrations()` call; make that canonical migration entrypoint run the
+  frozen legacy chain when needed and then `alembic upgrade head`.
+  `pipeline/db_migrate.py` owns the only supported existing-database adoption
+  path: run the legacy chain through v10, repair the known missing-index drift
+  in the existing column-migration owner, compare schema, abort on drift,
+  stamp the baseline, then upgrade to head. Keep migrate_v* readable but
+  frozen (no v11+). Document fresh, existing, upgrade, and downgrade workflows;
+  do not instruct operators to run an unguarded `alembic stamp`.
+- accept: Fresh DB via Alembic equals `create_all` schema; an existing database
+  migrated through v10 has an empty schema diff before baseline stamping;
+  stamping aborts on nonempty drift; the canonical pipeline migration call
+  applies post-baseline Alembic revisions; OPERATIONS documents
+  upgrade/downgrade.
 - verify: Schema diff script output empty; suite green.
 
 ### T-PLAT-2A: Patch Next.js's transitive Sharp runtime


### PR DESCRIPTION
## What changed
- record operator approval of G5 in the remediation ledger
- add an Accepted ADR for Alembic adoption
- preserve T-TIME-1 then T-TIME-2 sequencing before the Alembic baseline
- expand T-PLAT-1 ownership for root config, pinned dependency, migration docs, and schema-parity tests

## Why
This removes migration-tooling ambiguity before T-PLAT-1 starts without claiming Alembic is already implemented.

## Risk and compatibility
Docs and planning only. No migration, schema, dependency, runtime, or external-state change.

## Verification
- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py` (2 passed)
- PASS: positive G5, sequence, ownership, and ADR checks
- PASS: negative stale-sequence checks
- PASS: `git diff --check`
- PASS: independent planning review and pre-commit review; no remaining P1/P2

## Remaining work
T-PLAT-1 remains pending. T-TIME-1 and T-TIME-2 must land before its baseline.