### PR TITLE
T-DB-1B: Record maintenance callable cleanup completion

### DIFF
--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,6 +1,6 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 3.48
+version: 3.49
 generated: 2026-07-25
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
@@ -10,6 +10,10 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v3.49:** Completes T-DB-1B. PR #146 removed maintenance fallback callable
+  injection and the superseded summary facades, passed the complete local and
+  CI suites, resolved its review finding, and merged as `9132864`. The
+  temporary twenty-eight-file coordination grant is released.
 - **v3.48:** Resolves the T-DB-1B remote review P1 by replacing newly added
   mock call-count assertions with observable fake-boundary state and persisted
   outcomes. Existing historical tests outside this migration remain deferred
@@ -229,8 +233,8 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 | State | Tasks |
 |---|---|
-| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2, T-SEC-3, T-SEC-3C, T-SEC-4, T-SEC-4A, T-SEC-5, T-SEC-6, T-TIME-3, T-CRAWL-1, T-CRAWL-2, T-PLAT-2A, T-GOV-1, T-GOV-4, T-GOV-5, T-DA-1, T-DB-1A, T-DB-1 |
-| **In progress** | T-DB-1B |
+| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2, T-SEC-3, T-SEC-3C, T-SEC-4, T-SEC-4A, T-SEC-5, T-SEC-6, T-TIME-3, T-CRAWL-1, T-CRAWL-2, T-PLAT-2A, T-GOV-1, T-GOV-4, T-GOV-5, T-DA-1, T-DB-1A, T-DB-1, T-DB-1B |
+| **In progress** | None |
 | **Partially landed; acceptance incomplete** | T-GOV-6 |
 | **Pending** | T-TIME-1..2, T-DC-1, T-DD-1, T-DE-1, T-PLAT-1, T-PLAT-2, T-PLAT-3, T-PLAT-4, T-GOV-2..3 |
 
@@ -996,13 +1000,13 @@ files (GED-5 grant).
 
 ### T-DB-1B: Remove maintenance fallback callable injection
 - priority: P1
-- status: in progress; implementation authorized 2026-07-25
+- status: complete and verified 2026-07-25 (PR #146)
 - must_merge_after: T-DB-1
 - must_not_run_concurrently_with: agent-gov or any task touching the owned
   repaired/staged hydration scripts
-- coordination_grant: The exact task-level `files_owned` list is temporarily
-  authoritative over the broader DEDUP-B and GOV lane rows until T-DB-1B
-  merges.
+- coordination_grant: Released after PR #146 merged. The exact task-level
+  `files_owned` list was authoritative over the broader DEDUP-B and GOV lane
+  rows during implementation.
 - implementation_plan:
   `docs/plans/T_DB_1B_MAINTENANCE_CALLABLE_CLEANUP_PLAN.md`
 - files_owned:

--- a/docs/plans/T_DB_1B_MAINTENANCE_CALLABLE_CLEANUP_PLAN.md
+++ b/docs/plans/T_DB_1B_MAINTENANCE_CALLABLE_CLEANUP_PLAN.md
@@ -1,7 +1,7 @@
 # T-DB-1B: Remove Maintenance Fallback Callable Injection
 
 `artifact_contract: ce-unified-plan/v1`
-`artifact_readiness: implementation-ready`
+`artifact_readiness: complete`
 `execution: code`
 
 ## 1. Context & Alignment

--- a/docs/plans/T_DB_1B_MAINTENANCE_CALLABLE_CLEANUP_PLAN.md
+++ b/docs/plans/T_DB_1B_MAINTENANCE_CALLABLE_CLEANUP_PLAN.md
@@ -416,10 +416,40 @@ patches in tests, lower-to-facade imports, unrelated formatting, weakened
 assertions, added broad exceptions, type suppression, or edits outside the
 owned files.
 
-**y) Evidence.** Report PASS/FAIL for every command in section 6u, including
-tests-first red evidence, planning-review findings, simplification findings,
-pre-commit subagent findings, applied fixes, commit hashes, PR URL, unresolved
-thread count, and final CI state. Mark anything unrun `NOT VERIFIED`.
+**y) Evidence.**
+
+- `NOT VERIFIED`: The raw tests-first red output was not retained in the
+  delivery record. Final behavior and structural coverage passed, but this
+  missing artifact must not be represented as fresh red-phase evidence.
+- `PASS`: Independent planning review after scope corrections found no
+  remaining P1/P2 issue.
+- `NOT VERIFIED`: No separate simplification report was retained.
+- `PASS`: Initial pre-commit review found three P2 issues: configuration
+  errors could enter provider fallback, two runtime modules were absent from
+  the structural scan, and a test mutated `LocalAI._instance` directly. Commit
+  `606162b` corrected all three; a fresh review found no P1/P2 issue.
+- `PASS`: `./.venv/bin/ruff check .`
+- `PASS`: `./.venv/bin/pre-commit run ruff --all-files`
+- `PASS`: `./.venv/bin/mypy` checked 68 source files.
+- `PASS`: The combined targeted T-DB-1B command passed 95 tests, including
+  maintenance, staged/repaired hydration, orchestration, and provider
+  contracts.
+- `PASS`: Repository guardrails and docs links passed 393 tests.
+- `PASS`: `PYTHONPATH=. .venv/bin/pytest -q` passed 1,486 tests.
+- `PASS`: `git diff --check`
+- `PASS`: Remote review found one P1 against mock call-count assertions.
+  Commit `e5412af` replaced them with persisted outcomes and captured boundary
+  payloads; a fresh independent review and Codex re-review found no P1/P2.
+- `PASS`: PR
+  [#146](https://github.com/manumissio/town-council/pull/146) merged as
+  `9132864` with zero unresolved review threads.
+- `PASS`: Python Guardrails, Frontend Tests, and all CodeQL jobs passed on
+  commit `e5412af`.
+- `NOT VERIFIED`: Live PostgreSQL, Meilisearch, Celery, and inference-provider
+  smoke tests were not run. Approved boundary tests and CI are the completion
+  evidence for this behavior-preserving refactor.
+- Commits: `047739b`, `c2273c8`, `57d2f7f`, `716bf99`, `606162b`, and
+  `e5412af`.
 
 **z) Deviations.** The authorized ledger deviation is expansion from the
 original nine named files plus unspecified tests to the exact twenty-eight-file


### PR DESCRIPTION
## What changed
- mark T-DB-1B complete after PR #146
- record merge commit and verification evidence
- release the temporary 28-file coordination grant

## Why
The implementation merged cleanly, but the active remediation ledger still showed the task as in progress.

## Risk
Docs only. No runtime, API, schema, or policy behavior changes.

## Verification
- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py` (2 passed)
- PASS: `git diff --check`
- PASS: independent review, no P1/P2 findings