### PR TITLE
T-PLAT-1: Establish the Alembic baseline

### DIFF
--- a/.github/workflows/python-guardrails.yml
+++ b/.github/workflows/python-guardrails.yml
@@ -62,5 +62,8 @@ jobs:
           PYTHONPATH=. python -m pytest -q tests/test_pipeline_profile_report.py
           PYTHONPATH=. python -m pytest -q tests/test_docs_links.py
 
+      - name: Run PostgreSQL migration acceptance
+        run: PYTHONPATH=. python -m pytest -q tests/test_alembic_migrations.py
+
       - name: Run full Python test suite
         run: PYTHONPATH=. python -m pytest -q --cov --cov-config=.coveragerc --cov-report=term-missing:skip-covered tests/

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Town Council Architecture (2026)
 
-Last updated: 2026-05-16
+Last updated: 2026-07-26
 
 ## 1) System Overview
 
@@ -247,8 +247,9 @@ Primary owners:
 - `api/search_read_routes.py` facade plus focused `api/search_read_*` helpers
 - `api/search_semantic_routes.py`
 - `pipeline/semantic_index.py`
-- `pipeline/db_migrate.py` facade plus focused `pipeline/db_migration_*` helpers
-- `pipeline/migrate_v8.py` compatibility wrapper and `pipeline/migration_pgvector_semantic_embeddings.py`
+- `pipeline/db_migrate.py` facade plus the focused Alembic migration owner
+- `alembic/` baseline and post-baseline revision graph
+- frozen numbered migration history through v10 for existing-database adoption
 
 #### Lineage + Trends (Stable)
 
@@ -316,8 +317,8 @@ Primary owners:
   - `api/search_routes.py` (`/search` and `/search/semantic` paths)
   - `semantic_service/main.py` route facade plus focused `semantic_service/candidates.py`, `semantic_service/filters.py`, `semantic_service/retrieval.py`, and `semantic_service/hydration.py` helpers
   - `pipeline/semantic_index.py`
-  - `pipeline/db_migrate.py` facade plus focused `pipeline/db_migration_*` helpers
-  - `pipeline/migrate_v8.py` compatibility wrapper and `pipeline/migration_pgvector_semantic_embeddings.py`
+  - `pipeline/db_migrate.py` facade plus the focused Alembic migration owner
+  - `alembic/` baseline and post-baseline revision graph
 
 ### Code Map by Concern
 
@@ -328,7 +329,11 @@ Primary owners:
 - API surface and auth: `api/main.py`, `api/app_setup.py`, `api/search_routes.py`, `api/search_read_routes.py` facade plus focused `api/search_read_*` helpers, `api/task_routes.py` facade plus focused `api/task_*` helpers, `api/search_support.py` facade plus focused `api/search/*_support.py` helpers, `api/search/query_builder.py`, `api/metrics.py`
 - Semantic retrieval and embeddings: `semantic_service/main.py` route facade plus focused `semantic_service/*` helpers, `pipeline/semantic_index.py`, `pipeline/semantic_faiss_backend.py`, `pipeline/semantic_pgvector_backend.py`, focused semantic backend helpers, `pipeline/models.py` facade plus focused `pipeline/model_*` modules
 - Frontend query/task UX: `frontend/app/page.js`, `frontend/state/search-state.js`, `frontend/components/ResultCard.js`
-- Data model and persistence: `pipeline/models.py` facade plus focused `pipeline/model_*` modules, `pipeline/db_migrate.py` facade plus focused `pipeline/db_migration_*` helpers, `pipeline/migrate_v8.py` and `pipeline/migrate_v9.py` compatibility wrappers, descriptive `pipeline/migration_*` modules
+- Data model and persistence: `pipeline/models.py` facade plus focused
+  `pipeline/model_*` modules, `pipeline/db_migrate.py` as the single migration
+  entrypoint, `alembic/` as the authoritative baseline and post-baseline
+  revision graph, and frozen numbered migration history through v10 for
+  existing-database adoption
 - Onboarding orchestration and evaluation: `scripts/onboard_city_wave.sh`, `scripts/check_city_crawl_evidence.py`, `scripts/evaluate_city_onboarding.py` facade plus focused `pipeline/city_onboarding_*` helpers
 - Operator profiling and soak reports: `scripts/profile_pipeline.py` facade, `scripts/profile_pipeline_runner.py`, focused `scripts/profile_pipeline_*` helpers, `scripts/operator_profile_ab.py` facade plus focused `scripts/operator_profile_ab_*` helpers, focused `scripts/operator_profile_*` helpers, `scripts/evaluate_soak_week.py` plus `scripts/evaluate_soak_week_gates.py`, and `scripts/collect_ab_results.py` plus `scripts/collect_ab_results_rows.py`
 - City coverage diagnostics: `scripts/audit_city_coverage.py` command plus `pipeline/city_coverage_audit.py` facade and focused `pipeline/city_coverage_*` helpers

--- a/README.md
+++ b/README.md
@@ -31,22 +31,14 @@ This project ingests agendas/minutes, extracts text, indexes search content, and
 ### 2) Start stack and initialize DB
 ```bash
 test -f .env || cp .env.example .env
-docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build \
-  postgres redis meilisearch tika inference semantic semantic-worker api worker enrichment-worker monitor frontend ingress
-bash ./scripts/bootstrap_local_models.sh
-docker compose -f docker-compose.yml -f docker-compose.dev.yml run --rm \
-  pipeline python db_init.py
-```
-
-Optional helper (same steps, fewer flags to remember):
-```bash
 bash ./scripts/dev_up.sh
 ```
 
 What `scripts/dev_up.sh` does:
-- starts the core Docker Compose stack (with `--build`)
+- starts PostgreSQL and waits for it to accept connections
+- runs the canonical database migration entrypoint
 - bootstraps the shared local model volume
-- initializes the DB schema
+- starts the remaining Docker Compose stack (with `--build`)
 - runs a small smoke check (`/health`)
 
 Local development may use the fake Meilisearch reader fallback. Any reachable

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,8 @@
+# Town Council supplies runtime connections through Config.attributes.
+[alembic]
+script_location = %(here)s/alembic
+prepend_sys_path = .
+path_separator = os
+
+# Keep credentials in the established DATABASE_URL configuration boundary.
+sqlalchemy.url =

--- a/alembic/README
+++ b/alembic/README
@@ -1,0 +1,5 @@
+Town Council Alembic revisions.
+
+Use pipeline/db_migrate.py for fresh databases, existing database adoption,
+and upgrades. Do not run an unguarded alembic stamp. See docs/OPERATIONS.md
+for backup, parity, rollback, and derived-vector rehydration procedures.

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,54 @@
+from alembic import context
+from sqlalchemy.engine import Connection
+
+from pipeline.models import Base, db_connect
+
+
+config = context.config
+
+target_metadata = Base.metadata
+VERSION_TABLE_SCHEMA_ATTRIBUTE = "version_table_schema"
+CONNECTION_ATTRIBUTE = "connection"
+
+
+def run_migrations_offline() -> None:
+    raise RuntimeError(
+        "Town Council migrations require an online database connection."
+    )
+
+
+def _configure_connection(connection: Connection) -> None:
+    version_table_schema = config.attributes.get(VERSION_TABLE_SCHEMA_ATTRIBUTE)
+    if version_table_schema is not None and not isinstance(version_table_schema, str):
+        raise TypeError("Alembic version_table_schema must be a string.")
+    context.configure(
+        connection=connection,
+        target_metadata=target_metadata,
+        compare_type=True,
+        compare_server_default=True,
+        version_table_schema=version_table_schema,
+    )
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    supplied_connection = config.attributes.get(CONNECTION_ATTRIBUTE)
+    if supplied_connection is not None:
+        if not isinstance(supplied_connection, Connection):
+            raise TypeError("Alembic connection attribute must be a Connection.")
+        _configure_connection(supplied_connection)
+        return
+
+    engine = db_connect()
+    try:
+        with engine.begin() as connection:
+            _configure_connection(connection)
+    finally:
+        engine.dispose()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/alembic/script.py.mako
+++ b/alembic/script.py.mako
@@ -1,0 +1,28 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, Sequence[str], None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    ${downgrades if downgrades else "pass"}

--- a/alembic/versions/0001_v10_baseline.py
+++ b/alembic/versions/0001_v10_baseline.py
@@ -1,0 +1,559 @@
+"""Create the immutable Town Council v10 PostgreSQL baseline."""
+
+from __future__ import annotations
+
+from alembic import op
+from pgvector.sqlalchemy import Vector
+import sqlalchemy as sa
+
+
+revision: str = "0001_v10_baseline"
+down_revision: str | None = None
+branch_labels: tuple[str, ...] | None = None
+depends_on: tuple[str, ...] | None = None
+
+BASELINE_DOWNGRADE_ERROR = (
+    "The v10 baseline is the migration floor and cannot be downgraded."
+)
+VECTOR_EXTENSION_DDL = sa.DDL("CREATE EXTENSION IF NOT EXISTS vector")
+CURRENT_TIMESTAMP_DEFAULT = sa.text("now()")
+MENTIONED_PERSON_DEFAULT = sa.text("'mentioned'")
+
+
+def upgrade() -> None:
+    """Create the complete v10 schema without importing mutable ORM metadata."""
+    op.execute(VECTOR_EXTENSION_DDL)
+
+    op.create_table(
+        "catalog",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("url", sa.String(length=500), nullable=True),
+        sa.Column("url_hash", sa.String(length=64), nullable=False),
+        sa.Column("location", sa.String(length=500), nullable=True),
+        sa.Column("filename", sa.String(length=255), nullable=True),
+        sa.Column("content", sa.Text(), nullable=True),
+        sa.Column("content_hash", sa.String(length=64), nullable=True),
+        sa.Column("extraction_status", sa.String(length=20), nullable=True),
+        sa.Column(
+            "extraction_attempted_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+        sa.Column("extraction_attempt_count", sa.Integer(), nullable=True),
+        sa.Column("extraction_error", sa.Text(), nullable=True),
+        sa.Column("summary", sa.Text(), nullable=True),
+        sa.Column("summary_source_hash", sa.String(length=64), nullable=True),
+        sa.Column("summary_extractive", sa.Text(), nullable=True),
+        sa.Column("agenda_items_hash", sa.String(length=64), nullable=True),
+        sa.Column("entities", sa.JSON(), nullable=True),
+        sa.Column("entities_source_hash", sa.String(length=64), nullable=True),
+        sa.Column("tables", sa.JSON(), nullable=True),
+        sa.Column("topics", sa.JSON(), nullable=True),
+        sa.Column("topics_source_hash", sa.String(length=64), nullable=True),
+        sa.Column("related_ids", sa.JSON(), nullable=True),
+        sa.Column("lineage_id", sa.String(length=64), nullable=True),
+        sa.Column("lineage_confidence", sa.Float(), nullable=True),
+        sa.Column("lineage_updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "agenda_segmentation_status",
+            sa.String(length=20),
+            nullable=True,
+        ),
+        sa.Column(
+            "agenda_segmentation_attempted_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "agenda_segmentation_item_count",
+            sa.Integer(),
+            nullable=True,
+        ),
+        sa.Column("agenda_segmentation_error", sa.Text(), nullable=True),
+        sa.Column("processed", sa.Boolean(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=CURRENT_TIMESTAMP_DEFAULT,
+            nullable=True,
+        ),
+        sa.Column(
+            "uploaded_at",
+            sa.DateTime(timezone=True),
+            server_default=CURRENT_TIMESTAMP_DEFAULT,
+            nullable=True,
+        ),
+        sa.PrimaryKeyConstraint("id", name="catalog_pkey"),
+        sa.UniqueConstraint("url_hash", name="catalog_url_hash_key"),
+    )
+    op.create_index(
+        "idx_catalog_hash",
+        "catalog",
+        ["url_hash"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_catalog_extraction_attempted_at",
+        "catalog",
+        ["extraction_attempted_at"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_catalog_extraction_status",
+        "catalog",
+        ["extraction_status"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_catalog_lineage_confidence",
+        "catalog",
+        ["lineage_confidence"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_catalog_lineage_id",
+        "catalog",
+        ["lineage_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_catalog_agenda_segmentation_attempted_at",
+        "catalog",
+        ["agenda_segmentation_attempted_at"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_catalog_agenda_segmentation_status",
+        "catalog",
+        ["agenda_segmentation_status"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_catalog_lineage_updated_at",
+        "catalog",
+        ["lineage_updated_at"],
+        unique=False,
+    )
+
+    op.create_table(
+        "event_stage",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("ocd_division_id", sa.String(length=255), nullable=True),
+        sa.Column("organization_name", sa.String(length=255), nullable=True),
+        sa.Column("name", sa.String(length=255), nullable=True),
+        sa.Column(
+            "scraped_datetime",
+            sa.DateTime(timezone=True),
+            server_default=CURRENT_TIMESTAMP_DEFAULT,
+            nullable=True,
+        ),
+        sa.Column("record_date", sa.Date(), nullable=True),
+        sa.Column("source", sa.String(length=500), nullable=True),
+        sa.Column("source_url", sa.String(length=500), nullable=True),
+        sa.Column("meeting_type", sa.String(length=100), nullable=True),
+        sa.PrimaryKeyConstraint("id", name="event_stage_pkey"),
+    )
+
+    op.create_table(
+        "person",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("ocd_id", sa.String(length=255), nullable=True),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("image_url", sa.String(length=500), nullable=True),
+        sa.Column("biography", sa.String(length=5000), nullable=True),
+        sa.Column("current_role", sa.String(length=255), nullable=True),
+        sa.Column(
+            "is_elected",
+            sa.Boolean(),
+            server_default=sa.false(),
+            nullable=True,
+        ),
+        sa.Column(
+            "person_type",
+            sa.String(length=20),
+            server_default=MENTIONED_PERSON_DEFAULT,
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=CURRENT_TIMESTAMP_DEFAULT,
+            nullable=True,
+        ),
+        sa.PrimaryKeyConstraint("id", name="person_pkey"),
+    )
+    op.create_index(
+        "ix_person_is_elected",
+        "person",
+        ["is_elected"],
+        unique=False,
+    )
+    op.create_index("ix_person_name", "person", ["name"], unique=False)
+    op.create_index("ix_person_ocd_id", "person", ["ocd_id"], unique=True)
+    op.create_index(
+        "ix_person_person_type",
+        "person",
+        ["person_type"],
+        unique=False,
+    )
+
+    op.create_table(
+        "place",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("type_", sa.String(length=50), nullable=True),
+        sa.Column("state", sa.String(length=2), nullable=False),
+        sa.Column("country", sa.String(length=2), nullable=True),
+        sa.Column("display_name", sa.String(length=255), nullable=True),
+        sa.Column("ocd_division_id", sa.String(length=255), nullable=False),
+        sa.Column("seed_url", sa.String(length=500), nullable=True),
+        sa.Column("hosting_service", sa.String(length=100), nullable=True),
+        sa.Column("crawler", sa.Boolean(), nullable=True),
+        sa.Column("crawler_name", sa.String(length=100), nullable=True),
+        sa.Column("crawler_type", sa.String(length=50), nullable=True),
+        sa.Column("crawler_owner", sa.String(length=100), nullable=True),
+        sa.Column("legistar_client", sa.String(length=100), nullable=True),
+        sa.PrimaryKeyConstraint("id", name="place_pkey"),
+    )
+    op.create_index(
+        "ix_place_ocd_division_id",
+        "place",
+        ["ocd_division_id"],
+        unique=True,
+    )
+
+    op.create_table(
+        "url_stage",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("ocd_division_id", sa.String(length=255), nullable=True),
+        sa.Column("event", sa.String(length=255), nullable=True),
+        sa.Column("event_date", sa.Date(), nullable=True),
+        sa.Column("url", sa.String(length=500), nullable=True),
+        sa.Column("url_hash", sa.String(length=64), nullable=True),
+        sa.Column("category", sa.String(length=50), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=CURRENT_TIMESTAMP_DEFAULT,
+            nullable=True,
+        ),
+        sa.PrimaryKeyConstraint("id", name="url_stage_pkey"),
+    )
+
+    op.create_table(
+        "url_stage_hist",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("ocd_division_id", sa.String(length=255), nullable=True),
+        sa.Column("event", sa.String(length=255), nullable=True),
+        sa.Column("event_date", sa.Date(), nullable=True),
+        sa.Column("url", sa.String(length=500), nullable=True),
+        sa.Column("url_hash", sa.String(length=64), nullable=True),
+        sa.Column("category", sa.String(length=50), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=CURRENT_TIMESTAMP_DEFAULT,
+            nullable=True,
+        ),
+        sa.PrimaryKeyConstraint("id", name="url_stage_hist_pkey"),
+    )
+
+    op.create_table(
+        "organization",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("ocd_id", sa.String(length=255), nullable=True),
+        sa.Column("place_id", sa.Integer(), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("classification", sa.String(length=100), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["place_id"],
+            ["place.id"],
+            name="organization_place_id_fkey",
+        ),
+        sa.PrimaryKeyConstraint("id", name="organization_pkey"),
+    )
+    op.create_index(
+        "ix_organization_ocd_id",
+        "organization",
+        ["ocd_id"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_organization_place_id",
+        "organization",
+        ["place_id"],
+        unique=False,
+    )
+
+    op.create_table(
+        "event",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("ocd_id", sa.String(length=255), nullable=True),
+        sa.Column("ocd_division_id", sa.String(length=255), nullable=True),
+        sa.Column("place_id", sa.Integer(), nullable=False),
+        sa.Column("organization_id", sa.Integer(), nullable=True),
+        sa.Column("name", sa.String(length=255), nullable=True),
+        sa.Column(
+            "scraped_datetime",
+            sa.DateTime(timezone=True),
+            server_default=CURRENT_TIMESTAMP_DEFAULT,
+            nullable=True,
+        ),
+        sa.Column("record_date", sa.Date(), nullable=True),
+        sa.Column("source", sa.String(length=500), nullable=True),
+        sa.Column("source_url", sa.String(length=500), nullable=True),
+        sa.Column("meeting_type", sa.String(length=100), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["organization_id"],
+            ["organization.id"],
+            name="event_organization_id_fkey",
+        ),
+        sa.ForeignKeyConstraint(
+            ["place_id"],
+            ["place.id"],
+            name="event_place_id_fkey",
+        ),
+        sa.PrimaryKeyConstraint("id", name="event_pkey"),
+    )
+    op.create_index(
+        "idx_event_date_place",
+        "event",
+        ["record_date", "place_id"],
+        unique=False,
+    )
+    op.create_index(
+        "idx_event_org",
+        "event",
+        ["organization_id", "record_date"],
+        unique=False,
+    )
+    op.create_index("ix_event_ocd_id", "event", ["ocd_id"], unique=True)
+    op.create_index(
+        "ix_event_organization_id",
+        "event",
+        ["organization_id"],
+        unique=False,
+    )
+
+    op.create_table(
+        "membership",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("person_id", sa.Integer(), nullable=False),
+        sa.Column("organization_id", sa.Integer(), nullable=False),
+        sa.Column("label", sa.String(length=255), nullable=True),
+        sa.Column("role", sa.String(length=100), nullable=True),
+        sa.Column("start_date", sa.Date(), nullable=True),
+        sa.Column("end_date", sa.Date(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["organization_id"],
+            ["organization.id"],
+            name="membership_organization_id_fkey",
+        ),
+        sa.ForeignKeyConstraint(
+            ["person_id"],
+            ["person.id"],
+            name="membership_person_id_fkey",
+        ),
+        sa.PrimaryKeyConstraint("id", name="membership_pkey"),
+    )
+    op.create_index(
+        "ix_membership_organization_id",
+        "membership",
+        ["organization_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_membership_person_id",
+        "membership",
+        ["person_id"],
+        unique=False,
+    )
+
+    op.create_table(
+        "agenda_item",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("ocd_id", sa.String(length=255), nullable=True),
+        sa.Column("event_id", sa.Integer(), nullable=False),
+        sa.Column("order", sa.Integer(), nullable=True),
+        sa.Column("title", sa.String(length=1000), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("classification", sa.String(length=100), nullable=True),
+        sa.Column("result", sa.String(length=100), nullable=True),
+        sa.Column("page_number", sa.Integer(), nullable=True),
+        sa.Column("text_offset", sa.Integer(), nullable=True),
+        sa.Column("votes", sa.JSON(), nullable=True),
+        sa.Column("raw_history", sa.Text(), nullable=True),
+        sa.Column("legistar_matter_id", sa.Integer(), nullable=True),
+        sa.Column("spatial_coords", sa.JSON(), nullable=True),
+        sa.Column("catalog_id", sa.Integer(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["catalog_id"],
+            ["catalog.id"],
+            name="agenda_item_catalog_id_fkey",
+        ),
+        sa.ForeignKeyConstraint(
+            ["event_id"],
+            ["event.id"],
+            name="agenda_item_event_id_fkey",
+        ),
+        sa.PrimaryKeyConstraint("id", name="agenda_item_pkey"),
+    )
+    op.create_index(
+        "ix_agenda_item_event_id",
+        "agenda_item",
+        ["event_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_agenda_item_legistar_matter_id",
+        "agenda_item",
+        ["legistar_matter_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_agenda_item_ocd_id",
+        "agenda_item",
+        ["ocd_id"],
+        unique=True,
+    )
+
+    op.create_table(
+        "data_issue",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("event_id", sa.Integer(), nullable=False),
+        sa.Column("issue_type", sa.String(length=50), nullable=False),
+        sa.Column("description", sa.String(length=500), nullable=True),
+        sa.Column("status", sa.String(length=20), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=CURRENT_TIMESTAMP_DEFAULT,
+            nullable=True,
+        ),
+        sa.ForeignKeyConstraint(
+            ["event_id"],
+            ["event.id"],
+            name="data_issue_event_id_fkey",
+        ),
+        sa.PrimaryKeyConstraint("id", name="data_issue_pkey"),
+    )
+    op.create_index(
+        "ix_data_issue_event_id",
+        "data_issue",
+        ["event_id"],
+        unique=False,
+    )
+
+    op.create_table(
+        "document",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("place_id", sa.Integer(), nullable=False),
+        sa.Column("event_id", sa.Integer(), nullable=False),
+        sa.Column("catalog_id", sa.Integer(), nullable=True),
+        sa.Column("url", sa.String(length=500), nullable=True),
+        sa.Column("url_hash", sa.String(length=64), nullable=True),
+        sa.Column("media_type", sa.String(length=100), nullable=True),
+        sa.Column("category", sa.String(length=50), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=CURRENT_TIMESTAMP_DEFAULT,
+            nullable=True,
+        ),
+        sa.Column("page_count", sa.Integer(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["catalog_id"],
+            ["catalog.id"],
+            name="document_catalog_id_fkey",
+        ),
+        sa.ForeignKeyConstraint(
+            ["event_id"],
+            ["event.id"],
+            name="document_event_id_fkey",
+        ),
+        sa.ForeignKeyConstraint(
+            ["place_id"],
+            ["place.id"],
+            name="document_place_id_fkey",
+        ),
+        sa.PrimaryKeyConstraint("id", name="document_pkey"),
+    )
+    op.create_index(
+        "idx_doc_catalog",
+        "document",
+        ["catalog_id"],
+        unique=False,
+    )
+    op.create_index(
+        "idx_doc_category",
+        "document",
+        ["category", "created_at"],
+        unique=False,
+    )
+    op.create_index(
+        "idx_doc_place_event",
+        "document",
+        ["place_id", "event_id"],
+        unique=False,
+    )
+
+    op.create_table(
+        "semantic_embedding",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("catalog_id", sa.Integer(), nullable=True),
+        sa.Column("agenda_item_id", sa.Integer(), nullable=True),
+        sa.Column("model_name", sa.String(length=120), nullable=False),
+        sa.Column("embedding_dim", sa.Integer(), nullable=False),
+        sa.Column("embedding", Vector(384), nullable=True),
+        sa.Column("source_hash", sa.String(length=64), nullable=True),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=CURRENT_TIMESTAMP_DEFAULT,
+            nullable=True,
+        ),
+        sa.CheckConstraint(
+            "(catalog_id IS NOT NULL AND agenda_item_id IS NULL) OR "
+            "(catalog_id IS NULL AND agenda_item_id IS NOT NULL)",
+            name="check_single_entity_reference",
+        ),
+        sa.ForeignKeyConstraint(
+            ["agenda_item_id"],
+            ["agenda_item.id"],
+            name="semantic_embedding_agenda_item_id_fkey",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["catalog_id"],
+            ["catalog.id"],
+            name="semantic_embedding_catalog_id_fkey",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id", name="semantic_embedding_pkey"),
+    )
+    op.create_index(
+        "ix_semantic_embedding_catalog_model",
+        "semantic_embedding",
+        ["catalog_id", "model_name"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_semantic_embedding_item_model",
+        "semantic_embedding",
+        ["agenda_item_id", "model_name"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_semantic_embedding_hnsw",
+        "semantic_embedding",
+        ["embedding"],
+        unique=False,
+        postgresql_ops={"embedding": "vector_cosine_ops"},
+        postgresql_using="hnsw",
+        postgresql_where=sa.text("embedding IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    """Prevent destructive rollback below the adopted migration floor."""
+    raise RuntimeError(BASELINE_DOWNGRADE_ERROR)

--- a/docs/CONTRIBUTING_CITIES.md
+++ b/docs/CONTRIBUTING_CITIES.md
@@ -52,7 +52,12 @@ Important validation behavior:
   `council_crawler/council_crawler/pipelines.py`.
 
 ### 4) Seed + process
+
+Apply migrations before seeding. Seed and promotion commands intentionally
+fail when the schema is missing.
+
 ```bash
+docker compose run --rm pipeline python db_migrate.py
 docker compose run --rm pipeline python seed_places.py
 docker compose run --rm crawler scrapy crawl <city_spider_name>
 docker compose run --rm pipeline python run_pipeline.py

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,6 +1,6 @@
 # Operations Runbook
 
-Last updated: 2026-07-25
+Last updated: 2026-07-26
 
 ## Core workflow
 
@@ -17,15 +17,6 @@ cd "$REPO_ROOT"
 ### 1) Start stack
 ```bash
 test -f .env || cp .env.example .env
-docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build \
-  postgres redis meilisearch tika inference semantic semantic-worker api worker enrichment-worker monitor frontend ingress
-bash ./scripts/bootstrap_local_models.sh
-docker compose -f docker-compose.yml -f docker-compose.dev.yml run --rm \
-  pipeline python db_init.py
-```
-
-Optional helper (same steps, fewer flags to remember):
-```bash
 bash ./scripts/dev_up.sh
 ```
 
@@ -63,9 +54,10 @@ docker compose exec -T worker python scripts/worker_healthcheck.py
 ```
 
 What `scripts/dev_up.sh` does:
-- starts the core Docker Compose stack (with `--build`)
+- starts PostgreSQL and waits for it to accept connections
+- runs the canonical database migration entrypoint
 - bootstraps the shared local model volume
-- initializes the DB schema
+- starts the remaining Docker Compose stack (with `--build`)
 - runs a small smoke check (`/health`)
 
 Public frontend traffic enters through Caddy on `http://localhost:3000`.
@@ -91,7 +83,100 @@ What it does *not* do:
 - scrape any city data (no crawler runs)
 - process/index documents (no `run_pipeline.py`)
 
-### Timezone migration v10
+### Database migrations and backups
+
+`pipeline/db_migrate.py` is the only supported schema entrypoint. It handles
+fresh databases, guarded adoption of unversioned databases through the frozen
+v10 history, and upgrades to the current Alembic head. `db_init.py` remains a
+compatibility command that delegates to the same implementation. Seeding and
+promotion do not create tables; run migration first.
+
+Before migrating an existing database, stop every writer and create a verified
+PostgreSQL backup:
+
+```bash
+BACKUP_PATH="<BACKUP_PATH>/town_council_pre_migration.dump"
+
+docker compose -f docker-compose.yml -f docker-compose.dev.yml stop
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d postgres
+docker compose exec -T postgres pg_dump \
+  -U town_council -d town_council_db -Fc > "$BACKUP_PATH"
+docker compose exec -T postgres pg_restore --list < "$BACKUP_PATH" >/dev/null
+docker compose -f docker-compose.yml -f docker-compose.dev.yml run \
+  --rm --build --no-deps pipeline python db_migrate.py
+```
+
+Migration lock conflicts, legacy migration errors, and schema-parity failures
+exit nonzero without stamping the database. Do not run an unguarded
+`alembic stamp`. The baseline is the downgrade floor; restore the verified
+backup instead of attempting to downgrade below it.
+
+Verify the migrated database against the current Alembic head:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.dev.yml run \
+  --rm --no-deps pipeline python /app/scripts/check_schema_parity.py
+```
+
+The command must print `Schema parity: PASS`. Any reported object difference
+blocks writer restart until the migration or unexpected schema drift is
+resolved.
+
+Unversioned adoption logs `retired_catalog_vector_count`. A nonzero value
+means frozen v8 removed derived vectors from the retired `catalog` column.
+After the semantic worker is healthy, re-enqueue embeddings for catalogs with
+summaries:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.dev.yml run \
+  --rm --no-deps pipeline python - <<'PY'
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from pipeline.models import Catalog, db_connect
+from pipeline.summary_backfill_dispatch import enqueue_embed_catalogs
+
+EMBEDDING_DISPATCH_BATCH_SIZE = 500
+
+engine = db_connect()
+try:
+    with Session(engine) as session:
+        last_catalog_id = 0
+        while True:
+            catalog_ids = list(
+                session.scalars(
+                    select(Catalog.id)
+                    .where(
+                        Catalog.summary.is_not(None),
+                        Catalog.id > last_catalog_id,
+                    )
+                    .order_by(Catalog.id)
+                    .limit(EMBEDDING_DISPATCH_BATCH_SIZE)
+                )
+            )
+            if not catalog_ids:
+                break
+            print(enqueue_embed_catalogs(catalog_ids))
+            last_catalog_id = catalog_ids[-1]
+finally:
+    engine.dispose()
+PY
+```
+
+Confirm `embed_dispatch_failed=0`, then monitor the semantic worker until the
+queued tasks finish. Embeddings are derived data; the migration transaction
+preserves source catalog, document, event, agenda, and civic records.
+
+Rollback restores the backup while writers remain stopped:
+
+```bash
+docker compose exec -T postgres pg_restore \
+  -U town_council -d town_council_db --clean --if-exists --exit-on-error \
+  < "$BACKUP_PATH"
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build
+```
+
+#### Historical timezone migration v10
 
 Run v10 before restarting application writers after deploying the coordinated
 T-TIME-1 + T-TIME-2 release. The conversion takes PostgreSQL table locks and

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -1,6 +1,6 @@
 # Town Council Pipeline Guide
 
-Last updated: 2026-05-16
+Last updated: 2026-07-26
 
 ## 1) Purpose and Boundaries
 
@@ -44,9 +44,14 @@ Town Council uses two complementary pipelines:
 
 Why this exists:
 - Later stages assume canonical rows, valid schema, and local files already present.
-- `db_migrate.py` remains the supported additive upgrade facade for older Postgres schemas.
-  Focused `pipeline/db_migration_*` helpers own column checks, additive column plans, backfills, and submigration orchestration.
-- `pipeline/migrate_v8.py` and `pipeline/migrate_v9.py` remain compatibility wrappers around descriptive pgvector and lineage migration modules.
+- `db_migrate.py` is the single supported schema entrypoint. It migrates fresh
+  databases, adopts supported unversioned databases through frozen migration
+  history, and upgrades versioned databases to the current Alembic head.
+- Alembic owns the baseline and every post-baseline revision.
+- The numbered migration history through v10 is frozen adoption history, not a
+  second path for new schema changes.
+- `seed_places.py` and `promote_stage.py` require a migrated schema and fail
+  rather than creating missing tables.
 
 ### Stage B: Parallel document processing
 `run_parallel_processing()` finds records needing extraction or extraction-state repair and processes them in chunked parallel workers.

--- a/docs/plans/G5_ALEMBIC_ADOPTION_DECISION_PLAN.md
+++ b/docs/plans/G5_ALEMBIC_ADOPTION_DECISION_PLAN.md
@@ -23,9 +23,8 @@ silently choose between Alembic and the existing `migrate_v*` chain.
 - `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`
 - `docs/ADR.md`
 
-T-PLAT-1 remains pending and owns Alembic implementation. Coordinated
-T-TIME-1 + T-TIME-2 implementation is in progress and owns the final numbered
-timezone-column migration.
+T-TIME-1 and T-TIME-2 are complete after PR #148. T-PLAT-1 is active and owns
+Alembic implementation from the final numbered timezone-column migration.
 
 **d) Decision-gate check.** G5 is satisfied by explicit operator approval.
 G1-G4 remain unchanged. This record authorizes T-PLAT-1 after the existing
@@ -36,10 +35,10 @@ TIME migration work; it does not rewrite T-TIME-2 into an Alembic revision.
 **e) Step-by-step approach.**
 
 1. Record G5 as approved with date and rationale.
-2. Preserve the migration sequence: one coordinated T-TIME-1 + T-TIME-2 PR
-   updates model declarations and existing databases through
-   `migrate_v10.py`, then T-PLAT-1 establishes the Alembic baseline.
-3. Mark T-PLAT-1 as approved and pending, not complete.
+2. Preserve the migration sequence: the merged coordinated T-TIME-1 +
+   T-TIME-2 PR updated model declarations and existing databases through
+   `migrate_v10.py`; T-PLAT-1 now establishes the Alembic baseline.
+3. Mark T-PLAT-1 active, not complete.
 4. Add an Accepted ADR that preserves the current migration chain as frozen
    history after the baseline and assigns post-baseline migrations to Alembic.
 5. Expand T-PLAT-1 ownership for root configuration, the pinned dependency,
@@ -123,7 +122,7 @@ change is one plan and short decision updates.
 - Explicit filesystem checks cover every local link added by the G5 decision
   records in scenario 6. The existing docs-link test does not scan these files.
 - Separate positive and negative `rg` checks cover scenarios 1-5 and 7.
-- Manual diff review confirms T-PLAT-1 remains pending.
+- Manual diff review confirms T-PLAT-1 is active but not complete.
 - T-PLAT-1 contract tests must cover scenario 8 with both fresh and
   legacy-migrated database paths.
 - Ownership checks cover scenario 9.
@@ -156,7 +155,7 @@ test -f docs/plans/G5_ALEMBIC_ADOPTION_DECISION_PLAN.md
 test -f docs/reviews/architecture-review-2026-07-19.html
 rg -n "G5 migration_tooling: \\*\\*Approved 2026-07-24" \
   docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
-rg -n "status: approved; implementation pending" \
+rg -n "status: in progress" \
   docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
 rg -n "T-TIME-1 and T-TIME-2 execute in one coordinated PR" \
   docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -216,8 +215,8 @@ or external-state remediation is required.
 - Remediation plan: gate, sequence, task status, and changelog.
 - ADR: accepted migration-tooling decision.
 - Architecture review: unchanged historical artifact.
-- Operations: T-TIME-1 + T-TIME-2 owns v10 preflight and rollback; T-PLAT-1
-  later owns Alembic adoption and backup-policy sections.
+- Operations: the merged T-TIME-1 + T-TIME-2 work owns v10 preflight and
+  rollback; active T-PLAT-1 owns Alembic adoption and backup-policy sections.
 
 ## 7. Delivery Self-Audit
 

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,7 +1,7 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 3.50
-generated: 2026-07-25
+version: 3.51
+generated: 2026-07-26
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
 orchestrator_contract: Codex instantiates one agent per lane. Agents run in
@@ -10,6 +10,13 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v3.51:** Marks coordinated T-TIME-1 and T-TIME-2 complete after PR #148
+  merged with PostgreSQL migration evidence and activates T-PLAT-1. Expands
+  T-PLAT-1 ownership for its Full plan, strict legacy runner, focused Alembic
+  owner, typed schema contracts, parity CLI, and G5 status sync. Acceptance now
+  requires all four legacy-only indexes, one caller-owned transaction,
+  immediate transaction-lock conflict, complete object parity before stamp,
+  fail-fast setup ordering, and no optional PostgreSQL migration skips in CI.
 - **v3.50:** Activates T-TIME-1 and T-TIME-2 as one operator-approved
   coordinated PR because model-only or schema-only deployment is unsafe.
   Defines ten generated timestamps with server defaults, preserves three
@@ -240,10 +247,10 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 | State | Tasks |
 |---|---|
-| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2, T-SEC-3, T-SEC-3C, T-SEC-4, T-SEC-4A, T-SEC-5, T-SEC-6, T-TIME-3, T-CRAWL-1, T-CRAWL-2, T-PLAT-2A, T-GOV-1, T-GOV-4, T-GOV-5, T-DA-1, T-DB-1A, T-DB-1, T-DB-1B |
-| **In progress** | T-TIME-1 + T-TIME-2 |
+| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2, T-SEC-3, T-SEC-3C, T-SEC-4, T-SEC-4A, T-SEC-5, T-SEC-6, T-TIME-1, T-TIME-2, T-TIME-3, T-CRAWL-1, T-CRAWL-2, T-PLAT-2A, T-GOV-1, T-GOV-4, T-GOV-5, T-DA-1, T-DB-1A, T-DB-1, T-DB-1B |
+| **In progress** | T-PLAT-1 |
 | **Partially landed; acceptance incomplete** | T-GOV-6 |
-| **Pending** | T-DC-1, T-DD-1, T-DE-1, T-PLAT-1, T-PLAT-2, T-PLAT-3, T-PLAT-4, T-GOV-2..3 |
+| **Pending** | T-DC-1, T-DD-1, T-DE-1, T-PLAT-2, T-PLAT-3, T-PLAT-4, T-GOV-2..3 |
 
 ---
 
@@ -311,7 +318,7 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 | DEDUP-C   | agent-dc   | api/main.py, api/app_setup.py, tests/conftest.py, tests/test_*api* (Phase 2 only) |
 | DEDUP-D   | agent-dd   | scripts/flush_city_pipeline_state.py, scripts/reset_city_verification_state.py, scripts/*_healthcheck.py, tests for same |
 | DEDUP-E   | agent-de   | pipeline/http_inference_provider.py, pipeline/inprocess_inference_provider.py, pipeline/inference_provider_contract.py, tests for same |
-| PLAT      | agent-plat | alembic/** (new), alembic.ini (new), pipeline/requirements*.txt, pipeline/db_init.py (T-PLAT-1 only), pipeline/db_migrate.py (T-PLAT-1 only, after TIME), pipeline/db_migration_columns.py (T-PLAT-1 legacy parity only), pipeline/migrate_v8.py (T-PLAT-1 frozen metadata only), pipeline/migration_pgvector_semantic_embeddings.py (T-PLAT-1 frozen metadata only), pipeline/seed_places.py (T-PLAT-1 schema handoff only), pipeline/promote_stage.py (T-PLAT-1 schema handoff only), scripts/dev_up.sh (T-PLAT-1 only), README.md (T-PLAT-1 setup section only), ARCHITECTURE.md (T-PLAT-1 migration map only), api/requirements.txt, semantic_service/requirements.txt, constraints.txt (new), .github/dependabot.yml (new), .github/workflows/python-guardrails.yml (T-PLAT-1 PostgreSQL migration service/step only), docs/OPERATIONS.md (migration and backup sections only), docs/PIPELINE.md (T-PLAT-1 migration section only), docs/CONTRIBUTING_CITIES.md (T-PLAT-1 seed prerequisite only), tests/test_alembic_migrations.py (new), tests/test_db_init.py (T-PLAT-1 only), tests/test_db_migrate.py (T-PLAT-1 only), tests/test_docker_build_contracts.py (T-PLAT-1 fresh-DB contract only), tests/test_migrate_v8_pgvector_order.py (T-PLAT-1 only), tests/test_seed_places.py (T-PLAT-1 schema handoff only), tests/test_seed_places_includes_cupertino.py (T-PLAT-1 schema handoff only), tests/test_database.py (T-PLAT-1 promotion schema handoff only), tests/test_pipeline_idempotency.py (T-PLAT-1 promotion schema handoff only), tests/test_pipeline_integration.py (T-PLAT-1 promotion schema handoff only), tests/test_repository_guardrails.py (T-PLAT-1 migration CI contract only), tests/test_run_pipeline_orchestration.py (T-PLAT-1 migration-prelude contract only), api/cache.py |
+| PLAT      | agent-plat | alembic/** (new), alembic.ini (new), pipeline/requirements*.txt, pipeline/db_init.py (T-PLAT-1 only), pipeline/db_migrate.py (T-PLAT-1 only, after TIME), pipeline/db_migration_alembic.py (new, T-PLAT-1 only), pipeline/db_migration_backfills.py (T-PLAT-1 shared transaction only), pipeline/db_migration_runner.py (T-PLAT-1 strict legacy path only), pipeline/db_schema_contracts.py (new, T-PLAT-1 only), pipeline/db_migration_columns.py (T-PLAT-1 legacy parity only), pipeline/migrate_v8.py (T-PLAT-1 frozen transaction adapter only), pipeline/migration_pgvector_semantic_embeddings.py (T-PLAT-1 frozen metadata only), pipeline/migrate_v9.py and pipeline/migration_catalog_lineage_columns.py (T-PLAT-1 shared transaction only), pipeline/migrate_v10.py (T-PLAT-1 shared transaction only), pipeline/seed_places.py (T-PLAT-1 schema handoff only), pipeline/promote_stage.py (T-PLAT-1 schema handoff only), scripts/check_schema_parity.py (new, T-PLAT-1 only), scripts/dev_up.sh (T-PLAT-1 only), README.md (T-PLAT-1 setup section only), ARCHITECTURE.md (T-PLAT-1 migration map only), api/requirements.txt, semantic_service/requirements.txt, constraints.txt (new), .github/dependabot.yml (new), .github/workflows/python-guardrails.yml (T-PLAT-1 PostgreSQL migration service/step only), docs/OPERATIONS.md (migration and backup sections only), docs/PIPELINE.md (T-PLAT-1 migration section only), docs/CONTRIBUTING_CITIES.md (T-PLAT-1 seed prerequisite only), docs/plans/T_PLAT_1_ALEMBIC_BASELINE_PLAN.md (new), docs/plans/G5_ALEMBIC_ADOPTION_DECISION_PLAN.md (T-PLAT-1 status only), docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md (T-PLAT-1 only), tests/test_alembic_migrations.py (new), tests/test_db_init.py (T-PLAT-1 only), tests/test_db_migrate.py (T-PLAT-1 only), tests/test_docker_build_contracts.py (T-PLAT-1 fresh-DB contract only), tests/test_migrate_v8_pgvector_order.py (T-PLAT-1 only), tests/test_migrate_v9.py (T-PLAT-1 only), tests/test_migrate_v10.py (T-PLAT-1 only), tests/test_seed_places.py (T-PLAT-1 schema handoff only), tests/test_seed_places_includes_cupertino.py (T-PLAT-1 schema handoff only), tests/test_database.py (T-PLAT-1 promotion schema handoff only), tests/test_pipeline_idempotency.py (T-PLAT-1 promotion schema handoff only), tests/test_pipeline_integration.py (T-PLAT-1 promotion schema handoff only), tests/test_repository_guardrails.py (T-PLAT-1 migration CI contract only), tests/test_run_pipeline_orchestration.py (T-PLAT-1 migration-prelude contract only), api/cache.py |
 | GOV       | agent-gov  | docs/ADR.md, docs/ENGINEERING_GUARDRAILS.md, AGENTS.md, SECURITY.md (new), docs/TESTING.md (new), docs/DATA_GOVERNANCE.md (new), tests/test_repository_guardrails.py (Phase 3 only) |
 
 Sequencing rule: SEC and DEDUP-C both own api/app_setup.py + api/main.py —
@@ -1115,17 +1122,29 @@ files (GED-5 grant).
 
 ### T-PLAT-1: Alembic baseline (gate G5)
 - priority: P1
-- status: approved; implementation pending
+- status: in progress
 - must_not_run_concurrently_with: T-GOV-3
 - decision_record: `docs/plans/G5_ALEMBIC_ADOPTION_DECISION_PLAN.md`
+- implementation_plan: `docs/plans/T_PLAT_1_ALEMBIC_BASELINE_PLAN.md`
 - files_owned: alembic/** (new), alembic.ini (new),
+  docs/plans/T_PLAT_1_ALEMBIC_BASELINE_PLAN.md,
+  docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md,
+  docs/plans/G5_ALEMBIC_ADOPTION_DECISION_PLAN.md (status only),
   pipeline/requirements.txt, pipeline/db_init.py (fresh-DB handoff),
   pipeline/db_migrate.py (Alembic handoff),
+  pipeline/db_migration_alembic.py (new),
+  pipeline/db_migration_backfills.py (shared transaction only),
+  pipeline/db_migration_runner.py (strict legacy path only),
+  pipeline/db_schema_contracts.py (new),
   pipeline/db_migration_columns.py (legacy parity repair only),
   pipeline/migrate_v8.py and
   pipeline/migration_pgvector_semantic_embeddings.py (frozen metadata only),
+  pipeline/migrate_v9.py and
+  pipeline/migration_catalog_lineage_columns.py (shared transaction only),
+  pipeline/migrate_v10.py (shared transaction only),
   pipeline/seed_places.py (schema handoff only),
   pipeline/promote_stage.py (schema handoff only),
+  scripts/check_schema_parity.py (new),
   scripts/dev_up.sh, README.md (setup section), ARCHITECTURE.md (migration
   map), docs/OPERATIONS.md and docs/PIPELINE.md (migration sections),
   docs/CONTRIBUTING_CITIES.md (seed prerequisite),
@@ -1135,6 +1154,7 @@ files (GED-5 grant).
   tests/test_db_init.py, tests/test_db_migrate.py,
   tests/test_docker_build_contracts.py (fresh-DB contract only),
   tests/test_migrate_v8_pgvector_order.py,
+  tests/test_migrate_v9.py, tests/test_migrate_v10.py,
   tests/test_seed_places.py and tests/test_seed_places_includes_cupertino.py
   (schema handoff only), tests/test_database.py,
   tests/test_pipeline_idempotency.py, and tests/test_pipeline_integration.py
@@ -1144,8 +1164,10 @@ files (GED-5 grant).
 - do: `alembic init`; autogenerate a baseline revision from current models
   after T-TIME-2, then reconcile it against an explicit inventory of every
   schema object created by the frozen legacy migrations. This inventory must
-  include legacy-only objects absent from model metadata, including
-  `ix_semantic_embedding_hnsw` and `ix_catalog_lineage_updated_at`.
+  include legacy-only objects absent from model metadata:
+  `ix_catalog_agenda_segmentation_attempted_at`,
+  `ix_catalog_agenda_segmentation_status`,
+  `ix_catalog_lineage_updated_at`, and `ix_semantic_embedding_hnsw`.
   Preserve the existing `python db_migrate.py` subprocess in
   `pipeline.run_pipeline`; make `db_migrate.migrate()` delegate through the
   frozen legacy runner when needed and then run `alembic upgrade head`.
@@ -1156,13 +1178,21 @@ files (GED-5 grant).
   `promote_stage.py`; operators must migrate before seeding or promotion.
   `pipeline/db_migrate.py` owns the only supported existing-database adoption
   path: run the legacy chain through v10, repair the known missing-index drift
-  in the existing column-migration owner, compare against the frozen baseline
-  schema, abort on drift, stamp the baseline, then upgrade to head. Delayed
+  in the existing column-migration owner, compare tables, columns, rendered
+  types, nullability, defaults, keys, constraints, indexes, predicates,
+  operator classes, sequences, ownership, and required extensions against
+  the frozen baseline, abort on drift, stamp the baseline, then upgrade to
+  head. Delayed
   adopters use that same frozen comparison even when newer revisions exist.
   Replace v8's mutable `Base.metadata.create_all()` dependency with frozen
   baseline metadata so later models cannot mutate delayed adopters before the
   parity check.
   Baseline upgrade creates the pgvector extension before baseline table DDL.
+  Execute legacy repair, baseline parity, stamp, and upgrade in one
+  caller-owned PostgreSQL transaction. Serialize migration entrypoints with
+  an immediate `pg_try_advisory_xact_lock`; conflict must fail fast rather
+  than wait. Legacy migration failures must propagate and must never permit
+  committed partial DDL or stamping.
   Keep migrate_v* readable but frozen (no v11+). Document fresh, existing,
   delayed-adoption, upgrade, and downgrade workflows; do not instruct operators
   to run an unguarded `alembic stamp`. The baseline is the downgrade floor:
@@ -1177,7 +1207,8 @@ files (GED-5 grant).
   `python db_migrate.py` subprocess remains unchanged and applies
   post-baseline revisions; attempting to downgrade below the baseline exits
   nonzero without changing schema or representative data; OPERATIONS documents
-  the baseline floor and supported workflows. Python Guardrails runs fresh,
+  the baseline floor, migration lock, derived-vector rehydration, and
+  supported workflows. Python Guardrails runs fresh,
   existing, delayed-adoption, upgrade, and downgrade tests against an isolated
   pgvector PostgreSQL service without optional skips. ARCHITECTURE maps
   Alembic as the authoritative post-baseline migration graph.

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,6 +1,6 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 3.51
+version: 3.52
 generated: 2026-07-26
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
@@ -10,6 +10,10 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v3.52:** Grants T-PLAT-1 narrow ownership of `ruff.toml` to remove the
+  stale `pipeline/db_migration_runner.py` BLE001 selector after the strict
+  legacy runner eliminated its broad handler. No Ruff rule, source scope, or
+  other exception changes.
 - **v3.51:** Marks coordinated T-TIME-1 and T-TIME-2 complete after PR #148
   merged with PostgreSQL migration evidence and activates T-PLAT-1. Expands
   T-PLAT-1 ownership for its Full plan, strict legacy runner, focused Alembic
@@ -318,7 +322,7 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 | DEDUP-C   | agent-dc   | api/main.py, api/app_setup.py, tests/conftest.py, tests/test_*api* (Phase 2 only) |
 | DEDUP-D   | agent-dd   | scripts/flush_city_pipeline_state.py, scripts/reset_city_verification_state.py, scripts/*_healthcheck.py, tests for same |
 | DEDUP-E   | agent-de   | pipeline/http_inference_provider.py, pipeline/inprocess_inference_provider.py, pipeline/inference_provider_contract.py, tests for same |
-| PLAT      | agent-plat | alembic/** (new), alembic.ini (new), pipeline/requirements*.txt, pipeline/db_init.py (T-PLAT-1 only), pipeline/db_migrate.py (T-PLAT-1 only, after TIME), pipeline/db_migration_alembic.py (new, T-PLAT-1 only), pipeline/db_migration_backfills.py (T-PLAT-1 shared transaction only), pipeline/db_migration_runner.py (T-PLAT-1 strict legacy path only), pipeline/db_schema_contracts.py (new, T-PLAT-1 only), pipeline/db_migration_columns.py (T-PLAT-1 legacy parity only), pipeline/migrate_v8.py (T-PLAT-1 frozen transaction adapter only), pipeline/migration_pgvector_semantic_embeddings.py (T-PLAT-1 frozen metadata only), pipeline/migrate_v9.py and pipeline/migration_catalog_lineage_columns.py (T-PLAT-1 shared transaction only), pipeline/migrate_v10.py (T-PLAT-1 shared transaction only), pipeline/seed_places.py (T-PLAT-1 schema handoff only), pipeline/promote_stage.py (T-PLAT-1 schema handoff only), scripts/check_schema_parity.py (new, T-PLAT-1 only), scripts/dev_up.sh (T-PLAT-1 only), README.md (T-PLAT-1 setup section only), ARCHITECTURE.md (T-PLAT-1 migration map only), api/requirements.txt, semantic_service/requirements.txt, constraints.txt (new), .github/dependabot.yml (new), .github/workflows/python-guardrails.yml (T-PLAT-1 PostgreSQL migration service/step only), docs/OPERATIONS.md (migration and backup sections only), docs/PIPELINE.md (T-PLAT-1 migration section only), docs/CONTRIBUTING_CITIES.md (T-PLAT-1 seed prerequisite only), docs/plans/T_PLAT_1_ALEMBIC_BASELINE_PLAN.md (new), docs/plans/G5_ALEMBIC_ADOPTION_DECISION_PLAN.md (T-PLAT-1 status only), docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md (T-PLAT-1 only), tests/test_alembic_migrations.py (new), tests/test_db_init.py (T-PLAT-1 only), tests/test_db_migrate.py (T-PLAT-1 only), tests/test_docker_build_contracts.py (T-PLAT-1 fresh-DB contract only), tests/test_migrate_v8_pgvector_order.py (T-PLAT-1 only), tests/test_migrate_v9.py (T-PLAT-1 only), tests/test_migrate_v10.py (T-PLAT-1 only), tests/test_seed_places.py (T-PLAT-1 schema handoff only), tests/test_seed_places_includes_cupertino.py (T-PLAT-1 schema handoff only), tests/test_database.py (T-PLAT-1 promotion schema handoff only), tests/test_pipeline_idempotency.py (T-PLAT-1 promotion schema handoff only), tests/test_pipeline_integration.py (T-PLAT-1 promotion schema handoff only), tests/test_repository_guardrails.py (T-PLAT-1 migration CI contract only), tests/test_run_pipeline_orchestration.py (T-PLAT-1 migration-prelude contract only), api/cache.py |
+| PLAT      | agent-plat | alembic/** (new), alembic.ini (new), pipeline/requirements*.txt, pipeline/db_init.py (T-PLAT-1 only), pipeline/db_migrate.py (T-PLAT-1 only, after TIME), pipeline/db_migration_alembic.py (new, T-PLAT-1 only), pipeline/db_migration_backfills.py (T-PLAT-1 shared transaction only), pipeline/db_migration_runner.py (T-PLAT-1 strict legacy path only), pipeline/db_schema_contracts.py (new, T-PLAT-1 only), pipeline/db_migration_columns.py (T-PLAT-1 legacy parity only), pipeline/migrate_v8.py (T-PLAT-1 frozen transaction adapter only), pipeline/migration_pgvector_semantic_embeddings.py (T-PLAT-1 frozen metadata only), pipeline/migrate_v9.py and pipeline/migration_catalog_lineage_columns.py (T-PLAT-1 shared transaction only), pipeline/migrate_v10.py (T-PLAT-1 shared transaction only), pipeline/seed_places.py (T-PLAT-1 schema handoff only), pipeline/promote_stage.py (T-PLAT-1 schema handoff only), scripts/check_schema_parity.py (new, T-PLAT-1 only), scripts/dev_up.sh (T-PLAT-1 only), README.md (T-PLAT-1 setup section only), ARCHITECTURE.md (T-PLAT-1 migration map only), api/requirements.txt, semantic_service/requirements.txt, constraints.txt (new), .github/dependabot.yml (new), .github/workflows/python-guardrails.yml (T-PLAT-1 PostgreSQL migration service/step only), ruff.toml (T-PLAT-1 stale db_migration_runner.py BLE001 selector removal only), docs/OPERATIONS.md (migration and backup sections only), docs/PIPELINE.md (T-PLAT-1 migration section only), docs/CONTRIBUTING_CITIES.md (T-PLAT-1 seed prerequisite only), docs/plans/T_PLAT_1_ALEMBIC_BASELINE_PLAN.md (new), docs/plans/G5_ALEMBIC_ADOPTION_DECISION_PLAN.md (T-PLAT-1 status only), docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md (T-PLAT-1 only), tests/test_alembic_migrations.py (new), tests/test_db_init.py (T-PLAT-1 only), tests/test_db_migrate.py (T-PLAT-1 only), tests/test_docker_build_contracts.py (T-PLAT-1 fresh-DB contract only), tests/test_migrate_v8_pgvector_order.py (T-PLAT-1 only), tests/test_migrate_v9.py (T-PLAT-1 only), tests/test_migrate_v10.py (T-PLAT-1 only), tests/test_seed_places.py (T-PLAT-1 schema handoff only), tests/test_seed_places_includes_cupertino.py (T-PLAT-1 schema handoff only), tests/test_database.py (T-PLAT-1 promotion schema handoff only), tests/test_pipeline_idempotency.py (T-PLAT-1 promotion schema handoff only), tests/test_pipeline_integration.py (T-PLAT-1 promotion schema handoff only), tests/test_repository_guardrails.py (T-PLAT-1 migration CI and BLE001 ratchet only), tests/test_run_pipeline_orchestration.py (T-PLAT-1 migration-prelude contract only), api/cache.py |
 | GOV       | agent-gov  | docs/ADR.md, docs/ENGINEERING_GUARDRAILS.md, AGENTS.md, SECURITY.md (new), docs/TESTING.md (new), docs/DATA_GOVERNANCE.md (new), tests/test_repository_guardrails.py (Phase 3 only) |
 
 Sequencing rule: SEC and DEDUP-C both own api/app_setup.py + api/main.py —
@@ -347,6 +351,9 @@ in `AGENTS.md`, `docs/TESTING.MD`, and
 T-PLAT-1 and T-GOV-3 MUST NOT run concurrently because both own focused
 changes in `tests/test_repository_guardrails.py`; whichever starts second
 must wait for the first PR to merge and rebase on `master`.
+T-PLAT-1 also receives a narrow operator-approved coordination grant over
+CI-owned `ruff.toml` for removal of the stale
+`pipeline/db_migration_runner.py` BLE001 selector only.
 
 ---
 
@@ -1130,6 +1137,7 @@ files (GED-5 grant).
   docs/plans/T_PLAT_1_ALEMBIC_BASELINE_PLAN.md,
   docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md,
   docs/plans/G5_ALEMBIC_ADOPTION_DECISION_PLAN.md (status only),
+  ruff.toml (`pipeline/db_migration_runner.py` BLE001 selector removal only),
   pipeline/requirements.txt, pipeline/db_init.py (fresh-DB handoff),
   pipeline/db_migrate.py (Alembic handoff),
   pipeline/db_migration_alembic.py (new),
@@ -1159,7 +1167,7 @@ files (GED-5 grant).
   (schema handoff only), tests/test_database.py,
   tests/test_pipeline_idempotency.py, and tests/test_pipeline_integration.py
   (promotion schema handoff only),
-  tests/test_repository_guardrails.py (migration CI contract only),
+  tests/test_repository_guardrails.py (migration CI and BLE001 ratchet only),
   tests/test_run_pipeline_orchestration.py (migration-prelude contract only)
 - do: `alembic init`; autogenerate a baseline revision from current models
   after T-TIME-2, then reconcile it against an explicit inventory of every

--- a/docs/plans/T_PLAT_1_ALEMBIC_BASELINE_PLAN.md
+++ b/docs/plans/T_PLAT_1_ALEMBIC_BASELINE_PLAN.md
@@ -43,6 +43,7 @@ The task-level ownership set is authoritative for this PR:
 - `docs/plans/G5_ALEMBIC_ADOPTION_DECISION_PLAN.md`
 - `alembic.ini`
 - `alembic/**`
+- `ruff.toml` (`pipeline/db_migration_runner.py` BLE001 selector removal only)
 - `pipeline/requirements.txt`
 - `pipeline/db_init.py`
 - `pipeline/db_migrate.py`
@@ -78,7 +79,7 @@ The task-level ownership set is authoritative for this PR:
 - `tests/test_database.py` promotion handoff only
 - `tests/test_pipeline_idempotency.py` promotion handoff only
 - `tests/test_pipeline_integration.py` promotion handoff only
-- `tests/test_repository_guardrails.py` migration CI contract only
+- `tests/test_repository_guardrails.py` migration CI and BLE001 ratchet only
 - `tests/test_run_pipeline_orchestration.py` migration prelude only
 
 T-GOV-3 must not run concurrently. The pypdf and PostCSS security alerts are
@@ -190,8 +191,8 @@ New-module responsibilities and import direction:
 - `pipeline/db_migration_alembic.py`: state machine, transaction, lock, and
   Alembic commands; imports schema contracts and frozen legacy owners, never
   `db_migrate`.
-- `scripts/check_schema_parity.py`: CLI translation only; imports the schema
-  contract owner, never the facade.
+- `scripts/check_schema_parity.py`: CLI translation only; imports the Alembic
+  parity operation, which delegates comparison to the schema contract owner.
 - `alembic/env.py`: Alembic runtime adapter; imports model metadata only for
   future autogeneration and accepts an external connection through
   `Config.attributes`.
@@ -297,10 +298,11 @@ All timestamps remain timezone-aware UTC.
 - H2-H4: no type suppression, hand-rolled alternate contract, or import-time
   engine/network work.
 
-**o) Ratchet interaction.** No Ruff selector, BLE001 boundary, coverage floor,
-formatter scope, or Mypy scope is widened. `db_migration_runner.py` leaves the
-BLE001 inventory if its only broad handler is removed. The guardrail test adds
-only migration CI and no-v11 contracts.
+**o) Ratchet interaction.** No Ruff rule, coverage floor, formatter scope, or
+Mypy scope is widened. The operator-approved scope correction removes one
+stale selector: `pipeline/db_migration_runner.py` leaves the BLE001 inventory
+after its only broad handler is removed. The guardrail test adds only
+migration CI and no-v11 contracts.
 
 **p) Dead code and duplication audit.** Delete mutable v8 metadata access,
 best-effort migration swallowing, implicit schema creation in three
@@ -476,13 +478,19 @@ PYTHONPATH=. .venv/bin/python -m pytest -q \
   --cov-report=term-missing:skip-covered tests/
 docker compose config --quiet
 docker compose build pipeline api worker
-docker compose down --volumes
-docker compose up -d postgres
-docker compose run --rm pipeline python db_migrate.py
-docker compose run --rm pipeline python seed_places.py
-docker compose up -d api worker
-docker compose exec -T api python -c \
+COMPOSE_PROJECT_NAME=town-council-alembic-smoke \
+  docker compose up -d postgres
+COMPOSE_PROJECT_NAME=town-council-alembic-smoke \
+  docker compose run --rm pipeline python db_migrate.py
+COMPOSE_PROJECT_NAME=town-council-alembic-smoke \
+  docker compose run --rm pipeline python seed_places.py
+COMPOSE_PROJECT_NAME=town-council-alembic-smoke \
+  docker compose up -d api worker
+COMPOSE_PROJECT_NAME=town-council-alembic-smoke \
+  docker compose exec -T api python -c \
   "from pipeline.models import db_connect; print(db_connect().dialect.name)"
+COMPOSE_PROJECT_NAME=town-council-alembic-smoke \
+  docker compose down --volumes
 git diff --check
 git status --short
 ```
@@ -541,10 +549,11 @@ count, schema parity output, row checksums, downgrade result, Docker smoke,
 full-suite counts/coverage, planning-review findings, pre-commit findings,
 commit hashes, PR URL, unresolved thread count, and CI state.
 
-**z) Deviations.** Expected deviations: none. Any additional file, new
-environment variable, unsupported stamp path, optional PostgreSQL CI skip,
-post-v10 numbered migration, dual schema owner, unresolved P1/P2, or unrun
-required check blocks handoff.
+**z) Deviations.** Authorized deviation: T-PLAT-1 owns the one-line
+`ruff.toml` removal required by its strict legacy-runner change. Any other
+additional file, new environment variable, unsupported stamp path, optional
+PostgreSQL CI skip, post-v10 numbered migration, dual schema owner, unresolved
+P1/P2, or unrun required check blocks handoff.
 
 ## Independent Planning Review Incorporated
 

--- a/docs/plans/T_PLAT_1_ALEMBIC_BASELINE_PLAN.md
+++ b/docs/plans/T_PLAT_1_ALEMBIC_BASELINE_PLAN.md
@@ -1,0 +1,566 @@
+# T-PLAT-1: Establish the Alembic Baseline
+
+`artifact_contract: ce-unified-plan/v1`
+`artifact_readiness: implementation-ready`
+`execution: code`
+
+## 1. Context & Alignment
+
+**a) Driver.** T-TIME-1 and T-TIME-2 are merged, so the final numbered
+migration is authoritative on `master`. Town Council now needs one
+transactionally guarded migration entrypoint for fresh databases, existing
+unversioned databases, and future Alembic revisions. The current path is not
+safe enough to stamp: v8 reads mutable application metadata, v8/v9 failures
+are logged and swallowed, setup and operational commands can create tables
+outside migrations, and legacy-only indexes are absent from model metadata.
+
+**b) Canonical documents consulted.**
+
+- `AGENTS.md`: G5 approval, tests-first work, PostgreSQL evidence, config and
+  guardrail verification, no new compatibility seams, and exact reporting.
+- `ARCHITECTURE.md`: `pipeline/db_migrate.py` remains the migration facade and
+  `pipeline/run_pipeline.py` retains the `python db_migrate.py` subprocess.
+- `docs/TESTING.MD`: PostgreSQL is the approved database boundary; tests patch
+  implementation modules rather than migration facades.
+- `docs/ENGINEERING_GUARDRAILS.md`: SQL identifiers must use SQLAlchemy
+  constructs or dialect quoting; broad handlers require an existing boundary.
+- `docs/OPERATIONS.md`: existing migration and backup procedures must remain
+  fail-fast and locally reproducible.
+- `docs/DATA_GOVERNANCE.md`: schema adoption must preserve stored civic data.
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`: T-PLAT-1 scope, G5 decision,
+  immutable numbered-migration history, and exclusion with T-GOV-3.
+- `docs/plans/G5_ALEMBIC_ADOPTION_DECISION_PLAN.md`: Alembic owns every
+  post-baseline migration; `migrate_v1` through `migrate_v10` become frozen
+  adoption history.
+- `docs/reviews/architecture-review-2026-07-19.html`: do not add another
+  migration stratum; make one entrypoint authoritative.
+
+**c) Remediation alignment.** This is Phase 3 task T-PLAT-1 in the PLAT lane.
+The task-level ownership set is authoritative for this PR:
+
+- `docs/plans/T_PLAT_1_ALEMBIC_BASELINE_PLAN.md`
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`
+- `docs/plans/G5_ALEMBIC_ADOPTION_DECISION_PLAN.md`
+- `alembic.ini`
+- `alembic/**`
+- `pipeline/requirements.txt`
+- `pipeline/db_init.py`
+- `pipeline/db_migrate.py`
+- `pipeline/db_migration_alembic.py` (new)
+- `pipeline/db_migration_backfills.py`
+- `pipeline/db_migration_runner.py`
+- `pipeline/db_schema_contracts.py` (new)
+- `pipeline/db_migration_columns.py`
+- `pipeline/migrate_v8.py`
+- `pipeline/migration_pgvector_semantic_embeddings.py`
+- `pipeline/migrate_v9.py`
+- `pipeline/migration_catalog_lineage_columns.py`
+- `pipeline/migrate_v10.py`
+- `pipeline/seed_places.py`
+- `pipeline/promote_stage.py`
+- `scripts/check_schema_parity.py` (new)
+- `scripts/dev_up.sh`
+- `README.md` setup section
+- `ARCHITECTURE.md` migration map
+- `docs/OPERATIONS.md` migration and backup sections
+- `docs/PIPELINE.md` migration section
+- `docs/CONTRIBUTING_CITIES.md` seed prerequisite
+- `.github/workflows/python-guardrails.yml` migration step only
+- `tests/test_alembic_migrations.py` (new)
+- `tests/test_db_init.py`
+- `tests/test_db_migrate.py`
+- `tests/test_docker_build_contracts.py` fresh-database contract only
+- `tests/test_migrate_v8_pgvector_order.py`
+- `tests/test_migrate_v9.py`
+- `tests/test_migrate_v10.py`
+- `tests/test_seed_places.py`
+- `tests/test_seed_places_includes_cupertino.py`
+- `tests/test_database.py` promotion handoff only
+- `tests/test_pipeline_idempotency.py` promotion handoff only
+- `tests/test_pipeline_integration.py` promotion handoff only
+- `tests/test_repository_guardrails.py` migration CI contract only
+- `tests/test_run_pipeline_orchestration.py` migration prelude only
+
+T-GOV-3 must not run concurrently. The pypdf and PostCSS security alerts are
+separate dependency work and must not be hidden in this migration PR.
+
+**d) Decision-gate check.** G5 was approved on 2026-07-24. G1-G4 are not
+changed or foreclosed. No open decision gate blocks implementation.
+
+## 2. Design
+
+**e) Step-by-step approach.**
+
+1. Add Alembic `1.18.5` to `pipeline/requirements.txt`, initialize the standard
+   Alembic environment, and configure it from the repository-root
+   `alembic.ini`. Do not add an environment variable or a second database URL
+   parser.
+2. Generate the candidate baseline against an isolated, empty PostgreSQL
+   database after v10. Manually reconcile the revision with frozen legacy
+   behavior. The checked-in revision must contain explicit Alembic operations;
+   it must not import mutable application metadata.
+3. Make the baseline revision create the `vector` extension before any vector
+   column. Include every current table, column, constraint, sequence-backed
+   identity, server default, ordinary index, partial index, HNSW operator
+   class, and these four legacy-only indexes:
+   - `ix_catalog_agenda_segmentation_attempted_at`
+   - `ix_catalog_agenda_segmentation_status`
+   - `ix_catalog_lineage_updated_at`
+   - `ix_semantic_embedding_hnsw`
+4. Make the baseline the downgrade floor. Its `downgrade()` raises before DDL.
+   Later revisions may downgrade to the baseline but not below it.
+5. Add `pipeline/db_schema_contracts.py`. Its sole responsibility is to
+   inspect two PostgreSQL schemas into typed immutable contracts and return an
+   ordered, operator-readable difference. Compare tables, columns, rendered
+   types, nullability, normalized defaults, primary keys, foreign keys and
+   actions, unique/check constraints, indexes including predicates and
+   operator classes, sequences and ownership, and the required `vector`
+   extension. Exclude `alembic_version` and extension-owned objects.
+6. Add `pipeline/db_migration_alembic.py`. Its sole responsibility is to own
+   Alembic configuration, migration-state detection, a PostgreSQL advisory
+   lock, guarded adoption, stamping, and upgrade. It imports contracts but
+   neither contracts nor `alembic/env.py` import the facade.
+7. Preserve SQLite behavior as a migration no-op. For PostgreSQL, open one
+   connection and one outer transaction for the complete state transition:
+   - acquire `pg_try_advisory_xact_lock` once and fail immediately with a
+     typed lock-conflict error when another migrator owns it;
+   - if no application tables exist, run `upgrade head`;
+   - if an Alembic version exists, run `upgrade head`;
+   - if unversioned application tables exist, run the strict frozen legacy
+     chain through v10, repair known indexes, build the baseline in a unique
+     temporary schema, compare it with `public`, abort on any difference,
+     stamp the baseline, then upgrade to head;
+   - commit only after the complete state transition succeeds. Any migration,
+     parity, stamp, or upgrade error rolls back legacy DDL, data backfills,
+     temporary-schema work, and version state together.
+8. Use a shared SQLAlchemy `Connection` through `Config.attributes` for each
+   Alembic command. For reference construction, set
+   `version_table_schema` to the generated temporary schema, set transaction
+   local `search_path`, and restore it before the public comparison and stamp.
+   Generate temporary schema names internally and use SQLAlchemy schema DDL
+   plus bound values for `search_path`; never interpolate an identifier into
+   `text()`. Drop the temporary schema and temporary version table before
+   commit.
+9. Make the legacy runner strict. Remove its broad warning-and-continue
+   handler and injectable module arguments. Refactor v8, v9, v10, and core
+   backfills to operate on the caller-owned `Connection`; their historical
+   CLI wrappers may acquire a connection but contain no second implementation.
+   A v8, v9, v10, repair, parity, or Alembic failure propagates and guarantees
+   no committed schema or stamp.
+10. Freeze v8 table metadata inside
+    `migration_pgvector_semantic_embeddings.py`. It may create only the
+    semantic-embedding table and required referenced-table stubs; it must not
+    call current `Base.metadata.create_all()`. Preflight the legacy schema
+    contract and count values in the retired catalog vector column before v8.
+    The column drop and all other v8 work occur inside the adoption
+    transaction, so a later failure restores them. Successful adoption records
+    the derived-value count and documents rehydration.
+11. Ensure known indexes independently of whether their columns were added in
+    the current run. This repairs databases where a previous migration added a
+    column but failed before its index.
+12. Keep `pipeline/db_migrate.py` as the small public facade. It delegates once
+    to the Alembic migration owner. Keep the exact pipeline subprocess
+    `["python", "db_migrate.py"]`.
+13. Make `pipeline/db_init.py` delegate to the migration owner rather than
+    `create_tables()`. Update `scripts/dev_up.sh` to start migration
+    prerequisites, run migration, then start schema consumers so API and
+    workers cannot race table creation.
+14. Remove implicit `create_tables()` from seed and promotion commands. Missing
+    schema errors must cause a nonzero CLI exit after rollback and contextual
+    logging.
+15. Add `scripts/check_schema_parity.py` as a thin operator CLI over the typed
+    comparison owner. It prints an empty difference on parity and exits nonzero
+    with ordered differences on drift.
+16. Add PostgreSQL acceptance tests using isolated databases, not schemas, for
+    extension-free, fresh, existing-v10, delayed, drifted, partial,
+    concurrent, post-baseline upgrade, and downgrade-floor scenarios.
+17. Add a mandatory migration test step to Python Guardrails. Reuse its
+    existing `pgvector/pgvector:pg15` service and
+    `TEST_POSTGRES_DATABASE_URL`; do not add a second service.
+18. Update only the named setup, migration, backup, architecture, and
+    migrate-before-seed documentation.
+19. Run simplification, a fresh subagent pre-commit review, all required
+    verification, two atomic commits, push, PR creation, and bounded CI review
+    repair.
+
+New-module responsibilities and import direction:
+
+- `pipeline/db_schema_contracts.py`: PostgreSQL inspection and typed
+  comparison only; imports SQLAlchemy, never migration orchestration.
+- `pipeline/db_migration_alembic.py`: state machine, transaction, lock, and
+  Alembic commands; imports schema contracts and frozen legacy owners, never
+  `db_migrate`.
+- `scripts/check_schema_parity.py`: CLI translation only; imports the schema
+  contract owner, never the facade.
+- `alembic/env.py`: Alembic runtime adapter; imports model metadata only for
+  future autogeneration and accepts an external connection through
+  `Config.attributes`.
+
+**f) Reuse audit.** Reuse `pipeline/db_migrate.py` as facade,
+`pipeline/db_migration_columns.py` as legacy repair owner, v8-v10 as frozen
+history, `pipeline.models.db_connect`, the current PostgreSQL CI service, and
+the existing pipeline subprocess. New modules are required because migration
+state/locking and normalized schema comparison are separate responsibilities
+that do not fit the facade or Alembic runtime adapter. This supersedes
+`create_all()` setup and best-effort legacy migration; both supported paths
+are removed in the same PR.
+
+Rejected alternatives:
+
+- Stamp every existing database without comparison: rejected because it can
+  bless missing constraints or indexes.
+- Compare existing databases with current `Base.metadata`: rejected because
+  later model changes would mutate the adoption contract.
+- Keep both `db_init.py` table creation and Alembic setup: rejected because it
+  creates competing schema owners.
+- Put the entire adoption state machine in `alembic/env.py`: rejected because
+  the runtime adapter would become an application facade.
+- Use only `alembic check`: rejected because extensions, legacy-only objects,
+  sequence ownership, and PostgreSQL index details need explicit comparison.
+- Add a strict-mode boolean to the legacy runner: rejected because the
+  supported migration path must always fail fast.
+
+**g) Data contracts.** Use frozen dataclasses for schema, table, column,
+constraint, index, sequence, and difference contracts. Database introspection
+is a trust boundary; raw inspector dictionaries are normalized immediately
+and do not cross the contract owner. Alembic revision identifiers remain
+strings owned by Alembic.
+
+**h) Schema and migrations.** Add one immutable Alembic baseline revision
+representing the v10 schema. No application data transformation is added
+beyond the existing frozen legacy chain. The baseline is idempotent through
+Alembic versioning, uses timezone-aware timestamp declarations established by
+v10, and cannot downgrade. No `migrate_v11.py` or later numbered migration is
+allowed.
+
+Dependency change: add exact runtime pin `alembic==1.18.5`. A dry-run against
+the current environment resolves new transitive `Mako==1.3.12` and reuses
+SQLAlchemy `2.0.38`, typing-extensions `4.15.0`, and MarkupSafe `3.0.3`.
+No conflict was reported. Python 3.14 installation, import, and migration
+execution remain mandatory evidence because upstream package classifiers do
+not yet advertise Python 3.14.
+
+## 3. Security & Data Governance
+
+**i) Security-sensitive paths.** `.github/workflows/python-guardrails.yml` is
+not listed as a security-sensitive runtime path. No Docker, credential, CORS,
+or externally reachable boundary changes. The migration connection retains
+the existing database privilege boundary. The operator must have table,
+extension, temporary-schema, and advisory-lock privileges; missing privilege
+fails before stamping.
+
+**j) Secrets.** No credential, key, environment variable, or working default
+is added. Alembic receives the existing SQLAlchemy connection; the database URL
+is not printed.
+
+**k) Person data.** Existing civic records, including official-person records,
+are preserved. No person linking, aggregation, or exposure changes. Adoption
+tests compare representative row counts and checksums before and after
+stamping.
+
+**l) Untrusted input.** Existing database schemas are untrusted adoption input.
+They are inspected into typed contracts and must equal the immutable baseline
+before stamping. Schema names used by the temporary reference database path
+are internally generated. No scraped text is parsed or rendered.
+
+## 4. Code Health
+
+**m) GED conformance sweep.** New functions have complete annotations and one
+responsibility. Complex comparison and orchestration branches are decomposed
+before Ruff C901 reaches 10. Constants own the baseline revision, advisory
+lock key, required extension, legacy-only indexes, and temporary-schema
+prefix. New filesystem logic uses `Path`. Errors are raised as typed migration
+or schema-drift failures after contextual logging; no broad handler is added.
+All timestamps remain timezone-aware UTC.
+
+**n) Antipattern scan, plan pass.**
+
+- A1/H1: Alembic `1.18.5` APIs were verified with current official docs:
+  `Config`, `Config.attributes`, `command.upgrade`, `command.current`,
+  `command.stamp`, `command.downgrade`, and external-connection `env.py`.
+  Autogenerate limits require manual PostgreSQL reconciliation.
+- A2-A4: no env var, silent default, placeholder, or unverified success claim.
+- B1: the two production modules and one CLI have named, necessary
+  responsibilities; no generic manager, factory, registry, or utility module.
+- B2/C1: `create_all()` setup and best-effort migration are deleted; no dual
+  supported migration path or compatibility alias remains.
+- B3: validation covers reachable adoption drift and concurrent migration, not
+  speculative conditions.
+- C2/D2: tests use PostgreSQL/filesystem/subprocess boundaries and do not add
+  patchability arguments or facade patches.
+- D1/D3: no skip, xfail, tolerance increase, weakened assertion, or private
+  spelling contract.
+- E1-E3: edits stay within the registered set; no repository-wide formatting
+  or generated-file replacement.
+- F1/F2: one comparison owner and one orchestration owner; no copied schema
+  comparator.
+- H2-H4: no type suppression, hand-rolled alternate contract, or import-time
+  engine/network work.
+
+**o) Ratchet interaction.** No Ruff selector, BLE001 boundary, coverage floor,
+formatter scope, or Mypy scope is widened. `db_migration_runner.py` leaves the
+BLE001 inventory if its only broad handler is removed. The guardrail test adds
+only migration CI and no-v11 contracts.
+
+**p) Dead code and duplication audit.** Delete mutable v8 metadata access,
+best-effort migration swallowing, implicit schema creation in three
+entrypoints, and stale tests/docs that preserve those behaviors. Reuse the
+frozen v8-v10 operations and current database boundary. Production lines grow
+for the explicit baseline and parity contract, while supported migration
+entrypoints decrease from two to one.
+
+## 5. Testing
+
+**q) Edge cases, races, and failure scenarios.**
+
+1. Empty PostgreSQL without `vector`.
+2. SQLite invocation.
+3. Existing unversioned v10 database.
+4. Delayed adopter after a post-baseline revision exists.
+5. Partial legacy migration with columns present and indexes absent.
+6. Missing, extra, or changed table/column/type/nullability/default.
+7. Changed PK, FK action, unique/check constraint, index predicate/opclass, or
+   sequence ownership.
+8. v8, v9, v10, repair, parity, stamp, or upgrade failure.
+9. Two migrators start concurrently.
+10. Downgrade below baseline.
+11. Current model adds a table after the frozen v8 contract.
+12. Seed or promotion runs before migration.
+13. API/worker startup races migration.
+14. Existing derived catalog vector data is removed by frozen v8.
+15. Alembic on Python 3.14 with pinned SQLAlchemy and pgvector.
+16. Unknown Alembic revision or multiple heads.
+17. Temporary reference schema cleanup fails.
+
+Handling:
+
+- Scenarios 1 and 3-7 run inside isolated PostgreSQL databases and compare
+  immutable contracts before stamp.
+- Scenario 2 returns without schema work, preserving current local tests.
+- Scenario 8 propagates a typed failure; no stamp occurs.
+- Scenario 9 fails the second migrator immediately through a fixed
+  transaction-scoped advisory lock; it never waits indefinitely.
+- Scenario 10 raises before DDL and preserves schema plus data checksums.
+- Scenario 11 proves v8 does not read current metadata.
+- Scenario 12 exits nonzero and logs the missing-schema operation.
+- Scenario 13 changes startup ordering: dependencies, migrate, consumers.
+- Scenario 14 records derived-vector counts and documents mandatory
+  rehydration after adoption; system-of-record rows remain unchanged.
+- Scenarios 15-16 are mandatory CI failures, not optional skips.
+- Scenario 17 logs cleanup context and re-raises; the migration transaction
+  remains failed and unstamped.
+
+**r) Tests added or updated.**
+
+| Test | Scenarios |
+|---|---|
+| Fresh PostgreSQL baseline upgrade | 1, 7, 15 |
+| SQLite no-op contract | 2 |
+| Existing-v10 adoption and parity | 3, 5-8 |
+| Delayed adopter with test-only later revision | 4, 16 |
+| Parameterized drift rejection | 6, 7 |
+| Failure-before-stamp tests | 8, 17 |
+| Concurrent migrator integration test with elapsed-time ceiling | 9 |
+| Downgrade-floor data-preservation test | 10 |
+| Frozen-v8 sentinel metadata test | 11 |
+| Seed/promotion missing-schema CLI tests | 12 |
+| Dev startup and Docker contract tests | 13 |
+| Derived-vector remediation evidence test | 14 |
+| Guardrail workflow contract | 15 |
+| No-v11 repository guardrail | 16 |
+| Schema parity CLI contract | 3, 6, 7 |
+| Existing pipeline orchestration contract | 13 |
+
+Every PostgreSQL migration scenario is mandatory in CI. Local execution may
+report `NOT VERIFIED` only when the configured PostgreSQL boundary is absent;
+the PR cannot be considered decided until CI runs them without skips.
+
+**s) Fakes and mocks.** PostgreSQL tests use the approved database boundary and
+create unique temporary databases. CLI tests use approved filesystem and
+subprocess boundaries. Unit tests may patch `pipeline.models.db_connect` or
+the Alembic implementation module, never `pipeline.db_migrate` re-exports. No
+new seam is added.
+
+**t) Verification rows.** Apply guardrail/tooling, typed-subtree,
+pipeline/task orchestration, and docs-only rows. Run PostgreSQL migration
+acceptance, Docker configuration/build contracts, and the complete
+coverage-enforced Python suite because this is cross-cutting.
+
+## 6. Execution, Rollback, Docs
+
+**u) Exact commands.**
+
+Baseline and branch:
+
+```bash
+git fetch origin --prune
+git switch master
+git merge --ff-only origin/master
+git switch -c codex/t-plat-1-alembic-baseline
+```
+
+Dependency verification and installation:
+
+```bash
+.venv/bin/python -m pip index versions alembic
+.venv/bin/python -m pip install "alembic==1.18.5"
+.venv/bin/python -c \
+  "import alembic, sqlalchemy; print(alembic.__version__, sqlalchemy.__version__)"
+```
+
+Tests-first red evidence:
+
+```bash
+PYTHONPATH=. TEST_POSTGRES_DATABASE_URL="$TEST_POSTGRES_DATABASE_URL" \
+  .venv/bin/pytest -q \
+  tests/test_alembic_migrations.py \
+  tests/test_db_init.py \
+  tests/test_db_migrate.py \
+  tests/test_migrate_v8_pgvector_order.py \
+  tests/test_seed_places.py \
+  tests/test_database.py \
+  tests/test_docker_build_contracts.py
+```
+
+Generate the candidate revision only against a disposable empty PostgreSQL
+database. The preflight count must be zero before autogeneration. This example
+uses the existing Compose service and deletes only the named disposable
+database:
+
+```bash
+docker compose exec -T postgres \
+  sh -c 'dropdb --if-exists --username "$POSTGRES_USER" tc_alembic_candidate'
+docker compose exec -T postgres \
+  sh -c 'createdb --username "$POSTGRES_USER" tc_alembic_candidate'
+test "$(
+  docker compose exec -T postgres \
+    sh -c 'psql --username "$POSTGRES_USER" --dbname tc_alembic_candidate --tuples-only --no-align --command "select count(*) from pg_catalog.pg_tables where schemaname = current_schema()"'
+)" = "0"
+test -n "${TEST_POSTGRES_DATABASE_URL:-}"
+DATABASE_URL="${TEST_POSTGRES_DATABASE_URL%/*}/tc_alembic_candidate" \
+  .venv/bin/alembic revision \
+  --autogenerate \
+  -m "establish v10 baseline"
+docker compose exec -T postgres \
+  sh -c 'dropdb --username "$POSTGRES_USER" tc_alembic_candidate'
+```
+
+Focused verification:
+
+```bash
+./.venv/bin/ruff check .
+./.venv/bin/pre-commit run ruff --all-files
+./.venv/bin/mypy
+PYTHONPATH=. TEST_POSTGRES_DATABASE_URL="$TEST_POSTGRES_DATABASE_URL" \
+  .venv/bin/pytest -q tests/test_alembic_migrations.py
+PYTHONPATH=. .venv/bin/pytest -q \
+  tests/test_db_init.py \
+  tests/test_db_migrate.py \
+  tests/test_docker_build_contracts.py \
+  tests/test_migrate_v8_pgvector_order.py \
+  tests/test_seed_places.py \
+  tests/test_seed_places_includes_cupertino.py \
+  tests/test_database.py \
+  tests/test_pipeline_idempotency.py \
+  tests/test_pipeline_integration.py \
+  tests/test_repository_guardrails.py \
+  tests/test_run_pipeline_orchestration.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py
+```
+
+Full and container verification:
+
+```bash
+PYTHONPATH=. .venv/bin/python -m pytest -q \
+  --cov --cov-config=.coveragerc \
+  --cov-report=term-missing:skip-covered tests/
+docker compose config --quiet
+docker compose build pipeline api worker
+docker compose down --volumes
+docker compose up -d postgres
+docker compose run --rm pipeline python db_migrate.py
+docker compose run --rm pipeline python seed_places.py
+docker compose up -d api worker
+docker compose exec -T api python -c \
+  "from pipeline.models import db_connect; print(db_connect().dialect.name)"
+git diff --check
+git status --short
+```
+
+LFG delivery:
+
+1. Simplify the branch diff without changing contracts.
+2. Run a fresh subagent pre-commit review against this plan.
+3. Apply every eligible P1/P2 and rerun affected checks.
+4. Commit planning and implementation separately.
+5. Push `codex/t-plat-1-alembic-baseline`.
+6. Open `T-PLAT-1: Establish the Alembic baseline`.
+7. Run browser routing in pipeline mode; expect `NOT APPLICABLE`.
+8. Watch CI and review to a decided state without merging.
+
+**v) Rollback.** The baseline has no supported downgrade. Before deployment,
+take a `pg_dump --format=custom` backup and record row counts/checksums. If
+adoption fails, the outer PostgreSQL transaction restores schema, data, and
+version state; verify that rollback evidence, fix the reported error, and
+rerun. Never stamp manually. If code rollback is required after a successful stamp
+and before any later revision, stop writers, restore the pre-adoption backup,
+deploy the prior application, and verify v10 plus representative row
+checksums. Removing `alembic_version` without restoring or proving exact v10
+parity is forbidden. Once a post-baseline revision has run, use its supported
+downgrade only to the baseline or restore a backup; never cross the baseline
+floor.
+
+**w) Docs synchronization.**
+
+- `README.md`: fresh setup calls `python db_migrate.py`.
+- `ARCHITECTURE.md`: Alembic graph, frozen v1-v10 adoption history, and sole
+  migration facade.
+- `docs/OPERATIONS.md`: backup-before-adoption, fresh/existing/delayed
+  workflows, parity command, lock behavior, baseline floor, and vector
+  rehydration.
+- `docs/PIPELINE.md`: migration prelude and no numbered migrations after v10.
+- `docs/CONTRIBUTING_CITIES.md`: migrate before seed.
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`: T-TIME completion,
+  T-PLAT-1 activation, ownership, and final acceptance.
+- `docs/plans/G5_ALEMBIC_ADOPTION_DECISION_PLAN.md`: prerequisite completion
+  and active implementation status.
+- ADR: None. The accepted G5 ADR already records this decision; update only if
+  implementation must deviate.
+
+## 7. Delivery Self-Audit
+
+**x) Antipattern scan, diff pass.** Re-run A-F and H. Reject mutable model
+imports from the baseline, a second schema owner, best-effort migration,
+manual stamp guidance, interpolated SQL identifiers, generic helper modules,
+patchability parameters, facade patches, optional CI migration skips, new
+Ruff exceptions, unrelated dependency changes, or edits outside ownership.
+
+**y) Evidence.** Report every command in 6u as `PASS`, `FAIL`, or
+`NOT VERIFIED`; include dependency versions, red tests, PostgreSQL database
+count, schema parity output, row checksums, downgrade result, Docker smoke,
+full-suite counts/coverage, planning-review findings, pre-commit findings,
+commit hashes, PR URL, unresolved thread count, and CI state.
+
+**z) Deviations.** Expected deviations: none. Any additional file, new
+environment variable, unsupported stamp path, optional PostgreSQL CI skip,
+post-v10 numbered migration, dual schema owner, unresolved P1/P2, or unrun
+required check blocks handoff.
+
+## Independent Planning Review Incorporated
+
+- Add explicit ownership for the plan, ledger, strict runner, Alembic owner,
+  typed schema contracts, and parity CLI.
+- Add ownership for v9, v10, and backfills so adoption can use one
+  caller-owned transaction.
+- Treat all four legacy-only indexes as baseline objects.
+- Replace swallowed legacy failures rather than adding a strict-mode switch.
+- Compare full PostgreSQL contracts, not only Alembic metadata differences.
+- Use isolated databases where extension state matters.
+- Use an immediate transaction-scoped advisory lock instead of an unbounded
+  session lock.
+- Isolate the reference version table and restore transaction-local
+  `search_path` before public stamping.
+- Roll back destructive v8 work with the rest of adoption on any failure.
+- Migrate before starting API and workers.
+- Preserve system-of-record rows and document derived-vector rehydration.
+- Prove a test-only post-baseline revision reaches head.

--- a/pipeline/db_init.py
+++ b/pipeline/db_init.py
@@ -1,7 +1,7 @@
 import logging
 
+from pipeline import db_migrate
 from pipeline.cli_logging import configure_cli_logging
-from pipeline.models import db_connect, create_tables
 
 LOGGER_NAME = "db-init"
 LOGGER_FORMAT = "%(asctime)s - %(levelname)s - %(message)s"
@@ -14,18 +14,11 @@ def _configure_cli_logging() -> None:
     configure_cli_logging(LOGGER_FORMAT)
 
 
-def init_db():
-    """
-    Explicitly creates the database tables.
-    Run this script once when setting up the system.
-    """
-    logger.info("Connecting to database...")
-    engine = db_connect()
-    
-    logger.info("Creating tables...")
-    create_tables(engine)
-    
-    logger.info("Database initialization complete.")
+def init_db() -> None:
+    """Apply the canonical migration path for fresh and existing databases."""
+    logger.info("Applying database migrations...")
+    db_migrate.migrate()
+    logger.info("Database migration complete.")
 
 
 def main() -> int:

--- a/pipeline/db_migrate.py
+++ b/pipeline/db_migrate.py
@@ -1,47 +1,27 @@
-"""
-Additive schema migrations for local/dev environments.
-
-Why this exists:
-This repo does not use Alembic migrations yet. `create_all()` can create missing
-tables, but it will NOT add new columns to existing tables. When the Python
-models evolve, older databases can break at runtime.
-
-This script applies small, additive migrations (safe ALTER TABLE) so existing
-dev databases can keep working without requiring destructive resets.
-"""
-
 from __future__ import annotations
 
 import logging
 
-from sqlalchemy.engine import Connection
-
-from pipeline import migrate_v8
-from pipeline import migrate_v9
-from pipeline import migrate_v10
-from pipeline.db_migration_columns import add_column_if_missing, postgres_column_exists
-from pipeline.db_migration_runner import run_migrations
+from pipeline import db_migration_alembic
 from pipeline.models import db_connect
 
-logger = logging.getLogger("db-migrate")
 
-
-def _postgres_column_exists(conn: Connection, table: str, column: str) -> bool:
-    return postgres_column_exists(conn, table, column)
-
-
-def _add_column_if_missing(conn: Connection, table: str, column: str, ddl: str) -> bool:
-    return add_column_if_missing(conn, table, column, ddl, logger)
+LOGGER = logging.getLogger("db-migrate")
 
 
 def migrate() -> None:
-    run_migrations(
-        db_connect_callable=db_connect,
-        migrate_v8_module=migrate_v8,
-        migrate_v9_module=migrate_v9,
-        logger=logger,
-    )
-    migrate_v10.migrate()
+    engine = db_connect()
+    try:
+        migration_outcome = db_migration_alembic.migrate_database(engine)
+        LOGGER.info(
+            "database_migration_complete status=%s revision=%s "
+            "retired_catalog_vector_count=%d",
+            migration_outcome.status,
+            migration_outcome.revision,
+            migration_outcome.retired_vector_count,
+        )
+    finally:
+        engine.dispose()
 
 
 if __name__ == "__main__":

--- a/pipeline/db_migration_alembic.py
+++ b/pipeline/db_migration_alembic.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+from pathlib import Path
+from typing import Literal
+from uuid import uuid4
+
+from alembic import command
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+from sqlalchemy import func, inspect, select, text
+from sqlalchemy.engine import Connection, Engine
+from sqlalchemy.schema import CreateSchema, DropSchema
+
+from pipeline.db_migration_runner import run_migrations
+from pipeline.db_schema_contracts import (
+    SchemaDifference,
+    capture_schema_contract,
+    compare_schema_contracts,
+    format_schema_differences,
+)
+
+
+POSTGRESQL_DIALECT = "postgresql"
+PUBLIC_SCHEMA = "public"
+BASELINE_REVISION = "0001_v10_baseline"
+HEAD_REVISION = "head"
+MIGRATION_LOCK_ID = 8_490_716_003
+REFERENCE_SCHEMA_PREFIX = "tc_alembic_reference_"
+ROOT = Path(__file__).resolve().parents[1]
+LOGGER = logging.getLogger("db-migrate")
+
+
+class MigrationLockError(RuntimeError):
+    """Another migration process already owns the database migration lock."""
+
+
+class MigrationStateError(RuntimeError):
+    """The stored Alembic state cannot be advanced safely."""
+
+
+class SchemaDriftError(RuntimeError):
+    """An unversioned database differs from the frozen v10 baseline."""
+
+    def __init__(self, schema_differences: tuple[SchemaDifference, ...]) -> None:
+        self.schema_differences = schema_differences
+        super().__init__(
+            "Existing database does not match the v10 baseline:\n"
+            f"{format_schema_differences(schema_differences)}"
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class MigrationOutcome:
+    status: Literal["not_applicable", "current", "upgraded", "adopted"]
+    revision: str | None
+    retired_vector_count: int = 0
+
+
+def _alembic_config(
+    connection: Connection,
+    version_table_schema: str | None = None,
+) -> Config:
+    config = Config(ROOT / "alembic.ini")
+    config.attributes["connection"] = connection
+    if version_table_schema is not None:
+        config.attributes["version_table_schema"] = version_table_schema
+    return config
+
+
+def _head_revision(connection: Connection) -> str:
+    script_directory = ScriptDirectory.from_config(_alembic_config(connection))
+    heads = script_directory.get_heads()
+    if len(heads) != 1:
+        raise MigrationStateError(
+            f"Expected one Alembic head, found {len(heads)}: {heads}"
+        )
+    return heads[0]
+
+
+def _current_revisions(connection: Connection) -> tuple[str, ...]:
+    if not inspect(connection).has_table("alembic_version", schema=PUBLIC_SCHEMA):
+        return ()
+    revision_rows = connection.execute(
+        text("SELECT version_num FROM public.alembic_version ORDER BY version_num")
+    ).scalars()
+    return tuple(str(revision) for revision in revision_rows)
+
+
+def _has_application_tables(connection: Connection) -> bool:
+    return bool(
+        connection.scalar(
+            text(
+                """
+                SELECT EXISTS (
+                    SELECT 1
+                    FROM information_schema.tables
+                    WHERE table_schema = :schema_name
+                      AND table_type = 'BASE TABLE'
+                      AND table_name <> 'alembic_version'
+                )
+                """
+            ),
+            {"schema_name": PUBLIC_SCHEMA},
+        )
+    )
+
+
+def _acquire_migration_lock(connection: Connection) -> None:
+    acquired = connection.scalar(
+        text("SELECT pg_try_advisory_xact_lock(:lock_id)"),
+        {"lock_id": MIGRATION_LOCK_ID},
+    )
+    if acquired is not True:
+        raise MigrationLockError("Another database migration is already running.")
+
+
+def _set_search_path(connection: Connection, search_path: str) -> None:
+    connection.execute(select(func.set_config("search_path", search_path, True)))
+
+
+def _reference_schema_name() -> str:
+    return f"{REFERENCE_SCHEMA_PREFIX}{uuid4().hex}"
+
+
+def _build_reference_contract(
+    connection: Connection,
+    reference_schema: str,
+    target_revision: str,
+) -> tuple[SchemaDifference, ...]:
+    connection.execute(CreateSchema(reference_schema))
+    _set_search_path(connection, f"{reference_schema}, {PUBLIC_SCHEMA}")
+    command.upgrade(
+        _alembic_config(connection, reference_schema),
+        target_revision,
+    )
+    expected_contract = capture_schema_contract(connection, reference_schema)
+    _set_search_path(connection, PUBLIC_SCHEMA)
+    actual_contract = capture_schema_contract(connection, PUBLIC_SCHEMA)
+    differences = compare_schema_contracts(expected_contract, actual_contract)
+    connection.execute(DropSchema(reference_schema, cascade=True))
+    return differences
+
+
+def _upgrade_versioned_database(
+    connection: Connection,
+    current_revisions: tuple[str, ...],
+) -> MigrationOutcome:
+    if len(current_revisions) != 1:
+        raise MigrationStateError(
+            "Expected one stored Alembic revision, "
+            f"found {len(current_revisions)}: {current_revisions}"
+        )
+    head_revision = _head_revision(connection)
+    if current_revisions == (head_revision,):
+        return MigrationOutcome("current", head_revision)
+    command.upgrade(_alembic_config(connection), HEAD_REVISION)
+    return MigrationOutcome("upgraded", head_revision)
+
+
+def _upgrade_fresh_database(connection: Connection) -> MigrationOutcome:
+    command.upgrade(_alembic_config(connection), HEAD_REVISION)
+    return MigrationOutcome("upgraded", _head_revision(connection))
+
+
+def _adopt_unversioned_database(connection: Connection) -> MigrationOutcome:
+    legacy_report = run_migrations(connection, LOGGER)
+    reference_schema = _reference_schema_name()
+    schema_differences = _build_reference_contract(
+        connection,
+        reference_schema,
+        BASELINE_REVISION,
+    )
+    if schema_differences:
+        raise SchemaDriftError(schema_differences)
+    command.stamp(_alembic_config(connection), BASELINE_REVISION)
+    command.upgrade(_alembic_config(connection), HEAD_REVISION)
+    return MigrationOutcome(
+        "adopted",
+        _head_revision(connection),
+        legacy_report.retired_catalog_vector_count,
+    )
+
+
+def _migrate_postgres(connection: Connection) -> MigrationOutcome:
+    _set_search_path(connection, PUBLIC_SCHEMA)
+    _acquire_migration_lock(connection)
+    current_revisions = _current_revisions(connection)
+    if current_revisions:
+        return _upgrade_versioned_database(connection, current_revisions)
+    if not _has_application_tables(connection):
+        return _upgrade_fresh_database(connection)
+    return _adopt_unversioned_database(connection)
+
+
+def migrate_database(engine: Engine) -> MigrationOutcome:
+    if engine.dialect.name != POSTGRESQL_DIALECT:
+        return MigrationOutcome("not_applicable", None)
+    with engine.begin() as connection:
+        return _migrate_postgres(connection)
+
+
+def check_database_parity(engine: Engine) -> tuple[SchemaDifference, ...]:
+    if engine.dialect.name != POSTGRESQL_DIALECT:
+        raise MigrationStateError("Schema parity requires PostgreSQL.")
+    with engine.begin() as connection:
+        _set_search_path(connection, PUBLIC_SCHEMA)
+        _acquire_migration_lock(connection)
+        reference_schema = _reference_schema_name()
+        return _build_reference_contract(
+            connection,
+            reference_schema,
+            HEAD_REVISION,
+        )

--- a/pipeline/db_migration_columns.py
+++ b/pipeline/db_migration_columns.py
@@ -42,6 +42,11 @@ CORE_COLUMN_MIGRATIONS = (
     ColumnMigration("catalog", "entities_source_hash", "ALTER TABLE catalog ADD COLUMN entities_source_hash VARCHAR(64)"),
     ColumnMigration("catalog", "agenda_items_hash", "ALTER TABLE catalog ADD COLUMN agenda_items_hash VARCHAR(64)"),
 )
+PERSON_CONSTRAINT_REPAIRS = (
+    "ALTER TABLE person ALTER COLUMN is_elected SET DEFAULT false",
+    "ALTER TABLE person ALTER COLUMN person_type SET DEFAULT 'mentioned'",
+    "ALTER TABLE person ALTER COLUMN person_type SET NOT NULL",
+)
 
 
 def postgres_column_exists(conn: Connection, table: str, column: str) -> bool:
@@ -74,12 +79,17 @@ def add_column_if_missing(conn: Connection, table: str, column: str, ddl: str, l
 
 def apply_core_column_migrations(conn: Connection, logger: logging.Logger) -> None:
     for column_migration in CORE_COLUMN_MIGRATIONS:
-        added = add_column_if_missing(
+        add_column_if_missing(
             conn,
             column_migration.table,
             column_migration.column,
             column_migration.ddl,
             logger,
         )
-        if added and column_migration.index_sql:
+        if column_migration.index_sql:
             conn.execute(text(column_migration.index_sql))
+
+
+def apply_core_constraint_repairs(conn: Connection) -> None:
+    for constraint_repair in PERSON_CONSTRAINT_REPAIRS:
+        conn.execute(text(constraint_repair))

--- a/pipeline/db_migration_runner.py
+++ b/pipeline/db_migration_runner.py
@@ -1,38 +1,37 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable
-from types import ModuleType
+from dataclasses import dataclass
 
-from sqlalchemy.engine import Engine
+from sqlalchemy.engine import Connection
 
 from pipeline.db_migration_backfills import run_core_backfills
-from pipeline.db_migration_columns import apply_core_column_migrations
+from pipeline.db_migration_columns import (
+    apply_core_column_migrations,
+    apply_core_constraint_repairs,
+)
+from pipeline.migrate_v10 import migrate as migrate_v10
+from pipeline.migrate_v8 import migrate as migrate_v8
+from pipeline.migrate_v9 import migrate as migrate_v9
 
 
-DbConnectCallable = Callable[[], Engine]
+@dataclass(frozen=True, slots=True)
+class LegacyMigrationReport:
+    retired_catalog_vector_count: int
 
 
 def run_migrations(
-    *,
-    db_connect_callable: DbConnectCallable,
-    migrate_v8_module: ModuleType,
-    migrate_v9_module: ModuleType,
+    connection: Connection,
     logger: logging.Logger,
-) -> None:
-    engine = db_connect_callable()
-    with engine.begin() as conn:
-        if engine.dialect.name != "postgresql":
-            return
-        apply_core_column_migrations(conn, logger)
-        run_core_backfills(conn)
-
-    _run_submigration(migrate_v8_module, "migrate_v8", logger)
-    _run_submigration(migrate_v9_module, "migrate_v9", logger)
-
-
-def _run_submigration(migration_module: ModuleType, migration_label: str, logger: logging.Logger) -> None:
-    try:
-        migration_module.migrate()
-    except Exception as exc:
-        logger.warning("%s skipped: %s", migration_label, exc)
+) -> LegacyMigrationReport:
+    if connection.dialect.name != "postgresql":
+        return LegacyMigrationReport(retired_catalog_vector_count=0)
+    apply_core_column_migrations(connection, logger)
+    run_core_backfills(connection)
+    apply_core_constraint_repairs(connection)
+    retired_catalog_vector_count = migrate_v8(connection)
+    migrate_v9(connection)
+    migrate_v10(connection)
+    return LegacyMigrationReport(
+        retired_catalog_vector_count=retired_catalog_vector_count,
+    )

--- a/pipeline/db_schema_contracts.py
+++ b/pipeline/db_schema_contracts.py
@@ -1,0 +1,391 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Hashable
+from dataclasses import dataclass
+from typing import TypeVar
+
+from sqlalchemy import text
+from sqlalchemy.engine import Connection
+
+
+REQUIRED_EXTENSIONS = ("vector",)
+SCHEMA_QUALIFIER_PLACEHOLDER = "<schema>."
+ABSENT_CONTRACT_VALUE = "<absent>"
+MISSING_CONTRACT_VALUE = "<missing>"
+ContractRecord = TypeVar("ContractRecord")
+
+
+@dataclass(frozen=True, slots=True, order=True)
+class ColumnContract:
+    table_name: str
+    column_name: str
+    type_sql: str
+    nullable: bool
+    default_sql: str | None
+
+
+@dataclass(frozen=True, slots=True, order=True)
+class ConstraintContract:
+    table_name: str
+    constraint_name: str
+    constraint_kind: str
+    definition_sql: str
+
+
+@dataclass(frozen=True, slots=True, order=True)
+class IndexContract:
+    table_name: str
+    index_name: str
+    definition_sql: str
+    predicate_sql: str | None
+
+
+@dataclass(frozen=True, slots=True, order=True)
+class SequenceContract:
+    sequence_name: str
+    owner_table: str | None
+    owner_column: str | None
+    data_type: str
+    start_value: int
+    minimum_value: int
+    maximum_value: int
+    increment_by: int
+    cycle: bool
+    cache_size: int
+
+
+@dataclass(frozen=True, slots=True)
+class DatabaseSchemaContract:
+    schema_name: str
+    table_names: tuple[str, ...]
+    columns: tuple[ColumnContract, ...]
+    constraints: tuple[ConstraintContract, ...]
+    indexes: tuple[IndexContract, ...]
+    sequences: tuple[SequenceContract, ...]
+    extensions: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True, order=True)
+class SchemaDifference:
+    contract_part: str
+    expected: str
+    actual: str
+
+
+def _normalize_schema_sql(sql_value: str | None, schema_name: str) -> str | None:
+    if sql_value is None:
+        return None
+    normalized_sql = sql_value.replace(f'"{schema_name}".', SCHEMA_QUALIFIER_PLACEHOLDER)
+    return normalized_sql.replace(f"{schema_name}.", SCHEMA_QUALIFIER_PLACEHOLDER)
+
+
+def _table_names(connection: Connection, schema_name: str) -> tuple[str, ...]:
+    table_rows = connection.execute(
+        text(
+            """
+            SELECT table_name
+            FROM information_schema.tables
+            WHERE table_schema = :schema_name
+              AND table_type = 'BASE TABLE'
+              AND table_name <> 'alembic_version'
+            ORDER BY table_name
+            """
+        ),
+        {"schema_name": schema_name},
+    ).tuples()
+    return tuple(str(table_name) for (table_name,) in table_rows)
+
+
+def _columns(connection: Connection, schema_name: str) -> tuple[ColumnContract, ...]:
+    column_rows = connection.execute(
+        text(
+            """
+            SELECT table_rel.relname, column_attr.attname,
+                   pg_catalog.format_type(column_attr.atttypid, column_attr.atttypmod),
+                   NOT column_attr.attnotnull,
+                   pg_catalog.pg_get_expr(column_default.adbin, column_default.adrelid)
+            FROM pg_catalog.pg_attribute AS column_attr
+            JOIN pg_catalog.pg_class AS table_rel
+              ON table_rel.oid = column_attr.attrelid
+            JOIN pg_catalog.pg_namespace AS table_namespace
+              ON table_namespace.oid = table_rel.relnamespace
+            LEFT JOIN pg_catalog.pg_attrdef AS column_default
+              ON column_default.adrelid = table_rel.oid
+             AND column_default.adnum = column_attr.attnum
+            WHERE table_namespace.nspname = :schema_name
+              AND table_rel.relkind IN ('r', 'p')
+              AND column_attr.attnum > 0
+              AND NOT column_attr.attisdropped
+              AND table_rel.relname <> 'alembic_version'
+            ORDER BY table_rel.relname, column_attr.attnum
+            """
+        ),
+        {"schema_name": schema_name},
+    ).tuples()
+    return tuple(
+        ColumnContract(
+            table_name=str(table_name),
+            column_name=str(column_name),
+            type_sql=str(type_sql),
+            nullable=bool(nullable),
+            default_sql=_normalize_schema_sql(
+                None if default_sql is None else str(default_sql),
+                schema_name,
+            ),
+        )
+        for table_name, column_name, type_sql, nullable, default_sql in column_rows
+    )
+
+
+def _constraints(
+    connection: Connection,
+    schema_name: str,
+) -> tuple[ConstraintContract, ...]:
+    constraint_rows = connection.execute(
+        text(
+            """
+            SELECT table_rel.relname, table_constraint.conname,
+                   table_constraint.contype,
+                   pg_catalog.pg_get_constraintdef(table_constraint.oid, true)
+            FROM pg_catalog.pg_constraint AS table_constraint
+            JOIN pg_catalog.pg_class AS table_rel
+              ON table_rel.oid = table_constraint.conrelid
+            JOIN pg_catalog.pg_namespace AS table_namespace
+              ON table_namespace.oid = table_rel.relnamespace
+            WHERE table_namespace.nspname = :schema_name
+              AND table_rel.relname <> 'alembic_version'
+            ORDER BY table_rel.relname, table_constraint.conname
+            """
+        ),
+        {"schema_name": schema_name},
+    ).tuples()
+    return tuple(
+        ConstraintContract(
+            table_name=str(table_name),
+            constraint_name=str(constraint_name),
+            constraint_kind=str(constraint_kind),
+            definition_sql=_normalize_schema_sql(str(definition_sql), schema_name) or "",
+        )
+        for table_name, constraint_name, constraint_kind, definition_sql in constraint_rows
+    )
+
+
+def _indexes(connection: Connection, schema_name: str) -> tuple[IndexContract, ...]:
+    index_rows = connection.execute(
+        text(
+            """
+            SELECT table_rel.relname, index_rel.relname,
+                   pg_catalog.pg_get_indexdef(index_rel.oid),
+                   pg_catalog.pg_get_expr(index_meta.indpred, index_meta.indrelid)
+            FROM pg_catalog.pg_index AS index_meta
+            JOIN pg_catalog.pg_class AS index_rel
+              ON index_rel.oid = index_meta.indexrelid
+            JOIN pg_catalog.pg_class AS table_rel
+              ON table_rel.oid = index_meta.indrelid
+            JOIN pg_catalog.pg_namespace AS table_namespace
+              ON table_namespace.oid = table_rel.relnamespace
+            LEFT JOIN pg_catalog.pg_constraint AS table_constraint
+              ON table_constraint.conindid = index_rel.oid
+            WHERE table_namespace.nspname = :schema_name
+              AND table_constraint.oid IS NULL
+              AND table_rel.relname <> 'alembic_version'
+            ORDER BY table_rel.relname, index_rel.relname
+            """
+        ),
+        {"schema_name": schema_name},
+    ).tuples()
+    return tuple(
+        IndexContract(
+            table_name=str(table_name),
+            index_name=str(index_name),
+            definition_sql=_normalize_schema_sql(str(definition_sql), schema_name) or "",
+            predicate_sql=_normalize_schema_sql(
+                None if predicate_sql is None else str(predicate_sql),
+                schema_name,
+            ),
+        )
+        for table_name, index_name, definition_sql, predicate_sql in index_rows
+    )
+
+
+def _sequences(
+    connection: Connection,
+    schema_name: str,
+) -> tuple[SequenceContract, ...]:
+    sequence_rows = connection.execute(
+        text(
+            """
+            SELECT sequence_rel.relname, owner_table.relname, owner_column.attname,
+                   sequence_meta.data_type, sequence_meta.start_value,
+                   sequence_meta.min_value, sequence_meta.max_value,
+                   sequence_meta.increment_by, sequence_meta.cycle,
+                   sequence_meta.cache_size
+            FROM pg_catalog.pg_sequences AS sequence_meta
+            JOIN pg_catalog.pg_class AS sequence_rel
+              ON sequence_rel.relname = sequence_meta.sequencename
+            JOIN pg_catalog.pg_namespace AS sequence_namespace
+              ON sequence_namespace.oid = sequence_rel.relnamespace
+             AND sequence_namespace.nspname = sequence_meta.schemaname
+            LEFT JOIN pg_catalog.pg_depend AS sequence_dependency
+              ON sequence_dependency.objid = sequence_rel.oid
+             AND sequence_dependency.deptype IN ('a', 'i')
+            LEFT JOIN pg_catalog.pg_class AS owner_table
+              ON owner_table.oid = sequence_dependency.refobjid
+            LEFT JOIN pg_catalog.pg_attribute AS owner_column
+              ON owner_column.attrelid = owner_table.oid
+             AND owner_column.attnum = sequence_dependency.refobjsubid
+            WHERE sequence_namespace.nspname = :schema_name
+              AND sequence_rel.relkind = 'S'
+            ORDER BY sequence_rel.relname
+            """
+        ),
+        {"schema_name": schema_name},
+    ).tuples()
+    return tuple(
+            SequenceContract(
+                sequence_name=str(sequence_name),
+                owner_table=None if owner_table is None else str(owner_table),
+                owner_column=None if owner_column is None else str(owner_column),
+                data_type=str(data_type),
+                start_value=int(start_value),
+                minimum_value=int(minimum_value),
+                maximum_value=int(maximum_value),
+                increment_by=int(increment_by),
+                cycle=bool(cycle),
+                cache_size=int(cache_size),
+            )
+        for (
+            sequence_name,
+            owner_table,
+            owner_column,
+            data_type,
+            start_value,
+            minimum_value,
+            maximum_value,
+            increment_by,
+            cycle,
+            cache_size,
+        ) in sequence_rows
+    )
+
+
+def _extensions(connection: Connection) -> tuple[str, ...]:
+    extension_rows = connection.execute(
+        text(
+            """
+            SELECT extname
+            FROM pg_catalog.pg_extension
+            WHERE extname = ANY(:extension_names)
+            ORDER BY extname
+            """
+        ),
+        {"extension_names": list(REQUIRED_EXTENSIONS)},
+    ).tuples()
+    return tuple(str(extension_name) for (extension_name,) in extension_rows)
+
+
+def capture_schema_contract(
+    connection: Connection,
+    schema_name: str,
+) -> DatabaseSchemaContract:
+    return DatabaseSchemaContract(
+        schema_name=schema_name,
+        table_names=_table_names(connection, schema_name),
+        columns=_columns(connection, schema_name),
+        constraints=_constraints(connection, schema_name),
+        indexes=_indexes(connection, schema_name),
+        sequences=_sequences(connection, schema_name),
+        extensions=_extensions(connection),
+    )
+
+
+def _compare_records(
+    contract_part: str,
+    expected_records: tuple[ContractRecord, ...],
+    actual_records: tuple[ContractRecord, ...],
+    record_key: Callable[[ContractRecord], Hashable],
+) -> tuple[SchemaDifference, ...]:
+    expected_by_key = {record_key(record): record for record in expected_records}
+    actual_by_key = {record_key(record): record for record in actual_records}
+    record_differences = []
+    for key in sorted(expected_by_key.keys() | actual_by_key.keys(), key=str):
+        expected_record = expected_by_key.get(key)
+        actual_record = actual_by_key.get(key)
+        if expected_record == actual_record:
+            continue
+        record_differences.append(
+            SchemaDifference(
+                contract_part=f"{contract_part}[{key!r}]",
+                expected=(
+                    ABSENT_CONTRACT_VALUE
+                    if expected_record is None
+                    else repr(expected_record)
+                ),
+                actual=(
+                    MISSING_CONTRACT_VALUE
+                    if actual_record is None
+                    else repr(actual_record)
+                ),
+            )
+        )
+    return tuple(record_differences)
+
+
+def compare_schema_contracts(
+    expected_contract: DatabaseSchemaContract,
+    actual_contract: DatabaseSchemaContract,
+) -> tuple[SchemaDifference, ...]:
+    return (
+        *_compare_records(
+            "tables",
+            expected_contract.table_names,
+            actual_contract.table_names,
+            lambda table_name: table_name,
+        ),
+        *_compare_records(
+            "columns",
+            expected_contract.columns,
+            actual_contract.columns,
+            lambda column: (column.table_name, column.column_name),
+        ),
+        *_compare_records(
+            "constraints",
+            expected_contract.constraints,
+            actual_contract.constraints,
+            lambda constraint: (
+                constraint.table_name,
+                constraint.constraint_name,
+            ),
+        ),
+        *_compare_records(
+            "indexes",
+            expected_contract.indexes,
+            actual_contract.indexes,
+            lambda index: (index.table_name, index.index_name),
+        ),
+        *_compare_records(
+            "sequences",
+            expected_contract.sequences,
+            actual_contract.sequences,
+            lambda sequence: sequence.sequence_name,
+        ),
+        *_compare_records(
+            "extensions",
+            expected_contract.extensions,
+            actual_contract.extensions,
+            lambda extension_name: extension_name,
+        ),
+    )
+
+
+def format_schema_differences(
+    schema_differences: tuple[SchemaDifference, ...],
+) -> str:
+    return "\n".join(
+        (
+            f"{schema_difference.contract_part}: "
+            f"expected={schema_difference.expected} "
+            f"actual={schema_difference.actual}"
+        )
+        for schema_difference in schema_differences
+    )

--- a/pipeline/migrate_v10.py
+++ b/pipeline/migrate_v10.py
@@ -170,26 +170,34 @@ def _analyze_changed_tables(connection: Connection, changed_tables: set[str]) ->
         )
 
 
-def migrate() -> None:
-    engine = db_connect()
-    if engine.dialect.name != POSTGRESQL_DIALECT:
+def migrate(connection: Connection | None = None) -> None:
+    if connection is not None:
+        _migrate_connection(connection)
         return
 
-    with engine.begin() as connection:
-        timestamp_contracts = {
-            timestamp_spec: _read_timestamp_contract(connection, timestamp_spec)
-            for timestamp_spec in TIMESTAMP_COLUMNS
-        }
-        changed_tables = {
-            timestamp_spec.table_name
-            for timestamp_spec in TIMESTAMP_COLUMNS
-            if _migrate_timestamp_column(
-                connection,
-                timestamp_spec,
-                timestamp_contracts[timestamp_spec],
-            )
-        }
-        _analyze_changed_tables(connection, changed_tables)
+    engine = db_connect()
+    with engine.begin() as owned_connection:
+        _migrate_connection(owned_connection)
+
+
+def _migrate_connection(connection: Connection) -> None:
+    if connection.dialect.name != POSTGRESQL_DIALECT:
+        return
+
+    timestamp_contracts = {
+        timestamp_spec: _read_timestamp_contract(connection, timestamp_spec)
+        for timestamp_spec in TIMESTAMP_COLUMNS
+    }
+    changed_tables = {
+        timestamp_spec.table_name
+        for timestamp_spec in TIMESTAMP_COLUMNS
+        if _migrate_timestamp_column(
+            connection,
+            timestamp_spec,
+            timestamp_contracts[timestamp_spec],
+        )
+    }
+    _analyze_changed_tables(connection, changed_tables)
 
 
 if __name__ == "__main__":

--- a/pipeline/migrate_v8.py
+++ b/pipeline/migrate_v8.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
 
-from pipeline.migration_pgvector_semantic_embeddings import Base as Base, db_connect as db_connect
-from pipeline.migration_pgvector_semantic_embeddings import migrate as migrate_impl
+from sqlalchemy.engine import Connection
+
+from pipeline.migration_pgvector_semantic_embeddings import migrate as migrate_connection
+from pipeline.models import db_connect
 
 
-def migrate() -> None:
-    migrate_impl(db_connect_callable=db_connect, model_metadata=Base.metadata)
+def migrate(connection: Connection | None = None) -> int:
+    if connection is not None:
+        return migrate_connection(connection)
+
+    engine = db_connect()
+    with engine.begin() as owned_connection:
+        return migrate_connection(owned_connection)
 
 
 if __name__ == "__main__":

--- a/pipeline/migrate_v9.py
+++ b/pipeline/migrate_v9.py
@@ -1,12 +1,19 @@
 from __future__ import annotations
 
-from pipeline.migration_catalog_lineage_columns import column_exists, db_connect as db_connect, migrate as migrate_impl
+from sqlalchemy.engine import Connection
 
-_column_exists = column_exists
+from pipeline.migration_catalog_lineage_columns import migrate as migrate_connection
+from pipeline.models import db_connect
 
 
-def migrate() -> None:
-    migrate_impl(db_connect_callable=db_connect, column_exists_callable=_column_exists)
+def migrate(connection: Connection | None = None) -> None:
+    if connection is not None:
+        migrate_connection(connection)
+        return
+
+    engine = db_connect()
+    with engine.begin() as owned_connection:
+        migrate_connection(owned_connection)
 
 
 if __name__ == "__main__":

--- a/pipeline/migration_catalog_lineage_columns.py
+++ b/pipeline/migration_catalog_lineage_columns.py
@@ -1,67 +1,44 @@
 from __future__ import annotations
 
-from collections.abc import Callable
-
 from sqlalchemy import text
-from sqlalchemy.engine import Connection, Engine
+from sqlalchemy.engine import Connection
 
-from pipeline.models import db_connect
-
-
-DbConnectCallable = Callable[[], Engine]
-ColumnExistsCallable = Callable[[Connection, str, str], bool]
+from pipeline.db_migration_columns import ColumnMigration, postgres_column_exists
 
 
-def column_exists(conn: Connection, table: str, column: str) -> bool:
-    return (
-        conn.execute(
-            text(
-                """
-                SELECT 1
-                FROM information_schema.columns
-                WHERE table_schema = 'public'
-                  AND table_name = :table
-                  AND column_name = :column
-                LIMIT 1
-                """
-            ),
-            {"table": table, "column": column},
-        ).scalar()
-        is not None
-    )
+POSTGRESQL_DIALECT = "postgresql"
+LINEAGE_COLUMN_MIGRATIONS = (
+    ColumnMigration(
+        "catalog",
+        "lineage_id",
+        "ALTER TABLE catalog ADD COLUMN lineage_id VARCHAR(64)",
+        "CREATE INDEX IF NOT EXISTS ix_catalog_lineage_id ON catalog (lineage_id)",
+    ),
+    ColumnMigration(
+        "catalog",
+        "lineage_confidence",
+        "ALTER TABLE catalog ADD COLUMN lineage_confidence DOUBLE PRECISION",
+        "CREATE INDEX IF NOT EXISTS ix_catalog_lineage_confidence ON catalog (lineage_confidence)",
+    ),
+    ColumnMigration(
+        "catalog",
+        "lineage_updated_at",
+        "ALTER TABLE catalog ADD COLUMN lineage_updated_at TIMESTAMP",
+        "CREATE INDEX IF NOT EXISTS ix_catalog_lineage_updated_at ON catalog (lineage_updated_at)",
+    ),
+)
 
 
-def migrate(
-    *,
-    db_connect_callable: DbConnectCallable = db_connect,
-    column_exists_callable: ColumnExistsCallable = column_exists,
-) -> None:
-    engine = db_connect_callable()
-    if engine.dialect.name != "postgresql":
+def migrate(connection: Connection) -> None:
+    if connection.dialect.name != POSTGRESQL_DIALECT:
         return
 
-    with engine.begin() as conn:
-        _add_lineage_column(conn, "lineage_id", "VARCHAR(64)", "ix_catalog_lineage_id", column_exists_callable)
-        _add_lineage_column(
-            conn,
-            "lineage_confidence",
-            "DOUBLE PRECISION",
-            "ix_catalog_lineage_confidence",
-            column_exists_callable,
-        )
-        _add_lineage_column(
-            conn, "lineage_updated_at", "TIMESTAMP", "ix_catalog_lineage_updated_at", column_exists_callable
-        )
-
-
-def _add_lineage_column(
-    conn: Connection,
-    column: str,
-    column_type: str,
-    index_name: str,
-    column_exists_callable: ColumnExistsCallable,
-) -> None:
-    if column_exists_callable(conn, "catalog", column):
-        return
-    conn.execute(text(f"ALTER TABLE catalog ADD COLUMN {column} {column_type}"))
-    conn.execute(text(f"CREATE INDEX IF NOT EXISTS {index_name} ON catalog ({column})"))
+    for column_migration in LINEAGE_COLUMN_MIGRATIONS:
+        if not postgres_column_exists(
+            connection,
+            column_migration.table,
+            column_migration.column,
+        ):
+            connection.execute(text(column_migration.ddl))
+        if column_migration.index_sql:
+            connection.execute(text(column_migration.index_sql))

--- a/pipeline/migration_pgvector_semantic_embeddings.py
+++ b/pipeline/migration_pgvector_semantic_embeddings.py
@@ -1,47 +1,72 @@
 from __future__ import annotations
 
-from collections.abc import Callable
+from sqlalchemy import text
+from sqlalchemy.engine import Connection
 
-from sqlalchemy import MetaData, text
-from sqlalchemy.engine import Engine
-
-from pipeline.models import Base, db_connect
+from pipeline.db_migration_columns import postgres_column_exists
 
 
-DbConnectCallable = Callable[[], Engine]
-
-
-def migrate(
-    *,
-    db_connect_callable: DbConnectCallable = db_connect,
-    model_metadata: MetaData = Base.metadata,
-) -> None:
+POSTGRESQL_DIALECT = "postgresql"
+RETIRED_CATALOG_VECTOR_COLUMN = "semantic_embedding"
+RETIRED_CATALOG_VECTOR_COUNT_SQL = (
+    "SELECT count(*) FROM catalog WHERE semantic_embedding IS NOT NULL"
+)
+FROZEN_V8_STATEMENTS = (
+    "CREATE EXTENSION IF NOT EXISTS vector",
     """
-    Milestone B2 migration: enable pgvector and create dedicated semantic_embedding table.
-
-    Order matters:
-    1) extension
-    2) table creation
-    3) cleanup + ANN index
-    """
-    engine = db_connect_callable()
-    if engine.dialect.name != "postgresql":
-        return
-
-    with engine.begin() as conn:
-        conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
-
-    model_metadata.create_all(engine)
-
-    with engine.begin() as conn:
-        conn.execute(text("ALTER TABLE catalog DROP COLUMN IF EXISTS semantic_embedding"))
-        conn.execute(
-            text(
-                """
-                CREATE INDEX IF NOT EXISTS ix_semantic_embedding_hnsw
-                ON semantic_embedding
-                USING hnsw (embedding vector_cosine_ops)
-                WHERE embedding IS NOT NULL
-                """
-            )
+    CREATE TABLE IF NOT EXISTS semantic_embedding (
+        id SERIAL PRIMARY KEY,
+        catalog_id INTEGER REFERENCES catalog(id) ON DELETE CASCADE,
+        agenda_item_id INTEGER REFERENCES agenda_item(id) ON DELETE CASCADE,
+        model_name VARCHAR(120) NOT NULL,
+        embedding_dim INTEGER NOT NULL,
+        embedding VECTOR(384),
+        source_hash VARCHAR(64),
+        updated_at TIMESTAMP DEFAULT now(),
+        CONSTRAINT check_single_entity_reference CHECK (
+            (catalog_id IS NOT NULL AND agenda_item_id IS NULL)
+            OR (catalog_id IS NULL AND agenda_item_id IS NOT NULL)
         )
+    )
+    """,
+    "ALTER TABLE catalog DROP COLUMN IF EXISTS semantic_embedding",
+    """
+    CREATE UNIQUE INDEX IF NOT EXISTS ix_semantic_embedding_catalog_model
+    ON semantic_embedding (catalog_id, model_name)
+    """,
+    """
+    CREATE UNIQUE INDEX IF NOT EXISTS ix_semantic_embedding_item_model
+    ON semantic_embedding (agenda_item_id, model_name)
+    """,
+    """
+    CREATE INDEX IF NOT EXISTS ix_semantic_embedding_hnsw
+    ON semantic_embedding
+    USING hnsw (embedding vector_cosine_ops)
+    WHERE embedding IS NOT NULL
+    """,
+)
+
+
+def migrate(connection: Connection) -> int:
+    if connection.dialect.name != POSTGRESQL_DIALECT:
+        return 0
+
+    retired_catalog_vector_count = _retired_catalog_vector_count(connection)
+    for migration_statement in FROZEN_V8_STATEMENTS:
+        connection.execute(text(migration_statement))
+    return retired_catalog_vector_count
+
+
+def _retired_catalog_vector_count(connection: Connection) -> int:
+    if not postgres_column_exists(
+        connection,
+        "catalog",
+        RETIRED_CATALOG_VECTOR_COLUMN,
+    ):
+        return 0
+    retired_catalog_vector_count = connection.execute(
+        text(RETIRED_CATALOG_VECTOR_COUNT_SQL)
+    ).scalar_one()
+    if not isinstance(retired_catalog_vector_count, int):
+        raise RuntimeError("Invalid retired catalog vector count")
+    return retired_catalog_vector_count

--- a/pipeline/promote_stage.py
+++ b/pipeline/promote_stage.py
@@ -1,9 +1,10 @@
 import logging
-from sqlalchemy.orm import sessionmaker
+
 from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session, sessionmaker
 
 from pipeline.cli_logging import configure_cli_logging
-from pipeline.models import Event, EventStage, Place, db_connect, create_tables
+from pipeline.models import Event, EventStage, Place, db_connect
 from pipeline.utils import generate_ocd_id
 
 LOGGER_NAME = "promote-stage"
@@ -17,103 +18,96 @@ def _configure_cli_logging() -> None:
     configure_cli_logging(LOGGER_FORMAT)
 
 
-def promote_stage():
-    """
-    Moves scraped meeting data from the 'staging' table to the 'production' table.
-    
-    Why this is needed:
-    The crawler saves data to a temporary staging area first. This script checks
-    that data for validity and duplicates before officially adding it to the main
-    'Event' table that the application uses.
-    """
-    engine = db_connect()
-    create_tables(engine)
-    session_factory = sessionmaker(bind=engine)
-    session = session_factory()
-
-    logger.info("Promoting EventStage records to Event...")
-
-    # Get all the meetings currently sitting in the staging area.
-    staged_events = session.query(EventStage).all()
-    
+def _promote_staged_events(session: Session) -> tuple[list[int], int, int]:
     promoted_count = 0
     skipped_count = 0
-    promoted_ids = []
+    promoted_ids: list[int] = []
 
-    for staged in staged_events:
-        # 1. Find the City (Place) this meeting belongs to.
-        # We need to link the meeting to a valid Place ID in our database.
-        place = session.query(Place).filter(
-            Place.ocd_division_id == staged.ocd_division_id
-        ).first()
-
+    for staged_event in session.query(EventStage).all():
+        place = (
+            session.query(Place)
+            .filter(Place.ocd_division_id == staged_event.ocd_division_id)
+            .first()
+        )
         if not place:
             logger.warning(
                 "Skipping EventStage id=%s reason=blocked_missing_place ocd_division_id=%s event=%s",
-                staged.id,
-                staged.ocd_division_id,
-                staged.name,
+                staged_event.id,
+                staged_event.ocd_division_id,
+                staged_event.name,
             )
             skipped_count += 1
             continue
 
-        # 2. Check for Duplicates.
-        # Don't add the meeting if we already have it (same city, same date, same name).
-        existing = session.query(Event).filter(
-            Event.ocd_division_id == staged.ocd_division_id,
-            Event.record_date == staged.record_date,
-            Event.name == staged.name
-        ).first()
-
-        if not existing:
-            # 3. Create the Production Record.
-            # Copy valid data from staging to the live Event table.
-            event = Event(
-                ocd_id=generate_ocd_id('event'),
-                ocd_division_id=staged.ocd_division_id,
-                place_id=place.id,
-                name=staged.name,
-                scraped_datetime=staged.scraped_datetime,
-                record_date=staged.record_date,
-                source=staged.source,
-                source_url=staged.source_url,
-                meeting_type=staged.meeting_type
+        existing_event = (
+            session.query(Event)
+            .filter(
+                Event.ocd_division_id == staged_event.ocd_division_id,
+                Event.record_date == staged_event.record_date,
+                Event.name == staged_event.name,
             )
-            session.add(event)
-            promoted_count += 1
-            promoted_ids.append(staged.id)
-        else:
+            .first()
+        )
+        if existing_event:
             logger.info(
                 "Skipping EventStage id=%s reason=duplicate ocd_division_id=%s event=%s",
-                staged.id,
-                staged.ocd_division_id,
-                staged.name,
+                staged_event.id,
+                staged_event.ocd_division_id,
+                staged_event.name,
             )
             skipped_count += 1
+            continue
 
-    try:
-        # Save all the new events to the database.
-        session.commit()
-        logger.info(
-            "Promotion complete. promoted=%s skipped_or_duplicates=%s",
-            promoted_count,
-            skipped_count,
+        session.add(
+            Event(
+                ocd_id=generate_ocd_id("event"),
+                ocd_division_id=staged_event.ocd_division_id,
+                place_id=place.id,
+                name=staged_event.name,
+                scraped_datetime=staged_event.scraped_datetime,
+                record_date=staged_event.record_date,
+                source=staged_event.source,
+                source_url=staged_event.source_url,
+                meeting_type=staged_event.meeting_type,
+            )
         )
-        
-        # Clean up: Remove the processed records from the staging table.
-        if promoted_ids:
-            logger.info("Clearing %s promoted EventStage rows...", len(promoted_ids))
-            session.query(EventStage).filter(EventStage.id.in_(promoted_ids)).delete(synchronize_session=False)
-            session.commit()
+        promoted_count += 1
+        promoted_ids.append(staged_event.id)
 
-    except SQLAlchemyError as e:
-        # Database errors during event promotion: What can fail?
-        # - IntegrityError: Duplicate event (same date/name/location)
-        # - ForeignKeyError: Referenced place doesn't exist
-        # - OperationalError: Database connection lost during bulk insert
-        # Why rollback? If ANY promotion fails, undo ALL to keep staging/production in sync
-        logger.error("Error during promotion: %s", e, exc_info=True)
+    return promoted_ids, promoted_count, skipped_count
+
+
+def _commit_promotion(
+    session: Session,
+    promoted_ids: list[int],
+    promoted_count: int,
+    skipped_count: int,
+) -> None:
+    if promoted_ids:
+        logger.info("Clearing %s promoted EventStage rows...", len(promoted_ids))
+        session.query(EventStage).filter(EventStage.id.in_(promoted_ids)).delete(
+            synchronize_session=False
+        )
+    session.commit()
+    logger.info(
+        "Promotion complete. promoted=%s skipped_or_duplicates=%s",
+        promoted_count,
+        skipped_count,
+    )
+
+
+def promote_stage() -> None:
+    """Promote staging rows only after the canonical migration has run."""
+    engine = db_connect()
+    session = sessionmaker(bind=engine)()
+    try:
+        logger.info("Promoting EventStage records to Event...")
+        promotion = _promote_staged_events(session)
+        _commit_promotion(session, *promotion)
+    except SQLAlchemyError as error:
+        logger.error("Error during promotion: %s", error, exc_info=True)
         session.rollback()
+        raise
     finally:
         session.close()
 

--- a/pipeline/requirements.txt
+++ b/pipeline/requirements.txt
@@ -1,4 +1,5 @@
 sqlalchemy==2.0.38
+alembic==1.18.5
 requests==2.33.0
 tika==2.6.0
 meilisearch==0.31.0

--- a/pipeline/seed_places.py
+++ b/pipeline/seed_places.py
@@ -1,17 +1,17 @@
 import csv
 import logging
-import os
-from typing import Optional
+from pathlib import Path
 from urllib.parse import urlparse
-from sqlalchemy.orm import sessionmaker
+
 from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session, sessionmaker
 
 from pipeline.cli_logging import configure_cli_logging
-from pipeline.models import Place, db_connect, create_tables
+from pipeline.models import Place, db_connect
 
 LOGGER_NAME = "seed-places"
 LOGGER_FORMAT = "%(asctime)s - %(levelname)s - %(message)s"
-CITY_METADATA_PATH = os.path.join(os.path.dirname(__file__), "..", "city_metadata", "list_of_cities.csv")
+CITY_METADATA_PATH = Path(__file__).resolve().parents[1] / "city_metadata" / "list_of_cities.csv"
 
 logger = logging.getLogger(LOGGER_NAME)
 
@@ -21,7 +21,7 @@ def _configure_cli_logging() -> None:
     configure_cli_logging(LOGGER_FORMAT)
 
 
-def _derive_legistar_client(seed_url: str, hosting_services: str) -> Optional[str]:
+def _derive_legistar_client(seed_url: str, hosting_services: str) -> str | None:
     """
     Derive the Legistar "client" slug used by the Legistar Web API.
 
@@ -50,79 +50,72 @@ def _derive_legistar_client(seed_url: str, hosting_services: str) -> Optional[st
     subdomain = host.split(".")[0].strip()
     return subdomain or None
 
-def seed_places():
-    """
-    Populates the database with the initial list of cities.
-    
-    Why this is needed:
-    The application needs to know which cities (Places) exists before it can
-    save meeting data for them. This script reads a simple CSV file of city
-    information and ensures a record exists for each one in the 'place' table.
-    """
-    engine = db_connect()
-    create_tables(engine)
-    session_factory = sessionmaker(bind=engine)
-    session = session_factory()
 
-    # Locate the CSV file containing the city list.
-    csv_path = CITY_METADATA_PATH
-    
-    if not os.path.exists(csv_path):
-        logger.error("Metadata file not found at %s", csv_path)
+def _required_city_value(city_row: dict[str, str | None], column_name: str) -> str:
+    city_value = city_row.get(column_name)
+    if not city_value:
+        raise ValueError(f"City metadata is missing {column_name}")
+    return city_value
+
+
+def _seed_city(session: Session, city_row: dict[str, str | None]) -> None:
+    city_name = _required_city_value(city_row, "city")
+    ocd_division_id = _required_city_value(city_row, "ocd_division_id")
+    seed_url = _required_city_value(city_row, "city_council_url")
+    hosting_service = _required_city_value(city_row, "hosting_services")
+    display_name = _required_city_value(city_row, "display_name")
+    legistar_client = _derive_legistar_client(seed_url, hosting_service)
+    existing_place = (
+        session.query(Place)
+        .filter(Place.ocd_division_id == ocd_division_id)
+        .first()
+    )
+
+    if existing_place:
+        existing_place.seed_url = seed_url
+        existing_place.hosting_service = hosting_service
+        existing_place.legistar_client = legistar_client
+        logger.info("Updated place: %s", display_name)
         return
 
+    session.add(
+        Place(
+            name=city_name,
+            type_="city",
+            state=_required_city_value(city_row, "state"),
+            country=_required_city_value(city_row, "country"),
+            display_name=display_name,
+            ocd_division_id=ocd_division_id,
+            seed_url=seed_url,
+            hosting_service=hosting_service,
+            legistar_client=legistar_client,
+            crawler=True,
+            crawler_name=city_name,
+            crawler_type="scrapy",
+        )
+    )
+    logger.info("Added place: %s", display_name)
+
+
+def _seed_city_metadata(session: Session, csv_path: Path) -> None:
     logger.info("Seeding places from %s...", csv_path)
+    with csv_path.open(mode="r", encoding="utf-8") as city_metadata_file:
+        for city_row in csv.DictReader(city_metadata_file):
+            _seed_city(session, city_row)
 
-    with open(csv_path, mode='r', encoding='utf-8') as f:
-        reader = csv.DictReader(f)
-        for row in reader:
-            # For Legistar-hosted cities, this unlocks a more reliable agenda resolver path.
-            legistar_client = _derive_legistar_client(
-                seed_url=row.get("city_council_url") or "",
-                hosting_services=row.get("hosting_services") or "",
-            )
 
-            # Check if this city is already in our database.
-            existing = session.query(Place).filter(
-                Place.ocd_division_id == row['ocd_division_id']
-            ).first()
-
-            if not existing:
-                # Create a new record for the city.
-                place = Place(
-                    name=row['city'],
-                    type_='city',
-                    state=row['state'],
-                    country=row['country'],
-                    display_name=row['display_name'],
-                    ocd_division_id=row['ocd_division_id'],
-                    seed_url=row['city_council_url'],
-                    hosting_service=row['hosting_services'],
-                    legistar_client=legistar_client,
-                    crawler=True,
-                    crawler_name=row['city'],
-                    crawler_type='scrapy'
-                )
-                session.add(place)
-                logger.info("Added place: %s", row["display_name"])
-            else:
-                # If it exists, update the URL and hosting service details just in case they changed.
-                existing.seed_url = row['city_council_url']
-                existing.hosting_service = row['hosting_services']
-                existing.legistar_client = legistar_client
-                logger.info("Updated place: %s", row["display_name"])
-
+def seed_places() -> None:
+    """Seed cities after the canonical migration entrypoint has created the schema."""
+    engine = db_connect()
+    session = sessionmaker(bind=engine)()
     try:
+        _seed_city_metadata(session, CITY_METADATA_PATH)
         session.commit()
         logger.info("Seeding complete.")
-    except (SQLAlchemyError, OSError, ValueError) as e:
-        # Seeding errors: What can fail when loading city data?
-        # - SQLAlchemyError: Database error (duplicate city, invalid foreign key)
-        # - OSError: CSV file not found or unreadable
-        # - ValueError: Malformed CSV (missing columns, invalid data)
-        # Why rollback? Partial seeding creates inconsistent state
-        logger.error("Error during seeding: %s", e, exc_info=True)
+    except (SQLAlchemyError, OSError, ValueError) as error:
+        logger.error("Error during seeding: %s", error, exc_info=True)
         session.rollback()
+        raise
     finally:
         session.close()
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -66,7 +66,6 @@ extend-immutable-calls = ["fastapi.Depends", "fastapi.Query", "fastapi.Path", "f
 "pipeline/check_faiss_runtime.py" = ["BLE001"]
 "pipeline/city_coverage_audit.py" = ["DTZ011"]
 "pipeline/city_coverage_windows.py" = ["DTZ011"]
-"pipeline/db_migration_runner.py" = ["BLE001"]
 "pipeline/diagnose_search_sort.py" = ["BLE001", "C901", "S310"]
 "pipeline/diagnose_semantic_search.py" = ["BLE001", "S310"]
 "pipeline/downloader.py" = ["B905"]

--- a/scripts/check_schema_parity.py
+++ b/scripts/check_schema_parity.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import sys
+
+from pipeline.db_migration_alembic import check_database_parity
+from pipeline.db_schema_contracts import format_schema_differences
+from pipeline.models import db_connect
+
+
+def main() -> int:
+    engine = db_connect()
+    try:
+        schema_differences = check_database_parity(engine)
+    finally:
+        engine.dispose()
+    if not schema_differences:
+        print("Schema parity: PASS")
+        return 0
+    print(format_schema_differences(schema_differences), file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dev_up.sh
+++ b/scripts/dev_up.sh
@@ -14,17 +14,39 @@ if [[ ! -f .env ]]; then
   exit 1
 fi
 
+MIGRATION_PREREQUISITES=(postgres)
 CORE_SERVICES=(postgres redis meilisearch tika inference semantic semantic-worker api worker enrichment-worker monitor frontend ingress)
 COMPOSE=(docker compose -f docker-compose.yml -f docker-compose.dev.yml)
+POSTGRES_READY_ATTEMPTS=30
+POSTGRES_READY_DELAY_SECONDS=1
 
-echo "[dev_up] Building and starting core services..."
-"${COMPOSE[@]}" up -d --build "${CORE_SERVICES[@]}"
+echo "[dev_up] Building and starting migration prerequisites..."
+"${COMPOSE[@]}" up -d --build "${MIGRATION_PREREQUISITES[@]}"
+
+echo "[dev_up] Waiting for PostgreSQL..."
+postgres_ready=false
+for ((postgres_ready_attempt = 1; postgres_ready_attempt <= POSTGRES_READY_ATTEMPTS; postgres_ready_attempt++)); do
+  if "${COMPOSE[@]}" exec -T postgres pg_isready \
+    -U "${POSTGRES_USER:-town_council}" \
+    -d "${POSTGRES_DB:-town_council_db}"; then
+    postgres_ready=true
+    break
+  fi
+  sleep "$POSTGRES_READY_DELAY_SECONDS"
+done
+if [[ "$postgres_ready" != "true" ]]; then
+  echo "[dev_up] PostgreSQL did not become ready." >&2
+  exit 1
+fi
+
+echo "[dev_up] Migrating database schema..."
+"${COMPOSE[@]}" run --rm --build --no-deps pipeline python db_migrate.py
 
 echo "[dev_up] Bootstrapping local model artifacts..."
 bash ./scripts/bootstrap_local_models.sh
 
-echo "[dev_up] Initializing database schema..."
-"${COMPOSE[@]}" run --rm pipeline python db_init.py
+echo "[dev_up] Building and starting schema consumers..."
+"${COMPOSE[@]}" up -d --build "${CORE_SERVICES[@]}"
 
 echo "[dev_up] Smoke check: verify API container can import BeautifulSoup (bs4)..."
 "${COMPOSE[@]}" run --rm api python -c "import bs4; print('bs4', bs4.__version__)"

--- a/tests/test_alembic_migrations.py
+++ b/tests/test_alembic_migrations.py
@@ -1,0 +1,488 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+import importlib
+import os
+from pathlib import Path
+import time
+from types import ModuleType
+from uuid import uuid4
+
+from alembic import command
+from alembic.config import Config
+import pytest
+from sqlalchemy import DDL, Engine, create_engine, inspect, text
+from sqlalchemy.engine import URL, make_url
+
+from pipeline.db_schema_contracts import (
+    ColumnContract,
+    DatabaseSchemaContract,
+    compare_schema_contracts,
+    format_schema_differences,
+)
+from pipeline.models import Base
+
+
+ROOT = Path(__file__).resolve().parents[1]
+POSTGRES_TEST_URL_ENV = "TEST_POSTGRES_DATABASE_URL"
+BASELINE_REVISION = "0001_v10_baseline"
+POST_BASELINE_REVISION = "0002_test_head"
+POST_BASELINE_REVISION_SOURCE = f'''"""Test-only revision after the v10 baseline."""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "{POST_BASELINE_REVISION}"
+down_revision = "{BASELINE_REVISION}"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "post_baseline_probe",
+        sa.Column("id", sa.Integer(), primary_key=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("post_baseline_probe")
+'''
+LEGACY_ONLY_INDEXES = {
+    "ix_catalog_agenda_segmentation_attempted_at",
+    "ix_catalog_agenda_segmentation_status",
+    "ix_catalog_lineage_updated_at",
+    "ix_semantic_embedding_hnsw",
+}
+APPLICATION_TABLES = {
+    "agenda_item",
+    "catalog",
+    "data_issue",
+    "document",
+    "event",
+    "event_stage",
+    "membership",
+    "organization",
+    "person",
+    "place",
+    "semantic_embedding",
+    "url_stage",
+    "url_stage_hist",
+}
+
+
+def _migration_module() -> ModuleType:
+    return importlib.import_module("pipeline.db_migration_alembic")
+
+
+def _postgres_test_url() -> URL:
+    postgres_test_url = os.getenv(POSTGRES_TEST_URL_ENV)
+    if postgres_test_url:
+        return make_url(postgres_test_url)
+    if os.getenv("CI", "").lower() == "true":
+        pytest.fail(f"{POSTGRES_TEST_URL_ENV} is required in CI")
+    pytest.skip(f"{POSTGRES_TEST_URL_ENV} is not configured")
+
+
+def _quote_database_name(engine: Engine, database_name: str) -> str:
+    return engine.dialect.identifier_preparer.quote_identifier(database_name)
+
+
+@contextmanager
+def _isolated_postgres_database() -> Iterator[Engine]:
+    base_url = _postgres_test_url()
+    administration_url = base_url.set(database="postgres")
+    administration_engine = create_engine(
+        administration_url,
+        isolation_level="AUTOCOMMIT",
+    )
+    database_name = f"tc_alembic_{uuid4().hex}"
+    database_ddl_context = {
+        "database_identifier": _quote_database_name(
+            administration_engine,
+            database_name,
+        )
+    }
+    with administration_engine.connect() as connection:
+        connection.execute(
+            DDL(
+                "CREATE DATABASE %(database_identifier)s",
+                context=database_ddl_context,
+            )
+        )
+
+    database_engine = create_engine(base_url.set(database=database_name))
+    try:
+        yield database_engine
+    finally:
+        database_engine.dispose()
+        with administration_engine.connect() as connection:
+            connection.execute(
+                text(
+                    """
+                    SELECT pg_terminate_backend(pid)
+                    FROM pg_stat_activity
+                    WHERE datname = :database_name
+                      AND pid <> pg_backend_pid()
+                    """
+                ),
+                {"database_name": database_name},
+            )
+            connection.execute(
+                DDL(
+                    "DROP DATABASE %(database_identifier)s",
+                    context=database_ddl_context,
+                )
+            )
+        administration_engine.dispose()
+
+
+def _current_revision(engine: Engine) -> str | None:
+    with engine.connect() as connection:
+        if not inspect(connection).has_table("alembic_version"):
+            return None
+        return connection.scalar(text("SELECT version_num FROM alembic_version"))
+
+
+def _all_index_names(engine: Engine) -> set[str]:
+    with engine.connect() as connection:
+        index_rows = connection.execute(
+            text(
+                """
+                SELECT indexname
+                FROM pg_indexes
+                WHERE schemaname = current_schema()
+                """
+            )
+        )
+        return {index_name for (index_name,) in index_rows}
+
+
+def _reference_schema_names(engine: Engine) -> set[str]:
+    with engine.connect() as connection:
+        schema_rows = connection.execute(
+            text(
+                """
+                SELECT nspname
+                FROM pg_namespace
+                WHERE nspname LIKE 'tc_alembic_reference_%'
+                """
+            )
+        )
+        return {schema_name for (schema_name,) in schema_rows}
+
+
+def _alembic_config(connection: object) -> Config:
+    config = Config(ROOT / "alembic.ini")
+    config.attributes["connection"] = connection
+    return config
+
+
+def _install_post_baseline_test_runtime(temporary_root: Path) -> None:
+    runtime_paths = (
+        Path("alembic.ini"),
+        Path("alembic/env.py"),
+        Path("alembic/script.py.mako"),
+        Path("alembic/versions/0001_v10_baseline.py"),
+    )
+    for runtime_path in runtime_paths:
+        destination_path = temporary_root / runtime_path
+        destination_path.parent.mkdir(parents=True, exist_ok=True)
+        destination_path.write_text(
+            (ROOT / runtime_path).read_text(encoding="utf-8"),
+            encoding="utf-8",
+        )
+    (
+        temporary_root
+        / "alembic"
+        / "versions"
+        / f"{POST_BASELINE_REVISION}.py"
+    ).write_text(POST_BASELINE_REVISION_SOURCE, encoding="utf-8")
+
+
+def test_alembic_runtime_contract_is_checked_in() -> None:
+    assert (ROOT / "alembic.ini").is_file()
+    assert (ROOT / "alembic" / "env.py").is_file()
+    assert (ROOT / "alembic" / "versions" / f"{BASELINE_REVISION}.py").is_file()
+    assert "alembic==1.18.5" in (
+        ROOT / "pipeline" / "requirements.txt"
+    ).read_text(encoding="utf-8").splitlines()
+    assert not list((ROOT / "pipeline").glob("migrate_v1[1-9]*.py"))
+
+
+def test_migration_facade_keeps_sqlite_as_no_op() -> None:
+    migration_module = _migration_module()
+    sqlite_engine = create_engine("sqlite:///:memory:")
+
+    migration_outcome = migration_module.migrate_database(sqlite_engine)
+
+    assert migration_outcome.status == "not_applicable"
+    assert inspect(sqlite_engine).get_table_names() == []
+    sqlite_engine.dispose()
+
+
+def test_schema_differences_identify_exact_drifted_objects() -> None:
+    expected_contract = DatabaseSchemaContract(
+        schema_name="reference",
+        table_names=("catalog",),
+        columns=(ColumnContract("catalog", "summary", "text", True, None),),
+        constraints=(),
+        indexes=(),
+        sequences=(),
+        extensions=("vector",),
+    )
+    actual_contract = DatabaseSchemaContract(
+        schema_name="public",
+        table_names=("catalog", "unexpected_table"),
+        columns=(ColumnContract("catalog", "summary", "text", False, None),),
+        constraints=(),
+        indexes=(),
+        sequences=(),
+        extensions=("vector",),
+    )
+
+    schema_differences = compare_schema_contracts(
+        expected_contract,
+        actual_contract,
+    )
+    rendered_differences = format_schema_differences(schema_differences)
+
+    assert [difference.contract_part for difference in schema_differences] == [
+        "tables['unexpected_table']",
+        "columns[('catalog', 'summary')]",
+    ]
+    assert "actual=ColumnContract" in rendered_differences
+    assert "expected=<absent>" in rendered_differences
+
+
+def test_fresh_postgres_upgrade_creates_complete_baseline() -> None:
+    migration_module = _migration_module()
+    with _isolated_postgres_database() as database_engine:
+        migration_outcome = migration_module.migrate_database(database_engine)
+
+        assert migration_outcome.status == "upgraded"
+        assert _current_revision(database_engine) == BASELINE_REVISION
+        assert migration_module.check_database_parity(database_engine) == ()
+        assert APPLICATION_TABLES <= set(inspect(database_engine).get_table_names())
+        assert LEGACY_ONLY_INDEXES <= _all_index_names(database_engine)
+        with database_engine.connect() as connection:
+            assert connection.scalar(
+                text(
+                    """
+                    SELECT EXISTS (
+                        SELECT 1 FROM pg_extension WHERE extname = 'vector'
+                    )
+                    """
+                )
+            )
+        assert _reference_schema_names(database_engine) == set()
+
+
+def test_fresh_upgrade_is_idempotent() -> None:
+    migration_module = _migration_module()
+    with _isolated_postgres_database() as database_engine:
+        first_outcome = migration_module.migrate_database(database_engine)
+        first_indexes = _all_index_names(database_engine)
+
+        second_outcome = migration_module.migrate_database(database_engine)
+
+        assert first_outcome.status == "upgraded"
+        assert second_outcome.status == "current"
+        assert _current_revision(database_engine) == BASELINE_REVISION
+        assert _all_index_names(database_engine) == first_indexes
+
+
+def test_operator_parity_compares_against_current_head(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    migration_module = _migration_module()
+    _install_post_baseline_test_runtime(tmp_path)
+    monkeypatch.setattr(migration_module, "ROOT", tmp_path)
+
+    with _isolated_postgres_database() as database_engine:
+        migration_outcome = migration_module.migrate_database(database_engine)
+
+        assert migration_outcome.revision == POST_BASELINE_REVISION
+        assert migration_module.check_database_parity(database_engine) == ()
+
+
+def test_delayed_unversioned_adopter_compares_baseline_then_reaches_head(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    migration_module = _migration_module()
+    with _isolated_postgres_database() as database_engine:
+        migration_module.migrate_database(database_engine)
+        with database_engine.begin() as connection:
+            connection.execute(text("DROP TABLE alembic_version"))
+
+        _install_post_baseline_test_runtime(tmp_path)
+        monkeypatch.setattr(migration_module, "ROOT", tmp_path)
+        migration_outcome = migration_module.migrate_database(database_engine)
+
+        assert migration_outcome.status == "adopted"
+        assert migration_outcome.revision == POST_BASELINE_REVISION
+        assert _current_revision(database_engine) == POST_BASELINE_REVISION
+        assert inspect(database_engine).has_table("post_baseline_probe")
+        assert migration_module.check_database_parity(database_engine) == ()
+
+
+def test_sequence_settings_are_part_of_schema_parity() -> None:
+    migration_module = _migration_module()
+    with _isolated_postgres_database() as database_engine:
+        migration_module.migrate_database(database_engine)
+        with database_engine.begin() as connection:
+            connection.execute(text("ALTER SEQUENCE place_id_seq INCREMENT BY 2"))
+
+        schema_differences = migration_module.check_database_parity(database_engine)
+
+        assert [
+            difference.contract_part for difference in schema_differences
+        ] == ["sequences['place_id_seq']"]
+
+
+def test_current_unversioned_schema_is_repaired_and_adopted() -> None:
+    migration_module = _migration_module()
+    with _isolated_postgres_database() as database_engine:
+        with database_engine.begin() as connection:
+            connection.execute(text("CREATE EXTENSION vector"))
+        Base.metadata.create_all(database_engine)
+
+        migration_outcome = migration_module.migrate_database(database_engine)
+
+        assert migration_outcome.status == "adopted"
+        assert _current_revision(database_engine) == BASELINE_REVISION
+        assert _reference_schema_names(database_engine) == set()
+
+
+def test_unversioned_drift_aborts_without_stamp_or_data_loss() -> None:
+    migration_module = _migration_module()
+    with _isolated_postgres_database() as database_engine:
+        migration_module.migrate_database(database_engine)
+        with database_engine.begin() as connection:
+            connection.execute(
+                text(
+                    """
+                    INSERT INTO place (name, state, ocd_division_id)
+                    VALUES ('Drift Sentinel', 'CA', 'ocd-division/test:drift')
+                    """
+                )
+            )
+            connection.execute(
+                text(
+                    """
+                    INSERT INTO catalog (url_hash)
+                    VALUES ('drift-sentinel')
+                    """
+                )
+            )
+            connection.execute(text("DROP TABLE alembic_version"))
+            connection.execute(
+                text("ALTER TABLE catalog ADD COLUMN semantic_embedding VECTOR(384)")
+            )
+            connection.execute(
+                text(
+                    """
+                    UPDATE catalog
+                    SET semantic_embedding = array_fill(0.5, ARRAY[384])::vector
+                    WHERE id = (
+                        SELECT id FROM catalog ORDER BY id LIMIT 1
+                    )
+                    """
+                )
+            )
+            connection.execute(text("CREATE TABLE unexpected_drift (id INTEGER PRIMARY KEY)"))
+
+        with pytest.raises(migration_module.SchemaDriftError):
+            migration_module.migrate_database(database_engine)
+
+        assert _current_revision(database_engine) is None
+        with database_engine.connect() as connection:
+            assert connection.scalar(
+                text(
+                    """
+                    SELECT count(*) FROM place
+                    WHERE ocd_division_id = 'ocd-division/test:drift'
+                    """
+                )
+            ) == 1
+            assert inspect(connection).has_table("unexpected_drift")
+            assert connection.scalar(
+                text(
+                    """
+                    SELECT count(*)
+                    FROM catalog
+                    WHERE semantic_embedding IS NOT NULL
+                    """
+                )
+            ) == 1
+        assert _reference_schema_names(database_engine) == set()
+
+
+def test_unversioned_adoption_repairs_legacy_indexes_before_stamp() -> None:
+    migration_module = _migration_module()
+    with _isolated_postgres_database() as database_engine:
+        migration_module.migrate_database(database_engine)
+        with database_engine.begin() as connection:
+            connection.execute(text("DROP TABLE alembic_version"))
+            for index_name in sorted(LEGACY_ONLY_INDEXES):
+                quoted_index = connection.dialect.identifier_preparer.quote_identifier(
+                    index_name
+                )
+                connection.execute(text(f"DROP INDEX {quoted_index}"))
+
+        migration_outcome = migration_module.migrate_database(database_engine)
+
+        assert migration_outcome.status == "adopted"
+        assert _current_revision(database_engine) == BASELINE_REVISION
+        assert LEGACY_ONLY_INDEXES <= _all_index_names(database_engine)
+
+
+def test_second_migrator_fails_fast_when_transaction_lock_is_held() -> None:
+    migration_module = _migration_module()
+    with _isolated_postgres_database() as database_engine:
+        with database_engine.begin() as lock_connection:
+            assert lock_connection.scalar(
+                text("SELECT pg_try_advisory_xact_lock(:lock_id)"),
+                {"lock_id": migration_module.MIGRATION_LOCK_ID},
+            )
+            started_at = time.monotonic()
+            with pytest.raises(migration_module.MigrationLockError):
+                migration_module.migrate_database(database_engine)
+            elapsed_seconds = time.monotonic() - started_at
+
+        assert elapsed_seconds < 2
+        assert _current_revision(database_engine) is None
+
+
+def test_baseline_downgrade_fails_before_schema_or_data_changes() -> None:
+    migration_module = _migration_module()
+    with _isolated_postgres_database() as database_engine:
+        migration_module.migrate_database(database_engine)
+        with database_engine.begin() as connection:
+            connection.execute(
+                text(
+                    """
+                    INSERT INTO place (name, state, ocd_division_id)
+                    VALUES ('Downgrade Sentinel', 'CA', 'ocd-division/test:downgrade')
+                    """
+                )
+            )
+
+        with database_engine.begin() as connection:
+            with pytest.raises(RuntimeError, match="baseline"):
+                command.downgrade(_alembic_config(connection), "base")
+
+        assert _current_revision(database_engine) == BASELINE_REVISION
+        assert APPLICATION_TABLES <= set(inspect(database_engine).get_table_names())
+        with database_engine.connect() as connection:
+            assert connection.scalar(
+                text(
+                    """
+                    SELECT count(*) FROM place
+                    WHERE ocd_division_id = 'ocd-division/test:downgrade'
+                    """
+                )
+            ) == 1

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -3,7 +3,8 @@ import sys
 import os
 from pathlib import Path
 import pytest
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, event
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import sessionmaker
 
 # Setup: Add project root and pipeline dir to path so imports work.
@@ -103,6 +104,25 @@ def test_promotion_keeps_blocked_rows_in_event_stage(db_session, mocker):
     remaining = db_session.query(EventStage).all()
     assert len(remaining) == 1
     assert remaining[0].name == "Blocked Meeting"
+
+
+def test_promotion_fails_on_unmigrated_schema(mocker, caplog):
+    engine = create_engine("sqlite:///:memory:")
+    rollback_observed = False
+
+    def record_rollback(_connection) -> None:
+        nonlocal rollback_observed
+        rollback_observed = True
+
+    event.listen(engine, "rollback", record_rollback)
+    mocker.patch("pipeline.promote_stage.db_connect", return_value=engine)
+
+    with pytest.raises(OperationalError):
+        promote_stage()
+
+    assert rollback_observed is True
+    assert "Error during promotion" in caplog.text
+    engine.dispose()
 
 
 def test_db_connect_requires_explicit_database_url(monkeypatch):

--- a/tests/test_db_init.py
+++ b/tests/test_db_init.py
@@ -1,12 +1,19 @@
+import pytest
+from sqlalchemy import create_engine
+
 from pipeline import db_init
 
 
-def test_init_db_calls_connect_and_create_tables(mocker):
-    engine = object()
-    connect = mocker.patch.object(db_init, "db_connect", return_value=engine)
-    create = mocker.patch.object(db_init, "create_tables")
+def test_init_db_propagates_canonical_migration_failure(mocker):
+    migration_failure = RuntimeError("migration failed")
+    database_engine = create_engine("sqlite:///:memory:")
+    mocker.patch("pipeline.db_migrate.db_connect", return_value=database_engine)
+    mocker.patch(
+        "pipeline.db_migration_alembic.migrate_database",
+        side_effect=migration_failure,
+    )
 
-    db_init.init_db()
+    with pytest.raises(RuntimeError) as raised:
+        db_init.init_db()
 
-    connect.assert_called_once()
-    create.assert_called_once_with(engine)
+    assert raised.value is migration_failure

--- a/tests/test_db_migrate.py
+++ b/tests/test_db_migrate.py
@@ -1,65 +1,59 @@
+from collections.abc import Callable
+import logging
 from pathlib import Path
 
 import pytest
 
-from pipeline import db_migrate, migrate_v10
+from pipeline import db_migration_runner
+from pipeline.db_migration_backfills import run_core_backfills
+from pipeline.db_migration_columns import (
+    CORE_COLUMN_MIGRATIONS,
+    apply_core_column_migrations,
+    apply_core_constraint_repairs,
+)
 
 
 class _ScalarResult:
-    def __init__(self, value):
+    def __init__(self, value: object | None) -> None:
         self._value = value
 
-    def scalar(self):
+    def scalar(self) -> object | None:
         return self._value
 
 
 class _FakeConn:
-    def __init__(self, existing_columns=None):
+    def __init__(
+        self,
+        existing_columns: set[tuple[str, str]] | None = None,
+    ) -> None:
         self.existing_columns = set(existing_columns or [])
-        self.calls = []
+        self.calls: list[tuple[str, dict[str, str] | None]] = []
+        self.dialect = type("Dialect", (), {"name": "postgresql"})()
 
-    def execute(self, stmt, params=None):
-        sql = str(stmt)
+    def execute(
+        self,
+        statement: object,
+        params: dict[str, str] | None = None,
+    ) -> _ScalarResult:
+        sql = str(statement)
         self.calls.append((sql, params))
         if "information_schema.columns" in sql:
+            assert params is not None
             table = params["table"]
             column = params["column"]
             return _ScalarResult(1 if (table, column) in self.existing_columns else None)
         return _ScalarResult(None)
 
 
-class _BeginCtx:
-    def __init__(self, conn):
-        self.conn = conn
-
-    def __enter__(self):
-        return self.conn
-
-    def __exit__(self, _exc_type, exc, _tb):
-        return False
-
-
-class _FakeEngine:
-    def __init__(self, conn, dialect_name="postgresql"):
-        self.conn = conn
-        self.dialect = type("Dialect", (), {"name": dialect_name})()
-
-    def begin(self):
-        return _BeginCtx(self.conn)
-
-
-def _sql_calls(conn):
+def _sql_calls(conn: _FakeConn) -> list[str]:
     return [sql.lower() for sql, _ in conn.calls]
 
 
-def test_db_migrate_adds_legacy_columns_and_backfills(mocker):
+def test_core_migrations_add_legacy_columns_and_backfill_values() -> None:
     conn = _FakeConn()
-    engine = _FakeEngine(conn)
-    mocker.patch.object(db_migrate, "db_connect", return_value=engine)
-    migrate_v8_spy = mocker.patch.object(db_migrate.migrate_v8, "migrate")
-    migrate_v9_spy = mocker.patch.object(db_migrate.migrate_v9, "migrate")
 
-    db_migrate.migrate()
+    apply_core_column_migrations(conn, logging.getLogger("test-core-migrations"))
+    run_core_backfills(conn)
 
     calls = _sql_calls(conn)
     assert any("alter table event add column organization_id" in c for c in calls)
@@ -77,81 +71,47 @@ def test_db_migrate_adds_legacy_columns_and_backfills(mocker):
     assert any("create index if not exists ix_agenda_item_legistar_matter_id" in c for c in calls)
     assert any("update person" in c and "set person_type = 'mentioned'" in c for c in calls)
     assert any("update person" in c and "set person_type = 'official'" in c for c in calls)
-    migrate_v8_spy.assert_called_once_with()
-    migrate_v9_spy.assert_called_once_with()
 
 
-def test_db_migrate_skips_existing_columns_but_keeps_backfills(mocker):
+def test_core_migrations_skip_existing_columns_but_keep_indexes_and_backfills() -> None:
     existing_columns = {
-        ("event", "organization_id"),
-        ("event_stage", "organization_name"),
-        ("catalog", "related_ids"),
-        ("place", "legistar_client"),
-        ("person", "is_elected"),
-        ("person", "person_type"),
-        ("catalog", "content_hash"),
-        ("catalog", "summary_source_hash"),
-        ("catalog", "topics_source_hash"),
-        ("agenda_item", "page_number"),
-        ("agenda_item", "text_offset"),
-        ("agenda_item", "votes"),
-        ("agenda_item", "raw_history"),
-        ("agenda_item", "legistar_matter_id"),
-        ("agenda_item", "spatial_coords"),
-        ("catalog", "agenda_segmentation_status"),
-        ("catalog", "agenda_segmentation_attempted_at"),
-        ("catalog", "agenda_segmentation_item_count"),
-        ("catalog", "agenda_segmentation_error"),
-        ("catalog", "extraction_status"),
-        ("catalog", "extraction_attempted_at"),
-        ("catalog", "extraction_attempt_count"),
-        ("catalog", "extraction_error"),
-        ("catalog", "entities_source_hash"),
-        ("catalog", "agenda_items_hash"),
+        (column_migration.table, column_migration.column)
+        for column_migration in CORE_COLUMN_MIGRATIONS
     }
     conn = _FakeConn(existing_columns=existing_columns)
-    engine = _FakeEngine(conn)
-    mocker.patch.object(db_migrate, "db_connect", return_value=engine)
-    migrate_v8_spy = mocker.patch.object(db_migrate.migrate_v8, "migrate")
-    migrate_v9_spy = mocker.patch.object(db_migrate.migrate_v9, "migrate")
 
-    db_migrate.migrate()
+    apply_core_column_migrations(conn, logging.getLogger("test-core-migrations"))
+    run_core_backfills(conn)
 
     calls = _sql_calls(conn)
     assert not any("alter table" in c and "add column" in c for c in calls)
+    assert any("create index if not exists ix_person_is_elected" in c for c in calls)
     assert any("update catalog" in c and "set extraction_status" in c for c in calls)
     assert any("update person" in c and "set person_type = 'official'" in c for c in calls)
-    migrate_v8_spy.assert_called_once_with()
-    migrate_v9_spy.assert_called_once_with()
 
 
-def test_db_migrate_skips_sqlite_and_runtime_submigrations(mocker):
+def test_strict_legacy_runner_skips_sqlite(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     conn = _FakeConn()
-    engine = _FakeEngine(conn, dialect_name="sqlite")
-    mocker.patch.object(db_migrate, "db_connect", return_value=engine)
-    migrate_v8_spy = mocker.patch.object(db_migrate.migrate_v8, "migrate")
-    migrate_v9_spy = mocker.patch.object(db_migrate.migrate_v9, "migrate")
+    conn.dialect.name = "sqlite"
+    migration_events: list[str] = []
+    monkeypatch.setattr(
+        db_migration_runner,
+        "migrate_v8",
+        lambda _connection: migration_events.append("v8"),
+    )
 
-    db_migrate.migrate()
+    db_migration_runner.run_migrations(
+        conn,
+        logging.getLogger("test-strict-legacy-runner"),
+    )
 
     assert conn.calls == []
-    migrate_v8_spy.assert_not_called()
-    migrate_v9_spy.assert_not_called()
+    assert migration_events == []
 
 
-def test_db_migrate_facade_exports_compatibility_seams():
-    expected_names = [
-        "migrate",
-        "_postgres_column_exists",
-        "_add_column_if_missing",
-        "migrate_v8",
-        "migrate_v9",
-    ]
-
-    assert all(hasattr(db_migrate, name) for name in expected_names)
-
-
-def test_db_migration_implementation_modules_do_not_import_facade():
+def test_db_migration_implementation_modules_do_not_import_facade() -> None:
     module_paths = [
         "pipeline/db_migration_columns.py",
         "pipeline/db_migration_backfills.py",
@@ -164,49 +124,172 @@ def test_db_migration_implementation_modules_do_not_import_facade():
         assert "pipeline.db_migrate" not in Path(module_path).read_text(encoding="utf-8")
 
 
-def test_db_migrate_warns_and_keeps_core_migration_when_submigration_fails(mocker, caplog):
-    conn = _FakeConn()
-    engine = _FakeEngine(conn)
-    mocker.patch.object(db_migrate, "db_connect", return_value=engine)
-    mocker.patch.object(db_migrate.migrate_v8, "migrate", side_effect=RuntimeError("pgvector unavailable"))
-    migrate_v9_spy = mocker.patch.object(db_migrate.migrate_v9, "migrate")
+def test_strict_legacy_runner_uses_one_caller_owned_connection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    migration_connection = _FakeConn()
+    migration_events: list[tuple[str, object]] = []
 
-    db_migrate.migrate()
+    monkeypatch.setattr(
+        db_migration_runner,
+        "apply_core_column_migrations",
+        lambda connection, _logger: migration_events.append(("columns", connection)),
+    )
+    monkeypatch.setattr(
+        db_migration_runner,
+        "run_core_backfills",
+        lambda connection: migration_events.append(("backfills", connection)),
+    )
+    monkeypatch.setattr(
+        db_migration_runner,
+        "apply_core_constraint_repairs",
+        lambda connection: migration_events.append(("constraints", connection)),
+    )
 
-    calls = _sql_calls(conn)
-    assert any("alter table event add column organization_id" in c for c in calls)
-    assert "migrate_v8 skipped: pgvector unavailable" in caplog.text
-    migrate_v9_spy.assert_called_once_with()
+    def run_v8(connection: object) -> int:
+        migration_events.append(("v8", connection))
+        return 7
+
+    monkeypatch.setattr(db_migration_runner, "migrate_v8", run_v8)
+    monkeypatch.setattr(
+        db_migration_runner,
+        "migrate_v9",
+        lambda connection: migration_events.append(("v9", connection)),
+    )
+    monkeypatch.setattr(
+        db_migration_runner,
+        "migrate_v10",
+        lambda connection: migration_events.append(("v10", connection)),
+    )
+
+    migration_report = db_migration_runner.run_migrations(
+        migration_connection,
+        logging.getLogger("test-strict-legacy-runner"),
+    )
+
+    assert [migration_name for migration_name, _ in migration_events] == [
+        "columns",
+        "backfills",
+        "constraints",
+        "v8",
+        "v9",
+        "v10",
+    ]
+    assert all(connection is migration_connection for _, connection in migration_events)
+    assert migration_report.retired_catalog_vector_count == 7
 
 
-def test_db_migrate_runs_mandatory_v10_after_legacy_migrations(monkeypatch):
+@pytest.mark.parametrize(
+    ("failing_migration", "expected_events"),
+    [
+        ("migrate_v8", ["columns", "backfills", "constraints", "migrate_v8"]),
+        (
+            "migrate_v9",
+            ["columns", "backfills", "constraints", "migrate_v8", "migrate_v9"],
+        ),
+        (
+            "migrate_v10",
+            [
+                "columns",
+                "backfills",
+                "constraints",
+                "migrate_v8",
+                "migrate_v9",
+                "migrate_v10",
+            ],
+        ),
+    ],
+)
+def test_strict_legacy_runner_propagates_failure_and_stops(
+    monkeypatch: pytest.MonkeyPatch,
+    failing_migration: str,
+    expected_events: list[str],
+) -> None:
+    migration_connection = _FakeConn()
     migration_events: list[str] = []
 
-    def run_legacy_migrations(**_kwargs):
-        migration_events.append("legacy")
+    monkeypatch.setattr(
+        db_migration_runner,
+        "apply_core_column_migrations",
+        lambda _connection, _logger: migration_events.append("columns"),
+    )
+    monkeypatch.setattr(
+        db_migration_runner,
+        "run_core_backfills",
+        lambda _connection: migration_events.append("backfills"),
+    )
+    monkeypatch.setattr(
+        db_migration_runner,
+        "apply_core_constraint_repairs",
+        lambda _connection: migration_events.append("constraints"),
+    )
 
-    monkeypatch.setattr(db_migrate, "run_migrations", run_legacy_migrations)
-    monkeypatch.setattr(migrate_v10, "migrate", lambda: migration_events.append("v10"))
+    def record_migration(migration_name: str) -> Callable[[object], None]:
+        def run_migration(_connection: object) -> None:
+            migration_events.append(migration_name)
+            if migration_name == failing_migration:
+                raise RuntimeError(f"{migration_name} failed")
 
-    db_migrate.migrate()
+        return run_migration
 
-    assert migration_events == ["legacy", "v10"]
+    for migration_name in ("migrate_v8", "migrate_v9", "migrate_v10"):
+        monkeypatch.setattr(
+            db_migration_runner,
+            migration_name,
+            record_migration(migration_name),
+        )
+
+    with pytest.raises(RuntimeError, match=f"{failing_migration} failed"):
+        db_migration_runner.run_migrations(
+            migration_connection,
+            logging.getLogger("test-strict-legacy-runner"),
+        )
+
+    assert migration_events == expected_events
 
 
-def test_db_migrate_propagates_v10_failure(monkeypatch):
-    migration_events: list[str] = []
+def test_core_migrations_repair_indexes_for_existing_columns() -> None:
+    existing_columns = {
+        (column_migration.table, column_migration.column)
+        for column_migration in CORE_COLUMN_MIGRATIONS
+    }
+    migration_connection = _FakeConn(existing_columns=existing_columns)
 
-    def run_legacy_migrations(**_kwargs):
-        migration_events.append("legacy")
+    apply_core_column_migrations(
+        migration_connection,
+        logging.getLogger("test-core-index-repair"),
+    )
 
-    def fail_v10_migration():
-        migration_events.append("v10")
-        raise RuntimeError("timestamp schema drift")
+    migration_sql = _sql_calls(migration_connection)
+    assert not any("alter table" in statement for statement in migration_sql)
+    expected_indexes = {
+        column_migration.index_sql.lower()
+        for column_migration in CORE_COLUMN_MIGRATIONS
+        if column_migration.index_sql is not None
+    }
+    assert expected_indexes <= set(migration_sql)
 
-    monkeypatch.setattr(db_migrate, "run_migrations", run_legacy_migrations)
-    monkeypatch.setattr(migrate_v10, "migrate", fail_v10_migration)
 
-    with pytest.raises(RuntimeError, match="timestamp schema drift"):
-        db_migrate.migrate()
+def test_core_constraint_repairs_converge_person_defaults() -> None:
+    migration_connection = _FakeConn(
+        existing_columns={
+            ("person", "is_elected"),
+            ("person", "person_type"),
+        }
+    )
 
-    assert migration_events == ["legacy", "v10"]
+    apply_core_constraint_repairs(migration_connection)
+
+    migration_sql = _sql_calls(migration_connection)
+    assert (
+        "alter table person alter column is_elected set default false"
+        in migration_sql
+    )
+    assert (
+        "alter table person alter column person_type set default 'mentioned'"
+        in migration_sql
+    )
+    assert (
+        "alter table person alter column person_type set not null"
+        in migration_sql
+    )

--- a/tests/test_docker_build_contracts.py
+++ b/tests/test_docker_build_contracts.py
@@ -266,9 +266,9 @@ def test_dev_helper_requires_local_environment_file() -> None:
     assert "Create it from .env.example" in dev_helper
     assert "COMPOSE=(docker compose -f docker-compose.yml -f docker-compose.dev.yml)" in dev_helper
     assert "monitor frontend ingress)" in dev_helper
-    assert dev_helper.count('"${COMPOSE[@]}"') == 3
-    assert "monitor frontend ingress" in readme
-    assert "monitor frontend ingress" in operations
+    assert dev_helper.count('"${COMPOSE[@]}"') == 5
+    assert "bash ./scripts/dev_up.sh" in readme
+    assert "bash ./scripts/dev_up.sh" in operations
     assert "worker api pipeline frontend ingress" in profile_readme
 
 
@@ -317,19 +317,46 @@ def test_dockerfile_defines_split_python_targets():
     assert "semantic_cpu_constraints.txt" in source
 
 
-def test_dev_up_bootstraps_models_before_db_init():
+def test_dev_up_migrates_before_starting_schema_consumers():
     source = Path("scripts/dev_up.sh").read_text(encoding="utf-8")
+    prerequisite_command = (
+        '"${COMPOSE[@]}" up -d --build "${MIGRATION_PREREQUISITES[@]}"'
+    )
+    migration_command = (
+        '"${COMPOSE[@]}" run --rm --build --no-deps pipeline python db_migrate.py'
+    )
+    readiness_command = '"${COMPOSE[@]}" exec -T postgres pg_isready'
+    consumer_command = '"${COMPOSE[@]}" up -d --build "${CORE_SERVICES[@]}"'
 
-    assert '"${COMPOSE[@]}" up -d --build "${CORE_SERVICES[@]}"' in source
+    assert "MIGRATION_PREREQUISITES=(postgres)" in source
+    assert "POSTGRES_READY_ATTEMPTS=30" in source
+    assert "POSTGRES_READY_DELAY_SECONDS=1" in source
+    assert prerequisite_command in source
+    assert readiness_command in source
+    assert migration_command in source
+    assert consumer_command in source
     assert "semantic" in source
     assert "semantic-worker" in source
     assert "enrichment-worker" in source
     assert "monitor" in source
     assert " nlp" not in source
     assert "bash ./scripts/bootstrap_local_models.sh" in source
-    assert source.index("bash ./scripts/bootstrap_local_models.sh") < source.index(
-        '"${COMPOSE[@]}" run --rm pipeline python db_init.py'
+    assert "python db_init.py" not in source
+    assert source.index(prerequisite_command) < source.index(readiness_command)
+    assert source.index(readiness_command) < source.index(migration_command)
+    assert source.index(migration_command) < source.index(
+        "bash ./scripts/bootstrap_local_models.sh"
     )
+    assert source.index("bash ./scripts/bootstrap_local_models.sh") < source.index(
+        consumer_command
+    )
+
+
+def test_migration_runbook_uses_container_absolute_parity_script():
+    operations = Path("docs/OPERATIONS.md").read_text(encoding="utf-8")
+
+    assert "pipeline python /app/scripts/check_schema_parity.py" in operations
+    assert "pipeline python scripts/check_schema_parity.py" not in operations
 
 
 def test_compose_maps_worker_family_to_live_and_batch_images():

--- a/tests/test_migrate_v10.py
+++ b/tests/test_migrate_v10.py
@@ -87,9 +87,9 @@ def _create_legacy_timestamp_schema(engine: Engine, migration_module: ModuleType
             )
 
 
-def _run_migration(monkeypatch: pytest.MonkeyPatch, engine: Engine, migration_module: ModuleType) -> None:
-    monkeypatch.setattr(migration_module, "db_connect", lambda: engine)
-    migration_module.migrate()
+def _run_migration(engine: Engine, migration_module: ModuleType) -> None:
+    with engine.begin() as connection:
+        migration_module.migrate(connection)
 
 
 def _physical_timestamp_contract(engine: Engine) -> dict[tuple[str, str], tuple[str, str | None]]:
@@ -122,13 +122,12 @@ def _expected_physical_contract(migration_module: ModuleType) -> dict[tuple[str,
 
 
 def test_migrate_converts_all_timestamps_and_enforces_physical_defaults(
-    monkeypatch: pytest.MonkeyPatch,
     postgres_schema_engine: Engine,
 ) -> None:
     migration_module = _migration_module()
     _create_legacy_timestamp_schema(postgres_schema_engine, migration_module)
 
-    _run_migration(monkeypatch, postgres_schema_engine, migration_module)
+    _run_migration(postgres_schema_engine, migration_module)
 
     physical_contract = _physical_timestamp_contract(postgres_schema_engine)
     expected_contract = _expected_physical_contract(migration_module)
@@ -142,12 +141,11 @@ def test_migrate_converts_all_timestamps_and_enforces_physical_defaults(
 
 
 def test_migrate_preserves_utc_instant_under_non_utc_session(
-    monkeypatch: pytest.MonkeyPatch,
     postgres_schema_engine: Engine,
 ) -> None:
     migration_module = _migration_module()
     _create_legacy_timestamp_schema(postgres_schema_engine, migration_module)
-    _run_migration(monkeypatch, postgres_schema_engine, migration_module)
+    _run_migration(postgres_schema_engine, migration_module)
 
     with postgres_schema_engine.connect() as connection:
         connection.execute(text(f"SET TIME ZONE '{NON_UTC_SESSION_TIMEZONE}'"))
@@ -159,12 +157,11 @@ def test_migrate_preserves_utc_instant_under_non_utc_session(
 
 
 def test_migrate_is_idempotent(
-    monkeypatch: pytest.MonkeyPatch,
     postgres_schema_engine: Engine,
 ) -> None:
     migration_module = _migration_module()
     _create_legacy_timestamp_schema(postgres_schema_engine, migration_module)
-    _run_migration(monkeypatch, postgres_schema_engine, migration_module)
+    _run_migration(postgres_schema_engine, migration_module)
     first_contract = _physical_timestamp_contract(postgres_schema_engine)
     rerun_statements: list[str] = []
 
@@ -178,7 +175,7 @@ def test_migrate_is_idempotent(
         named=True,
     )
     try:
-        _run_migration(monkeypatch, postgres_schema_engine, migration_module)
+        _run_migration(postgres_schema_engine, migration_module)
     finally:
         event.remove(postgres_schema_engine, "before_cursor_execute", capture_rerun_statement)
 
@@ -188,7 +185,6 @@ def test_migrate_is_idempotent(
 
 
 def test_migrate_converges_mixed_timestamp_schema(
-    monkeypatch: pytest.MonkeyPatch,
     postgres_schema_engine: Engine,
 ) -> None:
     migration_module = _migration_module()
@@ -209,7 +205,7 @@ def test_migrate_converges_mixed_timestamp_schema(
             )
         )
 
-    _run_migration(monkeypatch, postgres_schema_engine, migration_module)
+    _run_migration(postgres_schema_engine, migration_module)
 
     physical_contract = _physical_timestamp_contract(postgres_schema_engine)
     assert all(data_type == "timestamp with time zone" for data_type, _ in physical_contract.values())
@@ -217,7 +213,6 @@ def test_migrate_converges_mixed_timestamp_schema(
 
 @pytest.mark.parametrize("schema_defect", ["missing", "unsupported"])
 def test_migrate_rolls_back_when_schema_is_not_supported(
-    monkeypatch: pytest.MonkeyPatch,
     postgres_schema_engine: Engine,
     schema_defect: str,
 ) -> None:
@@ -260,7 +255,7 @@ def test_migrate_rolls_back_when_schema_is_not_supported(
     )
     try:
         with pytest.raises(migration_module.TimestampMigrationError):
-            _run_migration(monkeypatch, postgres_schema_engine, migration_module)
+            _run_migration(postgres_schema_engine, migration_module)
     finally:
         event.remove(postgres_schema_engine, "before_cursor_execute", capture_migration_statement)
 
@@ -272,13 +267,25 @@ def test_migrate_rolls_back_when_schema_is_not_supported(
     assert not any(statement.lstrip().upper().startswith("ALTER TABLE") for statement in migration_statements)
 
 
-def test_migrate_is_no_op_for_sqlite(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_migrate_is_no_op_for_sqlite() -> None:
     migration_module = _migration_module()
     sqlite_engine = create_engine("sqlite:///:memory:")
     with sqlite_engine.begin() as connection:
         connection.execute(text("CREATE TABLE migration_sentinel (id INTEGER PRIMARY KEY)"))
 
-    _run_migration(monkeypatch, sqlite_engine, migration_module)
+    _run_migration(sqlite_engine, migration_module)
 
     assert inspect(sqlite_engine).has_table("migration_sentinel")
+    sqlite_engine.dispose()
+
+
+def test_migrate_preserves_historical_cli_entrypoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    migration_module = _migration_module()
+    sqlite_engine = create_engine("sqlite:///:memory:")
+    monkeypatch.setattr(migration_module, "db_connect", lambda: sqlite_engine)
+
+    migration_module.migrate()
+
     sqlite_engine.dispose()

--- a/tests/test_migrate_v8_pgvector_order.py
+++ b/tests/test_migrate_v8_pgvector_order.py
@@ -1,60 +1,108 @@
-from sqlalchemy import text
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine
 
 from pipeline import migrate_v8
 
 
 class _FakeConn:
-    def __init__(self, log):
+    def __init__(
+        self,
+        log: list[str],
+        *,
+        retired_catalog_vector_count: int = 0,
+    ) -> None:
         self.log = log
+        self.retired_catalog_vector_count = retired_catalog_vector_count
+        self.dialect = type("Dialect", (), {"name": "postgresql"})()
 
-    def execute(self, stmt, *args, **kwargs):
-        if isinstance(stmt, str):
-            sql = stmt
-        elif isinstance(stmt, type(text("x"))):
-            sql = str(stmt)
-        else:
-            sql = str(stmt)
+    def execute(
+        self,
+        statement: object,
+        _params: dict[str, str] | None = None,
+    ) -> "_ScalarResult":
+        sql = str(statement)
         self.log.append(sql.strip().lower())
-        return None
+        if "information_schema.columns" in sql:
+            return _ScalarResult(1)
+        if "count(*)" in sql:
+            return _ScalarResult(self.retired_catalog_vector_count)
+        return _ScalarResult(None)
 
 
-class _BeginCtx:
-    def __init__(self, conn):
-        self.conn = conn
+class _ScalarResult:
+    def __init__(self, value: object | None) -> None:
+        self.value = value
 
-    def __enter__(self):
-        return self.conn
+    def scalar_one(self) -> object:
+        assert self.value is not None
+        return self.value
 
-    def __exit__(self, _exc_type, exc, _tb):
-        return False
-
-
-class _FakeEngine:
-    def __init__(self, log):
-        self.log = log
-        self.dialect = type("D", (), {"name": "postgresql"})()
-        self.conn = _FakeConn(log)
-
-    def begin(self):
-        return _BeginCtx(self.conn)
+    def scalar(self) -> object | None:
+        return self.value
 
 
-def test_migrate_v8_orders_extension_before_create_all(monkeypatch):
-    log = []
-    engine = _FakeEngine(log)
+def test_migrate_v8_uses_frozen_ddl_on_caller_owned_connection() -> None:
+    log: list[str] = []
+    migration_connection = _FakeConn(log)
 
-    monkeypatch.setattr(migrate_v8, "db_connect", lambda: engine)
-
-    def _fake_create_all(_engine):
-        log.append("__create_all__")
-
-    monkeypatch.setattr(migrate_v8.Base.metadata, "create_all", _fake_create_all)
-
-    migrate_v8.migrate()
+    migrate_v8.migrate(migration_connection)
 
     create_ext_idx = next(i for i, s in enumerate(log) if "create extension if not exists vector" in s)
-    create_all_idx = next(i for i, s in enumerate(log) if s == "__create_all__")
+    create_table_idx = next(i for i, s in enumerate(log) if "create table if not exists semantic_embedding" in s)
     drop_idx = next(i for i, s in enumerate(log) if "alter table catalog drop column if exists semantic_embedding" in s)
     index_idx = next(i for i, s in enumerate(log) if "create index if not exists ix_semantic_embedding_hnsw" in s)
 
-    assert create_ext_idx < create_all_idx < drop_idx < index_idx
+    assert create_ext_idx < create_table_idx < drop_idx < index_idx
+    assert any(
+        "create unique index if not exists ix_semantic_embedding_catalog_model"
+        in statement
+        for statement in log
+    )
+    assert any(
+        "create unique index if not exists ix_semantic_embedding_item_model"
+        in statement
+        for statement in log
+    )
+
+
+def test_migrate_v8_returns_retired_catalog_vector_count_before_drop() -> None:
+    log: list[str] = []
+    migration_connection = _FakeConn(
+        log,
+        retired_catalog_vector_count=11,
+    )
+
+    retired_catalog_vector_count = migrate_v8.migrate(migration_connection)
+
+    count_idx = next(
+        index for index, statement in enumerate(log) if "count(*)" in statement
+    )
+    drop_idx = next(
+        index
+        for index, statement in enumerate(log)
+        if "alter table catalog drop column if exists semantic_embedding" in statement
+    )
+    assert retired_catalog_vector_count == 11
+    assert count_idx < drop_idx
+
+
+def test_migrate_v8_does_not_depend_on_current_model_metadata() -> None:
+    migration_source = Path("pipeline/migration_pgvector_semantic_embeddings.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert "pipeline.models" not in migration_source
+    assert "Base.metadata" not in migration_source
+
+
+def test_migrate_v8_preserves_historical_cli_entrypoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sqlite_engine = create_engine("sqlite:///:memory:")
+    monkeypatch.setattr(migrate_v8, "db_connect", lambda: sqlite_engine)
+
+    migrate_v8.migrate()
+
+    sqlite_engine.dispose()

--- a/tests/test_migrate_v9.py
+++ b/tests/test_migrate_v9.py
@@ -1,23 +1,37 @@
+from contextlib import AbstractContextManager
+from types import TracebackType
+
+from pytest_mock import MockerFixture
+
 from pipeline import migrate_v9
 
 
 class _ScalarResult:
-    def __init__(self, value):
+    def __init__(self, value: object | None) -> None:
         self._value = value
 
-    def scalar(self):
+    def scalar(self) -> object | None:
         return self._value
 
 
 class _FakeConn:
-    def __init__(self, existing_columns=None):
+    def __init__(
+        self,
+        existing_columns: set[tuple[str, str]] | None = None,
+    ) -> None:
         self.existing_columns = set(existing_columns or [])
-        self.calls = []
+        self.calls: list[tuple[str, dict[str, str] | None]] = []
+        self.dialect = type("Dialect", (), {"name": "postgresql"})()
 
-    def execute(self, stmt, params=None):
-        sql = str(stmt)
+    def execute(
+        self,
+        statement: object,
+        params: dict[str, str] | None = None,
+    ) -> _ScalarResult:
+        sql = str(statement)
         self.calls.append((sql, params))
         if "information_schema.columns" in sql:
+            assert params is not None
             table = params["table"]
             column = params["column"]
             return _ScalarResult(1 if (table, column) in self.existing_columns else None)
@@ -25,30 +39,35 @@ class _FakeConn:
 
 
 class _BeginCtx:
-    def __init__(self, conn):
+    def __init__(self, conn: _FakeConn) -> None:
         self.conn = conn
 
-    def __enter__(self):
+    def __enter__(self) -> _FakeConn:
         return self.conn
 
-    def __exit__(self, _exc_type, exc, _tb):
+    def __exit__(
+        self,
+        _exc_type: type[BaseException] | None,
+        _exc: BaseException | None,
+        _tb: TracebackType | None,
+    ) -> bool:
         return False
 
 
 class _FakeEngine:
-    def __init__(self, conn, dialect_name="postgresql"):
+    def __init__(self, conn: _FakeConn, dialect_name: str = "postgresql") -> None:
         self.conn = conn
         self.dialect = type("Dialect", (), {"name": dialect_name})()
 
-    def begin(self):
+    def begin(self) -> AbstractContextManager[_FakeConn]:
         return _BeginCtx(self.conn)
 
 
-def _sql_calls(conn):
+def _sql_calls(conn: _FakeConn) -> list[str]:
     return [sql.lower() for sql, _ in conn.calls]
 
 
-def test_migrate_v9_adds_missing_lineage_columns(mocker):
+def test_migrate_v9_adds_missing_lineage_columns(mocker: MockerFixture) -> None:
     conn = _FakeConn()
     engine = _FakeEngine(conn)
     mocker.patch.object(migrate_v9, "db_connect", return_value=engine)
@@ -62,7 +81,7 @@ def test_migrate_v9_adds_missing_lineage_columns(mocker):
     assert any("create index if not exists ix_catalog_lineage_id" in c for c in calls)
 
 
-def test_migrate_v9_is_idempotent_when_columns_exist(mocker):
+def test_migrate_v9_is_idempotent_when_columns_exist(mocker: MockerFixture) -> None:
     conn = _FakeConn(
         existing_columns={
             ("catalog", "lineage_id"),
@@ -77,15 +96,15 @@ def test_migrate_v9_is_idempotent_when_columns_exist(mocker):
 
     calls = _sql_calls(conn)
     assert not any("alter table" in c and "lineage_" in c for c in calls)
+    assert any("create index if not exists ix_catalog_lineage_id" in c for c in calls)
+    assert any("create index if not exists ix_catalog_lineage_confidence" in c for c in calls)
+    assert any("create index if not exists ix_catalog_lineage_updated_at" in c for c in calls)
 
 
-def test_migrate_v9_preserves_column_exists_patch_seam(mocker):
+def test_migrate_v9_uses_caller_owned_connection() -> None:
     conn = _FakeConn()
-    engine = _FakeEngine(conn)
-    mocker.patch.object(migrate_v9, "db_connect", return_value=engine)
-    mocker.patch.object(migrate_v9, "_column_exists", return_value=True)
 
-    migrate_v9.migrate()
+    migrate_v9.migrate(conn)
 
     calls = _sql_calls(conn)
-    assert not any("alter table" in c and "lineage_" in c for c in calls)
+    assert any("alter table catalog add column lineage_id" in c for c in calls)

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -92,7 +92,6 @@ APPROVED_BROAD_EXCEPTION_PATHS = {
     "pipeline/agenda_legistar.py",
     "pipeline/agenda_worker.py",
     "pipeline/check_faiss_runtime.py",
-    "pipeline/db_migration_runner.py",
     "pipeline/diagnose_search_sort.py",
     "pipeline/diagnose_semantic_search.py",
     "pipeline/indexer.py",
@@ -1110,6 +1109,27 @@ def test_python_guardrails_provide_mandatory_pgvector_postgres():
     }
     assert postgres_service["ports"] == ["5432:5432"]
     assert "pg_isready" in postgres_service["options"]
+
+
+def test_python_guardrails_run_migration_acceptance_before_full_suite():
+    workflow_text = (
+        ROOT / ".github" / "workflows" / "python-guardrails.yml"
+    ).read_text(encoding="utf-8")
+    migration_step = (
+        "      - name: Run PostgreSQL migration acceptance\n"
+        "        run: PYTHONPATH=. python -m pytest -q "
+        "tests/test_alembic_migrations.py"
+    )
+    full_suite_marker = "      - name: Run full Python test suite\n"
+
+    assert workflow_text.count(migration_step) == 1
+    assert workflow_text.index(migration_step) < workflow_text.index(full_suite_marker)
+    migration_step_body = workflow_text.partition(migration_step)[2].partition(
+        "\n      - name:"
+    )[0]
+    assert "continue-on-error:" not in migration_step_body
+    assert "if:" not in migration_step_body
+
 
 def test_coverage_configuration_measures_repository_production_python():
     coverage_config = configparser.ConfigParser()

--- a/tests/test_run_pipeline_orchestration.py
+++ b/tests/test_run_pipeline_orchestration.py
@@ -127,7 +127,7 @@ def test_main_runs_steps_in_expected_order(mocker):
 
     run_pipeline.main()
 
-    assert calls[0][0] == "DB Migrate"
+    assert calls[0] == ("DB Migrate", ("python", "db_migrate.py"))
     assert calls[1][0] == "Seed Places"
     assert calls[2][0] == "Promote Staged Events"
     assert calls[3][0] == "Downloader"

--- a/tests/test_seed_places.py
+++ b/tests/test_seed_places.py
@@ -1,6 +1,6 @@
-import io
-
-from sqlalchemy import create_engine
+import pytest
+from sqlalchemy import create_engine, event
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import sessionmaker
 
 from pipeline.models import Base, Place
@@ -13,7 +13,7 @@ def _engine():
     return engine
 
 
-def test_seed_places_inserts_and_updates_rows(mocker):
+def test_seed_places_inserts_and_updates_rows(mocker, tmp_path):
     engine = _engine()
     Session = sessionmaker(bind=engine)
     session = Session()
@@ -35,10 +35,10 @@ def test_seed_places_inserts_and_updates_rows(mocker):
         "Newville,CA,us,Newville City,ocd-division/country:us/state:ca/place:newville,https://newville.example.com,granicus\n"
     )
 
+    city_metadata_path = tmp_path / "cities.csv"
+    city_metadata_path.write_text(csv_text, encoding="utf-8")
     mocker.patch("pipeline.seed_places.db_connect", return_value=engine)
-    mocker.patch("pipeline.seed_places.create_tables")
-    mocker.patch("pipeline.seed_places.os.path.exists", return_value=True)
-    mocker.patch("builtins.open", return_value=io.StringIO(csv_text))
+    mocker.patch("pipeline.seed_places.CITY_METADATA_PATH", city_metadata_path)
 
     seed_places()
 
@@ -52,24 +52,47 @@ def test_seed_places_inserts_and_updates_rows(mocker):
     engine.dispose()
 
 
-def test_seed_places_rolls_back_on_commit_error(mocker):
+def test_seed_places_rolls_back_on_commit_error(mocker, tmp_path):
     fake_session = mocker.MagicMock()
     fake_session.commit.side_effect = ValueError("bad csv")
     fake_session.query.return_value.filter.return_value.first.return_value = None
+    rollback_observed = False
+
+    def record_rollback() -> None:
+        nonlocal rollback_observed
+        rollback_observed = True
 
     mocker.patch("pipeline.seed_places.db_connect", return_value=object())
-    mocker.patch("pipeline.seed_places.create_tables")
     mocker.patch("pipeline.seed_places.sessionmaker", return_value=lambda: fake_session)
-    mocker.patch("pipeline.seed_places.os.path.exists", return_value=True)
-    mocker.patch(
-        "builtins.open",
-        return_value=io.StringIO(
-            "city,state,country,display_name,ocd_division_id,city_council_url,hosting_services\n"
-            "Bad,CA,us,Bad City,ocd-division/country:us/state:ca/place:bad,https://bad.example.com,host\n"
-        ),
+    fake_session.rollback.side_effect = record_rollback
+    city_metadata_path = tmp_path / "cities.csv"
+    city_metadata_path.write_text(
+        "city,state,country,display_name,ocd_division_id,city_council_url,hosting_services\n"
+        "Bad,CA,us,Bad City,ocd-division/country:us/state:ca/place:bad,https://bad.example.com,host\n",
+        encoding="utf-8",
     )
+    mocker.patch("pipeline.seed_places.CITY_METADATA_PATH", city_metadata_path)
 
-    seed_places()
+    with pytest.raises(ValueError, match="bad csv"):
+        seed_places()
 
-    fake_session.rollback.assert_called_once()
-    fake_session.close.assert_called_once()
+    assert rollback_observed is True
+
+
+def test_seed_places_fails_on_unmigrated_schema(mocker, caplog):
+    engine = create_engine("sqlite:///:memory:")
+    rollback_observed = False
+
+    def record_rollback(_connection) -> None:
+        nonlocal rollback_observed
+        rollback_observed = True
+
+    event.listen(engine, "rollback", record_rollback)
+    mocker.patch("pipeline.seed_places.db_connect", return_value=engine)
+
+    with pytest.raises(OperationalError):
+        seed_places()
+
+    assert rollback_observed is True
+    assert "Error during seeding" in caplog.text
+    engine.dispose()

--- a/tests/test_seed_places_includes_cupertino.py
+++ b/tests/test_seed_places_includes_cupertino.py
@@ -20,8 +20,6 @@ def test_seed_places_includes_cupertino_from_repo_csv(mocker):
 
     # Force seed_places() to use our in-memory DB, but read the real CSV from the repo.
     mocker.patch("pipeline.seed_places.db_connect", return_value=engine)
-    mocker.patch("pipeline.seed_places.create_tables")  # tables already exist
-    mocker.patch("pipeline.seed_places.os.path.exists", return_value=True)
 
     seed_places()
 
@@ -48,8 +46,6 @@ def test_seed_places_updates_san_mateo_to_official_portal(mocker):
     Base.metadata.create_all(engine)
 
     mocker.patch("pipeline.seed_places.db_connect", return_value=engine)
-    mocker.patch("pipeline.seed_places.create_tables")
-    mocker.patch("pipeline.seed_places.os.path.exists", return_value=True)
 
     seed_places()
 


### PR DESCRIPTION
## What changed
- Add Alembic 1.18.5 with an explicit frozen v10 baseline revision.
- Make `pipeline/db_migrate.py` the only supported schema entrypoint for fresh, unversioned, and versioned PostgreSQL databases.
- Adopt unversioned databases only after strict legacy repair and object-level parity inside one advisory-locked transaction.
- Remove implicit table creation from seed/promotion flows and migrate before starting schema consumers.
- Add PostgreSQL CI acceptance, parity CLI, backup/rollback/vector-rehydration guidance, and remove the stale migration-runner BLE001 exemption.

## Why
Town Council had multiple schema owners, best-effort legacy migrations, and no versioned post-v10 graph. This establishes the G5-approved Alembic baseline without changing application APIs or runtime defaults.

## Risk and compatibility
- Baseline downgrade is intentionally forbidden; operators must restore the verified pre-adoption backup.
- Existing unversioned databases fail closed on schema drift and remain unstamped.
- Frozen v8 may retire derived catalog vectors; the runbook records the count and rehydration procedure.
- No database was modified outside disposable PostgreSQL test databases.

## Verification
- PASS: `./.venv/bin/ruff check .`
- PASS: `./.venv/bin/pre-commit validate-config`
- PASS: `./.venv/bin/pre-commit run ruff --all-files`
- PASS: `./.venv/bin/mypy`
- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_repository_guardrails.py` (396 passed)
- PASS: PostgreSQL migration/legacy acceptance (37 passed)
- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py tests/test_docker_build_contracts.py tests/test_run_pipeline_orchestration.py` (46 passed)
- PASS: PostgreSQL-backed full coverage suite (1,561 passed; 83.15%, floor 71%)
- PASS: live `scripts/check_schema_parity.py` smoke (`Schema parity: PASS`)
- PASS: `docker compose config --quiet`

## Remaining deficit
- NOT VERIFIED: local `docker compose build pipeline api worker`. Two attempts failed before repository layers ran because Docker Hub timed out resolving `docker/dockerfile:1`; a direct pull then stalled in Docker's credential path. PR CI is authoritative for the containerized environment.

## Review
Three independent reviews found four P2 issues. All were fixed with regression coverage: head-vs-baseline parity, absolute container CLI path, sequence settings, and delayed unversioned adoption. Final Ruff-ratchet review found no P1/P2 issues.