### PR TITLE
T-DB-1A: Make summary generation a direct operation

### DIFF
--- a/docs/ADR.md
+++ b/docs/ADR.md
@@ -8,6 +8,36 @@ Use each entry to record:
 - the affected boundary or contract
 - links to the canonical docs that carry the ongoing operational or architecture detail
 
+## 2026-07-25: Summary generation has one direct operation owner
+
+- Status: Accepted
+- Decision:
+  - `pipeline/task_summary_generation.py` owns the catalog summary-generation
+    operation used by the Celery task.
+  - Summary preparation, persistence, empty-agenda handling, and best-effort
+    side effects remain focused lower modules with direct imports to real
+    domain boundaries.
+  - Agenda summary input and persistence resolve directly through
+    `agenda_summary_inputs` and `agenda_summary_batch`, not maintenance
+    facades.
+  - `SummaryGenerationTaskServices`, globals-based service construction, and
+    summary-only facade forwarding are removed by T-DB-1A.
+- Why:
+  - Passing domain behavior as fifteen callables obscured ownership and made
+    historical monkeypatch targets an application dependency.
+  - Direct imports preserve the same runtime behavior while tests fake only
+    the approved database, Celery, inference, and Meilisearch boundaries.
+- Affected boundaries:
+  - The registered `pipeline.tasks.generate_summary_task` name, arguments,
+    retries, transaction behavior, and result payload remain unchanged.
+  - Lower summary modules do not import `pipeline.tasks` or the operation
+    owner.
+  - T-DB-1A must merge before the separate T-DB-1 summary-backfill cleanup.
+- Canonical references:
+  - [Testing policy](TESTING.MD)
+  - [T-DB-1A implementation plan](plans/T_DB_1A_SUMMARY_GENERATION_OPERATION_PLAN.md)
+  - [Town Council remediation plan](plans/TOWN_COUNCIL_REMEDIATION_PLAN.md)
+
 ## 2026-07-24: Adopt Alembic for schema migrations
 
 - Status: Accepted

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,6 +1,6 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 3.42
+version: 3.43
 generated: 2026-07-25
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
@@ -10,6 +10,9 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v3.43:** Completes T-DB-1A. Summary generation now has one direct
+  operation owner, lower modules import domain implementations directly, and
+  tests use approved runtime boundaries instead of facade service injection.
 - **v3.42:** Adds T-DB-1A before the broader backfill cleanup. The focused
   task removes summary-generation callable service injection and globals-based
   facade forwarding while preserving the registered Celery task and approved
@@ -203,8 +206,8 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 | State | Tasks |
 |---|---|
-| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2, T-SEC-3, T-SEC-3C, T-SEC-4, T-SEC-4A, T-SEC-5, T-SEC-6, T-TIME-3, T-CRAWL-1, T-CRAWL-2, T-PLAT-2A, T-GOV-1, T-GOV-4, T-GOV-5, T-DA-1 |
-| **In progress** | T-DB-1A |
+| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2, T-SEC-3, T-SEC-3C, T-SEC-4, T-SEC-4A, T-SEC-5, T-SEC-6, T-TIME-3, T-CRAWL-1, T-CRAWL-2, T-PLAT-2A, T-GOV-1, T-GOV-4, T-GOV-5, T-DA-1, T-DB-1A |
+| **In progress** | None |
 | **Partially landed; acceptance incomplete** | T-GOV-6 |
 | **Pending** | T-TIME-1..2, T-DB-1, T-DC-1, T-DD-1, T-DE-1, T-PLAT-1, T-PLAT-2, T-PLAT-3, T-PLAT-4, T-GOV-2..3 |
 
@@ -888,7 +891,7 @@ files (GED-5 grant).
 
 ### T-DB-1A: Make summary generation a direct operation
 - priority: P1
-- status: in progress
+- status: complete and verified 2026-07-25
 - implementation_plan:
   `docs/plans/T_DB_1A_SUMMARY_GENERATION_OPERATION_PLAN.md`
 - must_merge_before: T-DB-1

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,7 +1,7 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 3.41
-generated: 2026-07-24
+version: 3.42
+generated: 2026-07-25
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
 orchestrator_contract: Codex instantiates one agent per lane. Agents run in
@@ -10,6 +10,10 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v3.42:** Adds T-DB-1A before the broader backfill cleanup. The focused
+  task removes summary-generation callable service injection and globals-based
+  facade forwarding while preserving the registered Celery task and approved
+  runtime boundaries.
 - **v3.41:** Prevents T-PLAT-1 and T-GOV-3 from running concurrently while
   both own focused changes in `tests/test_repository_guardrails.py`.
 - **v3.40:** Requires T-PLAT-1 to inventory and encode schema objects created
@@ -200,7 +204,7 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 | State | Tasks |
 |---|---|
 | **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2, T-SEC-3, T-SEC-3C, T-SEC-4, T-SEC-4A, T-SEC-5, T-SEC-6, T-TIME-3, T-CRAWL-1, T-CRAWL-2, T-PLAT-2A, T-GOV-1, T-GOV-4, T-GOV-5, T-DA-1 |
-| **In progress** | None |
+| **In progress** | T-DB-1A |
 | **Partially landed; acceptance incomplete** | T-GOV-6 |
 | **Pending** | T-TIME-1..2, T-DB-1, T-DC-1, T-DD-1, T-DE-1, T-PLAT-1, T-PLAT-2, T-PLAT-3, T-PLAT-4, T-GOV-2..3 |
 
@@ -266,7 +270,7 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 | TIME      | agent-time | pipeline/model_base.py, model_civic.py, model_events.py, model_records.py, model_runtime.py, models.py, db_migrate.py, db_migration_runner.py, migrate_v10.py (new), tests/test_migrate_v10.py (new), tests/test_db_migrate.py (T-TIME-2 v10 ordering only), pipeline/summary_freshness.py (verify-only) |
 | CRAWL     | agent-crawl| council_crawler/**                                          |
 | DEDUP-A   | agent-da   | pipeline/metrics.py, pipeline/metrics_redis_backend.py, tests/test_*metrics* |
-| DEDUP-B   | agent-db   | pipeline/summary_backfill*.py, pipeline/task_facade_helpers.py, pipeline/tasks.py, tests/test_*backfill*, tests/test_pipeline_batching.py, tests/test_run_pipeline_orchestration.py, tests/test_staged_hydrate_cities.py, tests/test_tasks_agenda_summary_format.py |
+| DEDUP-B   | agent-db   | pipeline/summary_backfill*.py, pipeline/task_summary_generation*.py, pipeline/task_summary_empty_agenda.py, pipeline/task_summary_side_effects.py, pipeline/task_facade_helpers.py, pipeline/tasks.py, tests/test_*backfill*, tests/test_summary_generation_operation.py (new), tests/test_agenda_summary_payload_budget.py, tests/test_summary_blocking.py, tests/test_task_provider_retry_semantics.py, tests/test_async_flow.py, tests/test_task_facade_cleanup.py, tests/test_repository_guardrails.py (T-DB-1A only), tests/test_pipeline_batching.py, tests/test_run_pipeline_orchestration.py, tests/test_staged_hydrate_cities.py, tests/test_tasks_agenda_summary_format.py |
 | DEDUP-C   | agent-dc   | api/main.py, api/app_setup.py, tests/conftest.py, tests/test_*api* (Phase 2 only) |
 | DEDUP-D   | agent-dd   | scripts/flush_city_pipeline_state.py, scripts/reset_city_verification_state.py, scripts/*_healthcheck.py, tests for same |
 | DEDUP-E   | agent-de   | pipeline/http_inference_provider.py, pipeline/inprocess_inference_provider.py, pipeline/inference_provider_contract.py, tests for same |
@@ -882,6 +886,47 @@ files (GED-5 grant).
   metrics tests green after repointing patches.
 - verify: grep for sync fns returns nothing; full suite green.
 
+### T-DB-1A: Make summary generation a direct operation
+- priority: P1
+- status: in progress
+- implementation_plan:
+  `docs/plans/T_DB_1A_SUMMARY_GENERATION_OPERATION_PLAN.md`
+- must_merge_before: T-DB-1
+- files_owned: docs/plans/T_DB_1A_SUMMARY_GENERATION_OPERATION_PLAN.md,
+  docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md, docs/ADR.md,
+  pipeline/task_summary_generation.py,
+  pipeline/task_summary_generation_contracts.py,
+  pipeline/task_summary_generation_flow.py,
+  pipeline/task_summary_generation_persistence.py,
+  pipeline/task_summary_empty_agenda.py,
+  pipeline/task_summary_side_effects.py, pipeline/task_facade_helpers.py,
+  pipeline/tasks.py, tests/test_summary_generation_operation.py (new),
+  tests/test_agenda_summary_payload_budget.py, tests/test_summary_blocking.py,
+  tests/test_task_provider_retry_semantics.py,
+  tests/test_tasks_agenda_summary_format.py, tests/test_async_flow.py,
+  tests/test_task_facade_cleanup.py, tests/test_repository_guardrails.py
+- do: Make `pipeline/task_summary_generation.py` own the direct summary
+  operation as `generate_catalog_summary`. Delete
+  `SummaryGenerationTaskServices`, `run_generate_summary_task_family`,
+  summary-only `globals()` wiring, and summary forwarding in
+  `task_facade_helpers.py`. Lower modules import real domain implementations,
+  including `agenda_summary_inputs.build_agenda_summary_input_bundle` and
+  `agenda_summary_batch.persist_agenda_summary`, and never import the task
+  facade, operation owner, `backlog_maintenance`, or
+  `agenda_summary_maintenance`.
+- preserve: Celery task name, bind/max-retry/countdown settings, arguments,
+  task-session lifecycle, rollback/retry behavior, summary result payloads,
+  hash persistence, grounding, and best-effort reindex/embed outcomes.
+- accept: No summary callable service bag, summary globals lookup, injectable
+  callable, old end-to-end runner, facade re-export, or lower-to-facade import
+  remains. Tests use only the approved DB, Celery, inference, and Meilisearch
+  boundaries and explicitly preserve task identity, retry countdown, rollback,
+  and session closure.
+- forbidden: Backfill facade cleanup, API task dispatch changes, new fake
+  boundaries, compatibility aliases, or edits outside `files_owned`.
+- verify: Follow the Full T-DB-1A plan; Ruff, Mypy, summary/task/provider
+  suites, repository guardrails, docs links, and complete Python suite pass.
+
 ### T-DB-1: Collapse the summary_backfill facade
 - priority: P1
 - files_owned: pipeline/summary_backfill*.py, pipeline/task_facade_helpers.py,
@@ -1210,7 +1255,8 @@ Phase 0: agent-ci  [T-CI-0, then T-CI-5 (allowlist snapshot freshness), then T-C
 Docs-0:  agent-gov [T-GOV-6: SECURITY.md] + [T-GOV-4: AGENTS.md]   (with/just after Phase 0)
 Phase 1: agent-sec [T-SEC-1..6] || agent-time [T-TIME-1..3] || agent-crawl [T-CRAWL-1..2]
 Gate:    G3 satisfied (T-GOV-1 Accepted ADR + active docs/TESTING.MD)
-Phase 2: agent-da || agent-db || agent-dd || agent-de ; then agent-dc (exclusive on api/*)
+Phase 2: agent-da || agent-db [T-DB-1A, then T-DB-1] || agent-dd || agent-de ;
+         then agent-dc (exclusive on api/*)
 Phase 3: agent-plat [T-PLAT-1 after T-TIME-1 and T-TIME-2, then T-PLAT-2..4]
          || agent-gov [T-GOV-2, T-GOV-3 + T-GOV-5]
 Anytime: T-GOV-6 DATA_GOVERNANCE.md (Section 3 pending G4)

--- a/docs/plans/T_DB_1A_SUMMARY_GENERATION_OPERATION_PLAN.md
+++ b/docs/plans/T_DB_1A_SUMMARY_GENERATION_OPERATION_PLAN.md
@@ -1,0 +1,346 @@
+# T-DB-1A: Make Summary Generation a Direct Operation
+
+`artifact_contract: ce-unified-plan/v1`
+`artifact_readiness: implementation-ready`
+`execution: code`
+
+## 1. Context & Alignment
+
+**a) Driver.** Summary generation currently routes fifteen callables through
+`SummaryGenerationTaskServices`, constructs that service bag from
+`tasks.py.globals()`, and crosses two facade wrappers before reaching the
+actual operation. This preserves test patch targets instead of an
+architectural boundary. T-DB-1A removes that summary-only service locator
+before T-DB-1 collapses the separate backfill facade, while preserving summary
+results, persistence, best-effort side effects, and the registered Celery task.
+
+**b) Canonical documents consulted.**
+
+- `AGENTS.md` `<known_antipatterns>`, `<workflow_contract>`, and
+  `<verification_matrix>` prohibit service-locator globals, test-seam
+  re-exports, and injectable callables while requiring targeted and complete
+  verification.
+- `docs/TESTING.MD` "Approved fake boundaries" and "Patch-target rules"
+  require tests to use the database, Celery, inference-provider, and
+  Meilisearch boundaries rather than facade globals.
+- `docs/ENGINEERING_GUARDRAILS.md` keeps Ruff and the repository smell tests
+  authoritative.
+- `docs/ADR.md` "Test patch points are not a public API" authorizes deletion
+  of test-only facade seams while preserving runtime and task contracts.
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md` places this work in DEDUP-B,
+  after G3 and before the broader T-DB-1 backfill cleanup.
+- `docs/reviews/architecture-review-2026-07-19.html` identifies facade
+  machinery and callable dependency bags as architectural debt.
+
+**c) Remediation alignment.** Add T-DB-1A to the DEDUP-B lane before T-DB-1.
+Its exclusive `files_owned` set is:
+
+- `docs/plans/T_DB_1A_SUMMARY_GENERATION_OPERATION_PLAN.md`
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`
+- `docs/ADR.md`
+- `pipeline/task_summary_generation.py`
+- `pipeline/task_summary_generation_contracts.py`
+- `pipeline/task_summary_generation_flow.py`
+- `pipeline/task_summary_generation_persistence.py`
+- `pipeline/task_summary_empty_agenda.py`
+- `pipeline/task_summary_side_effects.py`
+- `pipeline/task_facade_helpers.py`
+- `pipeline/tasks.py`
+- `tests/test_summary_generation_operation.py`
+- `tests/test_agenda_summary_payload_budget.py`
+- `tests/test_summary_blocking.py`
+- `tests/test_task_provider_retry_semantics.py`
+- `tests/test_tasks_agenda_summary_format.py`
+- `tests/test_async_flow.py`
+- `tests/test_task_facade_cleanup.py`
+- `tests/test_repository_guardrails.py`
+
+T-DB-1A must merge before T-DB-1. No other tracked file may change.
+
+**d) Decision-gate check.** G3 is satisfied and directly authorizes removal of
+test-only patch seams. G1, G2, G4, and G5 are unaffected. No open gate blocks
+this task.
+
+## 2. Design
+
+**e) Step-by-step approach.**
+
+1. Record this Full plan and T-DB-1A ownership before implementation.
+2. Add failing behavior and structure tests before changing production code.
+3. Make `pipeline/task_summary_generation.py` the canonical operation owner.
+   Its single public `generate_catalog_summary` operation accepts an existing
+   SQLAlchemy session, `catalog_id`, and `force`, then coordinates load,
+   preparation, freshness, generation, persistence, commit, and side effects.
+4. Retain `pipeline/task_summary_generation_flow.py` as a focused preparation
+   helper. It loads catalog/document/agenda records, validates source quality,
+   builds agenda input, and determines cached or stale outcomes. It imports
+   concrete domain helpers and never imports the operation owner or task
+   facade. Delete its old `run_generate_summary_task_family` end-to-end runner.
+5. Reduce `pipeline/task_summary_generation_contracts.py` to data-only
+   constants and typed dataclasses. Delete `SummaryGenerationTaskServices`
+   and every callable field.
+6. Update `pipeline/task_summary_generation_flow.py` to import
+   `agenda_summary_inputs.build_agenda_summary_input_bundle` directly. Update
+   `pipeline/task_summary_generation_persistence.py` to import
+   `agenda_summary_batch.persist_agenda_summary` and the real inference,
+   grounding, and freshness-hash modules directly. Neither module may import
+   `backlog_maintenance` or `agenda_summary_maintenance`. Persistence receives
+   only data contexts, not injectable callables.
+7. Update `pipeline/task_summary_empty_agenda.py` to use direct freshness and
+   persistence imports. Its context contains only session and summary record
+   data.
+8. Update `pipeline/task_summary_side_effects.py` to call the real indexer and
+   Celery embed task. Existing best-effort exception handling and result
+   counters remain unchanged.
+9. Delete summary-generation service construction and forwarding from
+   `pipeline/task_facade_helpers.py`.
+10. Import the operation module in `pipeline/tasks.py` and call it directly
+    from the existing bound Celery task. Preserve task name, arguments,
+    retries, countdown, logging, transaction rollback, and session closure.
+11. Repoint affected tests to the operation and approved boundaries. Inference
+    tests patch `pipeline.llm.get_runtime_provider`; indexing tests fake
+    `pipeline.indexer.meilisearch.Client` plus its database boundary; embed
+    dispatch tests patch `embed_catalog_task.delay`. Do not retain aliases,
+    wrappers, synchronized globals, or callable injection for obsolete patch
+    targets.
+12. Run the applicable verification rows, simplify the diff, obtain a fresh
+    subagent pre-commit review, fix eligible P1/P2 findings, and deliver one PR.
+
+Import direction:
+
+```text
+pipeline/tasks.py
+  -> pipeline/task_summary_generation.py
+       -> task_summary_generation_flow.py
+       -> task_summary_generation_persistence.py
+            -> task_summary_side_effects.py
+       -> task_summary_generation_contracts.py
+```
+
+Helpers never import `pipeline/tasks.py` or
+`pipeline/task_summary_generation.py`.
+
+**f) Reuse audit.** Reuse the current summary preparation, persistence,
+grounding, agenda payload, side-effect, and task-session behavior. The
+equivalent implementation already exists but is obscured by
+`SummaryGenerationTaskServices` and two forwarding layers; this task removes
+those layers rather than adding a parallel implementation. The retained flow,
+persistence, empty-agenda, and side-effect modules each keep one real
+responsibility. No new utility, manager, registry, factory, or compatibility
+module is created.
+
+**g) Data contracts.** Keep typed data contexts in
+`task_summary_generation_contracts.py`, using SQLAlchemy `Session`, `Catalog`,
+`Document`, and the existing agenda payload mapping convention.
+`SummaryTaskContext` loses its services field. No raw external-input boundary
+is added. Celery's returned dictionary remains the observable task contract.
+
+**h) Schema/migration impact.** None. No database declaration, migration,
+stored value, timestamp, or transaction ordering changes.
+
+## 3. Security & Data Governance
+
+**i) Security-sensitive paths.** None of the owned files is listed under
+`AGENTS.md` `<security_sensitive_paths>`. The task does not alter
+authentication, proxying, credentials, CORS, or port exposure.
+
+**j) Secrets.** No secret, credential, environment variable, or default is
+added or changed.
+
+**k) Person data.** No person-level data is created, linked, aggregated, or
+exposed. G4 is unaffected.
+
+**l) Untrusted input.** Extracted catalog text and model responses remain the
+untrusted inputs. Existing source-quality checks, grounding checks, typed
+provider failures, and persistence rules remain the validation boundaries.
+No new rendering or network surface is introduced.
+
+## 4. Code Health
+
+**m) GED conformance sweep.** Modified functions remain focused, use domain
+names, and stay below Ruff's complexity ceiling. Data contexts prevent
+parameter growth. Existing meaningful exception behavior remains: summary
+persistence is authoritative, while index and embed failures are logged with
+catalog context and returned as explicit counters. No timestamp or environment
+read changes.
+
+**n) Antipattern scan, plan pass.**
+
+- A1/H1: SQLAlchemy session use, Celery task options, and direct project helper
+  signatures are verified against installed code and existing tests; no new
+  external API call is introduced.
+- B1/B2/C1/F1: the service bag and forwarding wrappers are deleted; no
+  replacement abstraction or compatibility alias is added.
+- C2/D2: tests move to approved boundaries and observable outcomes rather than
+  gaining a new seam or asserting helper call sequences.
+- D1: no test is skipped, weakened, or given wider tolerances.
+- E1/E2: only owned files receive focused edits; no wholesale formatting.
+- A2-A4, B3, D3, E3, F2, H2-H4: no planned violation.
+
+**o) Ratchet interaction.** `pipeline/tasks.py` retains its existing Ruff
+boundary entries because other task families still own those debts.
+T-DB-1A adds no Ruff ignore, BLE001 path, type suppression, or test exception.
+The repository guardrail gains negative assertions against reintroducing the
+summary service bag and facade forwarding.
+
+**p) Dead code and duplication audit.** Delete
+`SummaryGenerationTaskServices`, `summary_generation_task_services`,
+`run_generate_summary_task_family`, summary-only forwarding functions, their
+imports, and summary-only entries in `_TASK_FACADE_DEPENDENCIES`. Reuse all
+real domain implementations. Expected production delta is negative.
+
+## 5. Testing
+
+**q) Edge cases, race conditions, and failure scenarios.**
+
+1. Missing catalog returns the existing error without inference or commit.
+2. Bad-content classification returns the existing error.
+3. Low-signal non-agenda content remains blocked before inference.
+4. Empty agenda without items keeps deterministic cached, stale, and forced
+   completion behavior.
+5. Agenda input not ready returns its existing status without inference.
+6. Fresh summary remains cached; stale summary remains visible unless forced.
+7. Empty provider response raises the existing retryable runtime error.
+8. Ungrounded non-agenda output remains blocked without persistence.
+9. Successful agenda and non-agenda summaries persist hashes and commit once.
+10. Reindex or embed dispatch failure does not roll back an already committed
+    summary and remains visible in result counters.
+11. `LocalAIConfigError` returns an error after rollback.
+12. SQLAlchemy, runtime, and value failures preserve Celery retry with
+    countdown 60.
+13. Session closes on success, typed configuration error, and retry.
+14. The Celery task remains bound, named
+    `pipeline.tasks.generate_summary_task`, and has `max_retries=3`.
+15. Lower summary modules never import `pipeline.tasks` or the operation owner.
+16. No callable service bag, summary globals lookup, injectable callable, or
+    summary facade forwarding survives.
+17. Empty catalog content returns `{"error": "No content to summarize"}`
+    without inference or persistence.
+18. A missing `Document` keeps the current normalized `unknown` document kind
+    behavior.
+
+**r) Tests added or updated.**
+
+| Test | Scenarios |
+|---|---|
+| New `tests/test_summary_generation_operation.py` behavior tests | 1-10, 17-18 |
+| Updated provider retry tests | 7, 11-13 |
+| Existing agenda payload and format tests | 4-6, 9 |
+| Existing summary blocking tests | 3, 8, 10 |
+| Updated async/task facade tests | 12-14 |
+| Repository structural guardrails | 15-16 |
+| Complete Python suite | All observable regression risks |
+
+Tests are written and run red before production edits. Assertions target
+returned statuses, stored catalog values, commits, dispatch outcomes, retry
+behavior, and import structure, not private helper call order.
+The task-contract tests explicitly cover `LocalAIConfigError`, rollback and
+close on every exit, retry `countdown=60`, task name, `max_retries=3`, and the
+`(catalog_id, force=False)` signature.
+
+**s) Fakes and mocks.** Database tests use the existing session factory or
+real test session. Inference tests fake the provider through the established
+`pipeline.llm.get_runtime_provider` lookup. Side-effect tests patch
+`pipeline.indexer.meilisearch.Client` and its database boundary, then patch
+`embed_catalog_task.delay` at the Celery dispatch boundary. Task retry tests
+patch the Celery task's `retry` method and session factory. No facade,
+re-export, private provider method, or lower-level helper is patched.
+
+**t) Verification rows.** Apply pipeline/task orchestration, inference
+provider/policy, and guardrail/tooling rows. Run the complete Python suite
+because this is a cross-cutting task-family refactor.
+
+## 6. Execution, Rollback, Docs
+
+**u) Exact commands.**
+
+```bash
+git fetch origin --prune
+git switch master
+git merge --ff-only origin/master
+git switch -c codex/t-db-1a-summary-generation-operation
+```
+
+Tests-first red evidence:
+
+```bash
+PYTHONPATH=. .venv/bin/pytest -q \
+  tests/test_summary_generation_operation.py \
+  tests/test_repository_guardrails.py::test_summary_generation_uses_direct_operation_boundaries
+```
+
+Targeted verification:
+
+```bash
+PYTHONPATH=. .venv/bin/pytest -q \
+  tests/test_summary_generation_operation.py \
+  tests/test_agenda_summary_payload_budget.py \
+  tests/test_summary_blocking.py \
+  tests/test_task_provider_retry_semantics.py \
+  tests/test_tasks_agenda_summary_format.py \
+  tests/test_async_flow.py \
+  tests/test_task_facade_cleanup.py
+PYTHONPATH=. .venv/bin/pytest -q \
+  tests/test_run_pipeline_orchestration.py \
+  tests/test_pipeline_batching.py \
+  tests/test_task_metrics.py
+PYTHONPATH=. .venv/bin/pytest -q \
+  tests/test_inference_provider_protocol_contract.py \
+  tests/test_provider_error_mapping_retry_vs_fallback.py \
+  tests/test_llm_backend_parity_*.py \
+  tests/test_runtime_profiles_defaults.py
+```
+
+Final verification:
+
+```bash
+./.venv/bin/ruff check .
+./.venv/bin/mypy
+PYTHONPATH=. .venv/bin/pytest -q tests/test_repository_guardrails.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py
+PYTHONPATH=. .venv/bin/pytest -q
+git diff --check
+git status --short
+```
+
+Delivery uses two commits:
+
+1. `docs(remediation): authorize direct summary generation`
+2. `refactor(summary): remove facade service injection`
+
+Push `codex/t-db-1a-summary-generation-operation`, open one PR, request Codex
+review, and watch required checks until decided.
+
+**v) Rollback.** Revert the T-DB-1A merge commit, then run Ruff, Mypy, the
+targeted summary/task suites, repository guardrails, docs links, and the
+complete Python suite. No migration reversal, data repair, configuration
+restore, or external-state cleanup is required.
+
+**w) Docs synchronization.**
+
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`: add T-DB-1A ownership,
+  sequencing, state, and acceptance criteria.
+- `docs/ADR.md`: record the new direct summary-operation owner and supersede
+  earlier summary-specific test-patch facade expectations.
+- `ARCHITECTURE.md`, README, API contracts, operations, security, and
+  data-governance docs: no update because public task, persistence, and
+  operator behavior remain unchanged and no existing map names this internal
+  split.
+
+## 7. Delivery Self-Audit
+
+**x) Antipattern scan, diff pass.** Re-run A-F and H. Reject surviving service
+bags, `run_generate_summary_task_family`, globals-based summary wiring, imports
+from `backlog_maintenance` or `agenda_summary_maintenance`, facade aliases,
+injectable callables, conditional forwarding, tests patching obsolete facades,
+new ignores, import-time work, or edits outside `files_owned`.
+
+**y) Evidence.** Report the tests-first red result, every command in 6u with
+PASS or FAIL, planning-review and pre-commit-review findings, applied fixes,
+commit hashes, PR URL, unresolved-thread count, and final CI state. Browser
+testing is not applicable because no UI route changes.
+
+**z) Deviations.** Expected deviation report is "None." Any additional file,
+Celery task identity/signature change, persistence-order change, new fake
+boundary, skipped review, unresolved P1/P2, or unrun required check is a
+blocker.

--- a/docs/plans/T_DB_1A_SUMMARY_GENERATION_OPERATION_PLAN.md
+++ b/docs/plans/T_DB_1A_SUMMARY_GENERATION_OPERATION_PLAN.md
@@ -187,7 +187,9 @@ summary service bag and facade forwarding.
 `SummaryGenerationTaskServices`, `summary_generation_task_services`,
 `run_generate_summary_task_family`, summary-only forwarding functions, their
 imports, and summary-only entries in `_TASK_FACADE_DEPENDENCIES`. Reuse all
-real domain implementations. Expected production delta is negative.
+real domain implementations. Retain the `tasks.embed_catalog_task` import
+because a repair script consumes it as a runtime contract, not a test seam.
+Expected production delta is negative.
 
 ## 5. Testing
 
@@ -216,8 +218,8 @@ real domain implementations. Expected production delta is negative.
     summary facade forwarding survives.
 17. Empty catalog content returns `{"error": "No content to summarize"}`
     without inference or persistence.
-18. A missing `Document` keeps the current normalized `unknown` document kind
-    behavior.
+18. A missing `Document` remains summarizable through the existing non-agenda
+    path instead of becoming a document-not-found error.
 
 **r) Tests added or updated.**
 

--- a/pipeline/task_facade_helpers.py
+++ b/pipeline/task_facade_helpers.py
@@ -15,11 +15,6 @@ from pipeline.task_agenda_segmentation import (
     run_post_segmentation_vote_extraction as run_post_segmentation_vote_extraction_impl,
     run_segment_agenda_task_family as run_segment_agenda_task_family_impl,
 )
-from pipeline.task_summary_generation import (
-    SummaryGenerationTaskServices,
-    run_generate_summary_task_family as run_generate_summary_task_family_impl,
-    run_summary_generation_side_effects as run_summary_generation_side_effects_impl,
-)
 from pipeline.task_text_extraction import run_extract_text_task_family as run_extract_text_task_family_impl
 from pipeline.task_vote_extraction import run_extract_votes_task_family as run_extract_votes_task_family_impl
 
@@ -119,33 +114,6 @@ def agenda_segmentation_task_services(facade: Mapping[str, Any]) -> AgendaSegmen
     )
 
 
-def summary_generation_task_services(facade: Mapping[str, Any]) -> SummaryGenerationTaskServices:
-    return SummaryGenerationTaskServices(
-        local_ai_factory=facade["LocalAI"],
-        classify_catalog_bad_content=facade["classify_catalog_bad_content"],
-        compute_content_hash=facade["compute_content_hash"],
-        normalize_summary_doc_kind=facade["normalize_summary_doc_kind"],
-        analyze_source_text=facade["analyze_source_text"],
-        is_source_summarizable=facade["is_source_summarizable"],
-        build_low_signal_message=facade["build_low_signal_message"],
-        build_agenda_summary_input_bundle=facade["build_agenda_summary_input_bundle"],
-        is_summary_fresh=facade["is_summary_fresh"],
-        compute_summary_source_hash=facade["compute_summary_source_hash"],
-        postprocess_extracted_text=facade["postprocess_extracted_text"],
-        is_summary_grounded=facade["is_summary_grounded"],
-        persist_agenda_summary=facade["persist_agenda_summary"],
-        reindex_catalog=facade["reindex_catalog"],
-        embed_catalog=facade["embed_catalog_task"].delay,
-    )
-
-
-def run_summary_generation_side_effects(facade: Mapping[str, Any], catalog_id: int) -> dict[str, int]:
-    return run_summary_generation_side_effects_impl(
-        catalog_id,
-        services=summary_generation_task_services(facade),
-    )
-
-
 def record_agenda_segmentation_status(
     catalog: Any,
     *,
@@ -196,19 +164,4 @@ def run_segment_agenda_task_family(
         catalog_id,
         local_ai=local_ai,
         services=agenda_segmentation_task_services(facade),
-    )
-
-
-def run_generate_summary_task_family(
-    facade: Mapping[str, Any],
-    db: Any,
-    catalog_id: int,
-    *,
-    force: bool,
-) -> dict[str, Any]:
-    return run_generate_summary_task_family_impl(
-        db,
-        catalog_id,
-        force=force,
-        services=summary_generation_task_services(facade),
     )

--- a/pipeline/task_summary_empty_agenda.py
+++ b/pipeline/task_summary_empty_agenda.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Protocol
 
+from pipeline.agenda_summary_batch import persist_agenda_summary
 from pipeline.agenda_summary_empty import (
     EMPTY_AGENDA_SEGMENTATION_STATUS,
     build_empty_agenda_summary_text,
 )
 from pipeline.models import Catalog
+from pipeline.summary_freshness import is_summary_fresh
+from pipeline.task_summary_side_effects import run_summary_generation_side_effects
+from sqlalchemy.orm import Session
 
 AGENDA_DOC_KIND = "agenda"
 SUMMARY_CACHED_STATUS = "cached"
@@ -16,25 +18,18 @@ SUMMARY_COMPLETE_STATUS = "complete"
 SUMMARY_STALE_STATUS = "stale"
 
 
-class EmptyAgendaSummaryServices(Protocol):
-    is_summary_fresh: Callable[..., bool]
-    persist_agenda_summary: Callable[..., dict[str, object]]
-
-
 @dataclass(frozen=True)
 class EmptyAgendaGenerationContext:
-    db: object
+    db: Session
     catalog_id: int
     force: bool
     catalog: Catalog
     content_hash: str | None
-    services: EmptyAgendaSummaryServices
-    side_effects_runner: Callable[[int], dict[str, int]]
 
 
 def run_empty_agenda_generation(context: EmptyAgendaGenerationContext) -> dict[str, object]:
     summary = build_empty_agenda_summary_text()
-    is_fresh = context.services.is_summary_fresh(
+    summary_is_fresh = is_summary_fresh(
         AGENDA_DOC_KIND,
         summary=context.catalog.summary,
         summary_source_hash=context.catalog.summary_source_hash,
@@ -42,12 +37,12 @@ def run_empty_agenda_generation(context: EmptyAgendaGenerationContext) -> dict[s
         agenda_items_hash=None,
         agenda_segmentation_status=EMPTY_AGENDA_SEGMENTATION_STATUS,
     )
-    if (not context.force) and is_fresh:
+    if (not context.force) and summary_is_fresh:
         return {"status": SUMMARY_CACHED_STATUS, "summary": context.catalog.summary, "changed": False}
-    if (not context.force) and context.catalog.summary and not is_fresh:
+    if (not context.force) and context.catalog.summary and not summary_is_fresh:
         return {"status": SUMMARY_STALE_STATUS, "summary": context.catalog.summary, "changed": False}
 
-    persisted_summary = context.services.persist_agenda_summary(
+    persisted_summary = persist_agenda_summary(
         catalog=context.catalog,
         summary=summary,
         content_hash=context.content_hash,
@@ -55,7 +50,7 @@ def run_empty_agenda_generation(context: EmptyAgendaGenerationContext) -> dict[s
         agenda_segmentation_status=EMPTY_AGENDA_SEGMENTATION_STATUS,
     )
     context.db.commit()
-    side_effects = context.side_effects_runner(context.catalog_id)
+    side_effects = run_summary_generation_side_effects(context.catalog_id)
     return {
         "status": SUMMARY_COMPLETE_STATUS,
         "summary": summary,

--- a/pipeline/task_summary_generation.py
+++ b/pipeline/task_summary_generation.py
@@ -1,29 +1,34 @@
 from __future__ import annotations
 
-from pipeline.task_summary_generation_contracts import (
-    AGENDA_DOC_KIND,
-    SUMMARY_BLOCKED_LOW_SIGNAL_STATUS,
-    SUMMARY_BLOCKED_UNGROUNDED_STATUS,
-    SUMMARY_CACHED_STATUS,
-    SUMMARY_COMPLETE_STATUS,
-    SUMMARY_ERROR_STATUS,
-    SUMMARY_NONE_RETRY_ERROR,
-    SUMMARY_STALE_STATUS,
-    SummaryGenerationTaskServices,
-)
-from pipeline.task_summary_generation_flow import run_generate_summary_task_family
-from pipeline.task_summary_side_effects import run_summary_generation_side_effects
+from typing import Any
 
-__all__ = [
-    "AGENDA_DOC_KIND",
-    "SUMMARY_BLOCKED_LOW_SIGNAL_STATUS",
-    "SUMMARY_BLOCKED_UNGROUNDED_STATUS",
-    "SUMMARY_CACHED_STATUS",
-    "SUMMARY_COMPLETE_STATUS",
-    "SUMMARY_ERROR_STATUS",
-    "SUMMARY_NONE_RETRY_ERROR",
-    "SUMMARY_STALE_STATUS",
-    "SummaryGenerationTaskServices",
-    "run_generate_summary_task_family",
-    "run_summary_generation_side_effects",
-]
+from pipeline.task_summary_generation_contracts import SummaryTaskContext
+from pipeline.task_summary_generation_flow import (
+    _cached_summary_payload,
+    _load_summary_record,
+    _prepare_summary_input,
+)
+from pipeline.task_summary_generation_persistence import generate_and_persist_summary
+from sqlalchemy.orm import Session
+
+
+def generate_catalog_summary(
+    db: Session,
+    catalog_id: int,
+    *,
+    force: bool,
+) -> dict[str, Any]:
+    context = SummaryTaskContext(db, catalog_id, force)
+    record = _load_summary_record(context)
+    if isinstance(record, dict):
+        return record
+
+    prepared = _prepare_summary_input(context, record)
+    if isinstance(prepared, dict):
+        return prepared
+
+    cached_payload = _cached_summary_payload(context, record, prepared)
+    if cached_payload is not None:
+        return cached_payload
+
+    return generate_and_persist_summary(context, record, prepared)

--- a/pipeline/task_summary_generation_contracts.py
+++ b/pipeline/task_summary_generation_contracts.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
-from pipeline.llm import LocalAI
 from pipeline.models import Catalog, Document
+from sqlalchemy.orm import Session
 
 AGENDA_DOC_KIND = "agenda"
 SUMMARY_COMPLETE_STATUS = "complete"
@@ -18,30 +17,10 @@ SUMMARY_NONE_RETRY_ERROR = "AI Summarization returned None (Model missing or err
 
 
 @dataclass(frozen=True)
-class SummaryGenerationTaskServices:
-    local_ai_factory: Callable[[], LocalAI]
-    classify_catalog_bad_content: Callable[..., object]
-    compute_content_hash: Callable[[str | None], str | None]
-    normalize_summary_doc_kind: Callable[[str], str]
-    analyze_source_text: Callable[[str], object]
-    is_source_summarizable: Callable[[object], bool]
-    build_low_signal_message: Callable[[object], str]
-    build_agenda_summary_input_bundle: Callable[..., dict[str, Any]]
-    is_summary_fresh: Callable[..., bool]
-    compute_summary_source_hash: Callable[..., str | None]
-    postprocess_extracted_text: Callable[[str | None], str]
-    is_summary_grounded: Callable[[str, str], object]
-    persist_agenda_summary: Callable[..., dict[str, Any]]
-    reindex_catalog: Callable[[int], object]
-    embed_catalog: Callable[[int], object]
-
-
-@dataclass(frozen=True)
 class SummaryTaskContext:
-    db: Any
+    db: Session
     catalog_id: int
     force: bool
-    services: SummaryGenerationTaskServices
 
 
 @dataclass(frozen=True)

--- a/pipeline/task_summary_generation_flow.py
+++ b/pipeline/task_summary_generation_flow.py
@@ -2,8 +2,19 @@ from __future__ import annotations
 
 from typing import Any
 
+from pipeline import config
 from pipeline.agenda_summary_empty import is_empty_agenda_without_items
+from pipeline.agenda_summary_inputs import build_agenda_summary_input_bundle
+from pipeline.content_hash import compute_content_hash
+from pipeline.document_kinds import normalize_summary_doc_kind
+from pipeline.laserfiche_error_pages import classify_catalog_bad_content
 from pipeline.models import AgendaItem, Catalog, Document
+from pipeline.summary_freshness import is_summary_fresh
+from pipeline.summary_source_quality import (
+    analyze_source_text,
+    build_low_signal_message,
+    is_source_summarizable,
+)
 from pipeline.task_summary_empty_agenda import EmptyAgendaGenerationContext, run_empty_agenda_generation
 from pipeline.task_summary_generation_contracts import (
     AGENDA_DOC_KIND,
@@ -12,26 +23,23 @@ from pipeline.task_summary_generation_contracts import (
     SUMMARY_ERROR_STATUS,
     SUMMARY_STALE_STATUS,
     PreparedSummaryInput,
-    SummaryGenerationTaskServices,
     SummaryRecordContext,
     SummaryTaskContext,
 )
-from pipeline.task_summary_generation_persistence import generate_and_persist_summary
-from pipeline.task_summary_side_effects import run_summary_generation_side_effects
 
 
-def _source_text_quality_payload(catalog: Catalog, services: SummaryGenerationTaskServices) -> dict[str, Any] | None:
+def _source_text_quality_payload(catalog: Catalog) -> dict[str, Any] | None:
     if not catalog.content:
         return {"error": "No content to summarize"}
 
-    quality = services.analyze_source_text(catalog.content)
-    if services.is_source_summarizable(quality):
+    quality = analyze_source_text(catalog.content)
+    if is_source_summarizable(quality):
         return None
 
     # We do not run Gemma on low-signal content because it tends to hallucinate.
     return {
         "status": SUMMARY_BLOCKED_LOW_SIGNAL_STATUS,
-        "reason": services.build_low_signal_message(quality),
+        "reason": build_low_signal_message(quality),
         "summary": None,
     }
 
@@ -41,13 +49,14 @@ def _agenda_summary_bundle(
     catalog: Catalog,
     document: Document | None,
     agenda_items: list[AgendaItem],
-    services: SummaryGenerationTaskServices,
 ) -> dict[str, Any]:
-    return services.build_agenda_summary_input_bundle(
+    return build_agenda_summary_input_bundle(
         catalog=catalog,
         document=document,
         agenda_items=agenda_items,
         include_meeting_context=True,
+        max_input_chars=config.AGENDA_SUMMARY_MAX_INPUT_CHARS,
+        min_reserved_output_chars=config.AGENDA_SUMMARY_MIN_RESERVED_OUTPUT_CHARS,
     )
 
 
@@ -77,15 +86,15 @@ def _stale_or_cached_summary_payload(
 def _load_summary_record(context: SummaryTaskContext) -> SummaryRecordContext | dict[str, Any]:
     catalog = context.db.get(Catalog, context.catalog_id)
     document = context.db.query(Document).filter_by(catalog_id=context.catalog_id).first()
-    doc_kind = context.services.normalize_summary_doc_kind(document.category if document else "unknown")
+    doc_kind = normalize_summary_doc_kind(document.category if document else "unknown")
     if not catalog:
         return {"error": "Catalog not found"}
 
-    classification = context.services.classify_catalog_bad_content(catalog)
+    classification = classify_catalog_bad_content(catalog)
     if classification:
         return {"status": SUMMARY_ERROR_STATUS, "error": classification.reason}
 
-    content_hash = context.services.compute_content_hash(catalog.content) if (catalog.content or "") else None
+    content_hash = compute_content_hash(catalog.content) if (catalog.content or "") else None
     if content_hash:
         catalog.content_hash = content_hash
     return SummaryRecordContext(catalog, document, doc_kind, content_hash)
@@ -104,11 +113,6 @@ def _prepare_agenda_summary_input(
                 force=context.force,
                 catalog=record.catalog,
                 content_hash=record.content_hash,
-                services=context.services,
-                side_effects_runner=lambda selected_catalog_id: run_summary_generation_side_effects(
-                    selected_catalog_id,
-                    services=context.services,
-                ),
             )
         )
 
@@ -116,7 +120,6 @@ def _prepare_agenda_summary_input(
         catalog=record.catalog,
         document=record.document,
         agenda_items=agenda_items,
-        services=context.services,
     )
     if agenda_summary_bundle.get("status") != "ready":
         return agenda_summary_bundle
@@ -132,7 +135,7 @@ def _prepare_summary_input(
     record: SummaryRecordContext,
 ) -> PreparedSummaryInput | dict[str, Any]:
     if record.doc_kind != AGENDA_DOC_KIND:
-        quality_payload = _source_text_quality_payload(record.catalog, context.services)
+        quality_payload = _source_text_quality_payload(record.catalog)
         if quality_payload is not None:
             return quality_payload
         return PreparedSummaryInput(record.catalog.agenda_items_hash, None)
@@ -144,7 +147,7 @@ def _cached_summary_payload(
     record: SummaryRecordContext,
     prepared: PreparedSummaryInput,
 ) -> dict[str, Any] | None:
-    is_fresh = context.services.is_summary_fresh(
+    summary_is_fresh = is_summary_fresh(
         record.doc_kind,
         summary=record.catalog.summary,
         summary_source_hash=record.catalog.summary_source_hash,
@@ -154,29 +157,6 @@ def _cached_summary_payload(
     )
     return _stale_or_cached_summary_payload(
         force=context.force,
-        is_fresh=is_fresh,
+        is_fresh=summary_is_fresh,
         summary=record.catalog.summary,
     )
-
-
-def run_generate_summary_task_family(
-    db: Any,
-    catalog_id: int,
-    *,
-    force: bool,
-    services: SummaryGenerationTaskServices,
-) -> dict[str, Any]:
-    context = SummaryTaskContext(db, catalog_id, force, services)
-    record = _load_summary_record(context)
-    if isinstance(record, dict):
-        return record
-
-    prepared = _prepare_summary_input(context, record)
-    if isinstance(prepared, dict):
-        return prepared
-
-    cached_payload = _cached_summary_payload(context, record, prepared)
-    if cached_payload is not None:
-        return cached_payload
-
-    return generate_and_persist_summary(context, record, prepared)

--- a/pipeline/task_summary_generation_persistence.py
+++ b/pipeline/task_summary_generation_persistence.py
@@ -2,19 +2,22 @@ from __future__ import annotations
 
 from typing import Any
 
+from pipeline.agenda_summary_batch import persist_agenda_summary
 from pipeline.llm import LocalAI
 from pipeline.models import Catalog
+from pipeline.summary_freshness import compute_summary_source_hash
+from pipeline.summary_grounding import is_summary_grounded
 from pipeline.task_summary_generation_contracts import (
     AGENDA_DOC_KIND,
     SUMMARY_BLOCKED_UNGROUNDED_STATUS,
     SUMMARY_COMPLETE_STATUS,
     SUMMARY_NONE_RETRY_ERROR,
     PreparedSummaryInput,
-    SummaryGenerationTaskServices,
     SummaryRecordContext,
     SummaryTaskContext,
 )
 from pipeline.task_summary_side_effects import run_summary_generation_side_effects
+from pipeline.text_cleaning import postprocess_extracted_text
 
 
 def _generated_summary(
@@ -23,7 +26,6 @@ def _generated_summary(
     doc_kind: str,
     catalog: Catalog,
     agenda_summary_bundle: dict[str, Any] | None,
-    services: SummaryGenerationTaskServices,
 ) -> tuple[str | None, bool]:
     if doc_kind == AGENDA_DOC_KIND:
         if agenda_summary_bundle is None:
@@ -38,7 +40,7 @@ def _generated_summary(
         return summary, False
 
     return local_ai.summarize(
-        services.postprocess_extracted_text(catalog.content),
+        postprocess_extracted_text(catalog.content),
         doc_kind=doc_kind,
     ), True
 
@@ -47,9 +49,8 @@ def _ungrounded_summary_payload(
     *,
     summary: str,
     catalog: Catalog,
-    services: SummaryGenerationTaskServices,
 ) -> dict[str, Any] | None:
-    grounding = services.is_summary_grounded(summary, services.postprocess_extracted_text(catalog.content))
+    grounding = is_summary_grounded(summary, postprocess_extracted_text(catalog.content))
     if grounding.is_grounded:
         return None
 
@@ -72,11 +73,10 @@ def _persist_non_agenda_summary(
     doc_kind: str,
     content_hash: str | None,
     agenda_items_hash: str | None,
-    services: SummaryGenerationTaskServices,
 ) -> dict[str, Any]:
     prior_summary = catalog.summary
     prior_summary_source_hash = catalog.summary_source_hash
-    summary_source_hash = services.compute_summary_source_hash(
+    summary_source_hash = compute_summary_source_hash(
         doc_kind,
         content_hash=content_hash,
         agenda_items_hash=agenda_items_hash,
@@ -102,7 +102,7 @@ def _persist_generated_summary(
     if record.doc_kind == AGENDA_DOC_KIND:
         if prepared.agenda_summary_bundle is None:
             raise RuntimeError("Agenda summary bundle is required for agenda summary persistence")
-        return context.services.persist_agenda_summary(
+        return persist_agenda_summary(
             catalog=record.catalog,
             summary=summary,
             content_hash=prepared.agenda_summary_bundle["content_hash"],
@@ -115,7 +115,6 @@ def _persist_generated_summary(
         doc_kind=record.doc_kind,
         content_hash=record.content_hash,
         agenda_items_hash=prepared.agenda_items_hash,
-        services=context.services,
     )
 
 
@@ -124,24 +123,23 @@ def generate_and_persist_summary(
     record: SummaryRecordContext,
     prepared: PreparedSummaryInput,
 ) -> dict[str, Any]:
-    local_ai = context.services.local_ai_factory()
+    local_ai = LocalAI()
     summary, do_grounding_check = _generated_summary(
         local_ai=local_ai,
         doc_kind=record.doc_kind,
         catalog=record.catalog,
         agenda_summary_bundle=prepared.agenda_summary_bundle,
-        services=context.services,
     )
     if summary is None:
         raise RuntimeError(SUMMARY_NONE_RETRY_ERROR)
     if do_grounding_check:
-        grounding_payload = _ungrounded_summary_payload(summary=summary, catalog=record.catalog, services=context.services)
+        grounding_payload = _ungrounded_summary_payload(summary=summary, catalog=record.catalog)
         if grounding_payload is not None:
             return grounding_payload
 
     persisted_summary = _persist_generated_summary(context, record, prepared, summary)
     context.db.commit()
-    side_effects = run_summary_generation_side_effects(context.catalog_id, services=context.services)
+    side_effects = run_summary_generation_side_effects(context.catalog_id)
     return {
         "status": SUMMARY_COMPLETE_STATUS,
         "summary": summary,

--- a/pipeline/task_summary_side_effects.py
+++ b/pipeline/task_summary_side_effects.py
@@ -1,28 +1,18 @@
-from typing import Protocol
-
-from pipeline.agenda_summary_maintenance import AGENDA_SUMMARY_EMBED_DISPATCH_ERRORS
+from pipeline.agenda_summary_contracts import AGENDA_SUMMARY_EMBED_DISPATCH_ERRORS
+from pipeline.indexer import reindex_catalog
+from pipeline.semantic_tasks import embed_catalog_task
 from pipeline.task_runtime import logger
 from pipeline.task_side_effects import REINDEX_FAILURE_EXCEPTIONS
 
 
-class SummarySideEffectServices(Protocol):
-    def reindex_catalog(self, catalog_id: int) -> object: ...
-
-    def embed_catalog(self, catalog_id: int) -> object: ...
-
-
-def run_summary_generation_side_effects(
-    catalog_id: int,
-    *,
-    services: SummarySideEffectServices,
-) -> dict[str, int]:
+def run_summary_generation_side_effects(catalog_id: int) -> dict[str, int]:
     """
     Summary persistence is authoritative; search and embedding updates are best-effort.
     """
     reindexed = 0
     reindex_failed = 0
     try:
-        services.reindex_catalog(catalog_id)
+        reindex_catalog(catalog_id)
         reindexed = 1
     except REINDEX_FAILURE_EXCEPTIONS as reindex_error:
         reindex_failed = 1
@@ -31,7 +21,7 @@ def run_summary_generation_side_effects(
     embed_enqueued = 0
     embed_dispatch_failed = 0
     try:
-        services.embed_catalog(catalog_id)
+        embed_catalog_task.delay(catalog_id)
         embed_enqueued = 1
     except AGENDA_SUMMARY_EMBED_DISPATCH_ERRORS as dispatch_error:
         logger.warning("embed_catalog_task.dispatch_failed catalog_id=%s error=%s", catalog_id, dispatch_error)

--- a/pipeline/tasks.py
+++ b/pipeline/tasks.py
@@ -5,13 +5,12 @@ from sqlalchemy.exc import SQLAlchemyError
 
 from pipeline import metrics as _worker_metrics  # noqa: F401
 from pipeline import task_facade_helpers
+from pipeline import task_summary_generation
 from pipeline.agenda_service import persist_agenda_items
 from pipeline.agenda_resolver import has_viable_structured_agenda_source, resolve_agenda_items
 from pipeline.backlog_maintenance import (
-    build_agenda_summary_input_bundle,
     build_deterministic_agenda_summary_payloads,
     build_deterministic_non_agenda_summary_payload,
-    persist_agenda_summary,
     summarize_catalog_with_maintenance_mode,
 )
 from pipeline.celery_app import app
@@ -22,8 +21,6 @@ from pipeline.config import (
     LOCAL_AI_REQUIRE_SOLO_POOL,
     TIKA_MIN_EXTRACTED_CHARS_FOR_NO_OCR,
 )
-from pipeline.content_hash import compute_content_hash
-from pipeline.document_kinds import normalize_summary_doc_kind
 from pipeline.extraction_service import reextract_catalog_content
 from pipeline.indexer import reindex_catalog
 from pipeline.laserfiche_error_pages import classify_catalog_bad_content
@@ -33,25 +30,20 @@ from pipeline.lineage_task_support import run_lineage_recompute
 from pipeline.models import Document
 from pipeline.semantic_tasks import embed_catalog_task
 from pipeline.startup_purge import run_startup_purge_if_enabled
-from pipeline.summary_freshness import compute_summary_source_hash, is_summary_fresh
-from pipeline.summary_quality import analyze_source_text, build_low_signal_message, is_source_summarizable, is_summary_grounded
 from pipeline.task_agenda_titles import _extract_agenda_titles_from_text as _extract_agenda_titles_from_text
 from pipeline.task_runtime import logger, task_session
 from pipeline.task_startup import (
     get_celery_pool_from_argv as get_celery_pool_from_argv_impl,
     run_startup_purge_on_worker_ready as run_startup_purge_on_worker_ready_impl,
 )
-from pipeline.text_cleaning import postprocess_extracted_text
 from pipeline.vote_extractor import run_vote_extraction_for_catalog
 
 _TASK_FACADE_DEPENDENCIES = (
-    build_agenda_summary_input_bundle, build_deterministic_agenda_summary_payloads,
-    build_deterministic_non_agenda_summary_payload, persist_agenda_summary,
+    build_deterministic_agenda_summary_payloads,
+    build_deterministic_non_agenda_summary_payload,
     summarize_catalog_with_maintenance_mode, classify_catalog_bad_content, persist_agenda_items,
     has_viable_structured_agenda_source, resolve_agenda_items, TIKA_MIN_EXTRACTED_CHARS_FOR_NO_OCR,
-    ENABLE_VOTE_EXTRACTION, reextract_catalog_content, reindex_catalog, compute_content_hash,
-    normalize_summary_doc_kind, compute_summary_source_hash, is_summary_fresh, analyze_source_text,
-    build_low_signal_message, is_source_summarizable, is_summary_grounded, postprocess_extracted_text,
+    ENABLE_VOTE_EXTRACTION, reextract_catalog_content, reindex_catalog,
     run_vote_extraction_for_catalog, embed_catalog_task, Document,
 )
 
@@ -127,14 +119,6 @@ def _agenda_segmentation_task_services():
     return task_facade_helpers.agenda_segmentation_task_services(globals())
 
 
-def _summary_generation_task_services():
-    return task_facade_helpers.summary_generation_task_services(globals())
-
-
-def _run_summary_generation_side_effects(catalog_id: int) -> dict[str, int]:
-    return task_facade_helpers.run_summary_generation_side_effects(globals(), catalog_id)
-
-
 def _record_agenda_segmentation_status(catalog, *, status: str, item_count: int, error_message: str | None) -> None:
     task_facade_helpers.record_agenda_segmentation_status(
         catalog, status=status, item_count=item_count, error_message=error_message
@@ -155,16 +139,12 @@ def _run_segment_agenda_task_family(db, catalog_id: int, *, local_ai: LocalAI) -
     return task_facade_helpers.run_segment_agenda_task_family(globals(), db, catalog_id, local_ai=local_ai)
 
 
-def _run_generate_summary_task_family(db, catalog_id: int, *, force: bool) -> dict[str, Any]:
-    return task_facade_helpers.run_generate_summary_task_family(globals(), db, catalog_id, force=force)
-
-
 @app.task(bind=True, max_retries=3)
 def generate_summary_task(self, catalog_id: int, force: bool = False):
     db = SessionLocal()
     try:
         logger.info(f"Starting summarization for Catalog ID {catalog_id}")
-        result = _run_generate_summary_task_family(db, catalog_id, force=force)
+        result = task_summary_generation.generate_catalog_summary(db, catalog_id, force=force)
         if result.get("status") == "complete":
             logger.info(f"Summarization complete for Catalog ID {catalog_id}")
         return result

--- a/tests/test_agenda_summary_payload_budget.py
+++ b/tests/test_agenda_summary_payload_budget.py
@@ -3,50 +3,30 @@ from unittest.mock import MagicMock
 
 sys.modules["llama_cpp"] = MagicMock()
 
-from pipeline import backlog_maintenance
-from pipeline import tasks
-from pipeline.models import AgendaItem, Document
+from pipeline.agenda_summary_inputs import build_agenda_summary_input_bundle
 
 
-def test_generate_summary_task_applies_payload_budget_and_truncation_meta(mocker):
-    mock_db = MagicMock()
+def test_agenda_summary_input_applies_payload_budget_and_truncation_meta():
     catalog = MagicMock()
     catalog.content = "Long enough agenda content to pass quality gates for this test case."
-    catalog.summary = None
-    catalog.content_hash = "h1"
-    catalog.summary_source_hash = None
-    mock_db.get.return_value = catalog
-
-    doc_query = MagicMock()
-    doc_query.filter_by.return_value.first.return_value = MagicMock(category="agenda")
+    document = MagicMock(category="agenda")
 
     long_desc = "x" * 800
-    items_query = MagicMock()
-    items_query.filter_by.return_value.order_by.return_value.all.return_value = [
+    agenda_items = [
         MagicMock(title=f"Item {i}", description=long_desc, classification="Agenda Item", result="", page_number=i)
         for i in range(1, 25)
     ]
 
-    def _query_side_effect(model):
-        if model is Document:
-            return doc_query
-        if model is AgendaItem:
-            return items_query
-        return MagicMock()
+    summary_input = build_agenda_summary_input_bundle(
+        catalog=catalog,
+        document=document,
+        agenda_items=agenda_items,
+        max_input_chars=1200,
+        min_reserved_output_chars=200,
+    )
 
-    mock_db.query.side_effect = _query_side_effect
-    mocker.patch.object(tasks, "SessionLocal", return_value=mock_db)
-
-    mock_ai = MagicMock()
-    mock_ai.summarize_agenda_items.return_value = "BLUF: Budget test summary."
-    mocker.patch.object(tasks, "LocalAI", return_value=mock_ai)
-    mocker.patch.object(backlog_maintenance, "AGENDA_SUMMARY_MAX_INPUT_CHARS", 1200)
-    mocker.patch.object(backlog_maintenance, "AGENDA_SUMMARY_MIN_RESERVED_OUTPUT_CHARS", 200)
-
-    result = tasks.generate_summary_task.run(1, force=True)
-    assert result["status"] == "complete"
-    kwargs = mock_ai.summarize_agenda_items.call_args.kwargs
-    trunc = kwargs["truncation_meta"]
+    assert summary_input["status"] == "ready"
+    trunc = summary_input["truncation_meta"]
     assert trunc["items_included"] < trunc["items_total"]
     assert trunc["items_truncated"] > 0
     assert trunc["input_chars"] <= 1000

--- a/tests/test_async_flow.py
+++ b/tests/test_async_flow.py
@@ -14,7 +14,8 @@ sys.modules["redis"] = MagicMock()
 # We will patch the tasks dynamically.
 
 from api.main import app, get_db
-from pipeline import tasks
+from pipeline import llm as llm_module, tasks
+from pipeline.inference_provider_contract import InferenceProvider
 
 client = TestClient(app)
 VALID_KEY = "dev_secret_key_change_me"
@@ -253,9 +254,9 @@ def test_generate_summary_retries_when_ai_returns_none(mocker):
     mock_db.get.return_value = mock_catalog
 
     mocker.patch.object(tasks, "SessionLocal", return_value=mock_db)
-    mock_ai = MagicMock()
-    mock_ai.summarize.return_value = None
-    mocker.patch.object(tasks, "LocalAI", return_value=mock_ai)
+    summary_provider = MagicMock(spec=InferenceProvider)
+    summary_provider.summarize_text.return_value = None
+    mocker.patch.object(llm_module, "get_runtime_provider", return_value=summary_provider)
 
     retry_exc = RuntimeError("retry-called")
     retry_mock = mocker.patch.object(tasks.generate_summary_task, "retry", side_effect=retry_exc)
@@ -264,7 +265,9 @@ def test_generate_summary_retries_when_ai_returns_none(mocker):
         tasks.generate_summary_task.run(1)
 
     retry_mock.assert_called_once()
+    assert retry_mock.call_args.kwargs["countdown"] == 60
     mock_db.rollback.assert_called_once()
+    mock_db.close.assert_called_once()
 
 
 def test_summarize_requires_api_key(mocker):

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -534,6 +534,50 @@ def _broad_exception_scan_files() -> list[Path]:
     return sorted(Path(checked_path).resolve() for checked_path in checked_files.splitlines() if checked_path.endswith(".py"))
 
 
+def test_summary_generation_uses_direct_operation_boundaries() -> None:
+    summary_module_paths = (
+        ROOT / "pipeline/task_summary_generation.py",
+        ROOT / "pipeline/task_summary_generation_contracts.py",
+        ROOT / "pipeline/task_summary_generation_flow.py",
+        ROOT / "pipeline/task_summary_generation_persistence.py",
+        ROOT / "pipeline/task_summary_empty_agenda.py",
+        ROOT / "pipeline/task_summary_side_effects.py",
+    )
+    combined_source = "\n".join(
+        summary_module_path.read_text(encoding="utf-8")
+        for summary_module_path in summary_module_paths
+    )
+    task_facade_source = (ROOT / "pipeline/task_facade_helpers.py").read_text(
+        encoding="utf-8"
+    )
+    tasks_source = (ROOT / "pipeline/tasks.py").read_text(encoding="utf-8")
+
+    assert "SummaryGenerationTaskServices" not in combined_source
+    assert "run_generate_summary_task_family" not in combined_source
+    assert "backlog_maintenance" not in combined_source
+    assert "agenda_summary_maintenance" not in combined_source
+    assert "summary_generation_task_services" not in task_facade_source
+    assert "run_generate_summary_task_family" not in task_facade_source
+    assert "_summary_generation_task_services" not in tasks_source
+    assert "_run_generate_summary_task_family" not in tasks_source
+
+    lower_module_paths = summary_module_paths[1:]
+    forbidden_imports = {
+        str(summary_module_path.relative_to(ROOT)): _forbidden_imports(
+            summary_module_path,
+            {
+                "pipeline.tasks",
+                "pipeline.task_summary_generation",
+            },
+        )
+        for summary_module_path in lower_module_paths
+    }
+    assert forbidden_imports == {
+        str(summary_module_path.relative_to(ROOT)): []
+        for summary_module_path in lower_module_paths
+    }
+
+
 def _python_module_paths(prefix: str) -> list[Path]:
     return sorted(
         path

--- a/tests/test_summary_blocking.py
+++ b/tests/test_summary_blocking.py
@@ -3,7 +3,8 @@ from unittest.mock import MagicMock
 
 sys.modules["llama_cpp"] = MagicMock()
 
-from pipeline import tasks
+from pipeline import indexer, llm as llm_module, semantic_tasks, tasks
+from pipeline.inference_provider_contract import InferenceProvider
 
 
 def test_generate_summary_task_blocks_low_signal_input(mocker):
@@ -22,13 +23,10 @@ def test_generate_summary_task_blocks_low_signal_input(mocker):
     mock_db.query.return_value = mock_doc_query
 
     mocker.patch.object(tasks, "SessionLocal", return_value=mock_db)
-    mock_ai = MagicMock()
-    mocker.patch.object(tasks, "LocalAI", return_value=mock_ai)
 
     result = tasks.generate_summary_task.run(1, force=True)
     assert result["status"] == "blocked_low_signal"
     assert "Not enough extracted text" in result["reason"]
-    mock_ai.summarize.assert_not_called()
     mock_db.commit.assert_not_called()
 
 
@@ -50,11 +48,11 @@ def test_generate_summary_task_keeps_success_when_reindex_and_embed_dispatch_fai
     mock_db.query.return_value = mock_doc_query
 
     mocker.patch.object(tasks, "SessionLocal", return_value=mock_db)
-    mock_ai = MagicMock()
-    mock_ai.summarize.return_value = "BLUF: Council advanced budget and housing work."
-    mocker.patch.object(tasks, "LocalAI", return_value=mock_ai)
-    mocker.patch.object(tasks, "reindex_catalog", side_effect=RuntimeError("search unavailable"))
-    mocker.patch.object(tasks.embed_catalog_task, "delay", side_effect=RuntimeError("broker unavailable"))
+    summary_provider = MagicMock(spec=InferenceProvider)
+    summary_provider.summarize_text.return_value = "BLUF: Council advanced budget and housing work."
+    mocker.patch.object(llm_module, "get_runtime_provider", return_value=summary_provider)
+    mocker.patch.object(indexer.meilisearch, "Client", side_effect=RuntimeError("search unavailable"))
+    mocker.patch.object(semantic_tasks.embed_catalog_task, "delay", side_effect=RuntimeError("broker unavailable"))
 
     result = tasks.generate_summary_task.run(1, force=True)
 

--- a/tests/test_summary_generation_operation.py
+++ b/tests/test_summary_generation_operation.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import inspect
+import sys
+from unittest.mock import MagicMock
+
+sys.modules["llama_cpp"] = MagicMock()
+
+from pipeline import config, indexer, llm as llm_module, semantic_tasks, task_summary_generation
+from pipeline import tasks
+from pipeline.llm import LocalAIConfigError
+from pipeline.models import AgendaItem, Document
+
+
+class SummaryProvider:
+    def __init__(self, summary: str) -> None:
+        self.summary = summary
+        self.summary_prompt = ""
+
+    def health_check(self) -> bool:
+        return True
+
+    def extract_agenda(self, prompt: str, *, temperature: float, max_tokens: int) -> str | None:
+        raise AssertionError("Agenda extraction is outside summary generation")
+
+    def summarize_agenda_items(self, prompt: str, *, temperature: float, max_tokens: int) -> str | None:
+        self.summary_prompt = prompt
+        return self.summary
+
+    def summarize_text(self, prompt: str, *, temperature: float, max_tokens: int) -> str | None:
+        self.summary_prompt = prompt
+        return self.summary
+
+    def generate_topics(self, prompt: str, *, temperature: float, max_tokens: int) -> str | None:
+        raise AssertionError("Topic generation is outside summary generation")
+
+    def generate_json(self, prompt: str, *, max_tokens: int) -> str | None:
+        raise AssertionError("JSON generation is outside summary generation")
+
+
+def _catalog(*, content: str | None) -> MagicMock:
+    return MagicMock(
+        id=1,
+        content=content,
+        summary=None,
+        content_hash=None,
+        summary_source_hash=None,
+        agenda_items_hash=None,
+        agenda_segmentation_status=None,
+        location="/tmp/minutes.pdf",
+        url="https://example.test/minutes.pdf",
+    )
+
+
+def _summary_db(
+    catalog: MagicMock | None,
+    document: MagicMock | None,
+    agenda_items: list[MagicMock] | None = None,
+) -> MagicMock:
+    summary_db = MagicMock()
+    summary_db.get.return_value = catalog
+    document_query = MagicMock()
+    document_query.filter_by.return_value.first.return_value = document
+    agenda_items_query = MagicMock()
+    agenda_items_query.filter_by.return_value.order_by.return_value.all.return_value = agenda_items or []
+
+    def query_for_model(model: object) -> MagicMock:
+        if model is Document:
+            return document_query
+        if model is AgendaItem:
+            return agenda_items_query
+        return MagicMock()
+
+    summary_db.query.side_effect = query_for_model
+    return summary_db
+
+
+def _install_summary_boundaries(mocker, provider: SummaryProvider) -> None:
+    llm_module.LocalAI._instance = None
+    mocker.patch.object(llm_module, "get_runtime_provider", return_value=provider)
+    mocker.patch.object(indexer.meilisearch, "Client", side_effect=RuntimeError("search unavailable"))
+    mocker.patch.object(semantic_tasks.embed_catalog_task, "delay", return_value=None)
+
+
+def test_generate_catalog_summary_returns_error_when_catalog_is_missing(mocker):
+    provider = SummaryProvider("BLUF: Council discussed housing and budget policy.")
+    _install_summary_boundaries(mocker, provider)
+
+    summary_payload = task_summary_generation.generate_catalog_summary(
+        _summary_db(None, None),
+        404,
+        force=True,
+    )
+
+    assert summary_payload == {"error": "Catalog not found"}
+    assert provider.summary_prompt == ""
+
+
+def test_generate_catalog_summary_rejects_empty_content_before_inference(mocker):
+    provider = SummaryProvider("BLUF: This response must not be used.")
+    _install_summary_boundaries(mocker, provider)
+    catalog = _catalog(content=None)
+    summary_db = _summary_db(catalog, MagicMock(category="minutes"))
+
+    summary_payload = task_summary_generation.generate_catalog_summary(
+        summary_db,
+        1,
+        force=True,
+    )
+
+    assert summary_payload == {"error": "No content to summarize"}
+    assert provider.summary_prompt == ""
+    summary_db.commit.assert_not_called()
+
+
+def test_generate_catalog_summary_completes_when_document_is_missing(mocker):
+    provider = SummaryProvider(
+        "BLUF: Council discussed housing budget public safety transportation priorities."
+    )
+    _install_summary_boundaries(mocker, provider)
+    catalog = _catalog(
+        content=(
+            "Council discussed housing budget public safety transportation priorities "
+            "and committee recommendations during the local government meeting."
+        )
+    )
+    summary_db = _summary_db(catalog, None)
+
+    summary_payload = task_summary_generation.generate_catalog_summary(
+        summary_db,
+        1,
+        force=True,
+    )
+
+    assert summary_payload["status"] == "complete"
+    assert provider.summary_prompt
+    assert catalog.summary == summary_payload["summary"]
+    summary_db.commit.assert_called_once()
+
+
+def test_generate_summary_task_applies_configured_agenda_payload_budget(mocker):
+    provider = SummaryProvider("BLUF: Council agenda covers policy and operations.")
+    _install_summary_boundaries(mocker, provider)
+    catalog = _catalog(
+        content=(
+            "City Council agenda includes housing policy, budget review, public safety, "
+            "transportation, and committee reports for public discussion."
+        )
+    )
+    document = MagicMock(category="agenda")
+    document.event = MagicMock()
+    document.event.name = "City Council"
+    document.event.record_date = "2026-07-25"
+    agenda_items = [
+        MagicMock(
+            title=f"Agenda Item {agenda_item_number}",
+            description="Detailed agenda description " * 30,
+            classification="Agenda Item",
+            result="",
+            page_number=agenda_item_number,
+        )
+        for agenda_item_number in range(1, 25)
+    ]
+    summary_db = _summary_db(catalog, document, agenda_items)
+    mocker.patch.object(tasks, "SessionLocal", return_value=summary_db)
+    mocker.patch.object(config, "AGENDA_SUMMARY_MAX_INPUT_CHARS", 1200)
+    mocker.patch.object(config, "AGENDA_SUMMARY_MIN_RESERVED_OUTPUT_CHARS", 200)
+
+    summary_payload = tasks.generate_summary_task.run(1, force=True)
+
+    assert summary_payload["status"] == "complete"
+    assert "Input truncation: included 1 of 2 items." in provider.summary_prompt
+    assert "Agenda Item 1" in provider.summary_prompt
+    assert "Agenda Item 2" not in provider.summary_prompt
+    summary_db.close.assert_called_once()
+
+
+def test_generate_summary_task_keeps_registered_contract():
+    task_signature = inspect.signature(tasks.generate_summary_task.run)
+
+    assert tasks.generate_summary_task.name == "pipeline.tasks.generate_summary_task"
+    assert tasks.generate_summary_task.max_retries == 3
+    assert list(task_signature.parameters) == ["catalog_id", "force"]
+    assert task_signature.parameters["force"].default is False
+
+
+def test_generate_summary_task_rolls_back_and_closes_on_provider_configuration_error(
+    mocker,
+):
+    catalog = _catalog(
+        content=(
+            "Council discussed housing budget public safety transportation priorities "
+            "and committee recommendations during the local government meeting."
+        )
+    )
+    summary_db = _summary_db(catalog, MagicMock(category="minutes"))
+    mocker.patch.object(tasks, "SessionLocal", return_value=summary_db)
+    mocker.patch.object(
+        llm_module,
+        "get_runtime_provider",
+        side_effect=LocalAIConfigError("invalid provider configuration"),
+    )
+
+    summary_payload = tasks.generate_summary_task.run(1, force=True)
+
+    assert summary_payload == {
+        "status": "error",
+        "error": "invalid provider configuration",
+    }
+    summary_db.rollback.assert_called_once()
+    summary_db.close.assert_called_once()

--- a/tests/test_task_facade_cleanup.py
+++ b/tests/test_task_facade_cleanup.py
@@ -68,21 +68,3 @@ def test_summary_helper_uses_injected_task_facade_patch_seam():
         123,
         force=False,
     )
-
-
-def test_pipeline_tasks_summary_services_use_pipeline_tasks_patch_seams(monkeypatch):
-    import pipeline.tasks as tasks
-
-    fake_local_ai = MagicMock(name="fake_local_ai")
-    fake_reindex = MagicMock(name="fake_reindex")
-    fake_embed_task = MagicMock()
-
-    monkeypatch.setattr(tasks, "LocalAI", fake_local_ai)
-    monkeypatch.setattr(tasks, "reindex_catalog", fake_reindex)
-    monkeypatch.setattr(tasks, "embed_catalog_task", fake_embed_task)
-
-    services = tasks._summary_generation_task_services()
-
-    assert services.local_ai_factory is fake_local_ai
-    assert services.reindex_catalog is fake_reindex
-    assert services.embed_catalog is fake_embed_task.delay

--- a/tests/test_task_provider_retry_semantics.py
+++ b/tests/test_task_provider_retry_semantics.py
@@ -7,7 +7,9 @@ import pytest
 sys.modules["llama_cpp"] = MagicMock()
 
 from pipeline import llm as llm_mod
+from pipeline import indexer
 from pipeline import enrichment_tasks
+from pipeline import semantic_tasks
 from pipeline import tasks
 from pipeline.llm_provider import ProviderResponseError, ProviderTimeoutError
 from pipeline.models import AgendaItem, Document
@@ -61,13 +63,11 @@ def _mock_agenda_summary_db():
 def test_generate_summary_task_uses_deterministic_fallback_for_provider_response_errors(mocker):
     mock_db = _mock_agenda_summary_db()
     mocker.patch.object(tasks, "SessionLocal", return_value=mock_db)
-    mocker.patch.object(tasks, "reindex_catalog", lambda _catalog_id: None)
-    mocker.patch.object(tasks.embed_catalog_task, "delay", return_value=None)
+    mocker.patch.object(indexer.meilisearch, "Client", side_effect=RuntimeError("search unavailable"))
+    mocker.patch.object(semantic_tasks.embed_catalog_task, "delay", return_value=None)
 
     llm_mod.LocalAI._instance = None
-    ai = llm_mod.LocalAI()
-    mocker.patch.object(ai, "_get_provider", return_value=_AgendaResponseErrorProvider())
-    mocker.patch.object(tasks, "LocalAI", return_value=ai)
+    mocker.patch.object(llm_mod, "get_runtime_provider", return_value=_AgendaResponseErrorProvider())
 
     retry_mock = mocker.patch.object(tasks.generate_summary_task, "retry")
     result = tasks.generate_summary_task.run(1, force=True)
@@ -80,13 +80,11 @@ def test_generate_summary_task_uses_deterministic_fallback_for_provider_response
 def test_generate_summary_task_retries_for_provider_timeout_errors(mocker):
     mock_db = _mock_agenda_summary_db()
     mocker.patch.object(tasks, "SessionLocal", return_value=mock_db)
-    mocker.patch.object(tasks, "reindex_catalog", lambda _catalog_id: None)
-    mocker.patch.object(tasks.embed_catalog_task, "delay", return_value=None)
+    mocker.patch.object(indexer.meilisearch, "Client", side_effect=RuntimeError("search unavailable"))
+    mocker.patch.object(semantic_tasks.embed_catalog_task, "delay", return_value=None)
 
     llm_mod.LocalAI._instance = None
-    ai = llm_mod.LocalAI()
-    mocker.patch.object(ai, "_get_provider", return_value=_AgendaTimeoutProvider())
-    mocker.patch.object(tasks, "LocalAI", return_value=ai)
+    mocker.patch.object(llm_mod, "get_runtime_provider", return_value=_AgendaTimeoutProvider())
 
     retry_exc = RuntimeError("retry-called")
     retry_mock = mocker.patch.object(tasks.generate_summary_task, "retry", side_effect=retry_exc)
@@ -95,7 +93,9 @@ def test_generate_summary_task_retries_for_provider_timeout_errors(mocker):
         tasks.generate_summary_task.run(1, force=True)
 
     retry_mock.assert_called_once()
+    assert retry_mock.call_args.kwargs["countdown"] == 60
     mock_db.rollback.assert_called_once()
+    mock_db.close.assert_called_once()
 
 
 def test_generate_topics_task_retries_on_transient_generation_errors(mocker):

--- a/tests/test_tasks_agenda_summary_format.py
+++ b/tests/test_tasks_agenda_summary_format.py
@@ -5,7 +5,8 @@ from unittest.mock import MagicMock
 sys.modules["llama_cpp"] = MagicMock()
 
 from pipeline import backlog_maintenance
-from pipeline import tasks
+from pipeline import indexer, llm as llm_module, semantic_tasks, tasks
+from pipeline.inference_provider_contract import InferenceProvider
 from pipeline.models import AgendaItem, Document
 from pipeline.summary_freshness import compute_agenda_items_hash
 
@@ -23,8 +24,14 @@ def test_generate_summary_task_agenda_requires_segmentation_and_calls_agenda_ite
     catalog.summary_source_hash = None
     mock_db.get.return_value = catalog
 
+    event = MagicMock()
+    event.name = "City Council"
+    event.record_date = "2026-02-10"
     doc_query = MagicMock()
-    doc_query.filter_by.return_value.first.return_value = MagicMock(category="agenda")
+    doc_query.filter_by.return_value.first.return_value = MagicMock(
+        category="agenda",
+        event=event,
+    )
 
     items_query = MagicMock()
     items_query.filter_by.return_value.order_by.return_value.all.return_value = [
@@ -43,11 +50,13 @@ def test_generate_summary_task_agenda_requires_segmentation_and_calls_agenda_ite
     mock_db.query.side_effect = _query_side_effect
 
     mocker.patch.object(tasks, "SessionLocal", return_value=mock_db)
-    mocker.patch.object(tasks, "reindex_catalog")
-    mocker.patch.object(tasks.embed_catalog_task, "delay")
-    mock_ai = MagicMock()
-    mock_ai.summarize_agenda_items.return_value = "BLUF: Agenda focuses on core policy and operational items."
-    mocker.patch.object(tasks, "LocalAI", return_value=mock_ai)
+    mocker.patch.object(indexer.meilisearch, "Client", side_effect=RuntimeError("search unavailable"))
+    mocker.patch.object(semantic_tasks.embed_catalog_task, "delay", return_value=None)
+    summary_provider = MagicMock(spec=InferenceProvider)
+    summary_provider.summarize_agenda_items.return_value = (
+        "BLUF: Agenda focuses on core policy and operational items."
+    )
+    mocker.patch.object(llm_module, "get_runtime_provider", return_value=summary_provider)
 
     result = tasks.generate_summary_task.run(1, force=True)
     assert result["status"] == "complete"
@@ -56,12 +65,10 @@ def test_generate_summary_task_agenda_requires_segmentation_and_calls_agenda_ite
     expected_hash = compute_agenda_items_hash(items_query.filter_by.return_value.order_by.return_value.all.return_value)
     assert catalog.summary_source_hash == expected_hash
     assert catalog.agenda_items_hash == expected_hash
-    mock_ai.summarize_agenda_items.assert_called_once()
-    kwargs = mock_ai.summarize_agenda_items.call_args.kwargs
-    assert isinstance(kwargs["items"], list)
-    assert kwargs["items"][0]["title"] == "Item One"
-    assert kwargs["items"][0]["description"] == "Description one"
-    assert kwargs["truncation_meta"]["items_total"] == 3
+    provider_prompt = summary_provider.summarize_agenda_items.call_args.args[0]
+    assert "Item One" in provider_prompt
+    assert "Description one" in provider_prompt
+    mock_db.close.assert_called_once()
 
 
 def test_generate_summary_task_agenda_returns_not_generated_yet_when_no_items(mocker):
@@ -92,11 +99,6 @@ def test_generate_summary_task_agenda_returns_not_generated_yet_when_no_items(mo
     mock_db.query.side_effect = _query_side_effect
 
     mocker.patch.object(tasks, "SessionLocal", return_value=mock_db)
-    mocker.patch.object(tasks, "reindex_catalog")
-    mocker.patch.object(tasks.embed_catalog_task, "delay")
-    mock_ai = MagicMock()
-    mocker.patch.object(tasks, "LocalAI", return_value=mock_ai)
-
     result = tasks.generate_summary_task.run(1, force=True)
     assert result["status"] == "not_generated_yet"
     assert "segmentation" in (result.get("reason") or "").lower()
@@ -130,11 +132,6 @@ def test_generate_summary_task_agenda_html_returns_not_generated_yet_when_no_ite
     mock_db.query.side_effect = _query_side_effect
 
     mocker.patch.object(tasks, "SessionLocal", return_value=mock_db)
-    mocker.patch.object(tasks, "reindex_catalog")
-    mocker.patch.object(tasks.embed_catalog_task, "delay")
-    mock_ai = MagicMock()
-    mocker.patch.object(tasks, "LocalAI", return_value=mock_ai)
-
     result = tasks.generate_summary_task.run(1, force=True)
     assert result["status"] == "not_generated_yet"
     assert "segmentation" in (result.get("reason") or "").lower()
@@ -152,14 +149,15 @@ def test_generate_summary_task_blocks_laserfiche_error_page_content(mocker):
     mock_db.get.return_value = catalog
 
     mocker.patch.object(tasks, "SessionLocal", return_value=mock_db)
-    mock_ai = MagicMock()
-    mocker.patch.object(tasks, "LocalAI", return_value=mock_ai)
+    mocker.patch.object(
+        llm_module,
+        "get_runtime_provider",
+        side_effect=AssertionError("Bad content must not reach inference"),
+    )
 
     result = tasks.generate_summary_task.run(1, force=True)
 
     assert result == {"status": "error", "error": "laserfiche_error_page_detected"}
-    mock_ai.summarize.assert_not_called()
-    mock_ai.summarize_agenda_items.assert_not_called()
     mock_db.commit.assert_not_called()
 
 
@@ -175,14 +173,15 @@ def test_generate_summary_task_blocks_laserfiche_loading_shell_content(mocker):
     mock_db.get.return_value = catalog
 
     mocker.patch.object(tasks, "SessionLocal", return_value=mock_db)
-    mock_ai = MagicMock()
-    mocker.patch.object(tasks, "LocalAI", return_value=mock_ai)
+    mocker.patch.object(
+        llm_module,
+        "get_runtime_provider",
+        side_effect=AssertionError("Bad content must not reach inference"),
+    )
 
     result = tasks.generate_summary_task.run(1, force=True)
 
     assert result == {"status": "error", "error": "laserfiche_loading_shell_detected"}
-    mock_ai.summarize.assert_not_called()
-    mock_ai.summarize_agenda_items.assert_not_called()
     mock_db.commit.assert_not_called()
 
 
@@ -379,7 +378,9 @@ def test_generate_summary_task_agenda_matches_maintenance_summary_inputs(mocker)
     mock_db.get.return_value = catalog
 
     doc = MagicMock(category="agenda")
-    doc.event = MagicMock(name="City Council", record_date="2026-02-10")
+    doc.event = MagicMock()
+    doc.event.name = "City Council"
+    doc.event.record_date = "2026-02-10"
 
     agenda_items = [
         MagicMock(title="Housing Update", description="Discuss housing pipeline.", classification="Agenda Item", result="", page_number=1),
@@ -397,9 +398,8 @@ def test_generate_summary_task_agenda_matches_maintenance_summary_inputs(mocker)
 
     mock_db.query.side_effect = _query_side_effect
     mocker.patch.object(tasks, "SessionLocal", return_value=mock_db)
-    mocker.patch.object(tasks, "classify_catalog_bad_content", return_value=None)
-    mocker.patch.object(tasks, "reindex_catalog")
-    mocker.patch.object(tasks.embed_catalog_task, "delay")
+    mocker.patch.object(indexer.meilisearch, "Client", side_effect=RuntimeError("search unavailable"))
+    mocker.patch.object(semantic_tasks.embed_catalog_task, "delay", return_value=None)
 
     agenda_bundle = backlog_maintenance.build_agenda_summary_input_bundle(
         catalog=catalog,
@@ -411,22 +411,20 @@ def test_generate_summary_task_agenda_matches_maintenance_summary_inputs(mocker)
         truncation_meta=agenda_bundle["truncation_meta"],
     )
 
-    fake_ai = MagicMock()
-    fake_ai.summarize_agenda_items.side_effect = (
-        lambda *, meeting_title, meeting_date, items, truncation_meta: backlog_maintenance.llm_mod._deterministic_agenda_items_summary(
-            items,
-            truncation_meta=truncation_meta,
-        )
-    )
-    mocker.patch.object(tasks, "LocalAI", return_value=fake_ai)
+    summary_provider = MagicMock(spec=InferenceProvider)
+    summary_provider.summarize_agenda_items.return_value = expected_summary
+    mocker.patch.object(llm_module, "get_runtime_provider", return_value=summary_provider)
 
     result = tasks.generate_summary_task.run(1, force=True)
 
     assert result["status"] == "complete"
-    assert result["summary"] == expected_summary
-    assert catalog.summary == expected_summary
+    assert result["summary"].startswith("BLUF:")
+    assert catalog.summary == result["summary"]
     assert catalog.agenda_items_hash == agenda_bundle["agenda_items_hash"]
     assert catalog.summary_source_hash == agenda_bundle["agenda_items_hash"]
+    provider_prompt = summary_provider.summarize_agenda_items.call_args.args[0]
+    assert "Housing Update" in provider_prompt
+    assert "Budget Adoption" in provider_prompt
 
 
 def test_build_agenda_summary_input_bundle_preserves_truncation_disclosure(monkeypatch):


### PR DESCRIPTION
## What changed

- Made `pipeline.task_summary_generation.generate_catalog_summary` the direct summary operation owner.
- Removed `SummaryGenerationTaskServices`, summary-only `globals()` wiring, and facade forwarding.
- Switched lower summary modules to direct domain imports while preserving persistence and best-effort reindex/embed behavior.
- Repointed tests to approved DB, inference-provider, Meilisearch, and Celery boundaries.
- Added task-level payload-budget coverage and AST import-direction guardrails.
- Marked T-DB-1A complete in the remediation ledger.

## Why

Summary generation routed fifteen callables through a service bag and two facade layers. That structure existed for historical patch targets, not a runtime boundary. T-DB-1A removes it before the broader T-DB-1 backfill facade cleanup.

## Risk and compatibility

Low-to-moderate internal refactor risk. Celery task name, signature, retry countdown, session lifecycle, summary payloads, hash persistence, grounding, and side-effect counters remain unchanged. No schema, migration, API, runtime default, or model-policy change.

## Verification

- PASS: `./.venv/bin/ruff check .`
- PASS: `./.venv/bin/mypy`
- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_repository_guardrails.py tests/test_docs_links.py` (391 passed)
- PASS: targeted summary, provider, and orchestration suite (75 passed)
- PASS: `PYTHONPATH=. .venv/bin/pytest -q` (1,495 passed)
- PASS: `git diff --check`
- PASS: independent pre-commit review; two P2 test gaps fixed; fresh re-review found no P1/P2.

## Remaining work

T-DB-1 remains separate and will collapse the summary backfill facade after this PR merges.
