### PR TITLE
T-DD-1A: Consolidate worker health probes

### DIFF
--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,6 +1,6 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 3.55
+version: 3.56
 generated: 2026-07-26
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
@@ -10,6 +10,10 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v3.56:** Expands T-DD-1A ownership with exact-path role CLI parity tests
+  after pre-commit review found that direct script execution and role failure
+  aggregation were not durably covered. All three CLIs must work without
+  `PYTHONPATH`; real role containers remain the success-path evidence.
 - **v3.55:** Marks T-PLAT-2B complete after PR #152 merged and Dependabot
   alerts 116 through 119 closed as fixed. Splits the inaccurate T-DD-1 task
   into T-DD-1A worker-healthcheck consolidation and T-DD-1B city-state
@@ -1128,6 +1132,7 @@ files (GED-5 grant).
   `scripts/semantic_worker_healthcheck.py`;
   `tests/test_worker_health_probes.py`;
   `tests/test_worker_healthcheck.py`;
+  `tests/test_role_worker_healthchecks.py`;
   `tests/test_docker_health_contracts.py`
 - do: Move shared URL/TCP, Redis/PostgreSQL, failure aggregation, and reporting
   behavior into one implementation owner. Preserve all three CLI filenames,

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,6 +1,6 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 3.54
+version: 3.55
 generated: 2026-07-26
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
@@ -10,6 +10,12 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v3.55:** Marks T-PLAT-2B complete after PR #152 merged and Dependabot
+  alerts 116 through 119 closed as fixed. Splits the inaccurate T-DD-1 task
+  into T-DD-1A worker-healthcheck consolidation and T-DD-1B city-state
+  mutation analysis. Activates T-DD-1A with exact ownership for all three
+  worker healthcheck CLIs, a focused shared probe owner, parity tests, Docker
+  contracts, and its Full implementation plan.
 - **v3.54:** Marks T-PLAT-1 and T-PLAT-1A complete after PRs #150 and #151
   merged with required checks green and the late migration-outcome review
   thread resolved. Activates T-PLAT-2B before broader dependency hygiene to
@@ -263,10 +269,10 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 | State | Tasks |
 |---|---|
-| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2, T-SEC-3, T-SEC-3C, T-SEC-4, T-SEC-4A, T-SEC-5, T-SEC-6, T-TIME-1, T-TIME-2, T-TIME-3, T-CRAWL-1, T-CRAWL-2, T-PLAT-1, T-PLAT-1A, T-PLAT-2A, T-GOV-1, T-GOV-4, T-GOV-5, T-DA-1, T-DB-1A, T-DB-1, T-DB-1B |
-| **In progress** | T-PLAT-2B |
+| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2, T-SEC-3, T-SEC-3C, T-SEC-4, T-SEC-4A, T-SEC-5, T-SEC-6, T-TIME-1, T-TIME-2, T-TIME-3, T-CRAWL-1, T-CRAWL-2, T-PLAT-1, T-PLAT-1A, T-PLAT-2A, T-PLAT-2B, T-GOV-1, T-GOV-4, T-GOV-5, T-DA-1, T-DB-1A, T-DB-1, T-DB-1B |
+| **In progress** | T-DD-1A |
 | **Partially landed; acceptance incomplete** | T-GOV-6 |
-| **Pending** | T-DC-1, T-DD-1, T-DE-1, T-PLAT-2, T-PLAT-3, T-PLAT-4, T-GOV-2..3 |
+| **Pending** | T-DC-1, T-DD-1B, T-DE-1, T-PLAT-2, T-PLAT-3, T-PLAT-4, T-GOV-2..3 |
 
 ---
 
@@ -332,7 +338,7 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 | DEDUP-A   | agent-da   | pipeline/metrics.py, pipeline/metrics_redis_backend.py, tests/test_*metrics* |
 | DEDUP-B   | agent-db   | pipeline/summary_backfill*.py, pipeline/task_summary_generation*.py, pipeline/task_summary_empty_agenda.py, pipeline/task_summary_side_effects.py, pipeline/task_facade_helpers.py, pipeline/tasks.py, pipeline/run_pipeline.py (T-DB-1 only), pipeline/backlog_maintenance.py (T-DB-1B only), pipeline/agenda_summary_maintenance.py (T-DB-1B only), pipeline/agenda_summary_fallback.py (T-DB-1B only), pipeline/non_agenda_summary_fallback.py (T-DB-1B only), pipeline/agenda_summary_batch.py (T-DB-1B only), scripts/backfill_summaries.py, scripts/staged_hydrate_cities.py, scripts/profile_pipeline_selection.py, scripts/staged_hydration_runner.py (T-DB-1B only), ARCHITECTURE.md and docs/PIPELINE.md (T-DB-1B agenda-summary maintenance map only), tests/test_*backfill*, tests/test_summary_generation_operation.py (new), tests/test_agenda_summary_payload_budget.py, tests/test_summary_blocking.py, tests/test_task_provider_retry_semantics.py, tests/test_async_flow.py, tests/test_task_facade_cleanup.py, tests/test_repository_guardrails.py (T-DB tasks only), tests/test_pipeline_batching.py, tests/test_run_pipeline_orchestration.py, tests/test_staged_hydrate_cities.py, tests/test_tasks_agenda_summary_format.py, tests/test_profile_pipeline_cli.py |
 | DEDUP-C   | agent-dc   | api/main.py, api/app_setup.py, tests/conftest.py, tests/test_*api* (Phase 2 only) |
-| DEDUP-D   | agent-dd   | scripts/flush_city_pipeline_state.py, scripts/reset_city_verification_state.py, scripts/*_healthcheck.py, tests for same |
+| DEDUP-D   | agent-dd   | scripts/flush_city_pipeline_state.py, scripts/reset_city_verification_state.py, scripts/worker_health_probes.py, scripts/*_healthcheck.py, tests for same |
 | DEDUP-E   | agent-de   | pipeline/http_inference_provider.py, pipeline/inprocess_inference_provider.py, pipeline/inference_provider_contract.py, tests for same |
 | PLAT      | agent-plat | alembic/** (new), alembic.ini (new), pipeline/requirements*.txt, pipeline/db_init.py (T-PLAT-1 only), pipeline/db_migrate.py (T-PLAT-1 only, after TIME), pipeline/db_migration_alembic.py (new, T-PLAT-1 only), pipeline/db_migration_backfills.py (T-PLAT-1 shared transaction only), pipeline/db_migration_runner.py (T-PLAT-1 strict legacy path only), pipeline/db_schema_contracts.py (new, T-PLAT-1 only), pipeline/db_migration_columns.py (T-PLAT-1 legacy parity only), pipeline/migrate_v8.py (T-PLAT-1 frozen transaction adapter only), pipeline/migration_pgvector_semantic_embeddings.py (T-PLAT-1 frozen metadata only), pipeline/migrate_v9.py and pipeline/migration_catalog_lineage_columns.py (T-PLAT-1 shared transaction only), pipeline/migrate_v10.py (T-PLAT-1 shared transaction only), pipeline/seed_places.py (T-PLAT-1 schema handoff only), pipeline/promote_stage.py (T-PLAT-1 schema handoff only), scripts/check_schema_parity.py (new, T-PLAT-1 only), scripts/dev_up.sh (T-PLAT-1 only), README.md (T-PLAT-1 setup section only), ARCHITECTURE.md (T-PLAT-1 migration map only), api/requirements.txt, semantic_service/requirements.txt, constraints.txt (new), .github/dependabot.yml (new), .github/workflows/python-guardrails.yml (T-PLAT-1 PostgreSQL migration service/step only), ruff.toml (T-PLAT-1 stale db_migration_runner.py BLE001 selector removal only), docs/OPERATIONS.md (migration and backup sections only), docs/PIPELINE.md (T-PLAT-1 migration section only), docs/CONTRIBUTING_CITIES.md (T-PLAT-1 seed prerequisite only), docs/plans/T_PLAT_1_ALEMBIC_BASELINE_PLAN.md (new), docs/plans/G5_ALEMBIC_ADOPTION_DECISION_PLAN.md (T-PLAT-1 status only), docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md (T-PLAT-1 only), tests/test_alembic_migrations.py (new), tests/test_db_init.py (T-PLAT-1 only), tests/test_db_migrate.py (T-PLAT-1 only), tests/test_docker_build_contracts.py (T-PLAT-1 fresh-DB contract only), tests/test_migrate_v8_pgvector_order.py (T-PLAT-1 only), tests/test_migrate_v9.py (T-PLAT-1 only), tests/test_migrate_v10.py (T-PLAT-1 only), tests/test_seed_places.py (T-PLAT-1 schema handoff only), tests/test_seed_places_includes_cupertino.py (T-PLAT-1 schema handoff only), tests/test_database.py (T-PLAT-1 promotion schema handoff only), tests/test_pipeline_idempotency.py (T-PLAT-1 promotion schema handoff only), tests/test_pipeline_integration.py (T-PLAT-1 promotion schema handoff only), tests/test_repository_guardrails.py (T-PLAT-1 migration CI and BLE001 ratchet only), tests/test_run_pipeline_orchestration.py (T-PLAT-1 migration-prelude contract only), api/cache.py |
 | GOV       | agent-gov  | docs/ADR.md, docs/ENGINEERING_GUARDRAILS.md, AGENTS.md, SECURITY.md (new), docs/TESTING.md (new), docs/DATA_GOVERNANCE.md (new), tests/test_repository_guardrails.py (Phase 3 only) |
@@ -1112,15 +1118,39 @@ files (GED-5 grant).
 - risk: Highest-touch task in the plan. Land as one PR; do not interleave.
 - verify: Full suite + a manual `uvicorn api.main:app` boot smoke.
 
-### T-DD-1: Consolidate twin scripts
+### T-DD-1A: Consolidate worker health probes
 - priority: P2
-- files_owned: per lane table (flush/reset city state, worker healthchecks)
-- do: Extract the 26-window shared core of flush_city_pipeline_state /
-  reset_city_verification_state into one shared helper module in scripts/;
-  same for the two healthchecks. CLIs keep identical names, flags, output.
-- accept: Duplicate-window count between each pair ~0; CLI contract
-  unchanged (capture before/after --help and a dry-run output).
-- verify: Suite green; manual dry-run parity.
+- status: in progress
+- implementation_plan: `docs/plans/T_DD_1A_WORKER_HEALTHCHECK_PLAN.md`
+- files_owned: the plan and ledger; `scripts/worker_health_probes.py`;
+  `scripts/worker_healthcheck.py`;
+  `scripts/enrichment_worker_healthcheck.py`;
+  `scripts/semantic_worker_healthcheck.py`;
+  `tests/test_worker_health_probes.py`;
+  `tests/test_worker_healthcheck.py`;
+  `tests/test_docker_health_contracts.py`
+- do: Move shared URL/TCP, Redis/PostgreSQL, failure aggregation, and reporting
+  behavior into one implementation owner. Preserve all three CLI filenames,
+  role-specific probes, labels, defaults, timeouts, and exit behavior.
+- accept: No healthcheck CLI imports private helpers from another CLI; the
+  shared module never imports a CLI; all three role contracts and Compose
+  entrypoints remain unchanged; no BLE001 selector is added or widened.
+- verify: Follow the Full T-DD-1A plan; targeted healthcheck and Docker
+  contracts, Ruff, Mypy, docs links, and the complete Python suite pass.
+
+### T-DD-1B: Evaluate city-state mutation consolidation
+- priority: P2
+- status: pending after T-DD-1A
+- files_owned: `scripts/flush_city_pipeline_state.py`,
+  `scripts/reset_city_verification_state.py`, and focused tests to be named in
+  a separate Full plan
+- do: Characterize the exact shared event-graph deletion invariant before
+  extracting code. Preserve each command's distinct stage-row behavior,
+  defaults, temporal selection, output, and dry-run contract.
+- accept: Consolidate only proven identical mutation policy; do not force
+  shallow reuse when semantics differ.
+- verify: Separate tests-first Full plan, CLI parity, targeted tests, and the
+  complete suite.
 
 ### T-DE-1: Shared provider retry/telemetry
 - priority: P2

--- a/docs/plans/T_DD_1A_WORKER_HEALTHCHECK_PLAN.md
+++ b/docs/plans/T_DD_1A_WORKER_HEALTHCHECK_PLAN.md
@@ -230,9 +230,11 @@ PYTHONPATH=. .venv/bin/pytest -q \
   tests/test_docker_health_contracts.py \
   tests/test_docker_build_contracts.py
 
+docker compose --profile batch-tools build pipeline-batch semantic worker
 docker compose up -d \
   redis postgres inference worker enrichment-worker semantic-worker
-docker compose exec -T worker python scripts/worker_healthcheck.py
+docker compose exec -T -e LOCAL_AI_BACKEND=disabled \
+  worker python scripts/worker_healthcheck.py
 docker compose exec -T enrichment-worker \
   python scripts/enrichment_worker_healthcheck.py
 docker compose exec -T semantic-worker \

--- a/docs/plans/T_DD_1A_WORKER_HEALTHCHECK_PLAN.md
+++ b/docs/plans/T_DD_1A_WORKER_HEALTHCHECK_PLAN.md
@@ -64,8 +64,9 @@ comparability remain unchanged.
    - printing all collected failures and returning the CLI exit code.
 5. Have all three CLIs import the module, not copied symbols. This keeps tests
    on the implementation owner and avoids bound-name patch seams.
-6. Keep all environment reads and role policy in each CLI, including the
-   primary worker's `REDIS_HOST` fallback.
+6. Add the repository root inside each role CLI's `main()` for direct project
+   imports. Keep environment reads and role policy local, including the primary
+   worker's `REDIS_HOST` fallback.
 7. Keep primary-worker metrics and inference HTTP/model probes in
    `worker_healthcheck.py`.
 8. Keep enrichment task registration and `sklearn`/`spacy`/`pytextrank`

--- a/docs/plans/T_DD_1A_WORKER_HEALTHCHECK_PLAN.md
+++ b/docs/plans/T_DD_1A_WORKER_HEALTHCHECK_PLAN.md
@@ -3,16 +3,13 @@
 `artifact_contract: ce-unified-plan/v1`
 `artifact_readiness: implementation-ready`
 `execution: code`
-
 ## 1. Context & Alignment
 
-**a) Driver.** Town Council has three worker healthcheck CLIs, not the two
-described by the older remediation task. All three aggregate failures and
-probe Redis/PostgreSQL connectivity, while each owns different runtime checks.
-The architecture review recommends a deeper shared health-probe module and
-stable CLI entrypoints. T-DD-1A isolates that proven overlap from the disputed
-city-state mutation overlap in T-DD-1B.
-
+**a) Driver.** Town Council has three worker healthcheck CLIs, not the two in
+the older remediation task. All aggregate failures and probe Redis/PostgreSQL,
+while each owns different runtime checks. The architecture review recommends a
+shared health-probe module and stable CLI entrypoints. T-DD-1A isolates that
+overlap from the disputed city-state mutation overlap in T-DD-1B.
 **b) Canonical documents consulted.**
 
 - `AGENTS.md`: preserve CLI/runtime behavior, use approved test boundaries,
@@ -40,6 +37,7 @@ exactly:
 - `scripts/semantic_worker_healthcheck.py`
 - `tests/test_worker_health_probes.py` (new)
 - `tests/test_worker_healthcheck.py`
+- `tests/test_role_worker_healthchecks.py` (new)
 - `tests/test_docker_health_contracts.py`
 
 T-DD-1B retains the two city-state scripts and their focused tests. The two
@@ -48,7 +46,6 @@ tasks must not run concurrently with each other because they share the ledger.
 **d) Decision-gate check.** No G1-G5 decision is required or foreclosed.
 Runtime defaults, service topology, model policy, task registration, and soak
 comparability remain unchanged.
-
 ## 2. Design
 
 **e) Step-by-step approach.**
@@ -116,7 +113,6 @@ The observable contract remains: print every failure to stderr, return `1` if
 any probe fails, otherwise return `0`.
 
 **h) Schema/migration impact.** None.
-
 ## 3. Security & Data Governance
 
 **i) Security-sensitive paths.** None. Compose is verified but not edited.
@@ -165,8 +161,8 @@ selectors remain unchanged.
 **p) Dead code and duplication audit.** Delete private helper imports from the
 role CLIs and repeated broker/database/reporting blocks. Reuse existing probe
 logic rather than copying it. Expected production line count decreases; tests
-increase around the shared and primary-worker contracts. The task owns nine
-files.
+increase around the shared, primary-worker, and role CLI contracts. The task
+owns ten files.
 
 ## 5. Testing
 
@@ -196,6 +192,7 @@ files.
 |---|---|
 | New shared-probe tests using real loopback sockets | 1-4, 7-8 |
 | Updated primary-worker tests | 3, 5, 7-9, 12 |
+| New exact-path role CLI tests | 6-8, 10-13 |
 | Import-direction structural contract | 6, 11, 13 |
 | Docker health contract plus real role-container smoke | 6, 10, 12-13 |
 | Ruff, Mypy, and complete suite | 1-13 regression check |
@@ -227,6 +224,7 @@ git switch -c codex/t-dd-1a-worker-healthchecks
 PYTHONPATH=. .venv/bin/pytest -q \
   tests/test_worker_health_probes.py \
   tests/test_worker_healthcheck.py \
+  tests/test_role_worker_healthchecks.py \
   tests/test_docker_health_contracts.py \
   tests/test_docker_build_contracts.py
 
@@ -295,8 +293,7 @@ weakened tests, or files outside ownership.
 independent planning/pre-commit findings, applied fixes, commit hashes, PR URL,
 review threads, and CI state. Mark unrun checks `NOT VERIFIED`.
 
-**z) Deviations.** Authorized changes are splitting T-DD-1 into T-DD-1A and
-T-DD-1B and correcting the healthcheck count from two to three. Any other
-owned-file expansion, CLI/Compose contract change, role-check relocation,
-new exception, skipped review, unresolved P1/P2, or unrun required check is a
-blocker.
+**z) Deviations.** Authorized changes split T-DD-1 into T-DD-1A/T-DD-1B and
+correct the healthcheck count from two to three. Any other owned-file
+expansion, CLI/Compose contract change, role-check relocation, new exception,
+skipped review, unresolved P1/P2, or unrun required check is a blocker.

--- a/docs/plans/T_DD_1A_WORKER_HEALTHCHECK_PLAN.md
+++ b/docs/plans/T_DD_1A_WORKER_HEALTHCHECK_PLAN.md
@@ -1,0 +1,300 @@
+# T-DD-1A: Consolidate Worker Health Probes
+
+`artifact_contract: ce-unified-plan/v1`
+`artifact_readiness: implementation-ready`
+`execution: code`
+
+## 1. Context & Alignment
+
+**a) Driver.** Town Council has three worker healthcheck CLIs, not the two
+described by the older remediation task. All three aggregate failures and
+probe Redis/PostgreSQL connectivity, while each owns different runtime checks.
+The architecture review recommends a deeper shared health-probe module and
+stable CLI entrypoints. T-DD-1A isolates that proven overlap from the disputed
+city-state mutation overlap in T-DD-1B.
+
+**b) Canonical documents consulted.**
+
+- `AGENTS.md`: preserve CLI/runtime behavior, use approved test boundaries,
+  avoid compatibility seams, and run applicable script and full-suite checks.
+- `docs/TESTING.MD`: use approved outbound HTTP and filesystem boundaries;
+  use real loopback sockets and real role containers instead of inventing
+  socket, subprocess, environment, or dependency-import fakes.
+- `docs/ENGINEERING_GUARDRAILS.md`: Ruff config owns BLE001 boundaries and
+  repository scope.
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`: DEDUP-D owns the three
+  healthcheck scripts and their tests; task-level ownership must be exact.
+- `docs/reviews/architecture-review-2026-07-19.html`, Candidate 05: separate
+  health probing from city mutation; keep CLI names stable and test parity.
+- `SECURITY.md` and `docs/DATA_GOVERNANCE.md`: no affected security or person
+  data boundary.
+
+**c) Remediation alignment.** T-DD-1 becomes two ordered tasks. T-DD-1A owns
+exactly:
+
+- `docs/plans/T_DD_1A_WORKER_HEALTHCHECK_PLAN.md`
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`
+- `scripts/worker_health_probes.py` (new)
+- `scripts/worker_healthcheck.py`
+- `scripts/enrichment_worker_healthcheck.py`
+- `scripts/semantic_worker_healthcheck.py`
+- `tests/test_worker_health_probes.py` (new)
+- `tests/test_worker_healthcheck.py`
+- `tests/test_docker_health_contracts.py`
+
+T-DD-1B retains the two city-state scripts and their focused tests. The two
+tasks must not run concurrently with each other because they share the ledger.
+
+**d) Decision-gate check.** No G1-G5 decision is required or foreclosed.
+Runtime defaults, service topology, model policy, task registration, and soak
+comparability remain unchanged.
+
+## 2. Design
+
+**e) Step-by-step approach.**
+
+1. Register T-DD-1A and T-DD-1B in the remediation ledger before production
+   edits.
+2. Add characterization tests first for shared TCP targeting, failure
+   aggregation/reporting, primary-worker probes, import direction, and
+   unchanged Compose entrypoints.
+3. Record red evidence that enrichment and semantic CLIs import private
+   helpers from `worker_healthcheck.py` and duplicate network/report blocks.
+4. Add `scripts/worker_health_probes.py` as the single owner of:
+   - URL-to-socket target parsing;
+   - TCP connection probing;
+   - Redis/PostgreSQL probe aggregation from targets resolved by each CLI;
+   - printing all collected failures and returning the CLI exit code.
+5. Have all three CLIs import the module, not copied symbols. This keeps tests
+   on the implementation owner and avoids bound-name patch seams.
+6. Keep all environment reads and role policy in each CLI, including the
+   primary worker's `REDIS_HOST` fallback.
+7. Keep primary-worker metrics and inference HTTP/model probes in
+   `worker_healthcheck.py`.
+8. Keep enrichment task registration and `sklearn`/`spacy`/`pytextrank`
+   subprocess checks in `enrichment_worker_healthcheck.py`.
+9. Keep semantic runtime imports, task registration, and artifact-directory
+   write checks in `semantic_worker_healthcheck.py`.
+10. Preserve broad exception handling only in the two existing role CLI
+   boundaries. Do not move broad handlers into the shared module or widen
+   Ruff.
+11. Preserve malformed numeric configuration as fail-fast, and preserve probe
+    order, timeout values, labels, and sequential execution. Compose's existing
+    ten-second timeout tension is a separate operational issue.
+12. Run targeted, static, docs-link, and complete-suite verification; perform
+    simplification and independent pre-commit review; apply eligible findings.
+13. Commit authorization and implementation separately, push one branch, open
+    one PR, request review, and watch required checks to a decided state.
+
+Existing primary-worker tests that monkeypatch `_probe_tcp` and
+`_probe_http_model` are replaced with real loopback sockets and the approved
+outbound HTTP boundary. The refactor must not preserve those private patch
+targets.
+
+Each shared function has one responsibility. `worker_health_probes.py` imports
+only the standard library and never imports a CLI module.
+
+**f) Reuse audit.** Move the existing URL parser and TCP probe from
+`worker_healthcheck.py`; extend the existing aggregate-and-print behavior.
+There is no current shared owner beyond private imports from the primary CLI,
+so a focused module is justified. The old private imports and duplicated
+blocks are deleted in the same PR.
+
+Rejected alternatives:
+
+- Keep importing primary-worker private helpers: preserves a CLI as a shallow
+  facade and leaves reporting/network behavior split across three owners.
+- Extract all role checks: creates a generic registry/manager and weakens
+  domain ownership.
+- Combine three CLIs: breaks Compose entrypoints and role-specific images.
+- Include city-state scripts: mixes a disputed data-mutation invariant with
+  proven health-probe duplication.
+
+**g) Data contracts.** Shared functions use typed tuples and `list[str]`, the
+family's existing convention. No external payload or new dataclass is needed.
+The observable contract remains: print every failure to stderr, return `1` if
+any probe fails, otherwise return `0`.
+
+**h) Schema/migration impact.** None.
+
+## 3. Security & Data Governance
+
+**i) Security-sensitive paths.** None. Compose is verified but not edited.
+Socket and local HTTP probes retain their current targets, timeouts, and
+privileges. An attacker gains no new endpoint or capability.
+
+**j) Secrets.** No credential, environment variable, key, or default is added.
+Connection URLs remain read by the CLIs and are not printed.
+
+**k) Person data.** No person-level data is created, linked, aggregated, or
+exposed. G4 is unaffected.
+
+**l) Untrusted input.** Environment URLs and provider JSON retain their current
+parsing boundaries. The shared module parses only URL host/port values and
+reports connection failures without echoing credentials.
+
+## 4. Code Health
+
+**m) GED conformance sweep.** New and modified functions have complete type
+annotations, one responsibility, at most three parameters, and no nested
+branching beyond two levels. Existing timeout/port values move with their
+probe behavior or remain named constants. No timestamp or new environment read
+is introduced. Shared handlers catch specific socket failures; broad role
+boundary handlers still aggregate failures so all probes run before exit.
+
+**n) Antipattern scan, plan pass.**
+
+- A1/H1: `socket.create_connection`, `urlparse`, `subprocess.run`, and
+  `NamedTemporaryFile` calls are unchanged and verified against installed
+  Python 3.14 behavior.
+- B1/F1: one focused probe module replaces duplicated code; no manager,
+  registry, base class, or `utils` module.
+- B2/C1: no compatibility re-export; private CLI imports are removed.
+- C2/D2: tests patch implementation dependency boundaries, not facade aliases
+  or the unit under test.
+- D1/D3: characterization preserves outputs and role checks without skips,
+  weaker assertions, or call-count contracts.
+- E1/E2: only the nine owned files may change; no broad formatting.
+- A2-A4, B3, F2, and H2-H4: no planned violations.
+
+**o) Ratchet interaction.** Existing BLE001 entries for enrichment and semantic
+healthcheck CLIs remain because their boundary aggregation is intentional.
+The new shared module receives no exception. Ruff rule families and all other
+selectors remain unchanged.
+
+**p) Dead code and duplication audit.** Delete private helper imports from the
+role CLIs and repeated broker/database/reporting blocks. Reuse existing probe
+logic rather than copying it. Expected production line count decreases; tests
+increase around the shared and primary-worker contracts. The task owns nine
+files.
+
+## 5. Testing
+
+**q) Edge cases and failure scenarios.**
+
+1. Missing URL host or port yields a configured-target failure.
+2. Socket refusal/timeout becomes a compact failure and does not abort later
+   probes.
+3. Malformed ports and non-integer metrics ports retain their fail-fast
+   exceptions rather than becoming compact failures.
+4. IPv6 URLs continue to resolve host and port correctly.
+5. Primary worker retains `REDIS_HOST:6379` fallback when broker URL is empty.
+6. Enrichment and semantic workers do not gain that fallback.
+7. Multiple failures are all written to stderr and return exit `1`.
+8. No failures produce no stderr and return exit `0`.
+9. Primary metrics and Ollama/OpenAI-compatible model probes remain intact.
+10. Compose keeps all three exact script entrypoints.
+11. A shared helper importing a CLI or a role CLI importing another CLI fails
+    the structural contract.
+12. Probe order and timeout values remain unchanged.
+13. Local test environment lacks role-only packages; host availability must
+    not be treated as image behavior.
+
+**r) Tests mapped to scenarios.**
+
+| Test | Scenarios |
+|---|---|
+| New shared-probe tests using real loopback sockets | 1-4, 7-8 |
+| Updated primary-worker tests | 3, 5, 7-9, 12 |
+| Import-direction structural contract | 6, 11, 13 |
+| Docker health contract plus real role-container smoke | 6, 10, 12-13 |
+| Ruff, Mypy, and complete suite | 1-13 regression check |
+
+Characterization tests are added and run red before the shared module exists.
+
+**s) Fakes and mocks.** Shared TCP behavior uses real loopback listeners, not a
+socket fake. Primary-worker inference tests use the approved outbound HTTP
+boundary and remove private `_probe_tcp`/`_probe_http_model` monkeypatches.
+Role-only dependency and task-registration success paths are verified in their
+real Compose images, not with unapproved import or subprocess fakes. No facade,
+re-export, injectable callable, or production test seam is added.
+
+**t) Verification rows.** No named matrix row covers script-only behavior, so
+run focused healthcheck and Docker contract tests, the docs-only row for the
+plan, Ruff for Python changes, Mypy for repository confidence, and the
+complete Python suite before handoff.
+
+## 6. Execution, Rollback, Docs
+
+**u) Exact commands.**
+
+```bash
+git fetch origin --prune
+git switch master
+git merge --ff-only origin/master
+git switch -c codex/t-dd-1a-worker-healthchecks
+
+PYTHONPATH=. .venv/bin/pytest -q \
+  tests/test_worker_health_probes.py \
+  tests/test_worker_healthcheck.py \
+  tests/test_docker_health_contracts.py \
+  tests/test_docker_build_contracts.py
+
+docker compose up -d \
+  redis postgres inference worker enrichment-worker semantic-worker
+docker compose exec -T worker python scripts/worker_healthcheck.py
+docker compose exec -T enrichment-worker \
+  python scripts/enrichment_worker_healthcheck.py
+docker compose exec -T semantic-worker \
+  python scripts/semantic_worker_healthcheck.py
+
+set +e
+enrichment_failure=$(
+  docker compose run --rm --no-deps \
+    -e CELERY_BROKER_URL= -e DATABASE_URL= \
+    enrichment-worker python scripts/enrichment_worker_healthcheck.py 2>&1
+)
+enrichment_exit=$?
+semantic_failure=$(
+  docker compose run --rm --no-deps \
+    -e CELERY_BROKER_URL= -e DATABASE_URL= \
+    semantic-worker python scripts/semantic_worker_healthcheck.py 2>&1
+)
+semantic_exit=$?
+set -e
+test "$enrichment_exit" -eq 1
+test "$semantic_exit" -eq 1
+printf '%s\n' "$enrichment_failure" | grep -F "redis broker target is not configured"
+printf '%s\n' "$semantic_failure" | grep -F "redis broker target is not configured"
+
+./.venv/bin/ruff check .
+./.venv/bin/mypy
+PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py
+PYTHONPATH=. .venv/bin/pytest -q
+git diff --check
+git status --short
+```
+
+Delivery:
+
+```bash
+git push -u origin codex/t-dd-1a-worker-healthchecks
+gh pr create --base master --head codex/t-dd-1a-worker-healthchecks \
+  --title "T-DD-1A: Consolidate worker health probes"
+```
+
+**v) Rollback.** Revert the T-DD-1A merge commit and rerun focused healthcheck,
+Docker contracts, Ruff, Mypy, docs links, and the complete suite. Compose
+continues to call the same three filenames, so no operational command, data,
+migration, or external-state rollback is needed.
+
+**w) Docs sync.** Update only the remediation ledger and this implementation
+plan. README, ADR, architecture review, operations, testing policy,
+guardrails, API contracts, security, and data-governance docs remain accurate.
+
+## 7. Delivery Self-Audit
+
+**x) Antipattern scan, diff pass.** Re-run A-F/H. Reject callable injection,
+CLI-to-CLI imports, compatibility exports, a generic probe registry, moved
+broad handlers, new Ruff exceptions, altered probe labels/timeouts/defaults,
+weakened tests, or files outside ownership.
+
+**y) Evidence.** Report the tests-first red result, all commands in 6u,
+independent planning/pre-commit findings, applied fixes, commit hashes, PR URL,
+review threads, and CI state. Mark unrun checks `NOT VERIFIED`.
+
+**z) Deviations.** Authorized changes are splitting T-DD-1 into T-DD-1A and
+T-DD-1B and correcting the healthcheck count from two to three. Any other
+owned-file expansion, CLI/Compose contract change, role-check relocation,
+new exception, skipped review, unresolved P1/P2, or unrun required check is a
+blocker.

--- a/scripts/enrichment_worker_healthcheck.py
+++ b/scripts/enrichment_worker_healthcheck.py
@@ -5,25 +5,14 @@ import os
 import subprocess
 import sys
 
-from scripts.worker_healthcheck import _probe_tcp, _socket_target_from_url
+import worker_health_probes
 
 
 def main() -> int:
-    failures: list[str] = []
-
-    broker_failure = _probe_tcp(
-        *_socket_target_from_url((os.getenv("CELERY_BROKER_URL") or "").strip()),
-        label="redis broker",
+    failures = worker_health_probes.probe_broker_and_database(
+        worker_health_probes.socket_target_from_url((os.getenv("CELERY_BROKER_URL") or "").strip()),
+        worker_health_probes.socket_target_from_url((os.getenv("DATABASE_URL") or "").strip()),
     )
-    if broker_failure:
-        failures.append(broker_failure)
-
-    database_failure = _probe_tcp(
-        *_socket_target_from_url((os.getenv("DATABASE_URL") or "").strip()),
-        label="postgres",
-    )
-    if database_failure:
-        failures.append(database_failure)
 
     try:
         import pipeline.enrichment_tasks  # noqa: F401
@@ -45,11 +34,7 @@ def main() -> int:
             detail = (probe.stderr or probe.stdout).strip() or f"exit {probe.returncode}"
             failures.append(f"enrichment runtime import probe failed for {module_name}: {detail}")
 
-    if failures:
-        for failure in failures:
-            print(failure, file=sys.stderr)
-        return 1
-    return 0
+    return worker_health_probes.healthcheck_exit_code(failures)
 
 
 if __name__ == "__main__":

--- a/scripts/enrichment_worker_healthcheck.py
+++ b/scripts/enrichment_worker_healthcheck.py
@@ -4,11 +4,17 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
+from pathlib import Path
 
 import worker_health_probes
 
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
 
 def main() -> int:
+    if str(PROJECT_ROOT) not in sys.path:
+        sys.path.insert(0, str(PROJECT_ROOT))
+
     failures = worker_health_probes.probe_broker_and_database(
         worker_health_probes.socket_target_from_url((os.getenv("CELERY_BROKER_URL") or "").strip()),
         worker_health_probes.socket_target_from_url((os.getenv("DATABASE_URL") or "").strip()),

--- a/scripts/semantic_worker_healthcheck.py
+++ b/scripts/semantic_worker_healthcheck.py
@@ -2,29 +2,17 @@
 from __future__ import annotations
 
 import os
-import sys
 import tempfile
 from pathlib import Path
 
-from scripts.worker_healthcheck import _probe_tcp, _socket_target_from_url
+import worker_health_probes
 
 
 def main() -> int:
-    failures: list[str] = []
-
-    broker_failure = _probe_tcp(
-        *_socket_target_from_url((os.getenv("CELERY_BROKER_URL") or "").strip()),
-        label="redis broker",
+    failures = worker_health_probes.probe_broker_and_database(
+        worker_health_probes.socket_target_from_url((os.getenv("CELERY_BROKER_URL") or "").strip()),
+        worker_health_probes.socket_target_from_url((os.getenv("DATABASE_URL") or "").strip()),
     )
-    if broker_failure:
-        failures.append(broker_failure)
-
-    database_failure = _probe_tcp(
-        *_socket_target_from_url((os.getenv("DATABASE_URL") or "").strip()),
-        label="postgres",
-    )
-    if database_failure:
-        failures.append(database_failure)
 
     try:
         import torch  # noqa: F401
@@ -50,11 +38,7 @@ def main() -> int:
     except Exception as exc:
         failures.append(f"semantic artifact directory probe failed: {exc}")
 
-    if failures:
-        for failure in failures:
-            print(failure, file=sys.stderr)
-        return 1
-    return 0
+    return worker_health_probes.healthcheck_exit_code(failures)
 
 
 if __name__ == "__main__":

--- a/scripts/semantic_worker_healthcheck.py
+++ b/scripts/semantic_worker_healthcheck.py
@@ -2,13 +2,19 @@
 from __future__ import annotations
 
 import os
+import sys
 import tempfile
 from pathlib import Path
 
 import worker_health_probes
 
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
 
 def main() -> int:
+    if str(PROJECT_ROOT) not in sys.path:
+        sys.path.insert(0, str(PROJECT_ROOT))
+
     failures = worker_health_probes.probe_broker_and_database(
         worker_health_probes.socket_target_from_url((os.getenv("CELERY_BROKER_URL") or "").strip()),
         worker_health_probes.socket_target_from_url((os.getenv("DATABASE_URL") or "").strip()),

--- a/scripts/worker_health_probes.py
+++ b/scripts/worker_health_probes.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import socket
+import sys
+from urllib.parse import urlparse
+
+
+TCP_PROBE_TIMEOUT_SECONDS = 2
+REDIS_BROKER_LABEL = "redis broker"
+POSTGRES_LABEL = "postgres"
+
+SocketTarget = tuple[str | None, int | None]
+
+
+def socket_target_from_url(url: str) -> SocketTarget:
+    parsed_url = urlparse(url)
+    return parsed_url.hostname, parsed_url.port
+
+
+def socket_target_from_host(host: str, default_port: int) -> SocketTarget:
+    normalized_host = host.strip()
+    if not normalized_host:
+        return None, None
+    return normalized_host, default_port
+
+
+def probe_tcp(
+    host: str | None,
+    port: int | None,
+    *,
+    label: str,
+) -> str | None:
+    if not host or port is None:
+        return f"{label} target is not configured"
+    try:
+        with socket.create_connection(
+            (host, port),
+            timeout=TCP_PROBE_TIMEOUT_SECONDS,
+        ):
+            return None
+    except OSError as exc:
+        return f"{label} probe failed: {exc}"
+
+
+def probe_broker_and_database(
+    broker_target: SocketTarget,
+    database_target: SocketTarget,
+) -> list[str]:
+    failures: list[str] = []
+    broker_failure = probe_tcp(*broker_target, label=REDIS_BROKER_LABEL)
+    if broker_failure:
+        failures.append(broker_failure)
+
+    database_failure = probe_tcp(*database_target, label=POSTGRES_LABEL)
+    if database_failure:
+        failures.append(database_failure)
+    return failures
+
+
+def healthcheck_exit_code(failures: list[str]) -> int:
+    for failure in failures:
+        print(failure, file=sys.stderr)
+    return 1 if failures else 0

--- a/scripts/worker_healthcheck.py
+++ b/scripts/worker_healthcheck.py
@@ -1,41 +1,24 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
-import os
-import socket
-import sys
 import json
+import os
 import urllib.error
 import urllib.request
-from urllib.parse import urlparse
+
+import worker_health_probes
 
 
 OPENAI_COMPAT_HTTP_API = "openai_compat"
 OLLAMA_TAGS_PATH = "/api/tags"
 OPENAI_HEALTH_PATH = "/health"
 OPENAI_MODELS_PATH = "/v1/models"
-
-
-def _socket_target_from_url(url: str) -> tuple[str | None, int | None]:
-    parsed = urlparse(url)
-    return parsed.hostname, parsed.port
-
-
-def _socket_target_from_env(host_env: str, default_port: int) -> tuple[str | None, int | None]:
-    host = (os.getenv(host_env) or "").strip()
-    if not host:
-        return None, None
-    return host, default_port
-
-
-def _probe_tcp(host: str | None, port: int | None, *, label: str) -> str | None:
-    if not host or port is None:
-        return f"{label} target is not configured"
-    try:
-        with socket.create_connection((host, port), timeout=2):
-            return None
-    except OSError as exc:
-        return f"{label} probe failed: {exc}"
+HTTP_PROBE_TIMEOUT_SECONDS = 5
+WORKER_METRICS_DEFAULT_PORT = 8001
+REDIS_DEFAULT_PORT = 6379
+DEFAULT_HTTP_BASE_URL = "http://inference:11434"
+DEFAULT_HTTP_MODEL = "gemma-3-270m-custom"
+DEFAULT_HTTP_API = "ollama"
 
 
 def _read_json_url(url: str, *, timeout_seconds: int) -> dict[str, object]:
@@ -50,16 +33,25 @@ def _read_json_url(url: str, *, timeout_seconds: int) -> dict[str, object]:
 
 
 def _ollama_model_names(base_url: str) -> list[str]:
-    payload = _read_json_url(f"{base_url.rstrip('/')}{OLLAMA_TAGS_PATH}", timeout_seconds=5)
+    payload = _read_json_url(
+        f"{base_url.rstrip('/')}{OLLAMA_TAGS_PATH}",
+        timeout_seconds=HTTP_PROBE_TIMEOUT_SECONDS,
+    )
     models = payload.get("models") or []
     return [entry.get("name") for entry in models if isinstance(entry, dict) and isinstance(entry.get("name"), str)]
 
 
 def _openai_compatible_model_names(base_url: str) -> list[str]:
     try:
-        with urllib.request.urlopen(f"{base_url.rstrip('/')}{OPENAI_HEALTH_PATH}", timeout=5):
+        with urllib.request.urlopen(
+            f"{base_url.rstrip('/')}{OPENAI_HEALTH_PATH}",
+            timeout=HTTP_PROBE_TIMEOUT_SECONDS,
+        ):
             pass
-        payload = _read_json_url(f"{base_url.rstrip('/')}{OPENAI_MODELS_PATH}", timeout_seconds=5)
+        payload = _read_json_url(
+            f"{base_url.rstrip('/')}{OPENAI_MODELS_PATH}",
+            timeout_seconds=HTTP_PROBE_TIMEOUT_SECONDS,
+        )
     except (OSError, TimeoutError, urllib.error.URLError, RuntimeError) as exc:
         raise RuntimeError(f"{exc}") from exc
     models = payload.get("data") or []
@@ -83,33 +75,37 @@ def _probe_http_model(base_url: str, model_name: str, http_api: str) -> str | No
 
 def _infrastructure_failures() -> list[str]:
     failures: list[str] = []
-    metrics_port = int((os.getenv("TC_WORKER_METRICS_PORT") or "8001").strip())
-    metrics_failure = _probe_tcp("127.0.0.1", metrics_port, label="worker metrics")
+    metrics_port = int((os.getenv("TC_WORKER_METRICS_PORT") or str(WORKER_METRICS_DEFAULT_PORT)).strip())
+    metrics_failure = worker_health_probes.probe_tcp(
+        "127.0.0.1",
+        metrics_port,
+        label="worker metrics",
+    )
     if metrics_failure:
         failures.append(metrics_failure)
 
-    broker_target = _socket_target_from_url((os.getenv("CELERY_BROKER_URL") or "").strip())
+    broker_target = worker_health_probes.socket_target_from_url((os.getenv("CELERY_BROKER_URL") or "").strip())
     if broker_target == (None, None):
-        broker_target = _socket_target_from_env("REDIS_HOST", 6379)
-    broker_failure = _probe_tcp(*broker_target, label="redis broker")
-    if broker_failure:
-        failures.append(broker_failure)
-
-    database_failure = _probe_tcp(
-        *_socket_target_from_url((os.getenv("DATABASE_URL") or "").strip()),
-        label="postgres",
+        broker_target = worker_health_probes.socket_target_from_host(
+            os.getenv("REDIS_HOST") or "",
+            REDIS_DEFAULT_PORT,
+        )
+    database_target = worker_health_probes.socket_target_from_url((os.getenv("DATABASE_URL") or "").strip())
+    failures.extend(
+        worker_health_probes.probe_broker_and_database(
+            broker_target,
+            database_target,
+        )
     )
-    if database_failure:
-        failures.append(database_failure)
     return failures
 
 
 def _inference_failure() -> str | None:
     if (os.getenv("LOCAL_AI_BACKEND") or "http").strip().lower() == "http":
         return _probe_http_model(
-            os.getenv("LOCAL_AI_HTTP_BASE_URL", "http://inference:11434").strip(),
-            (os.getenv("LOCAL_AI_HTTP_MODEL") or "gemma-3-270m-custom").strip() or "gemma-3-270m-custom",
-            (os.getenv("LOCAL_AI_HTTP_API") or "ollama").strip().lower() or "ollama",
+            os.getenv("LOCAL_AI_HTTP_BASE_URL", DEFAULT_HTTP_BASE_URL).strip(),
+            (os.getenv("LOCAL_AI_HTTP_MODEL") or DEFAULT_HTTP_MODEL).strip() or DEFAULT_HTTP_MODEL,
+            (os.getenv("LOCAL_AI_HTTP_API") or DEFAULT_HTTP_API).strip().lower() or DEFAULT_HTTP_API,
         )
     return None
 
@@ -119,11 +115,7 @@ def main() -> int:
     inference_failure = _inference_failure()
     if inference_failure:
         failures.append(inference_failure)
-    if failures:
-        for failure in failures:
-            print(failure, file=sys.stderr)
-        return 1
-    return 0
+    return worker_health_probes.healthcheck_exit_code(failures)
 
 
 if __name__ == "__main__":

--- a/tests/test_docker_health_contracts.py
+++ b/tests/test_docker_health_contracts.py
@@ -6,4 +6,6 @@ def test_compose_uses_explicit_local_healthchecks():
 
     assert "http://127.0.0.1:9998/tika" in source
     assert "python scripts/worker_healthcheck.py" in source
+    assert "python scripts/enrichment_worker_healthcheck.py" in source
+    assert "python scripts/semantic_worker_healthcheck.py" in source
     assert "http://127.0.0.1:3000/" in source

--- a/tests/test_role_worker_healthchecks.py
+++ b/tests/test_role_worker_healthchecks.py
@@ -39,3 +39,4 @@ def test_role_healthcheck_runs_without_pythonpath_and_aggregates_missing_targets
     assert "redis broker target is not configured" in healthcheck.stderr
     assert "postgres target is not configured" in healthcheck.stderr
     assert "redis broker probe failed:" not in healthcheck.stderr
+    assert "task registration probe failed:" not in healthcheck.stderr

--- a/tests/test_role_worker_healthchecks.py
+++ b/tests/test_role_worker_healthchecks.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROLE_HEALTHCHECK_PATHS = (
+    Path("scripts/enrichment_worker_healthcheck.py"),
+    Path("scripts/semantic_worker_healthcheck.py"),
+)
+
+
+@pytest.mark.parametrize("healthcheck_path", ROLE_HEALTHCHECK_PATHS)
+def test_role_healthcheck_runs_without_pythonpath_and_aggregates_missing_targets(
+    healthcheck_path: Path,
+    tmp_path: Path,
+) -> None:
+    healthcheck_environment = os.environ.copy()
+    healthcheck_environment.pop("PYTHONPATH", None)
+    healthcheck_environment["CELERY_BROKER_URL"] = ""
+    healthcheck_environment["DATABASE_URL"] = ""
+    healthcheck_environment["REDIS_HOST"] = "town-council-invalid.invalid"
+    healthcheck_environment["SEMANTIC_INDEX_DIR"] = str(tmp_path / "semantic")
+
+    healthcheck = subprocess.run(
+        [sys.executable, str(healthcheck_path)],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=healthcheck_environment,
+    )
+
+    assert healthcheck.returncode == 1
+    assert "redis broker target is not configured" in healthcheck.stderr
+    assert "postgres target is not configured" in healthcheck.stderr
+    assert "redis broker probe failed:" not in healthcheck.stderr

--- a/tests/test_worker_health_probes.py
+++ b/tests/test_worker_health_probes.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import importlib
+import socket
+from contextlib import contextmanager
+from pathlib import Path
+from types import ModuleType
+from typing import Iterator
+
+import pytest
+
+
+HEALTHCHECK_PATHS = (
+    Path("scripts/worker_healthcheck.py"),
+    Path("scripts/enrichment_worker_healthcheck.py"),
+    Path("scripts/semantic_worker_healthcheck.py"),
+)
+
+
+def _health_probes() -> ModuleType:
+    return importlib.import_module("scripts.worker_health_probes")
+
+
+@contextmanager
+def _listening_socket() -> Iterator[socket.socket]:
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.bind(("127.0.0.1", 0))
+    listener.listen(8)
+    try:
+        yield listener
+    finally:
+        listener.close()
+
+
+def _closed_local_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as candidate:
+        candidate.bind(("127.0.0.1", 0))
+        return int(candidate.getsockname()[1])
+
+
+def test_socket_target_from_url_parses_credentials_and_ipv6() -> None:
+    health_probes = _health_probes()
+
+    assert health_probes.socket_target_from_url("redis://:secret@redis:6379/0") == ("redis", 6379)
+    assert health_probes.socket_target_from_url("postgresql://user:pass@[::1]:5432/db") == ("::1", 5432)
+
+
+def test_socket_target_from_url_preserves_malformed_port_failure() -> None:
+    health_probes = _health_probes()
+
+    with pytest.raises(ValueError, match="Port could not be cast"):
+        health_probes.socket_target_from_url("redis://redis:not-a-port/0")
+
+
+def test_probe_tcp_reports_missing_and_refused_targets() -> None:
+    health_probes = _health_probes()
+
+    assert health_probes.probe_tcp(None, None, label="redis broker") == ("redis broker target is not configured")
+    refusal = health_probes.probe_tcp(
+        "127.0.0.1",
+        _closed_local_port(),
+        label="postgres",
+    )
+    assert refusal is not None
+    assert refusal.startswith("postgres probe failed:")
+
+
+def test_probe_tcp_accepts_reachable_loopback_target() -> None:
+    health_probes = _health_probes()
+
+    with _listening_socket() as listener:
+        assert (
+            health_probes.probe_tcp(
+                "127.0.0.1",
+                int(listener.getsockname()[1]),
+                label="redis broker",
+            )
+            is None
+        )
+
+
+def test_probe_broker_and_database_collects_all_failures() -> None:
+    health_probes = _health_probes()
+    closed_port = _closed_local_port()
+
+    failures = health_probes.probe_broker_and_database(
+        ("127.0.0.1", closed_port),
+        (None, None),
+    )
+
+    assert len(failures) == 2
+    assert failures[0].startswith("redis broker probe failed:")
+    assert failures[1] == "postgres target is not configured"
+
+
+def test_healthcheck_exit_code_reports_each_failure_once(capsys) -> None:
+    health_probes = _health_probes()
+
+    assert health_probes.healthcheck_exit_code([]) == 0
+    assert capsys.readouterr().err == ""
+
+    failures = ["redis broker probe failed: refused", "postgres target is not configured"]
+    assert health_probes.healthcheck_exit_code(failures) == 1
+    assert capsys.readouterr().err.splitlines() == failures
+
+
+def test_healthcheck_clis_import_one_probe_owner() -> None:
+    for healthcheck_path in HEALTHCHECK_PATHS:
+        source = healthcheck_path.read_text(encoding="utf-8")
+        assert "import worker_health_probes" in source
+
+    for role_healthcheck_path in HEALTHCHECK_PATHS[1:]:
+        source = role_healthcheck_path.read_text(encoding="utf-8")
+        assert "scripts.worker_healthcheck" not in source
+
+    shared_source = Path("scripts/worker_health_probes.py").read_text(encoding="utf-8")
+    assert "worker_healthcheck" not in shared_source
+    assert "enrichment_worker_healthcheck" not in shared_source
+    assert "semantic_worker_healthcheck" not in shared_source

--- a/tests/test_worker_healthcheck.py
+++ b/tests/test_worker_healthcheck.py
@@ -1,100 +1,209 @@
-import importlib.util
+from __future__ import annotations
+
+import json
 import os
+import socket
+import subprocess
 import sys
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
+from threading import Thread
+from typing import ClassVar, Iterator
 
 
-spec = importlib.util.spec_from_file_location(
-    "worker_healthcheck", Path("scripts/worker_healthcheck.py")
+WORKER_HEALTHCHECK_PATH = Path("scripts/worker_healthcheck.py")
+HEALTHCHECK_ENVIRONMENT_KEYS = (
+    "TC_WORKER_METRICS_PORT",
+    "CELERY_BROKER_URL",
+    "REDIS_HOST",
+    "DATABASE_URL",
+    "LOCAL_AI_BACKEND",
+    "LOCAL_AI_HTTP_API",
+    "LOCAL_AI_HTTP_BASE_URL",
+    "LOCAL_AI_HTTP_MODEL",
 )
-mod = importlib.util.module_from_spec(spec)
-sys.modules[spec.name] = mod
-spec.loader.exec_module(mod)
 
 
-def test_socket_target_from_url_parses_host_and_port():
-    host, port = mod._socket_target_from_url("redis://:secret@redis:6379/0")
-    assert host == "redis"
-    assert port == 6379
+class _ProviderHandler(BaseHTTPRequestHandler):
+    responses: ClassVar[dict[str, object]] = {}
+
+    def do_GET(self) -> None:
+        response_body = self.responses[self.path]
+        payload = response_body if isinstance(response_body, bytes) else json.dumps(response_body).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, format: str, *args: object) -> None:
+        return
 
 
-def test_worker_healthcheck_main_returns_zero_when_all_probes_pass(monkeypatch):
-    monkeypatch.setenv("TC_WORKER_METRICS_PORT", "8001")
-    monkeypatch.setenv("CELERY_BROKER_URL", "redis://:secret@redis:6379/0")
-    monkeypatch.setenv("DATABASE_URL", "postgresql://user:pass@postgres:5432/town_council_db")
-    monkeypatch.setenv("LOCAL_AI_BACKEND", "http")
-    monkeypatch.setenv("LOCAL_AI_HTTP_API", "ollama")
-    monkeypatch.setenv("LOCAL_AI_HTTP_BASE_URL", "http://inference:11434")
-    monkeypatch.setenv("LOCAL_AI_HTTP_MODEL", "gemma-3-270m-custom")
-    monkeypatch.setattr(mod, "_probe_tcp", lambda host, port, label: None)
-    monkeypatch.setattr(mod, "_probe_http_model", lambda base_url, model_name, http_api: None)
-
-    assert mod.main() == 0
-
-
-def test_worker_healthcheck_main_returns_one_with_compact_failures(monkeypatch, capsys):
-    monkeypatch.setenv("TC_WORKER_METRICS_PORT", "8001")
-    monkeypatch.setenv("CELERY_BROKER_URL", "redis://:secret@redis:6379/0")
-    monkeypatch.setenv("DATABASE_URL", "postgresql://user:pass@postgres:5432/town_council_db")
-    monkeypatch.setenv("LOCAL_AI_BACKEND", "http")
-    monkeypatch.setenv("LOCAL_AI_HTTP_API", "ollama")
-    monkeypatch.setenv("LOCAL_AI_HTTP_BASE_URL", "http://inference:11434")
-    monkeypatch.setenv("LOCAL_AI_HTTP_MODEL", "gemma-3-270m-custom")
-
-    def fake_probe(host, port, label):
-        return f"{label} probe failed: boom" if label != "postgres" else None
-
-    monkeypatch.setattr(mod, "_probe_tcp", fake_probe)
-    monkeypatch.setattr(mod, "_probe_http_model", lambda base_url, model_name, http_api: None)
-
-    assert mod.main() == 1
-    stderr = capsys.readouterr().err
-    assert "worker metrics probe failed: boom" in stderr
-    assert "redis broker probe failed: boom" in stderr
+@contextmanager
+def _provider_server(responses: dict[str, object]) -> Iterator[str]:
+    handler = type("ProviderHandler", (_ProviderHandler,), {"responses": responses})
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    server_thread = Thread(target=server.serve_forever, daemon=True)
+    server_thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_address[1]}"
+    finally:
+        server.shutdown()
+        server.server_close()
+        server_thread.join()
 
 
-def test_worker_healthcheck_reports_missing_inference_model(monkeypatch, capsys):
-    monkeypatch.setenv("TC_WORKER_METRICS_PORT", "8001")
-    monkeypatch.setenv("CELERY_BROKER_URL", "redis://:secret@redis:6379/0")
-    monkeypatch.setenv("DATABASE_URL", "postgresql://user:pass@postgres:5432/town_council_db")
-    monkeypatch.setenv("LOCAL_AI_BACKEND", "http")
-    monkeypatch.setenv("LOCAL_AI_HTTP_API", "ollama")
-    monkeypatch.setenv("LOCAL_AI_HTTP_BASE_URL", "http://inference:11434")
-    monkeypatch.setenv("LOCAL_AI_HTTP_MODEL", "gemma-3-270m-custom")
-    monkeypatch.setattr(mod, "_probe_tcp", lambda host, port, label: None)
-    monkeypatch.setattr(
-        mod,
-        "_probe_http_model",
-        lambda base_url, model_name, http_api: f"inference model probe failed: api={http_api} model '{model_name}' is missing",
+@contextmanager
+def _listening_socket() -> Iterator[socket.socket]:
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.bind(("127.0.0.1", 0))
+    listener.listen(8)
+    try:
+        yield listener
+    finally:
+        listener.close()
+
+
+def _closed_local_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as candidate:
+        candidate.bind(("127.0.0.1", 0))
+        return int(candidate.getsockname()[1])
+
+
+def _healthcheck_environment(**overrides: str) -> dict[str, str]:
+    healthcheck_environment = os.environ.copy()
+    healthcheck_environment.pop("PYTHONPATH", None)
+    for environment_key in HEALTHCHECK_ENVIRONMENT_KEYS:
+        healthcheck_environment.pop(environment_key, None)
+    healthcheck_environment.update(overrides)
+    return healthcheck_environment
+
+
+def _worker_network_environment(port: int) -> dict[str, str]:
+    return {
+        "TC_WORKER_METRICS_PORT": str(port),
+        "CELERY_BROKER_URL": f"redis://127.0.0.1:{port}/0",
+        "DATABASE_URL": (f"postgresql://user:pass@127.0.0.1:{port}/town_council_db"),
+    }
+
+
+def _run_worker_healthcheck(
+    healthcheck_environment: dict[str, str],
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(WORKER_HEALTHCHECK_PATH)],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=15,
+        env=healthcheck_environment,
     )
 
-    assert mod.main() == 1
-    stderr = capsys.readouterr().err
-    assert "inference model probe failed: api=ollama model 'gemma-3-270m-custom' is missing" in stderr
+
+def test_worker_healthcheck_runs_without_pythonpath_when_all_probes_pass() -> None:
+    with _listening_socket() as listener:
+        network_environment = _worker_network_environment(int(listener.getsockname()[1]))
+        healthcheck = _run_worker_healthcheck(
+            _healthcheck_environment(
+                **network_environment,
+                LOCAL_AI_BACKEND="disabled",
+            )
+        )
+
+    assert healthcheck.returncode == 0
+    assert healthcheck.stderr == ""
 
 
-def test_worker_healthcheck_uses_openai_compatible_model_probe(monkeypatch):
-    observed = {}
+def test_worker_healthcheck_reports_all_network_failures() -> None:
+    closed_port = _closed_local_port()
+    network_environment = _worker_network_environment(closed_port)
+    healthcheck = _run_worker_healthcheck(
+        _healthcheck_environment(
+            **network_environment,
+            LOCAL_AI_BACKEND="disabled",
+        )
+    )
 
-    def fake_probe(base_url, model_name, http_api):
-        observed["base_url"] = base_url
-        observed["model_name"] = model_name
-        observed["http_api"] = http_api
-        return None
+    assert healthcheck.returncode == 1
+    assert "worker metrics probe failed:" in healthcheck.stderr
+    assert "redis broker probe failed:" in healthcheck.stderr
+    assert "postgres probe failed:" in healthcheck.stderr
 
-    monkeypatch.setenv("TC_WORKER_METRICS_PORT", "8001")
-    monkeypatch.setenv("CELERY_BROKER_URL", "redis://:secret@redis:6379/0")
-    monkeypatch.setenv("DATABASE_URL", "postgresql://user:pass@postgres:5432/town_council_db")
-    monkeypatch.setenv("LOCAL_AI_BACKEND", "http")
-    monkeypatch.setenv("LOCAL_AI_HTTP_API", "openai_compat")
-    monkeypatch.setenv("LOCAL_AI_HTTP_BASE_URL", "http://host.docker.internal:8080")
-    monkeypatch.setenv("LOCAL_AI_HTTP_MODEL", "mlx-community/test-model")
-    monkeypatch.setattr(mod, "_probe_tcp", lambda host, port, label: None)
-    monkeypatch.setattr(mod, "_probe_http_model", fake_probe)
 
-    assert mod.main() == 0
-    assert observed == {
-        "base_url": "http://host.docker.internal:8080",
-        "model_name": "mlx-community/test-model",
-        "http_api": "openai_compat",
+def test_worker_healthcheck_retains_redis_host_fallback() -> None:
+    healthcheck = _run_worker_healthcheck(
+        _healthcheck_environment(
+            TC_WORKER_METRICS_PORT=str(_closed_local_port()),
+            REDIS_HOST="town-council-invalid.invalid",
+            LOCAL_AI_BACKEND="disabled",
+        )
+    )
+
+    assert healthcheck.returncode == 1
+    assert "redis broker probe failed:" in healthcheck.stderr
+    assert "redis broker target is not configured" not in healthcheck.stderr
+
+
+def test_worker_healthcheck_preserves_invalid_metrics_port_failure() -> None:
+    healthcheck = _run_worker_healthcheck(_healthcheck_environment(TC_WORKER_METRICS_PORT="not-a-port"))
+
+    assert healthcheck.returncode != 0
+    assert "ValueError: invalid literal" in healthcheck.stderr
+
+
+def test_worker_healthcheck_reports_missing_ollama_model() -> None:
+    with _listening_socket() as listener, _provider_server({"/api/tags": {"models": []}}) as base_url:
+        network_environment = _worker_network_environment(int(listener.getsockname()[1]))
+        healthcheck = _run_worker_healthcheck(
+            _healthcheck_environment(
+                **network_environment,
+                LOCAL_AI_BACKEND="http",
+                LOCAL_AI_HTTP_API="ollama",
+                LOCAL_AI_HTTP_BASE_URL=base_url,
+                LOCAL_AI_HTTP_MODEL="gemma-3-270m-custom",
+            )
+        )
+
+    assert healthcheck.returncode == 1
+    assert ("inference model probe failed: api=ollama model 'gemma-3-270m-custom' is missing") in healthcheck.stderr
+
+
+def test_worker_healthcheck_accepts_openai_compatible_model() -> None:
+    responses = {
+        "/health": {},
+        "/v1/models": {"data": [{"id": "mlx-community/test-model"}]},
     }
+    with _listening_socket() as listener, _provider_server(responses) as base_url:
+        network_environment = _worker_network_environment(int(listener.getsockname()[1]))
+        healthcheck = _run_worker_healthcheck(
+            _healthcheck_environment(
+                **network_environment,
+                LOCAL_AI_BACKEND="http",
+                LOCAL_AI_HTTP_API="openai_compat",
+                LOCAL_AI_HTTP_BASE_URL=base_url,
+                LOCAL_AI_HTTP_MODEL="mlx-community/test-model",
+            )
+        )
+
+    assert healthcheck.returncode == 0
+    assert healthcheck.stderr == ""
+
+
+def test_worker_healthcheck_reports_malformed_provider_payload() -> None:
+    with _listening_socket() as listener, _provider_server({"/api/tags": b"not-json"}) as base_url:
+        network_environment = _worker_network_environment(int(listener.getsockname()[1]))
+        healthcheck = _run_worker_healthcheck(
+            _healthcheck_environment(
+                **network_environment,
+                LOCAL_AI_BACKEND="http",
+                LOCAL_AI_HTTP_API="ollama",
+                LOCAL_AI_HTTP_BASE_URL=base_url,
+                LOCAL_AI_HTTP_MODEL="gemma-3-270m-custom",
+            )
+        )
+
+    assert healthcheck.returncode == 1
+    assert "inference model probe failed:" in healthcheck.stderr
+    assert "Expecting value" in healthcheck.stderr


### PR DESCRIPTION
## What changed
- Added one shared owner for URL target parsing, TCP probes, Redis/PostgreSQL aggregation, and failure reporting.
- Preserved the three direct worker healthcheck CLIs and their role-specific checks.
- Added loopback, exact-path, role-parity, provider, and Compose entrypoint contracts.
- Split T-DD-1 into health-probe and city-state remediation tasks.

## Why
The three worker healthchecks duplicated network and reporting behavior while importing private helpers from the primary worker CLI. This removes that coupling without changing runtime defaults, probe order, timeouts, labels, or Compose entrypoints.

## Risk and compatibility
Low. CLI filenames, exit codes, stderr behavior, role checks, and runtime defaults are preserved. No schema, dependency, environment-variable, or service-topology changes.

## Verification
- PASS: `./.venv/bin/ruff check .`
- PASS: `./.venv/bin/mypy`
- PASS: focused healthcheck and Docker contracts, 42 tests
- PASS: docs links, 2 tests
- PASS: complete Python suite, 1,562 passed and 17 skipped
- PASS: coverage suite, 82.70% against the 71% floor
- PASS: real worker, enrichment-worker, and semantic-worker container healthchecks
- PASS: role-container negative checks preserve aggregate failure behavior
- PASS: independent pre-commit review, no actionable findings

## Remaining deficit
The primary worker default-model smoke remains environment-dependent because this host does not have `gemma-3-270m-custom` cached. The model-disabled healthcheck path and both role-specific container paths passed; runtime model policy is unchanged.