### PR TITLE
T-PLAT-2B: Patch pypdf batch parsing

### DIFF
--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1295,8 +1295,9 @@ files (GED-5 grant).
   `pypdf==6.14.2`, the first release that closes all four open repository
   advisories. Catch pypdf's documented `PyPdfError` base at both table-parser
   boundaries because patched malformed inputs now raise `PdfReadError` and
-  `LimitReachedError`. Narrow the optional import fallback to `ImportError`
-  and remove the resulting stale table-worker BLE001 allowance.
+  `LimitReachedError`. Limit the optional import fallback to an absent
+  top-level `pypdf` package and remove the resulting stale table-worker
+  BLE001 allowance.
 - accept: The batch manifest has exactly one pypdf pin at 6.14.2; the core
   worker manifest still excludes pypdf; the batch image imports
   `pypdf.errors.PyPdfError`; malformed pypdf failures persist `tables=[]`

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,6 +1,6 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 3.53
+version: 3.54
 generated: 2026-07-26
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
@@ -10,6 +10,13 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v3.54:** Marks T-PLAT-1 and T-PLAT-1A complete after PRs #150 and #151
+  merged with required checks green and the late migration-outcome review
+  thread resolved. Activates T-PLAT-2B before broader dependency hygiene to
+  patch four open pypdf advisories, including two high-severity findings,
+  without mixing audit or constraints work into the urgent pin update. The
+  task also broadens malformed-PDF handling to pypdf's documented base
+  exception and removes the obsolete table-worker BLE001 allowance.
 - **v3.53:** Registers T-PLAT-1A after a late PR #150 review finding showed
   that direct migration commands discard the INFO outcome used to decide
   whether derived embeddings need rehydration. T-PLAT-1 remains implemented
@@ -256,9 +263,8 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 | State | Tasks |
 |---|---|
-| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2, T-SEC-3, T-SEC-3C, T-SEC-4, T-SEC-4A, T-SEC-5, T-SEC-6, T-TIME-1, T-TIME-2, T-TIME-3, T-CRAWL-1, T-CRAWL-2, T-PLAT-2A, T-GOV-1, T-GOV-4, T-GOV-5, T-DA-1, T-DB-1A, T-DB-1, T-DB-1B |
-| **In progress** | T-PLAT-1A |
-| **Implemented; acceptance incomplete** | T-PLAT-1 |
+| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2, T-SEC-3, T-SEC-3C, T-SEC-4, T-SEC-4A, T-SEC-5, T-SEC-6, T-TIME-1, T-TIME-2, T-TIME-3, T-CRAWL-1, T-CRAWL-2, T-PLAT-1, T-PLAT-1A, T-PLAT-2A, T-GOV-1, T-GOV-4, T-GOV-5, T-DA-1, T-DB-1A, T-DB-1, T-DB-1B |
+| **In progress** | T-PLAT-2B |
 | **Partially landed; acceptance incomplete** | T-GOV-6 |
 | **Pending** | T-DC-1, T-DD-1, T-DE-1, T-PLAT-2, T-PLAT-3, T-PLAT-4, T-GOV-2..3 |
 
@@ -1135,7 +1141,7 @@ files (GED-5 grant).
 
 ### T-PLAT-1: Alembic baseline (gate G5)
 - priority: P1
-- status: implemented in PR #150; acceptance incomplete pending T-PLAT-1A
+- status: complete and verified 2026-07-26 (PRs #150 and #151)
 - must_not_run_concurrently_with: T-GOV-3
 - decision_record: `docs/plans/G5_ALEMBIC_ADOPTION_DECISION_PLAN.md`
 - implementation_plan: `docs/plans/T_PLAT_1_ALEMBIC_BASELINE_PLAN.md`
@@ -1230,7 +1236,7 @@ files (GED-5 grant).
 
 ### T-PLAT-1A: Make migration outcomes visible
 - priority: P1 (PR #150 closure)
-- status: in progress
+- status: complete and verified 2026-07-26 (PR #151)
 - depends_on: T-PLAT-1 implementation
 - implementation_plan:
   `docs/plans/T_PLAT_1A_MIGRATION_OUTCOME_VISIBILITY_PLAN.md`
@@ -1273,6 +1279,36 @@ files (GED-5 grant).
 - verify: Follow the Full T-PLAT-2A plan, including tests-first red evidence,
   lockfile-only generation, clean install, native and Docker build smokes,
   frontend tests, audit, docs links, independent review, and diff checks.
+
+### T-PLAT-2B: Patch pypdf batch parsing
+- priority: P0 (urgent dependency security patch)
+- status: in progress
+- depends_on: T-PLAT-1A closure
+- implementation_plan:
+  `docs/plans/T_PLAT_2B_PYPDF_SECURITY_PATCH_PLAN.md`
+- files_owned: docs/plans/T_PLAT_2B_PYPDF_SECURITY_PATCH_PLAN.md,
+  docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md,
+  pipeline/requirements-batch.txt, pipeline/table_worker.py, ruff.toml,
+  tests/test_docker_build_contracts.py, tests/test_repository_guardrails.py,
+  tests/test_table_worker.py
+- do: Replace the vulnerable `pypdf==6.13.3` batch-only pin with
+  `pypdf==6.14.2`, the first release that closes all four open repository
+  advisories. Catch pypdf's documented `PyPdfError` base at both table-parser
+  boundaries because patched malformed inputs now raise `PdfReadError` and
+  `LimitReachedError`. Narrow the optional import fallback to `ImportError`
+  and remove the resulting stale table-worker BLE001 allowance.
+- accept: The batch manifest has exactly one pypdf pin at 6.14.2; the core
+  worker manifest still excludes pypdf; the batch image imports
+  `pypdf.errors.PyPdfError`; malformed pypdf failures persist `tables=[]`
+  instead of aborting the batch; the stale BLE001 allowance is removed; the
+  complete Python suite remains green; alerts 116-119 report `fixed` after
+  merge.
+- forbidden: Broad constraints, audit workflow, parser logic, Camelot,
+  unrelated dependency changes, or a compatibility alias for
+  `PdfStreamError`.
+- verify: Follow the Full T-PLAT-2B plan, including tests-first pin evidence,
+  published-wheel import verification, dependency and table-worker contracts,
+  complete suite, independent review, and post-merge Dependabot readback.
 
 ### T-PLAT-2: Dependency hygiene
 - priority: P2
@@ -1455,7 +1491,7 @@ Gate:    G3 satisfied (T-GOV-1 Accepted ADR + active docs/TESTING.MD)
 Phase 2: agent-da || agent-db [T-DB-1A, then T-DB-1, then T-DB-1B] || agent-dd || agent-de ;
          then agent-dc (exclusive on api/*)
 Phase 3: agent-plat [T-PLAT-1 after T-TIME-1 and T-TIME-2, T-PLAT-1A
-         closure, then T-PLAT-2..4]
+         closure, T-PLAT-2B security patch, then T-PLAT-2..4]
          || agent-gov [T-GOV-2, T-GOV-3 + T-GOV-5]
 Anytime: T-GOV-6 DATA_GOVERNANCE.md (Section 3 pending G4)
 ```

--- a/docs/plans/T_PLAT_2B_PYPDF_SECURITY_PATCH_PLAN.md
+++ b/docs/plans/T_PLAT_2B_PYPDF_SECURITY_PATCH_PLAN.md
@@ -50,8 +50,9 @@ seam, migration behavior, model policy, runtime default, or soak baseline.
 2. Add a malformed-PDF test requiring `PyPdfError` from both Camelot strategies
    to persist `tables=[]` without aborting catalog processing.
 3. Run both tests and record failures against 6.13.3 and `PdfStreamError`.
-4. Pin 6.14.2; import and catch `PyPdfError`; narrow the optional import
-   fallback to `ImportError`; remove the stale table-worker BLE001 allowance.
+4. Pin 6.14.2; import and catch `PyPdfError`; limit the optional import
+   fallback to an absent top-level `pypdf` package; remove the stale
+   table-worker BLE001 allowance.
 5. Download the exact wheel without installing it. Verify Python 3.14,
    `Requires-Python`, version 6.14.2, and the public exception import.
 6. Build the real batch image and smoke pypdf, Camelot, and `PyPdfError`.
@@ -124,8 +125,8 @@ persisting an empty table result. Tests use existing approved boundaries.
 - A2, A4, B2-B3, C1-C2, D2, E3, F2, and H2-H4: no planned violations.
 
 **o) Ratchets.** Remove the table-worker BLE001 selector and matching exact
-boundary inventory after replacing broad import fallback with `ImportError`.
-No selector is added or widened.
+boundary inventory after replacing the broad import fallback with a guarded
+`ModuleNotFoundError`. No selector is added or widened.
 
 **p) Dead code and duplication.** Remove the obsolete pin expectation,
 `PdfStreamError` import/fallback, and stale BLE001 entries. Do not preserve an

--- a/docs/plans/T_PLAT_2B_PYPDF_SECURITY_PATCH_PLAN.md
+++ b/docs/plans/T_PLAT_2B_PYPDF_SECURITY_PATCH_PLAN.md
@@ -1,0 +1,298 @@
+# T-PLAT-2B: Patch pypdf Batch Parsing
+
+`artifact_contract: ce-unified-plan/v1`
+`artifact_readiness: implementation-ready`
+`execution: code`
+
+## 1. Context & Alignment
+
+**a) Driver.** The default branch pins `pypdf==6.13.3` in the batch worker.
+Dependabot alerts 116 through 119 report two high- and two medium-severity
+denial-of-service risks in malformed PDF parsing. Version 6.14.2 is the first
+release that closes all four alerts. Civic documents are externally sourced,
+so the parser must not retain known unbounded-loop or memory-risk defects.
+
+**b) Canonical documents consulted.**
+
+- `AGENTS.md`: current dependency evidence, tests first, narrow ownership,
+  exact verification, and no runtime-policy drift.
+- `SECURITY.md`: crawled documents are untrusted; patch dependencies without
+  broadening exposure.
+- `docs/TESTING.MD`: use observable filesystem, subprocess, and dependency
+  contracts rather than test-only seams.
+- `docs/ENGINEERING_GUARDRAILS.md`: Ruff and the complete suite are
+  authoritative Python checks.
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md` assigns dependency hygiene to
+  the PLAT lane. T-PLAT-2B isolates the urgent pypdf patch from the broader
+  constraints, Dependabot, and audit work in T-PLAT-2.
+- `docs/reviews/architecture-review-2026-07-19.html`: keep platform dependency
+  work separate from facade and runtime architecture changes.
+
+**c) Remediation alignment.** T-PLAT-2B is a focused child of T-PLAT-2 and
+follows merged T-PLAT-1A. It owns exactly the two planning documents,
+`pipeline/requirements-batch.txt`, `pipeline/table_worker.py`, `ruff.toml`,
+`tests/test_docker_build_contracts.py`, `tests/test_repository_guardrails.py`,
+and `tests/test_table_worker.py`.
+
+The ledger closes T-PLAT-1 and T-PLAT-1A, activates T-PLAT-2B, and leaves
+broader dependency hygiene pending.
+
+**d) Decision-gate check.** No G1-G5 decision is required or foreclosed. This
+patch changes no deployment posture, visitor policy, person-data policy, test
+seam, migration behavior, model policy, runtime default, or soak baseline.
+
+## 2. Design
+
+**e) Step-by-step approach.**
+
+1. Add a focused batch dependency contract requiring exactly one pypdf pin at
+   6.14.2 while preserving its exclusion from the live-worker manifest.
+2. Add a malformed-PDF test requiring `PyPdfError` from both Camelot strategies
+   to persist `tables=[]` without aborting catalog processing.
+3. Run both tests and record failures against 6.13.3 and `PdfStreamError`.
+4. Pin 6.14.2; import and catch `PyPdfError`; narrow the optional import
+   fallback to `ImportError`; remove the stale table-worker BLE001 allowance.
+5. Download the exact wheel without installing it. Verify Python 3.14,
+   `Requires-Python`, version 6.14.2, and the public exception import.
+6. Build the real batch image and smoke pypdf, Camelot, and `PyPdfError`.
+7. Run focused behavior, Docker and guardrail contracts, static gates, docs
+   links, and the complete suite.
+8. Inspect the diff and obtain a fresh subagent pre-commit review; apply P1/P2
+   findings and rerun affected checks.
+9. Commit implementation separately from authorization, push one branch,
+   open one PR, request Codex review, and watch required checks.
+10. After merge, query alerts 116-119 directly and require `state=fixed`.
+
+**f) Reuse audit.** Extend the existing batch requirements split, parser error
+boundary, Docker contract, table-worker tests, and Ruff ratchet. pypdf 6.14.2
+uses `PdfReadError` and `LimitReachedError` for the patched failures; their
+existing `PyPdfError` base is the single correct boundary. T-PLAT-2 retains
+constraints and audit automation.
+
+Rejected alternatives: 6.14.0/6.14.1 leave a high alert open; moving pypdf to
+the core worker breaks the batch-only split; preserving `PdfStreamError` lets
+sibling exceptions abort the batch; broad T-PLAT-2 delays urgent remediation.
+
+**g) Contracts.**
+
+- Old batch pin: `pypdf==6.13.3`.
+- New batch pin: `pypdf==6.14.2`.
+- Old parser boundary: `PdfStreamError`.
+- New parser boundary: `PyPdfError`, covering documented pypdf parse failures.
+- Unchanged: live-worker exclusion, batch image ownership, successful table
+  extraction, runtime defaults, task signatures, and application interfaces.
+
+**h) Schema and migrations.** None.
+## 3. Security & Data Governance
+
+**i) Security boundary.** The changed files are not listed under
+`AGENTS.md` security-sensitive paths. The dependency parses externally sourced
+PDF bytes in the batch worker. The patch removes known denial-of-service risks
+and ensures the library's new bounded failures remain catalog-local rather
+than aborting the batch. It changes no inputs, privileges, or exposure.
+
+**j) Secrets.** No credential, key, token, environment variable, package index,
+or default is added.
+
+**k) Person data.** No person-level data is created, linked, aggregated,
+retained, or exposed. G4 is unaffected.
+
+**l) Untrusted input.** PDF bytes remain untrusted at the Camelot/pypdf
+boundary. The failure catch expands to pypdf's documented base exception;
+successful parsing and persistence are unchanged.
+
+## 4. Code Health
+
+**m) Conformance.** The implementation changes one pin and one existing
+exception boundary. The error handler still takes meaningful action by
+persisting an empty table result. Tests use existing approved boundaries.
+
+**n) Antipattern scan, plan pass.**
+
+- A1/H1: Context7 verifies current pypdf exception documentation and Python
+  support. PyPI verifies 6.14.2 as a universal wheel with Python 3.14 support.
+  Installed pip 26.1.1 help verifies `download`, `--no-deps`,
+  `--only-binary`, and `--dest`.
+- A3: package installation is not claimed. Wheel download/import and CI
+  results are reported separately; the batch image build is explicit.
+- B1/F1: reuse the manifest and existing contract test; add no dependency
+  abstraction.
+- D1: update the exact security expectation; do not skip, suppress, or dismiss
+  an alert.
+- D3: exact version matching is the public security outcome.
+- E1/E2: edit only the eight owned files; no generated file exists.
+- A2, A4, B2-B3, C1-C2, D2, E3, F2, and H2-H4: no planned violations.
+
+**o) Ratchets.** Remove the table-worker BLE001 selector and matching exact
+boundary inventory after replacing broad import fallback with `ImportError`.
+No selector is added or widened.
+
+**p) Dead code and duplication.** Remove the obsolete pin expectation,
+`PdfStreamError` import/fallback, and stale BLE001 entries. Do not preserve an
+alias. Expected production delta is neutral apart from exception naming.
+
+## 5. Testing
+
+**q) Edge and failure scenarios.**
+
+1. The batch manifest remains on vulnerable 6.13.3.
+2. More than one pypdf pin appears.
+3. pypdf leaks into the live-worker manifest.
+4. A patched `PdfReadError` or `LimitReachedError` escapes catalog processing.
+5. Both Camelot strategies fail and the catalog is not marked `tables=[]`.
+6. The wheel or batch image fails under its configured Python runtime.
+7. Wheel metadata/version or `PyPdfError` import is wrong.
+8. The table-worker BLE001 allowance remains after its violation is removed.
+9. An unrelated dependency or application file changes.
+10. Any alert 116-119 is not `fixed` after merge.
+
+**r) Test mapping.**
+
+| Test or evidence | Scenarios |
+|---|---|
+| Focused batch pypdf pin contract | 1-3 |
+| New malformed-pypdf behavior test | 4-5 |
+| Published wheel plus real batch-image smoke | 6-7 |
+| Repository guardrail test | 8 |
+| `git diff --check`, status, and file inventory | 9 |
+| Direct per-alert Dependabot readback | 10 |
+
+Both focused contracts are written and run red before implementation.
+
+**s) Fakes and mocks.** The pin contract uses the filesystem boundary. The
+behavior test uses the existing Camelot dependency fake and DB-session
+boundary, patching `pipeline.table_worker`, not a facade. No seam is added.
+
+**t) Verification rows.** Apply guardrail/tooling and docs-only rows, focused
+table-worker and Docker contracts, real batch-image smoke, and the complete
+suite. Required PR checks remain authoritative.
+## 6. Execution, Rollback, Docs
+
+**u) Exact commands.**
+
+```bash
+git fetch origin --prune
+git switch master
+git merge --ff-only origin/master
+git switch -c codex/t-plat-2b-pypdf-security-patch
+```
+
+Tests-first red evidence:
+
+```bash
+PYTHONPATH=. .venv/bin/pytest -q \
+  tests/test_docker_build_contracts.py::test_batch_pdf_parser_uses_patched_pypdf \
+  tests/test_table_worker.py::test_process_single_pdf_handles_pypdf_error_as_broken_pdf
+```
+
+Published-wheel verification without installation:
+
+```bash
+.venv/bin/python - <<'PY'
+from importlib.metadata import metadata, version
+from pathlib import Path
+import subprocess
+import sys
+from tempfile import TemporaryDirectory
+
+assert sys.version_info[:2] == (3, 14)
+with TemporaryDirectory(prefix="tc-pypdf-wheel-") as wheel_directory:
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "download",
+            "--no-deps",
+            "--only-binary=:all:",
+            "--dest",
+            wheel_directory,
+            "pypdf==6.14.2",
+        ],
+        check=True,
+    )
+    wheel_path = next(Path(wheel_directory).glob("pypdf-6.14.2-*.whl"))
+    sys.path.insert(0, str(wheel_path))
+
+    from pypdf.errors import PyPdfError
+
+    assert version("pypdf") == "6.14.2"
+    assert metadata("pypdf")["Requires-Python"] == ">=3.9"
+    assert issubclass(PyPdfError, Exception)
+    print(f"verified pypdf=={version('pypdf')}")
+PY
+```
+
+Batch-image verification requires operator approval because it installs packages:
+
+```bash
+docker build --target python-worker-batch \
+  -t town-council-pypdf-6.14.2-smoke .
+docker run --rm --entrypoint python town-council-pypdf-6.14.2-smoke \
+  -c "import camelot,pypdf; from pypdf.errors import PyPdfError; assert pypdf.__version__ == '6.14.2'; assert callable(camelot.read_pdf)"
+```
+
+Final verification:
+
+```bash
+./.venv/bin/ruff check .
+./.venv/bin/mypy
+PYTHONPATH=. .venv/bin/pytest -q tests/test_docker_build_contracts.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_table_worker.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_repository_guardrails.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py
+PYTHONPATH=. .venv/bin/pytest -q
+git diff --check
+git status --short
+```
+
+Delivery uses two commits:
+
+1. `docs(remediation): authorize T-PLAT-2B pypdf patch`
+2. `fix(deps): patch pypdf batch parsing`
+
+Push the branch, open one PR titled
+`T-PLAT-2B: Patch pypdf batch parsing`, request Codex review, and watch all
+required checks. Do not merge without operator approval.
+
+Post-merge readback:
+
+```bash
+set -e
+for alert_number in 116 117 118 119; do
+  test "$(gh api --method GET \
+    "repos/manumissio/town-council/dependabot/alerts/$alert_number" \
+    --jq .state)" = "fixed"
+done
+```
+
+Dismissed or open alerts fail the loop.
+
+**v) Rollback.** Revert the merge commit, rebuild the batch image, and rerun
+the focused behavior, Docker, guardrail, static, docs, and complete-suite
+checks. No data remediation is required. Rollback knowingly restores four
+advisories and the narrower parser exception boundary.
+
+**w) Docs synchronization.**
+
+- Remediation plan: close T-PLAT-1/T-PLAT-1A, register T-PLAT-2B, and update
+  execution order.
+- New T-PLAT-2B Full plan.
+- README, ADR, architecture, operations, testing policy, security policy, and
+  data-governance docs: no change because behavior and operator commands do
+  not change.
+
+## 7. Delivery Self-Audit
+
+**x) Diff scan.** Re-run A-F and H. Reject code outside the parser boundary,
+constraints/audit machinery, another manifest, compatibility aliases,
+dependency churn, unrelated formatting, or paths outside the eight-file set.
+
+**y) Evidence.** Report both red tests, wheel metadata/import, batch-image
+smoke, Ruff, Mypy, Docker/table-worker/guardrail/docs tests, complete-suite
+counts, reviews, commits, PR, CI, and per-alert readback. Mark unrun package
+installation or image build as `NOT VERIFIED`.
+
+**z) Deviations.** Expected result is none. Any extra file, wrong version,
+package installation without approval, swallowed non-pypdf error, audit
+suppression, skipped review, unresolved P1/P2, or missing check is a blocker.

--- a/pipeline/requirements-batch.txt
+++ b/pipeline/requirements-batch.txt
@@ -1,5 +1,5 @@
 spacy==3.7.4
-pypdf==6.13.3
+pypdf==6.14.2
 scikit-learn==1.5.0
 pytextrank==3.3.0
 camelot-py==0.11.0

--- a/pipeline/table_worker.py
+++ b/pipeline/table_worker.py
@@ -5,10 +5,13 @@ from multiprocessing import cpu_count, get_context
 from sqlalchemy.exc import SQLAlchemyError
 
 try:
-    from pypdf.errors import PdfStreamError
-except Exception:  # pragma: no cover - host test env may not install pypdf
-    class PdfStreamError(Exception):
-        pass
+    from pypdf.errors import PyPdfError
+except ModuleNotFoundError as import_error:  # pragma: no cover - optional in live workers
+    if import_error.name != "pypdf":
+        raise
+
+    class PyPdfError(Exception):
+        """Fallback keeps non-batch development imports available."""
 
 from pipeline.models import Catalog
 from pipeline.cli_logging import configure_cli_logging
@@ -94,7 +97,7 @@ def process_single_pdf(catalog_id):
                 # Try lattice mode first (best for tables with visible borders)
                 try:
                     tables = camelot.read_pdf(record.location, pages=pages, flavor='lattice')
-                except (ValueError, OSError, RuntimeError, IndexError, PdfStreamError):
+                except (ValueError, OSError, RuntimeError, IndexError, PyPdfError):
                     # PDF parsing errors: Why do we need a fallback strategy?
                     # Lattice mode can fail for several reasons:
                     # - ValueError: PDF has no grid lines (needs stream mode instead)
@@ -120,7 +123,7 @@ def process_single_pdf(catalog_id):
                 record.tables = extracted_data
                 session.commit()
                 return 1
-            except (ValueError, OSError, RuntimeError, MemoryError, IndexError, PdfStreamError) as e:
+            except (ValueError, OSError, RuntimeError, MemoryError, IndexError, PyPdfError) as e:
                 # Table extraction failures: What else can go wrong?
                 # - ValueError: Invalid page range, malformed PDF structure
                 # - OSError: File disappeared, permissions changed, disk full

--- a/ruff.toml
+++ b/ruff.toml
@@ -88,7 +88,6 @@ extend-immutable-calls = ["fastapi.Depends", "fastapi.Query", "fastapi.Path", "f
 "pipeline/startup_purge.py" = ["BLE001"]
 "pipeline/summary_backfill_dispatch.py" = ["BLE001"]
 "pipeline/task_startup.py" = ["BLE001"]
-"pipeline/table_worker.py" = ["BLE001"]
 "pipeline/task_agenda_titles.py" = ["C901"]
 "pipeline/tasks.py" = ["B904", "BLE001"]
 "pipeline/text_cleaning.py" = ["BLE001"]

--- a/tests/test_docker_build_contracts.py
+++ b/tests/test_docker_build_contracts.py
@@ -7,6 +7,13 @@ from pathlib import Path
 import pytest
 
 TEST_MEILI_MASTER_KEY = "test-only-meilisearch-master-key"
+RUNTIME_REQUIREMENT_PATHS = (
+    Path("api/requirements.txt"),
+    Path("council_crawler/requirements.txt"),
+    Path("pipeline/requirements.txt"),
+    Path("pipeline/requirements-batch.txt"),
+    Path("semantic_service/requirements.txt"),
+)
 
 
 def _compose_services(
@@ -56,15 +63,26 @@ def _service_dependencies(
     }
 
 
+def _normalized_requirement_name(requirement_line: str) -> str | None:
+    requirement_specifier = requirement_line.partition("#")[0].strip()
+    if not requirement_specifier:
+        return None
+    requirement_name = re.split(
+        r"[<>=!~;\[\s]",
+        requirement_specifier,
+        maxsplit=1,
+    )[0]
+    return re.sub(r"[-_.]+", "-", requirement_name).lower()
+
+
 def _requirement_names(requirements_path: Path) -> set[str]:
-    requirement_names = set()
-    for requirement_line in requirements_path.read_text(encoding="utf-8").splitlines():
-        requirement_specifier = requirement_line.partition("#")[0].strip()
-        if not requirement_specifier:
-            continue
-        requirement_name = re.split(r"[<>=!~;\[\s]", requirement_specifier, maxsplit=1)[0]
-        requirement_names.add(re.sub(r"[-_.]+", "-", requirement_name).lower())
-    return requirement_names
+    return {
+        requirement_name
+        for requirement_line in requirements_path.read_text(
+            encoding="utf-8"
+        ).splitlines()
+        if (requirement_name := _normalized_requirement_name(requirement_line))
+    }
 
 
 def test_compose_uses_role_specific_python_images_and_model_volume():
@@ -378,11 +396,9 @@ def test_compose_maps_worker_family_to_live_and_batch_images():
 def test_worker_runtime_requirements_exclude_development_tooling():
     runtime = Path("pipeline/requirements.txt").read_text(encoding="utf-8")
     dev = Path("pipeline/requirements-dev.txt").read_text(encoding="utf-8")
-    runtime_requirement_names = {
-        re.split(r"[<>=!~;\[\s]", requirement_line, maxsplit=1)[0].lower()
-        for runtime_line in runtime.splitlines()
-        if (requirement_line := runtime_line.partition("#")[0].strip())
-    }
+    runtime_requirement_names = _requirement_names(
+        Path("pipeline/requirements.txt")
+    )
 
     for package in (
         "pytest==9.0.3",
@@ -397,16 +413,9 @@ def test_worker_runtime_requirements_exclude_development_tooling():
 
 
 def test_coverage_tooling_is_development_only():
-    runtime_requirement_paths = (
-        Path("api/requirements.txt"),
-        Path("council_crawler/requirements.txt"),
-        Path("pipeline/requirements.txt"),
-        Path("pipeline/requirements-batch.txt"),
-        Path("semantic_service/requirements.txt"),
-    )
     development_requirements = Path("pipeline/requirements-dev.txt").read_text(encoding="utf-8")
 
-    for runtime_requirement_path in runtime_requirement_paths:
+    for runtime_requirement_path in RUNTIME_REQUIREMENT_PATHS:
         runtime_requirements = runtime_requirement_path.read_text(encoding="utf-8")
         runtime_requirement_names = _requirement_names(runtime_requirement_path)
         runtime_requirement_directives = [
@@ -442,9 +451,28 @@ def test_worker_live_and_batch_requirements_split_table_stack_only():
         assert package not in core
         assert package in batch
 
-    for package in ("spacy==3.7.4", "pytextrank==3.3.0", "scikit-learn==1.5.0", "pypdf==6.13.3"):
+    for package in ("spacy==3.7.4", "pytextrank==3.3.0", "scikit-learn==1.5.0"):
         assert package not in core
         assert package in batch
+
+
+def test_batch_pdf_parser_uses_patched_pypdf():
+    batch_requirements_path = Path("pipeline/requirements-batch.txt")
+    pypdf_requirement_paths = [
+        requirements_path
+        for requirements_path in RUNTIME_REQUIREMENT_PATHS
+        if "pypdf" in _requirement_names(requirements_path)
+    ]
+    batch_pypdf_requirements = [
+        requirement_line.partition("#")[0].strip()
+        for requirement_line in batch_requirements_path.read_text(
+            encoding="utf-8"
+        ).splitlines()
+        if _normalized_requirement_name(requirement_line) == "pypdf"
+    ]
+
+    assert pypdf_requirement_paths == [batch_requirements_path]
+    assert batch_pypdf_requirements == ["pypdf==6.14.2"]
 
 
 def test_bootstrap_and_runbook_use_semantic_image_for_semantic_artifacts():

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -106,7 +106,6 @@ APPROVED_BROAD_EXCEPTION_PATHS = {
     "pipeline/semantic_tasks.py",
     "pipeline/startup_purge.py",
     "pipeline/task_startup.py",
-    "pipeline/table_worker.py",
     "pipeline/tasks.py",
     "pipeline/text_cleaning.py",
     "pipeline/topic_worker.py",

--- a/tests/test_table_worker.py
+++ b/tests/test_table_worker.py
@@ -1,6 +1,11 @@
 import importlib
+import os
+from pathlib import Path
+import subprocess
 import sys
 from types import SimpleNamespace
+
+import pytest
 
 
 class _Ctx:
@@ -75,15 +80,17 @@ def test_process_single_pdf_handles_indexerror_as_broken_pdf(mocker):
     assert result == 1
     assert record.tables == []
     assert camelot.read_pdf.call_count == 2
-    session.commit.assert_called_once()
 
 
-def test_process_single_pdf_handles_pdfstreamerror_as_broken_pdf(mocker):
+def test_process_single_pdf_handles_pypdf_error_as_broken_pdf(mocker):
     tw, camelot = _load_table_worker(mocker)
     record = SimpleNamespace(id=4, location="/tmp/broken-stream.pdf", filename="broken-stream.pdf", tables=None)
     session = mocker.MagicMock()
     session.get.return_value = record
-    camelot.read_pdf.side_effect = [tw.PdfStreamError("truncated"), tw.PdfStreamError("truncated")]
+    camelot.read_pdf.side_effect = [
+        tw.PyPdfError("malformed PDF"),
+        tw.PyPdfError("malformed PDF"),
+    ]
 
     mocker.patch.object(tw, "db_session", return_value=_Ctx(session))
     mocker.patch.object(tw.os.path, "exists", return_value=True)
@@ -94,6 +101,52 @@ def test_process_single_pdf_handles_pdfstreamerror_as_broken_pdf(mocker):
     assert record.tables == []
     assert camelot.read_pdf.call_count == 2
     session.commit.assert_called_once()
+
+
+def test_process_single_pdf_propagates_unexpected_parser_error(mocker):
+    tw, camelot = _load_table_worker(mocker)
+    record = SimpleNamespace(
+        id=5,
+        location="/tmp/unexpected.pdf",
+        filename="unexpected.pdf",
+        tables=None,
+    )
+    session = mocker.MagicMock()
+    session.get.return_value = record
+    camelot.read_pdf.side_effect = TypeError("unexpected parser defect")
+
+    mocker.patch.object(tw, "db_session", return_value=_Ctx(session))
+    mocker.patch.object(tw.os.path, "exists", return_value=True)
+
+    with pytest.raises(TypeError, match="unexpected parser defect"):
+        tw.process_single_pdf(5)
+
+    assert record.tables is None
+
+
+def test_table_worker_does_not_hide_broken_pypdf_install(tmp_path):
+    pypdf_package = tmp_path / "pypdf"
+    pypdf_package.mkdir()
+    (pypdf_package / "__init__.py").write_text("", encoding="utf-8")
+    (pypdf_package / "errors.py").write_text(
+        "import missing_pypdf_dependency\n",
+        encoding="utf-8",
+    )
+    import_environment = os.environ.copy()
+    import_environment["PYTHONPATH"] = os.pathsep.join(
+        (str(tmp_path), str(Path.cwd()))
+    )
+
+    import_process = subprocess.run(
+        [sys.executable, "-c", "import pipeline.table_worker"],
+        cwd=Path.cwd(),
+        env=import_environment,
+        capture_output=True,
+        text=True,
+    )
+
+    assert import_process.returncode != 0
+    assert "missing_pypdf_dependency" in import_process.stderr
 
 
 def test_run_table_pipeline_returns_when_nothing_to_process(mocker):

--- a/tests/test_table_worker.py
+++ b/tests/test_table_worker.py
@@ -80,6 +80,7 @@ def test_process_single_pdf_handles_indexerror_as_broken_pdf(mocker):
     assert result == 1
     assert record.tables == []
     assert camelot.read_pdf.call_count == 2
+    session.commit.assert_called_once()
 
 
 def test_process_single_pdf_handles_pypdf_error_as_broken_pdf(mocker):


### PR DESCRIPTION
## What changed

- Upgrade batch-only `pypdf` from 6.13.3 to 6.14.2.
- Handle malformed PDF failures through pypdf's public `PyPdfError` base.
- Fall back only when the top-level `pypdf` package is absent; broken installations still fail fast.
- Keep unexpected parser defects visible.
- Enforce one exact batch-only pypdf pin and remove the stale table-worker BLE001 allowance.

## Why

Dependabot alerts 116-119 cover four malformed-PDF denial-of-service vulnerabilities, including two high-severity alerts. Version 6.14.2 is the first release that closes all four. Patched inputs may now fail with `PdfReadError` or `LimitReachedError`, both deriving from `PyPdfError`.

## Risk and compatibility

The change is confined to the batch table-extraction image and its parser failure boundary. Live workers, APIs, task signatures, schemas, runtime defaults, model policy, and soak policy are unchanged. Externally sourced PDFs remain untrusted; known parser failures stay catalog-local and persist `tables=[]` rather than aborting the batch. Unexpected exceptions still propagate.

## Verification

Tests-first red evidence:
- `test_batch_pdf_parser_uses_patched_pypdf`: failed on 6.13.3.
- `test_process_single_pdf_handles_pypdf_error_as_broken_pdf`: failed because the old boundary exposed only `PdfStreamError`.
- Broad-exception allowlist contract: failed until the stale table-worker BLE001 entry was removed.

PASS:
- `./.venv/bin/ruff check .`
- `./.venv/bin/mypy` (68 source files)
- `PYTHONPATH=. .venv/bin/pytest -q tests/test_docker_build_contracts.py tests/test_table_worker.py` (34 passed)
- `PYTHONPATH=. .venv/bin/pytest -q tests/test_repository_guardrails.py` (396 passed)
- `PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py` (2 passed)
- `PYTHONPATH=. .venv/bin/pytest -q` (1,551 passed, 17 skipped)
- Published pypdf 6.14.2 wheel metadata/import on Python 3.14 (`Requires-Python >=3.9`)
- Real `python-worker-batch` image build
- Batch-image runtime smoke for Camelot, pypdf 6.14.2, `PyPdfError`, `PdfReadError`, and `LimitReachedError`
- `git diff --check`

Independent pre-commit review found no P1. Its missing-wheel P2 was resolved with the published-wheel verification; its P3 exact commit-count assertion was removed. No unresolved P1/P2 remains locally.

## Remaining deficit

Dependabot alerts 116-119 remain open against `master` until merge. After merge, each alert will be queried directly and must report `fixed`.
