### PR TITLE
T-PLAT-1A: Surface migration outcomes in CLI runs

### DIFF
--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,6 +1,6 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 3.52
+version: 3.53
 generated: 2026-07-26
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
@@ -10,6 +10,11 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v3.53:** Registers T-PLAT-1A after a late PR #150 review finding showed
+  that direct migration commands discard the INFO outcome used to decide
+  whether derived embeddings need rehydration. T-PLAT-1 remains implemented
+  but acceptance-incomplete until the CLI makes that outcome visible. Broader
+  dependency work remains pending.
 - **v3.52:** Grants T-PLAT-1 narrow ownership of `ruff.toml` to remove the
   stale `pipeline/db_migration_runner.py` BLE001 selector after the strict
   legacy runner eliminated its broad handler. No Ruff rule, source scope, or
@@ -252,7 +257,8 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 | State | Tasks |
 |---|---|
 | **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2, T-SEC-3, T-SEC-3C, T-SEC-4, T-SEC-4A, T-SEC-5, T-SEC-6, T-TIME-1, T-TIME-2, T-TIME-3, T-CRAWL-1, T-CRAWL-2, T-PLAT-2A, T-GOV-1, T-GOV-4, T-GOV-5, T-DA-1, T-DB-1A, T-DB-1, T-DB-1B |
-| **In progress** | T-PLAT-1 |
+| **In progress** | T-PLAT-1A |
+| **Implemented; acceptance incomplete** | T-PLAT-1 |
 | **Partially landed; acceptance incomplete** | T-GOV-6 |
 | **Pending** | T-DC-1, T-DD-1, T-DE-1, T-PLAT-2, T-PLAT-3, T-PLAT-4, T-GOV-2..3 |
 
@@ -1129,7 +1135,7 @@ files (GED-5 grant).
 
 ### T-PLAT-1: Alembic baseline (gate G5)
 - priority: P1
-- status: in progress
+- status: implemented in PR #150; acceptance incomplete pending T-PLAT-1A
 - must_not_run_concurrently_with: T-GOV-3
 - decision_record: `docs/plans/G5_ALEMBIC_ADOPTION_DECISION_PLAN.md`
 - implementation_plan: `docs/plans/T_PLAT_1_ALEMBIC_BASELINE_PLAN.md`
@@ -1221,6 +1227,30 @@ files (GED-5 grant).
   pgvector PostgreSQL service without optional skips. ARCHITECTURE maps
   Alembic as the authoritative post-baseline migration graph.
 - verify: Schema diff script output empty; suite green.
+
+### T-PLAT-1A: Make migration outcomes visible
+- priority: P1 (PR #150 closure)
+- status: in progress
+- depends_on: T-PLAT-1 implementation
+- implementation_plan:
+  `docs/plans/T_PLAT_1A_MIGRATION_OUTCOME_VISIBILITY_PLAN.md`
+- files_owned: docs/plans/T_PLAT_1A_MIGRATION_OUTCOME_VISIBILITY_PLAN.md,
+  docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md, pipeline/db_migrate.py,
+  tests/test_db_migrate.py, tests/test_alembic_migrations.py
+- do: Configure INFO logging only at the `db_migrate.py` CLI boundary and
+  preserve the import-safe `migrate()` operation. Make direct commands display
+  migration status, revision, and `retired_catalog_vector_count` so operators
+  can follow the existing embedding-rehydration procedure.
+- accept: Direct CLI execution exits successfully and writes the structured
+  migration outcome to stderr, including a zero or nonzero retired-vector
+  count; importing the module has no logging side effect; migration and
+  disposal behavior remain unchanged.
+- forbidden: Printing from the migration implementation, configuring logging
+  at import time, changing the migration result contract, swallowing failures,
+  or editing outside the five owned files.
+- verify: Follow the Full T-PLAT-1A plan, including tests-first subprocess
+  evidence, migration and docs contracts, full suite, independent review, and
+  CI.
 
 ### T-PLAT-2A: Patch Next.js's transitive Sharp runtime
 - priority: P0 (urgent dependency security patch)
@@ -1424,7 +1454,8 @@ Phase 1: agent-sec [T-SEC-1..6] || agent-time [T-TIME-1 + T-TIME-2 coordinated, 
 Gate:    G3 satisfied (T-GOV-1 Accepted ADR + active docs/TESTING.MD)
 Phase 2: agent-da || agent-db [T-DB-1A, then T-DB-1, then T-DB-1B] || agent-dd || agent-de ;
          then agent-dc (exclusive on api/*)
-Phase 3: agent-plat [T-PLAT-1 after T-TIME-1 and T-TIME-2, then T-PLAT-2..4]
+Phase 3: agent-plat [T-PLAT-1 after T-TIME-1 and T-TIME-2, T-PLAT-1A
+         closure, then T-PLAT-2..4]
          || agent-gov [T-GOV-2, T-GOV-3 + T-GOV-5]
 Anytime: T-GOV-6 DATA_GOVERNANCE.md (Section 3 pending G4)
 ```

--- a/docs/plans/T_PLAT_1A_MIGRATION_OUTCOME_VISIBILITY_PLAN.md
+++ b/docs/plans/T_PLAT_1A_MIGRATION_OUTCOME_VISIBILITY_PLAN.md
@@ -1,0 +1,248 @@
+# T-PLAT-1A: Make Migration Outcomes Visible
+
+`artifact_contract: ce-unified-plan/v1`
+
+`artifact_readiness: implementation-ready`
+
+`execution: code`
+
+## 1. Context & Alignment
+
+**a) Driver.** PR #150 established the Alembic baseline, but a late review
+finding identified an operator-visible defect. `pipeline/db_migrate.py` emits
+the migration outcome at INFO while its direct CLI entrypoint never configures
+logging. Python therefore discards the status, revision, and retired-vector
+count that `docs/OPERATIONS.md` uses to determine whether embedding
+rehydration is required.
+
+**b) Canonical documents consulted.**
+
+- `AGENTS.md` requires CLI behavior to match operational documentation,
+  import-time side effects to remain absent, and review findings to be resolved
+  with fresh evidence.
+- `docs/TESTING.MD` permits subprocess verification and database factory
+  substitution at the implementation-module lookup.
+- `docs/ENGINEERING_GUARDRAILS.md` requires Ruff, Mypy, import-side-effect,
+  and repository contract enforcement.
+- `docs/OPERATIONS.md` treats `retired_catalog_vector_count` as the decision
+  input for derived-vector rehydration.
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md` owns Alembic adoption in
+  T-PLAT-1 and requires a separately registered follow-up.
+- `docs/reviews/architecture-review-2026-07-19.html` requires one canonical
+  migration entrypoint and observable operational outcomes.
+
+**c) Remediation alignment.** T-PLAT-1A is the closure task for the late
+PR #150 P2. It owns exactly:
+
+- `docs/plans/T_PLAT_1A_MIGRATION_OUTCOME_VISIBILITY_PLAN.md`
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`
+- `pipeline/db_migrate.py`
+- `tests/test_db_migrate.py`
+- `tests/test_alembic_migrations.py`
+
+The task registration and plan are committed before runtime implementation.
+
+**d) Decision-gate check.** No G1-G5 decision is required or foreclosed. G5
+already approved Alembic adoption. This task changes CLI visibility only, not
+migration policy or database state.
+
+## 2. Design
+
+**e) Step-by-step approach.**
+
+1. Register T-PLAT-1A and commit this implementation-ready plan.
+2. Add a subprocess test that replaces only the database engine factory with
+   a SQLite-dialect fake, invokes the CLI `main()`, and requires the structured
+   zero-count migration outcome on stderr.
+3. Add focused success and failure tests proving `migrate()` always disposes
+   the engine and propagates migration failures.
+4. Add a PostgreSQL acceptance test that creates an unversioned legacy
+   catalog vector, invokes the real CLI subprocess, and requires
+   `retired_catalog_vector_count=1` on stderr.
+5. Run the new tests red because `main()` does not exist and INFO remains
+   disabled.
+6. Reuse `pipeline.cli_logging.configure_cli_logging` and the established
+   CLI-only pattern from `db_init.py`.
+7. Add `LOGGER_FORMAT`, a focused `_configure_cli_logging()`, and
+   `main() -> int`.
+8. Have `main()` configure INFO logging, call the unchanged `migrate()`, and
+   return zero. Use `raise SystemExit(main())` under the existing
+   `if __name__ == "__main__"` guard.
+9. Preserve migration exception propagation and engine disposal.
+10. Run targeted migration, import-side-effect, docs-link, and complete-suite
+   verification.
+11. Obtain fresh subagent review before commit, apply every eligible P1/P2,
+   then rerun affected checks.
+12. Commit, push, open one PR, reply to the late PR #150 review thread with
+    the follow-up evidence, and watch CI to a decided state.
+
+Each new function owns one concern. Imports continue from the CLI facade to
+the shared logging helper and migration implementation; helpers do not import
+the facade.
+
+**f) Reuse audit.** Reuse `configure_cli_logging`, the established CLI
+entrypoint pattern, `MigrationOutcome`, and the existing migration logger.
+Do not add a logging wrapper, callback, return-value alias, compatibility path,
+or second migration implementation.
+
+Rejected alternatives:
+
+- Raise the migration logger to WARNING: rejected because successful
+  migrations are informational, and severity inflation would distort logs.
+- Use `print()` inside `migrate_database()`: rejected because the
+  implementation is also called programmatically and must not own CLI output.
+- Configure logging at import time: rejected because Celery prefork and
+  guardrail policy forbid import-time global side effects.
+- Return a second result from `migrate()`: rejected because the existing
+  operation already logs the typed result and no caller needs a new contract.
+
+**g) Data contracts.** No application or database contract changes. The CLI
+now guarantees one INFO record with `status`, `revision`, and
+`retired_catalog_vector_count` after success. Exceptions still propagate and
+produce a nonzero process exit. `migrate()` remains `-> None`.
+
+**h) Schema and migrations.** None. The task does not execute new DDL or add
+an Alembic revision.
+
+## 3. Security & Data Governance
+
+**i) Security boundary.** No `AGENTS.md` security-sensitive path is touched.
+The additional output contains migration state and a count, not credentials
+or document content. An attacker gains no new capability.
+
+**j) Secrets.** No credential, key, environment variable, or default is added
+or logged.
+
+**k) Person data.** No person-level data is created, linked, aggregated, or
+exposed. G4 is unaffected.
+
+**l) Untrusted input.** No scraped content, provider response, HTML, or user
+input is parsed. The subprocess test supplies a test-only database factory.
+
+## 4. Code Health
+
+**m) GED conformance sweep.** New functions have no parameters, complete
+annotations, no nested branches, and one responsibility. The log format is a
+named constant. No error handler, timestamp, environment read, broad exception,
+or database behavior changes.
+
+**n) Antipattern scan, plan pass.**
+
+- A1/H1: the repository's installed `logging.basicConfig` wrapper and existing
+  `db_init.py` pattern define the verified API.
+- B1/F1: reuse the existing helper instead of adding logging machinery.
+- B2/C1: `migrate()` remains the single programmatic operation; `main()` is
+  only the standard CLI boundary, not a compatibility path.
+- D2: the test asserts process exit and stderr, not helper calls.
+- D3: the structured log fields are the operator-visible contract.
+- H4: logging is configured only inside `main()`.
+- A2-A4, B3, C2, D1, E1-E3, F2, and H2-H3: no planned violations.
+
+**o) Ratchet interaction.** `pipeline/db_migrate.py` and
+`tests/test_db_migrate.py` have no Ruff per-file selectors or BLE001
+boundaries. No exception is added or widened.
+
+**p) Dead code and duplication audit.** No code becomes dead. The CLI logging
+pattern is reused through the existing shared helper. Expected production
+delta is one constant and two small CLI functions.
+
+## 5. Testing
+
+**q) Edge and failure scenarios.**
+
+1. Direct CLI execution keeps INFO logging disabled.
+2. A successful no-op migration omits status or revision.
+3. A zero retired-vector count is omitted because it is falsey.
+4. A real unversioned adoption retires a vector but does not display count one.
+5. Importing `pipeline.db_migrate` configures global logging.
+6. Migration exceptions are swallowed or converted to success.
+7. The engine is not disposed after success or failure.
+8. Programmatic callers unexpectedly configure logging.
+
+**r) Tests and evidence.**
+
+| Test or command | Scenarios |
+|---|---|
+| New isolated SQLite CLI subprocess test | 1-3 |
+| New PostgreSQL CLI adoption test | 4 |
+| Existing import-side-effect guardrails | 5, 8 |
+| New migration failure/disposal tests | 6, 7 |
+| Complete Python suite | 1-8 regression sweep |
+
+The subprocess test is added and run red before the implementation edit.
+
+**s) Fakes and mocks.** Unit tests replace `db_connect` where
+`pipeline.db_migrate` looks it up. This is the approved database factory
+boundary from `docs/TESTING.MD`. The fake engines select the existing
+`not_applicable` and failure paths; no migration implementation is patched.
+The nonzero test uses an isolated real PostgreSQL database and the real CLI.
+
+**t) Verification rows.** Apply docs-only verification and the typed-subtree
+row because `pipeline/db_migrate.py` changes. Run migration-focused tests,
+the import-side-effect guardrail, and the complete Python suite before
+handoff.
+
+## 6. Execution, Rollback, Docs
+
+**u) Exact commands.**
+
+```bash
+git fetch origin --prune
+git switch master
+git merge --ff-only origin/master
+git switch -c codex/t-plat-1a-migration-outcome-visibility
+```
+
+Tests-first red evidence:
+
+```bash
+PYTHONPATH=. .venv/bin/pytest -q \
+  tests/test_db_migrate.py::test_db_migrate_cli_reports_migration_outcome \
+  tests/test_alembic_migrations.py::test_cli_reports_retired_legacy_vectors
+```
+
+Final verification:
+
+```bash
+./.venv/bin/ruff check .
+./.venv/bin/mypy
+PYTHONPATH=. .venv/bin/pytest -q tests/test_db_migrate.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_alembic_migrations.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_pipeline_import_side_effects.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py
+PYTHONPATH=. .venv/bin/pytest -q
+git diff --check
+git status --short
+```
+
+Delivery uses two commits:
+
+1. `docs(remediation): authorize migration outcome visibility`
+2. `fix(db): show migration outcomes in CLI runs`
+
+**v) Rollback.** Revert the T-PLAT-1A merge commit and rerun the same targeted
+and full verification. No migration reversal or data remediation is required.
+Rollback knowingly restores invisible successful migration outcomes; operators
+must inspect the database manually before deciding on rehydration.
+
+**w) Docs synchronization.** Add this plan and update only the remediation
+ledger's version, changelog, task status, T-PLAT-1 acceptance state,
+T-PLAT-1A entry, and execution order. Existing operations instructions remain
+correct once the CLI output is fixed. README, ADR, architecture, testing,
+guardrails, security, and data-governance docs remain unchanged.
+
+## 7. Delivery Self-Audit
+
+**x) Antipattern scan, diff pass.** Re-run A-F and H. Reject import-time
+logging, print calls in migration implementation, new result wrappers,
+exception swallowing, test call-count assertions, unrelated formatting, or
+edits outside the four owned files.
+
+**y) Evidence.** Report the expected red test, stderr outcome, targeted and
+full verification, planning and pre-commit review findings, commit hashes,
+PR URL, thread response, unresolved-thread count, and CI state. Mark anything
+unrun as `NOT VERIFIED`.
+
+**z) Deviations.** Expected result is none. Any additional file, changed
+migration behavior, skipped review, unresolved P1/P2, or unrun required check
+is a blocker.

--- a/pipeline/db_migrate.py
+++ b/pipeline/db_migrate.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 import logging
 
 from pipeline import db_migration_alembic
+from pipeline.cli_logging import configure_cli_logging
 from pipeline.models import db_connect
 
 
 LOGGER = logging.getLogger("db-migrate")
+LOGGER_FORMAT = "%(asctime)s - %(levelname)s - %(message)s"
 
 
 def migrate() -> None:
@@ -24,5 +26,11 @@ def migrate() -> None:
         engine.dispose()
 
 
-if __name__ == "__main__":
+def main() -> int:
+    configure_cli_logging(LOGGER_FORMAT)
     migrate()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_alembic_migrations.py
+++ b/tests/test_alembic_migrations.py
@@ -5,6 +5,8 @@ from contextlib import contextmanager
 import importlib
 import os
 from pathlib import Path
+import subprocess
+import sys
 import time
 from types import ModuleType
 from uuid import uuid4
@@ -355,6 +357,53 @@ def test_current_unversioned_schema_is_repaired_and_adopted() -> None:
         assert migration_outcome.status == "adopted"
         assert _current_revision(database_engine) == BASELINE_REVISION
         assert _reference_schema_names(database_engine) == set()
+
+
+def test_direct_migration_cli_reports_retired_catalog_vectors() -> None:
+    migration_module = _migration_module()
+    with _isolated_postgres_database() as database_engine:
+        migration_module.migrate_database(database_engine)
+        with database_engine.begin() as connection:
+            connection.execute(text("DROP TABLE alembic_version"))
+            connection.execute(
+                text("ALTER TABLE catalog ADD COLUMN semantic_embedding VECTOR(384)")
+            )
+            connection.execute(
+                text(
+                    """
+                    INSERT INTO catalog (url_hash, semantic_embedding)
+                    VALUES (
+                        'retired-vector-sentinel',
+                        array_fill(0.5, ARRAY[384])::vector
+                    )
+                    """
+                )
+            )
+
+        cli_environment = os.environ.copy()
+        cli_environment["DATABASE_URL"] = database_engine.url.render_as_string(
+            hide_password=False
+        )
+        cli_environment["PYTHONPATH"] = str(ROOT)
+        completed_cli = subprocess.run(
+            [sys.executable, str(ROOT / "pipeline" / "db_migrate.py")],
+            cwd=ROOT,
+            env=cli_environment,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        assert completed_cli.returncode == 0
+        assert "database_migration_complete" in completed_cli.stderr
+        assert "status=adopted" in completed_cli.stderr
+        assert f"revision={BASELINE_REVISION}" in completed_cli.stderr
+        assert "retired_catalog_vector_count=1" in completed_cli.stderr
+        assert _current_revision(database_engine) == BASELINE_REVISION
+        assert not any(
+            column["name"] == "semantic_embedding"
+            for column in inspect(database_engine).get_columns("catalog")
+        )
 
 
 def test_unversioned_drift_aborts_without_stamp_or_data_loss() -> None:

--- a/tests/test_db_migrate.py
+++ b/tests/test_db_migrate.py
@@ -1,9 +1,13 @@
 from collections.abc import Callable
 import logging
+import os
 from pathlib import Path
+import subprocess
+import sys
 
 import pytest
 
+from pipeline import db_migrate
 from pipeline import db_migration_runner
 from pipeline.db_migration_backfills import run_core_backfills
 from pipeline.db_migration_columns import (
@@ -45,8 +49,87 @@ class _FakeConn:
         return _ScalarResult(None)
 
 
+class _DisposableMigrationEngine:
+    def __init__(self, dialect_name: str | None = "sqlite") -> None:
+        self._dialect_name = dialect_name
+        self.disposed = False
+        self.dialect = self
+
+    @property
+    def name(self) -> str:
+        if self._dialect_name is None:
+            raise RuntimeError("migration failed")
+        return self._dialect_name
+
+    def dispose(self) -> None:
+        self.disposed = True
+
+
 def _sql_calls(conn: _FakeConn) -> list[str]:
     return [sql.lower() for sql, _ in conn.calls]
+
+
+def test_direct_migration_cli_reports_no_op_outcome() -> None:
+    cli_source = """
+from pathlib import Path
+import runpy
+
+from pipeline import models
+
+
+class Engine:
+    class Dialect:
+        name = "sqlite"
+
+    dialect = Dialect()
+
+    def dispose(self) -> None:
+        pass
+
+
+models.db_connect = Engine
+runpy.run_path(Path("pipeline/db_migrate.py"), run_name="__main__")
+"""
+    cli_environment = os.environ.copy()
+    cli_environment["PYTHONPATH"] = str(Path.cwd())
+
+    completed_cli = subprocess.run(
+        [sys.executable, "-c", cli_source],
+        cwd=Path.cwd(),
+        env=cli_environment,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed_cli.returncode == 0
+    assert "database_migration_complete" in completed_cli.stderr
+    assert "status=not_applicable" in completed_cli.stderr
+    assert "revision=None" in completed_cli.stderr
+    assert "retired_catalog_vector_count=0" in completed_cli.stderr
+
+
+def test_migration_facade_disposes_engine_after_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    migration_engine = _DisposableMigrationEngine()
+    monkeypatch.setattr(db_migrate, "db_connect", lambda: migration_engine)
+
+    db_migrate.migrate()
+
+    assert migration_engine.disposed
+
+
+def test_migration_facade_disposes_engine_after_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    migration_engine = _DisposableMigrationEngine(dialect_name=None)
+    monkeypatch.setattr(db_migrate, "db_connect", lambda: migration_engine)
+
+    with pytest.raises(RuntimeError, match="migration failed"):
+        db_migrate.migrate()
+
+    assert migration_engine.disposed
 
 
 def test_core_migrations_add_legacy_columns_and_backfill_values() -> None:


### PR DESCRIPTION
## What changed

- register T-PLAT-1A as the focused acceptance follow-up to PR #150
- configure INFO logging only when `pipeline/db_migrate.py` runs as a CLI
- report migration status, revision, and retired catalog vector count to stderr
- test zero and nonzero retirement outcomes through direct subprocess execution
- preserve engine disposal and exception propagation

## Why

PR #150 logged migration outcomes at INFO but did not configure logging for direct CLI execution. Operators therefore could not see whether retired catalog vectors require embedding rehydration.

## Risk and compatibility

Low. `migrate()` and migration behavior are unchanged. Importing the module does not configure logging. No schema, runtime default, API, or data-policy change is included.

## Verification

- Expected red: `PYTHONPATH=. .venv/bin/pytest -q tests/test_db_migrate.py::test_direct_migration_cli_reports_no_op_outcome tests/test_db_migrate.py::test_migration_facade_disposes_engine_after_success tests/test_db_migrate.py::test_migration_facade_disposes_engine_after_failure` -> **FAIL**: direct CLI stderr was empty; two disposal tests passed
- `./.venv/bin/ruff check .` -> **PASS**
- `./.venv/bin/pre-commit run ruff --all-files` -> **PASS**
- `./.venv/bin/mypy` -> **PASS**, 68 source files
- `TEST_POSTGRES_DATABASE_URL=postgresql://town_council:town_council_test@localhost:55432/town_council_test PYTHONPATH=. .venv/bin/pytest -q tests/test_db_migrate.py tests/test_alembic_migrations.py` -> **PASS**, 27 tests
- `PYTHONPATH=. .venv/bin/pytest -q tests/test_db_migrate.py::test_db_migration_implementation_modules_do_not_import_facade tests/test_docs_links.py` -> **PASS**, 3 tests
- `TEST_POSTGRES_DATABASE_URL=postgresql://town_council:town_council_test@localhost:55432/town_council_test PYTHONPATH=. .venv/bin/pytest -q` -> **PASS**, 1,565 tests
- `git diff --check` -> **PASS**
- independent planning review -> **PASS**, no remaining P1/P2
- independent pre-commit review -> **PASS**, no findings

## Remaining deficits

- CI is pending and is authoritative for the checked-in runner environment.
- One diagnostic command referenced nonexistent `tests/test_import_boundaries.py`; it was replaced by the existing migration facade boundary test above. No implementation defect was involved.
- The plan proposed a one-line `_configure_cli_logging()` wrapper; implementation omitted it because direct use of the existing logging helper is simpler and avoids unrequested machinery.
