### PR TITLE
T-PLAT-3: Add verified PostgreSQL backups

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -448,12 +448,14 @@ services:
   # This reduces database load by ~95% for read-heavy operations.
   redis:
     image: redis:7-alpine
-    command: redis-server --requirepass ${REDIS_PASSWORD:-secure_redis_password} --maxmemory 256mb --maxmemory-policy allkeys-lru
+    environment:
+      - REDIS_PASSWORD=${REDIS_PASSWORD:-secure_redis_password}
+    command: sh -eu -c 'exec redis-server --requirepass "$$REDIS_PASSWORD" --maxmemory 256mb --maxmemory-policy allkeys-lru'
     volumes:
       - redis_data:/data
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "redis-cli -a ${REDIS_PASSWORD:-secure_redis_password} ping | grep PONG || exit 1"]
+      test: ["CMD-SHELL", "REDISCLI_AUTH=\"$$REDIS_PASSWORD\" redis-cli -e ping | grep -qx PONG"]
       interval: 30s
       timeout: 10s
       retries: 5

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -85,6 +85,110 @@ What it does *not* do:
 
 ### Database migrations and backups
 
+#### Routine database backup and recovery
+
+Create backups outside the repository. The archive can contain the complete
+database, including governed person-level records, so keep it private and use
+encrypted storage for any off-host copy. The command refuses overwrite,
+creates the archive with owner-only permissions, and publishes it only after
+`pg_restore --list` validates the custom-format output:
+
+```bash
+BACKUP_PATH="<BACKUP_PATH>/town_council_$(date -u +%Y%m%dT%H%M%SZ).dump"
+bash ./scripts/backup_db.sh "$BACKUP_PATH"
+```
+
+PostgreSQL gives `pg_dump` one consistent snapshot while ordinary writes
+continue. Still stop all writers before migration, destructive maintenance, or
+a recovery backup whose exact application boundary matters.
+
+Recommended cadence:
+
+- back up daily while actively ingesting or curating records
+- back up weekly when the local dataset is otherwise stable
+- always take a fresh backup before schema migration or destructive maintenance
+- retain enough daily and weekly copies to recover from corruption discovered
+  after the latest run, and keep at least one encrypted copy outside the host
+- periodically perform the disposable-database restore drill below; archive
+  listing alone does not prove successful restoration
+
+`STARTUP_PURGE_DERIVED=true` clears agenda items and derived catalog fields but
+preserves source ingest records. That development convenience is not a backup:
+the archive covers the complete PostgreSQL snapshot, including the system of
+record and any derived rows present when the dump starts.
+
+To validate an archive without touching the active database, restore into a
+new, uniquely named database created from `template0`, inspect
+`alembic_version` and representative row counts, then drop only that validation
+database.
+
+For full recovery, stop every Compose writer plus schedulers or manual commands
+running outside this project. Validate the archive before dropping the target:
+
+```bash
+BACKUP_PATH="<BACKUP_PATH>/town_council_recovery.dump"
+POSTGRES_USER="$(docker compose exec -T postgres printenv POSTGRES_USER)"
+POSTGRES_DB="$(docker compose exec -T postgres printenv POSTGRES_DB)"
+
+docker compose exec -T postgres pg_restore --list < "$BACKUP_PATH" >/dev/null
+docker compose -f docker-compose.yml -f docker-compose.dev.yml stop
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d postgres
+docker compose exec -T postgres dropdb \
+  -U "$POSTGRES_USER" --maintenance-db=postgres --force --if-exists "$POSTGRES_DB"
+docker compose exec -T postgres createdb \
+  -U "$POSTGRES_USER" -T template0 "$POSTGRES_DB"
+docker compose exec -T postgres pg_restore \
+  -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
+  --exit-on-error --no-owner --no-privileges < "$BACKUP_PATH"
+STARTUP_PURGE_DERIVED=false docker compose \
+  -f docker-compose.yml -f docker-compose.dev.yml run \
+  --rm --build --no-deps pipeline python db_migrate.py
+STARTUP_PURGE_DERIVED=false docker compose \
+  -f docker-compose.yml -f docker-compose.dev.yml run \
+  --rm --no-deps pipeline python /app/scripts/check_schema_parity.py
+docker compose exec -T postgres psql \
+  -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
+  -c "select 'catalog' as relation, count(*) from catalog
+      union all
+      select 'event' as relation, count(*) from event
+      order by relation"
+```
+
+Confirm those counts against the expected recovery corpus or the latest
+successful restore-drill record. Do not accept traffic yet. PostgreSQL is
+authoritative, so replace any external search state that may be newer than the
+restored snapshot:
+
+```bash
+STARTUP_PURGE_DERIVED=false docker compose \
+  -f docker-compose.yml -f docker-compose.dev.yml up -d postgres redis meilisearch
+STARTUP_PURGE_DERIVED=false docker compose \
+  -f docker-compose.yml -f docker-compose.dev.yml run \
+  --rm --no-deps pipeline python reindex_only.py --replace-all
+
+# Required when SEMANTIC_BACKEND=faiss; pgvector state is inside the backup.
+docker compose -f docker-compose.yml -f docker-compose.dev.yml run \
+  --rm --no-deps semantic python ../pipeline/reindex_semantic.py
+```
+
+`--replace-all` waits up to five minutes for the Meilisearch deletion and
+rebuild queue, then verifies the index settings and compares the indexed
+document count with the restored PostgreSQL corpus. Any deletion failure,
+timeout, settings mismatch, or count mismatch blocks restart. After schema
+parity, row-count inspection, and required search rebuilds pass, restart
+without the development purge:
+
+```bash
+STARTUP_PURGE_DERIVED=false docker compose \
+  -f docker-compose.yml -f docker-compose.dev.yml up -d --build
+```
+
+The runbook provides cadence and recovery controls, but it does not configure a
+scheduler or prove an off-host copy exists. Keep the `SECURITY.md` backup
+checklist open until the operator has configured and tested those controls.
+
+#### Schema migration workflow
+
 `pipeline/db_migrate.py` is the only supported schema entrypoint. It handles
 fresh databases, guarded adoption of unversioned databases through the frozen
 v10 history, and upgrades to the current Alembic head. `db_init.py` remains a
@@ -99,9 +203,7 @@ BACKUP_PATH="<BACKUP_PATH>/town_council_pre_migration.dump"
 
 docker compose -f docker-compose.yml -f docker-compose.dev.yml stop
 docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d postgres
-docker compose exec -T postgres pg_dump \
-  -U town_council -d town_council_db -Fc > "$BACKUP_PATH"
-docker compose exec -T postgres pg_restore --list < "$BACKUP_PATH" >/dev/null
+bash ./scripts/backup_db.sh "$BACKUP_PATH"
 docker compose -f docker-compose.yml -f docker-compose.dev.yml run \
   --rm --build --no-deps pipeline python db_migrate.py
 ```
@@ -167,14 +269,8 @@ Confirm `embed_dispatch_failed=0`, then monitor the semantic worker until the
 queued tasks finish. Embeddings are derived data; the migration transaction
 preserves source catalog, document, event, agenda, and civic records.
 
-Rollback restores the backup while writers remain stopped:
-
-```bash
-docker compose exec -T postgres pg_restore \
-  -U town_council -d town_council_db --clean --if-exists --exit-on-error \
-  < "$BACKUP_PATH"
-docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build
-```
+Rollback follows the routine replacement-restore procedure above while writers
+remain stopped, then repeats schema parity before restart.
 
 #### Historical timezone migration v10
 
@@ -215,9 +311,7 @@ before running these commands; `docker compose stop` cannot quiesce them.
 ```bash
 docker compose -f docker-compose.yml -f docker-compose.dev.yml stop
 docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d postgres
-docker compose exec -T postgres pg_dump \
-  -U town_council -d town_council_db -Fc > "$BACKUP_PATH"
-docker compose exec -T postgres pg_restore --list < "$BACKUP_PATH" >/dev/null
+bash ./scripts/backup_db.sh "$BACKUP_PATH"
 docker compose -f docker-compose.yml -f docker-compose.dev.yml run \
   --rm --no-deps pipeline python db_migrate.py
 docker compose exec -T postgres psql -U town_council -d town_council_db \
@@ -232,22 +326,9 @@ Every migrated timestamp must report `timestamp with time zone`. Generated
 timestamps have a `now()` default; lifecycle-attempt timestamps intentionally
 have no default so null continues to mean not attempted.
 
-Rollback uses the verified preflight backup. Keep all writers stopped while
-restoring:
-
-```bash
-docker compose -f docker-compose.yml -f docker-compose.dev.yml stop
-docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d postgres
-docker compose exec -T postgres pg_restore \
-  -U town_council -d town_council_db --clean --if-exists --exit-on-error \
-  < "$BACKUP_PATH"
-docker compose exec -T postgres psql -U town_council -d town_council_db \
-  -c "select table_name, column_name, data_type, column_default
-      from information_schema.columns
-      where table_schema = 'public' and data_type like 'timestamp%'
-      order by table_name, ordinal_position"
-docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build
-```
+Rollback uses the verified preflight backup and the routine replacement-restore
+procedure above. Keep all writers stopped, then repeat the timestamp-column
+query before restart.
 
 Do not reverse-convert a database that accepted post-migration writes. Restore
 the backup, then revert the application release.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -171,12 +171,12 @@ running outside this project. Validate the archive before dropping the target:
 
 ```bash
 BACKUP_PATH="<BACKUP_PATH>/town_council_recovery.dump"
-POSTGRES_USER="$(docker compose exec -T postgres printenv POSTGRES_USER)"
-POSTGRES_DB="$(docker compose exec -T postgres printenv POSTGRES_DB)"
 
-docker compose exec -T postgres pg_restore --list < "$BACKUP_PATH" >/dev/null
 docker compose -f docker-compose.yml -f docker-compose.dev.yml stop
 docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d postgres
+POSTGRES_USER="$(docker compose exec -T postgres printenv POSTGRES_USER)"
+POSTGRES_DB="$(docker compose exec -T postgres printenv POSTGRES_DB)"
+docker compose exec -T postgres pg_restore --list < "$BACKUP_PATH" >/dev/null
 docker compose exec -T postgres dropdb \
   -U "$POSTGRES_USER" --maintenance-db=postgres --force --if-exists "$POSTGRES_DB"
 docker compose exec -T postgres createdb \

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -166,6 +166,39 @@ Record the archive identifier, Alembic revision, and row counts as restore-drill
 evidence. The high-entropy database name and ownership flag keep cleanup from
 dropping the active database or a database the drill did not create.
 
+Before full recovery or failed-schema rollback, select the exact Compose files
+and project that own the currently deployed Redis volume. The default below is
+the repository development stack. For a prebuilt deployment, replace it with
+the deployment's project name and every current Compose file. Do not proceed
+until `docker compose ps redis` identifies the Redis service used by the
+deployment being recovered. Also stop schedulers and manual writers outside
+that project before running this block:
+
+```bash
+set -euo pipefail
+RECOVERY_COMPOSE=(docker compose -f docker-compose.yml -f docker-compose.dev.yml)
+# Prebuilt example; replace the line above rather than running both:
+# RECOVERY_COMPOSE=(docker compose -p "<CURRENT_DEPLOYMENT_PROJECT>" -f "<CURRENT_DEPLOYMENT_COMPOSE_FILE>")
+
+"${RECOVERY_COMPOSE[@]}" stop
+"${RECOVERY_COMPOSE[@]}" up --wait --wait-timeout 60 redis
+"${RECOVERY_COMPOSE[@]}" exec -T redis sh -eu -c '
+    export REDISCLI_AUTH="$REDIS_PASSWORD"
+    redis-cli -e FLUSHDB SYNC >/dev/null
+    redis-cli -e SAVE >/dev/null
+    test "$(redis-cli -e --raw DBSIZE)" = 0
+  '
+```
+
+`redis-cli -e` makes authentication and command errors fail the block.
+Synchronous flush plus `SAVE` prevents an older persisted queue/cache snapshot
+from returning after Redis restarts, and `DBSIZE=0` verifies database 0 before
+recovery continues. The password is resolved by Compose into the Redis
+container environment and is never expanded into the host command. This
+intentionally discards pending Celery work, task results, and API cache entries.
+Re-enqueue only work that is still valid after PostgreSQL and search recovery
+have passed verification.
+
 For full recovery, stop every Compose writer plus schedulers or manual commands
 running outside this project. Validate the archive before dropping the target:
 
@@ -318,29 +351,28 @@ preserves source catalog, document, event, agenda, and civic records.
 
 ##### Roll back a failed schema release
 
-Keep all writers stopped. Choose one rollback procedure and use it for every
+Run the Redis recovery preflight above from the currently deployed
+control-plane checkout before selecting any rollback release. Keep all writers
+stopped afterward. Choose one rollback procedure and use it for every
 application command.
 
 **Checkout-based rollback.** Select the exact application release that was
 active when the pre-migration backup was created **before running `db_migrate.py`
-or schema parity against the restored database**:
+or schema parity against the restored database**. Initialize strict mode,
+select the release, and build every rollback application image as one block:
 
 ```bash
+set -euo pipefail
 ROLLBACK_REF="<PREVIOUS_RELEASE_REF>"
 git switch --detach "$ROLLBACK_REF"
+ROLLBACK_COMPOSE_FILES=(-f docker-compose.yml -f docker-compose.dev.yml)
+docker compose "${ROLLBACK_COMPOSE_FILES[@]}" build
 ```
 
 Follow the full recovery procedure through schema parity and the PostgreSQL
 row-count check, but skip its external-search block and final restart. Its
-`--build` migration command now builds the selected rollback checkout. Then
-select the checkout-based Compose files for the shared search-recovery block
-below:
-
-```bash
-set -euo pipefail
-ROLLBACK_COMPOSE_FILES=(-f docker-compose.yml -f docker-compose.dev.yml)
-docker compose "${ROLLBACK_COMPOSE_FILES[@]}" build
-```
+`--build` migration command now builds the selected rollback checkout. Keep
+`ROLLBACK_COMPOSE_FILES` for the shared search-recovery block below.
 
 **Prebuilt-image rollback.** The checked-in Compose files are not an
 image-only rollback interface: they include local build definitions and source

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -215,12 +215,13 @@ docker compose -f docker-compose.yml -f docker-compose.dev.yml run \
   --rm --no-deps semantic python ../pipeline/reindex_semantic.py
 ```
 
-`--replace-all` waits up to five minutes for the Meilisearch deletion and
-rebuild queue, then verifies the index settings and compares the indexed
-document count with the restored PostgreSQL corpus. Any deletion failure,
-timeout, settings mismatch, or count mismatch blocks restart. After schema
-parity, row-count inspection, and required search rebuilds pass, restart
-without the development purge:
+`--replace-all` bounds every Meilisearch HTTP request at 30 seconds and uses
+separate five-minute waits for deletion and rebuild-queue completion. It then
+verifies the index settings and compares the indexed document count with the
+restored PostgreSQL corpus. Any deletion failure, request or queue timeout,
+settings mismatch, or count mismatch blocks restart. After schema parity,
+row-count inspection, and required search rebuilds pass, restart without the
+development purge:
 
 ```bash
 STARTUP_PURGE_DERIVED=false docker compose \

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -330,35 +330,210 @@ ROLLBACK_REF="<PREVIOUS_RELEASE_REF>"
 git switch --detach "$ROLLBACK_REF"
 ```
 
-Follow the full recovery procedure above. Its `--build` commands now build the
-selected rollback checkout, so `db_migrate.py`, schema parity, and both reindex
-commands all come from the rollback release.
+Follow the full recovery procedure through schema parity and the PostgreSQL
+row-count check, but skip its external-search block and final restart. Its
+`--build` migration command now builds the selected rollback checkout. Then
+select the checkout-based Compose files for the shared search-recovery block
+below:
+
+```bash
+set -euo pipefail
+ROLLBACK_COMPOSE_FILES=(-f docker-compose.yml -f docker-compose.dev.yml)
+docker compose "${ROLLBACK_COMPOSE_FILES[@]}" build
+```
 
 **Prebuilt-image rollback.** The checked-in Compose files are not an
 image-only rollback interface: they include local build definitions and source
 bind mounts. Use a deployment-specific Compose file that pins every Town
 Council application service to an immutable previous-release image and does
 not mount the current checkout. Perform archive validation and database
-replacement through that file, then run the application-owned recovery steps
-without `--build`:
+replacement through that file, then run migration and schema parity without
+rebuilding images:
 
 ```bash
 set -euo pipefail
 ROLLBACK_COMPOSE_FILE="<ROLLBACK_COMPOSE_FILE>"
+ROLLBACK_COMPOSE_FILES=(-f "$ROLLBACK_COMPOSE_FILE")
 
-STARTUP_PURGE_DERIVED=false docker compose -f "$ROLLBACK_COMPOSE_FILE" run \
+STARTUP_PURGE_DERIVED=false docker compose "${ROLLBACK_COMPOSE_FILES[@]}" run \
   --rm --no-deps pipeline python db_migrate.py
-STARTUP_PURGE_DERIVED=false docker compose -f "$ROLLBACK_COMPOSE_FILE" run \
+STARTUP_PURGE_DERIVED=false docker compose "${ROLLBACK_COMPOSE_FILES[@]}" run \
   --rm --no-deps pipeline python /app/scripts/check_schema_parity.py
-STARTUP_PURGE_DERIVED=false docker compose -f "$ROLLBACK_COMPOSE_FILE" up \
+```
+
+The release being rolled back may predate replacement reindex mode. For either
+rollback procedure, keep `ROLLBACK_COMPOSE_FILES` in the same Bash session and
+use this release-independent HTTP step to create or clear the `documents`
+index. It uses only the rollback image's Python standard library, then the
+rollback release's existing additive reindex command:
+
+```bash
+set -euo pipefail
+STARTUP_PURGE_DERIVED=false docker compose "${ROLLBACK_COMPOSE_FILES[@]}" up \
   -d postgres redis meilisearch
-STARTUP_PURGE_DERIVED=false docker compose -f "$ROLLBACK_COMPOSE_FILE" run \
-  --rm --no-deps pipeline python reindex_only.py --replace-all
+MEILI_RECOVERY_TASK_UID="$(
+  STARTUP_PURGE_DERIVED=false docker compose "${ROLLBACK_COMPOSE_FILES[@]}" run \
+    -T --rm --no-deps pipeline python - <<'PY'
+import json
+import os
+import time
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+HTTP_TIMEOUT_SECONDS = 30
+TASK_TIMEOUT_SECONDS = 300
+TASK_POLL_SECONDS = 1
+MEILI_HOST = os.environ["MEILI_HOST"].rstrip("/")
+MEILI_KEY = os.environ["MEILI_MASTER_KEY"]
+
+
+def request_json(method, path, payload=None, *, allow_not_found=False):
+    request_body = None if payload is None else json.dumps(payload).encode()
+    request = Request(
+        f"{MEILI_HOST}{path}",
+        data=request_body,
+        headers={
+            "Authorization": f"Bearer {MEILI_KEY}",
+            "Content-Type": "application/json",
+        },
+        method=method,
+    )
+    try:
+        with urlopen(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
+            return json.load(response)
+    except HTTPError as error:
+        if allow_not_found and error.code == 404:
+            return None
+        raise
+
+
+def wait_for_task(task_uid):
+    deadline = time.monotonic() + TASK_TIMEOUT_SECONDS
+    while time.monotonic() < deadline:
+        task = request_json("GET", f"/tasks/{task_uid}")
+        if task["status"] == "succeeded":
+            return
+        if task["status"] in {"failed", "canceled"}:
+            raise RuntimeError(json.dumps(task, sort_keys=True))
+        time.sleep(TASK_POLL_SECONDS)
+    raise TimeoutError(f"Meilisearch task {task_uid} exceeded recovery timeout")
+
+
+index = request_json("GET", "/indexes/documents", allow_not_found=True)
+if index is None:
+    task = request_json(
+        "POST",
+        "/indexes",
+        {"uid": "documents", "primaryKey": "id"},
+    )
+else:
+    task = request_json("DELETE", "/indexes/documents/documents")
+task_uid = task["taskUid"]
+wait_for_task(task_uid)
+print(task_uid)
+PY
+)"
+test -n "$MEILI_RECOVERY_TASK_UID"
+
+POSTGRES_USER="$(
+  docker compose "${ROLLBACK_COMPOSE_FILES[@]}" exec -T postgres \
+    printenv POSTGRES_USER
+)"
+POSTGRES_DB="$(
+  docker compose "${ROLLBACK_COMPOSE_FILES[@]}" exec -T postgres \
+    printenv POSTGRES_DB
+)"
+EXPECTED_SEARCH_RECORDS="$(
+  docker compose "${ROLLBACK_COMPOSE_FILES[@]}" exec -T postgres psql \
+    -U "$POSTGRES_USER" -d "$POSTGRES_DB" -At -c "
+      select
+        (select count(*)
+         from document d
+         join catalog c on c.id = d.catalog_id
+         join event e on e.id = d.event_id
+         join place p on p.id = d.place_id
+         where c.content is not null and c.content <> '')
+        +
+        (select count(*)
+         from agenda_item ai
+         join event e on e.id = ai.event_id
+         join place p on p.id = e.place_id);
+    "
+)"
+STARTUP_PURGE_DERIVED=false docker compose "${ROLLBACK_COMPOSE_FILES[@]}" run \
+  --rm --no-deps pipeline python reindex_only.py
+STARTUP_PURGE_DERIVED=false docker compose "${ROLLBACK_COMPOSE_FILES[@]}" run \
+  --rm --no-deps \
+  -e MEILI_RECOVERY_TASK_UID="$MEILI_RECOVERY_TASK_UID" \
+  -e EXPECTED_SEARCH_RECORDS="$EXPECTED_SEARCH_RECORDS" \
+  pipeline python - <<'PY'
+import json
+import os
+import time
+from urllib.request import Request, urlopen
+
+HTTP_TIMEOUT_SECONDS = 30
+TASK_TIMEOUT_SECONDS = 300
+TASK_POLL_SECONDS = 1
+MEILI_HOST = os.environ["MEILI_HOST"].rstrip("/")
+MEILI_KEY = os.environ["MEILI_MASTER_KEY"]
+FIRST_REINDEX_TASK_UID = int(os.environ["MEILI_RECOVERY_TASK_UID"]) + 1
+EXPECTED_SEARCH_RECORDS = int(os.environ["EXPECTED_SEARCH_RECORDS"])
+
+
+def task_allows_rollback_reindex(task):
+    return task["status"] == "succeeded" or (
+        task["status"] == "failed"
+        and task["type"] == "indexCreation"
+        and task["error"]["code"] == "index_already_exists"
+    )
+
+
+def request_json(method, path):
+    request = Request(
+        f"{MEILI_HOST}{path}",
+        headers={"Authorization": f"Bearer {MEILI_KEY}"},
+        method=method,
+    )
+    with urlopen(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
+        return json.load(response)
+
+
+barrier = request_json(
+    "DELETE",
+    "/indexes/documents/documents/__town_council_recovery_barrier__",
+)
+barrier_task_uid = int(barrier["taskUid"])
+deadline = time.monotonic() + TASK_TIMEOUT_SECONDS
+while time.monotonic() < deadline:
+    pending = False
+    for task_uid in range(FIRST_REINDEX_TASK_UID, barrier_task_uid + 1):
+        task = request_json("GET", f"/tasks/{task_uid}")
+        if task_allows_rollback_reindex(task):
+            continue
+        if task["status"] in {"failed", "canceled"}:
+            raise RuntimeError(json.dumps(task, sort_keys=True))
+        pending = True
+    if not pending:
+        break
+    time.sleep(TASK_POLL_SECONDS)
+else:
+    raise TimeoutError("Meilisearch rollback reindex exceeded recovery timeout")
+
+stats = request_json("GET", "/indexes/documents/stats")
+actual_search_records = int(stats["numberOfDocuments"])
+if actual_search_records != EXPECTED_SEARCH_RECORDS:
+    raise RuntimeError(
+        "Meilisearch rollback count mismatch "
+        f"expected={EXPECTED_SEARCH_RECORDS} actual={actual_search_records}"
+    )
+print("Meilisearch rollback reindex completed")
+PY
 
 # Required when SEMANTIC_BACKEND=faiss; pgvector state is inside the backup.
-docker compose -f "$ROLLBACK_COMPOSE_FILE" run \
+docker compose "${ROLLBACK_COMPOSE_FILES[@]}" run \
   --rm --no-deps semantic python ../pipeline/reindex_semantic.py
-STARTUP_PURGE_DERIVED=false docker compose -f "$ROLLBACK_COMPOSE_FILE" up -d
+STARTUP_PURGE_DERIVED=false docker compose "${ROLLBACK_COMPOSE_FILES[@]}" up -d
 ```
 
 Do not run `db_migrate.py` from the failed release: it would upgrade the

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -170,6 +170,7 @@ For full recovery, stop every Compose writer plus schedulers or manual commands
 running outside this project. Validate the archive before dropping the target:
 
 ```bash
+set -euo pipefail
 BACKUP_PATH="<BACKUP_PATH>/town_council_recovery.dump"
 
 docker compose -f docker-compose.yml -f docker-compose.dev.yml stop
@@ -204,6 +205,7 @@ authoritative, so replace any external search state that may be newer than the
 restored snapshot:
 
 ```bash
+set -euo pipefail
 STARTUP_PURGE_DERIVED=false docker compose \
   -f docker-compose.yml -f docker-compose.dev.yml up -d postgres redis meilisearch
 STARTUP_PURGE_DERIVED=false docker compose \
@@ -212,7 +214,7 @@ STARTUP_PURGE_DERIVED=false docker compose \
 
 # Required when SEMANTIC_BACKEND=faiss; pgvector state is inside the backup.
 docker compose -f docker-compose.yml -f docker-compose.dev.yml run \
-  --rm --no-deps semantic python ../pipeline/reindex_semantic.py
+  --rm --build --no-deps semantic python ../pipeline/reindex_semantic.py
 ```
 
 `--replace-all` bounds every Meilisearch HTTP request at 30 seconds and uses
@@ -316,22 +318,52 @@ preserves source catalog, document, event, agenda, and civic records.
 
 ##### Roll back a failed schema release
 
-Keep all writers stopped. Select the exact application release that was active
-when the pre-migration backup was created **before running `db_migrate.py` or
-schema parity against the restored database**:
+Keep all writers stopped. Choose one rollback procedure and use it for every
+application command.
+
+**Checkout-based rollback.** Select the exact application release that was
+active when the pre-migration backup was created **before running `db_migrate.py`
+or schema parity against the restored database**:
 
 ```bash
 ROLLBACK_REF="<PREVIOUS_RELEASE_REF>"
 git switch --detach "$ROLLBACK_REF"
 ```
 
-For image-based deployment, select the equivalent previous image tag instead
-of changing the checkout. With the previous release active, follow the routine
-replacement-restore procedure above, including external search rebuilds. Its
-`db_migrate.py`, schema-parity check, and reindex commands must all come from
-the rollback release. Do not run `db_migrate.py` from the failed release: it
-would upgrade the restored backup to the schema being rolled back. Restart
-only the previous application release after every recovery check passes.
+Follow the full recovery procedure above. Its `--build` commands now build the
+selected rollback checkout, so `db_migrate.py`, schema parity, and both reindex
+commands all come from the rollback release.
+
+**Prebuilt-image rollback.** The checked-in Compose files are not an
+image-only rollback interface: they include local build definitions and source
+bind mounts. Use a deployment-specific Compose file that pins every Town
+Council application service to an immutable previous-release image and does
+not mount the current checkout. Perform archive validation and database
+replacement through that file, then run the application-owned recovery steps
+without `--build`:
+
+```bash
+set -euo pipefail
+ROLLBACK_COMPOSE_FILE="<ROLLBACK_COMPOSE_FILE>"
+
+STARTUP_PURGE_DERIVED=false docker compose -f "$ROLLBACK_COMPOSE_FILE" run \
+  --rm --no-deps pipeline python db_migrate.py
+STARTUP_PURGE_DERIVED=false docker compose -f "$ROLLBACK_COMPOSE_FILE" run \
+  --rm --no-deps pipeline python /app/scripts/check_schema_parity.py
+STARTUP_PURGE_DERIVED=false docker compose -f "$ROLLBACK_COMPOSE_FILE" up \
+  -d postgres redis meilisearch
+STARTUP_PURGE_DERIVED=false docker compose -f "$ROLLBACK_COMPOSE_FILE" run \
+  --rm --no-deps pipeline python reindex_only.py --replace-all
+
+# Required when SEMANTIC_BACKEND=faiss; pgvector state is inside the backup.
+docker compose -f "$ROLLBACK_COMPOSE_FILE" run \
+  --rm --no-deps semantic python ../pipeline/reindex_semantic.py
+STARTUP_PURGE_DERIVED=false docker compose -f "$ROLLBACK_COMPOSE_FILE" up -d
+```
+
+Do not run `db_migrate.py` from the failed release: it would upgrade the
+restored backup to the schema being rolled back. Restart only the previous
+application release after every recovery check passes.
 
 #### Historical timezone migration v10
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -120,7 +120,51 @@ record and any derived rows present when the dump starts.
 To validate an archive without touching the active database, restore into a
 new, uniquely named database created from `template0`, inspect
 `alembic_version` and representative row counts, then drop only that validation
-database.
+database:
+
+```bash
+set -euo pipefail
+BACKUP_PATH="<BACKUP_PATH>/town_council_restore_drill.dump"
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d postgres
+POSTGRES_USER="$(docker compose exec -T postgres printenv POSTGRES_USER)"
+RESTORE_DB="town_council_restore_check_$(.venv/bin/python -c \
+  'import secrets; print(secrets.token_hex(8))')"
+RESTORE_DB_CREATED=false
+
+cleanup_restore_drill() {
+  if [[ "$RESTORE_DB_CREATED" == "true" ]]; then
+    docker compose exec -T postgres dropdb \
+      -U "$POSTGRES_USER" --maintenance-db=postgres \
+      --force --if-exists "$RESTORE_DB" >/dev/null
+    RESTORE_DB_CREATED=false
+  fi
+}
+trap cleanup_restore_drill EXIT
+
+docker compose exec -T postgres pg_restore --list < "$BACKUP_PATH" >/dev/null
+if docker compose exec -T postgres createdb \
+  -U "$POSTGRES_USER" -T template0 "$RESTORE_DB"; then
+  RESTORE_DB_CREATED=true
+else
+  exit 1
+fi
+docker compose exec -T postgres pg_restore \
+  -U "$POSTGRES_USER" -d "$RESTORE_DB" \
+  --exit-on-error --no-owner --no-privileges < "$BACKUP_PATH"
+docker compose exec -T postgres psql \
+  -U "$POSTGRES_USER" -d "$RESTORE_DB" \
+  -c "select version_num from alembic_version;
+      select 'catalog' as relation, count(*) from catalog
+      union all
+      select 'event' as relation, count(*) from event
+      order by relation"
+cleanup_restore_drill
+trap - EXIT
+```
+
+Record the archive identifier, Alembic revision, and row counts as restore-drill
+evidence. The high-entropy database name and ownership flag keep cleanup from
+dropping the active database or a database the drill did not create.
 
 For full recovery, stop every Compose writer plus schedulers or manual commands
 running outside this project. Validate the archive before dropping the target:
@@ -269,8 +313,24 @@ Confirm `embed_dispatch_failed=0`, then monitor the semantic worker until the
 queued tasks finish. Embeddings are derived data; the migration transaction
 preserves source catalog, document, event, agenda, and civic records.
 
-Rollback follows the routine replacement-restore procedure above while writers
-remain stopped, then repeats schema parity before restart.
+##### Roll back a failed schema release
+
+Keep all writers stopped. Select the exact application release that was active
+when the pre-migration backup was created **before running `db_migrate.py` or
+schema parity against the restored database**:
+
+```bash
+ROLLBACK_REF="<PREVIOUS_RELEASE_REF>"
+git switch --detach "$ROLLBACK_REF"
+```
+
+For image-based deployment, select the equivalent previous image tag instead
+of changing the checkout. With the previous release active, follow the routine
+replacement-restore procedure above, including external search rebuilds. Its
+`db_migrate.py`, schema-parity check, and reindex commands must all come from
+the rollback release. Do not run `db_migrate.py` from the failed release: it
+would upgrade the restored backup to the schema being rolled back. Restart
+only the previous application release after every recovery check passes.
 
 #### Historical timezone migration v10
 
@@ -326,12 +386,13 @@ Every migrated timestamp must report `timestamp with time zone`. Generated
 timestamps have a `now()` default; lifecycle-attempt timestamps intentionally
 have no default so null continues to mean not attempted.
 
-Rollback uses the verified preflight backup and the routine replacement-restore
-procedure above. Keep all writers stopped, then repeat the timestamp-column
-query before restart.
+Rollback uses the failed-schema-release procedure above and the verified
+preflight backup. Keep all writers stopped, select the previous application
+release first, restore the backup, then repeat the timestamp-column query
+before restarting that previous release.
 
 Do not reverse-convert a database that accepted post-migration writes. Restore
-the backup, then revert the application release.
+the backup through the rollback release instead.
 
 Why the explicit model bootstrap exists:
 - local model downloads no longer happen during Docker image builds

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,6 +1,6 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 3.61
+version: 3.62
 generated: 2026-07-26
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
@@ -10,6 +10,10 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v3.62:** Expands active T-PLAT-3 ownership to the Redis service definition
+  and its Compose contract test. Recovery must clear persistent Redis database
+  0 after writers stop and before workers restart, using the service's existing
+  credential inside the container rather than expanding it in the host shell.
 - **v3.61:** Activates T-PLAT-3 with an implementation-ready backup and
   recovery plan. Expands ownership for tests-first shell contracts and the
   existing full-index maintenance path so a PostgreSQL restore cannot leave
@@ -1392,7 +1396,8 @@ files (GED-5 grant).
   `scripts/backup_db.sh`, `tests/test_backup_db_contract.py`,
   `docs/OPERATIONS.md`, `pipeline/indexer.py`,
   `pipeline/indexer_meilisearch.py`, `pipeline/reindex_only.py`,
-  `tests/test_indexer_logic.py`
+  `tests/test_indexer_logic.py`, `docker-compose.yml`,
+  `tests/test_docker_build_contracts.py`
 - do: Add one private, atomic, custom-format `pg_dump` command; document
   cadence and fresh-database replacement restore; make the
   `STARTUP_PURGE_DERIVED` interaction explicit; and add a tested full-index
@@ -1402,8 +1407,8 @@ files (GED-5 grant).
   publication, never overwrites a destination, and leaves no partial archive.
   A disposable database restore proves archive usability. Recovery guidance
   keeps writers stopped, recreates the database from `template0`, migrates and
-  verifies it, rebuilds external search state, and restarts with startup purge
-  disabled.
+  verifies it, clears persistent Redis database 0, rebuilds external search
+  state, and restarts with startup purge disabled.
 - forbidden: Automatic scheduling or restore; embedded credentials; a default
   archive destination; Docker fake seams; runtime-default, schema, migration,
   or search-query behavior changes; edits outside `files_owned`.

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,6 +1,6 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 3.60
+version: 3.61
 generated: 2026-07-26
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
@@ -10,6 +10,11 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v3.61:** Activates T-PLAT-3 with an implementation-ready backup and
+  recovery plan. Expands ownership for tests-first shell contracts and the
+  existing full-index maintenance path so a PostgreSQL restore cannot leave
+  Meilisearch or FAISS newer than the restored system of record. T-PLAT-3 and
+  T-DD-1B must serialize their shared operations-runbook edits.
 - **v3.60:** Removes the partial source-line semantic analyzer added during
   T-GOV-3A review. Arbitrary Python data flow cannot be soundly enforced by a
   small repository test; Ruff C901 and registered dependency rules remain the
@@ -293,7 +298,8 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 |---|---|
 | **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2, T-SEC-3, T-SEC-3C, T-SEC-4, T-SEC-4A, T-SEC-5, T-SEC-6, T-TIME-1, T-TIME-2, T-TIME-3, T-CRAWL-1, T-CRAWL-2, T-PLAT-1, T-PLAT-1A, T-PLAT-2A, T-PLAT-2B, T-GOV-1, T-GOV-3A, T-GOV-4, T-GOV-5, T-DA-1, T-DB-1A, T-DB-1, T-DB-1B, T-DD-1A |
 | **Partially landed; acceptance incomplete** | T-GOV-3, T-GOV-6 |
-| **Pending** | T-DC-1, T-DD-1B, T-DE-1, T-PLAT-2, T-PLAT-3, T-PLAT-4, T-GOV-2, T-GOV-3B |
+| **Active** | T-PLAT-3 |
+| **Pending** | T-DC-1, T-DD-1B, T-DE-1, T-PLAT-2, T-PLAT-4, T-GOV-2, T-GOV-3B |
 
 ---
 
@@ -1378,12 +1384,33 @@ files (GED-5 grant).
 
 ### T-PLAT-3: Backup/restore runbook
 - priority: P1
-- files_owned: docs/OPERATIONS.md (new section), scripts/backup_db.sh (new)
-- do: pg_dump-based backup script (custom format), restore procedure,
-  cadence recommendation, and an explicit note on the STARTUP_PURGE
-  interaction (purge is derived-only; backups still cover system of record).
-- accept: Documented, script exits 0 against dev stack.
-- verify: Manual run against dev compose.
+- status: active
+- implementation_plan: `docs/plans/T_PLAT_3_BACKUP_RESTORE_PLAN.md`
+- must_not_run_concurrently_with: T-DD-1B
+- files_owned: `docs/plans/T_PLAT_3_BACKUP_RESTORE_PLAN.md`,
+  `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`,
+  `scripts/backup_db.sh`, `tests/test_backup_db_contract.py`,
+  `docs/OPERATIONS.md`, `pipeline/indexer.py`,
+  `pipeline/indexer_meilisearch.py`, `pipeline/reindex_only.py`,
+  `tests/test_indexer_logic.py`
+- do: Add one private, atomic, custom-format `pg_dump` command; document
+  cadence and fresh-database replacement restore; make the
+  `STARTUP_PURGE_DERIVED` interaction explicit; and add a tested full-index
+  replacement mode so restored PostgreSQL, Meilisearch, and FAISS converge
+  before traffic resumes.
+- accept: The script exits 0 against the dev stack, validates before
+  publication, never overwrites a destination, and leaves no partial archive.
+  A disposable database restore proves archive usability. Recovery guidance
+  keeps writers stopped, recreates the database from `template0`, migrates and
+  verifies it, rebuilds external search state, and restarts with startup purge
+  disabled.
+- forbidden: Automatic scheduling or restore; embedded credentials; a default
+  archive destination; Docker fake seams; runtime-default, schema, migration,
+  or search-query behavior changes; edits outside `files_owned`.
+- verify: Follow the Full T-PLAT-3 plan, including tests-first evidence, shell
+  syntax, Ruff, Mypy, focused backup/indexer contracts, docs links, complete
+  suite, real dev-stack backup, disposable restore drill, independent review,
+  and PR CI.
 
 ### T-PLAT-4: cache.py right-sizing
 - priority: P3

--- a/docs/plans/T_PLAT_3_BACKUP_RESTORE_PLAN.md
+++ b/docs/plans/T_PLAT_3_BACKUP_RESTORE_PLAN.md
@@ -107,7 +107,9 @@ uniquely named temporary validation database.
     `replace_documents_index()`. The operation waits for the rebuild queue and
     verifies the live index settings before comparing the final Meilisearch
     document count with the PostgreSQL corpus count returned by
-    `index_documents()`.
+    `index_documents()`. Every maintenance request uses one client with a
+    30-second HTTP timeout so the five-minute task and idle waits cannot block
+    inside an unbounded request.
 15. Require the recovery runbook to rebuild Meilisearch with `--replace-all`
     before accepting traffic. When `SEMANTIC_BACKEND=faiss`, rebuild FAISS
     artifacts from the restored database too. Pgvector embeddings are restored
@@ -287,6 +289,8 @@ concise runbook/ledger text.
     verification blocks restart.
 19. Failed schema release: selecting the rollback release before migration and
     parity prevents the failed current migration from being reapplied.
+20. Meilisearch stops responding during recovery: every maintenance request
+    times out before control returns to the task or idle deadline.
 
 **r) Tests added or updated.**
 
@@ -305,6 +309,7 @@ concise runbook/ledger text.
 | `test_full_reindex_rejects_missing_index_settings` | 17 |
 | `test_full_reindex_rejects_document_count_mismatch` | 17 |
 | `test_indexer_reports_agenda_source_count_after_batch_attempt` | 18 |
+| `test_full_reindex_uses_one_bounded_maintenance_client` | 20 |
 | `test_backup_runbook_rebuilds_external_search_state` | 15-18 |
 | Real dev-stack backup and temporary restore drill | 5-13 |
 | Existing docs-link suite | Runbook and plan links |

--- a/docs/plans/T_PLAT_3_BACKUP_RESTORE_PLAN.md
+++ b/docs/plans/T_PLAT_3_BACKUP_RESTORE_PLAN.md
@@ -1,0 +1,434 @@
+# T-PLAT-3: Add a Verified PostgreSQL Backup and Restore Workflow
+
+`artifact_contract: ce-unified-plan/v1`  
+`artifact_readiness: implementation-ready`  
+`execution: code`
+
+## 1. Context & Alignment
+
+**a) Driver.** Town Council has migration-specific `pg_dump` snippets but no
+reusable backup command, routine cadence, or end-to-end restore drill. T-PLAT-3
+must give local operators one safe PostgreSQL archive workflow before further
+destructive maintenance or architecture remediation. The workflow must protect
+the complete database without changing local-first runtime defaults or treating
+derived-data startup purge as a substitute for backups.
+
+**b) Canonical documents consulted.**
+
+- `AGENTS.md` `<security_sensitive_paths>`, `<workflow_contract>`,
+  `<verification_matrix>`, and `<docs_sync_rules>` require a Full plan,
+  trust-boundary reporting, exact verification, and current operator commands.
+- `SECURITY.md` "Secrets and configuration" requires database credentials to
+  remain in environment configuration and lists backups as unfinished
+  hardening work.
+- `docs/OPERATIONS.md` "Database migrations and backups" already owns
+  migration preflight and restore commands; T-PLAT-3 must extend that section
+  rather than introduce a competing runbook.
+- `docs/TESTING.MD` permits filesystem-based tests but does not approve a fake
+  Docker CLI boundary; the real dev-stack smoke remains authoritative.
+- `docs/DATA_GOVERNANCE.md` requires retained private-individual content to
+  stay access-controlled; database archives reproduce that governed content.
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md` assigns T-PLAT-3 a custom-format
+  `pg_dump` script, restore procedure, cadence guidance, and explicit
+  `STARTUP_PURGE_DERIVED` interaction.
+- `ARCHITECTURE.md` identifies PostgreSQL as the system of record.
+
+**c) Remediation alignment.** This is T-PLAT-3 in the PLAT lane. Expand its
+exclusive `files_owned` set before implementation to:
+
+- `docs/plans/T_PLAT_3_BACKUP_RESTORE_PLAN.md`
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`
+- `scripts/backup_db.sh`
+- `tests/test_backup_db_contract.py`
+- `docs/OPERATIONS.md`
+- `pipeline/indexer.py`
+- `pipeline/indexer_meilisearch.py`
+- `pipeline/reindex_only.py`
+- `tests/test_indexer_logic.py`
+
+T-DD-1B also expects a later `docs/OPERATIONS.md` edit. The two tasks must run
+serially; T-PLAT-3 lands first and T-DD-1B rebases before implementation.
+
+**d) Decision-gate check.** No G1-G5 decision is required or foreclosed. G5
+Alembic adoption is already approved and complete. The script does not restore
+or delete data automatically, so no additional destructive-operation approval
+is needed for implementation. The manual restore drill creates and drops only a
+uniquely named temporary validation database.
+
+## 2. Design
+
+**e) Step-by-step approach.**
+
+1. Create branch `codex/t-plat-3-backup-restore` from current `origin/master`.
+2. Add this implementation-ready plan and update T-PLAT-3 ownership,
+   dependencies, acceptance criteria, and verification in the remediation
+   ledger.
+3. Add failing tests before the script and runbook implementation.
+4. Add executable `scripts/backup_db.sh` with one required positional
+   argument: the destination archive path, plus standard `-h`/`--help`.
+5. Resolve the repository root from the script location and use the existing
+   development Compose pair:
+   `docker compose -f docker-compose.yml -f docker-compose.dev.yml`.
+6. Require the destination parent directory to exist and refuse to overwrite
+   an existing destination.
+7. Set `umask 077`, create a temporary archive beside the destination with
+   `mktemp`, and register an exit trap that removes incomplete output.
+8. Run `pg_dump` inside the existing `postgres` service with the container's
+   `POSTGRES_USER` and `POSTGRES_DB`. Use custom format, omit ownership and ACL
+   restoration metadata, and redirect binary stdout to the temporary host file.
+9. Validate the completed archive through in-container
+   `pg_restore --list`. Atomically rename the temporary file to the requested
+   destination only after validation succeeds.
+10. Extend `docs/OPERATIONS.md` with routine backup, restore, cadence,
+    retention, credential, and `STARTUP_PURGE_DERIVED` guidance.
+11. Replace the two migration-specific inline `pg_dump` and archive-list
+    command pairs with calls to `scripts/backup_db.sh`, retaining the existing
+    writer-stop and migration ordering.
+12. Document active-database restore as a maintenance operation: validate the
+    archive, stop Compose and external writers, start only PostgreSQL, drop the
+    target database with forced connection termination, recreate it from
+    `template0`, restore with error/owner/ACL controls, run migrations and
+    schema parity, inspect core row counts, then restart with
+    `STARTUP_PURGE_DERIVED=false`.
+13. Add one focused typed helper to existing `indexer_meilisearch.py`: delete
+    every document and wait for the documented asynchronous task to succeed.
+    Add one focused `replace_documents_index()` operation to `indexer.py` that
+    calls that helper and then the unchanged `index_documents()`.
+14. Extend the existing `reindex_only.py` CLI with explicit `--replace-all`.
+    The default remains unchanged. Replacement mode routes to
+    `replace_documents_index()`.
+15. Require the recovery runbook to rebuild Meilisearch with `--replace-all`
+    before accepting traffic. When `SEMANTIC_BACKEND=faiss`, rebuild FAISS
+    artifacts from the restored database too. Pgvector embeddings are restored
+    inside PostgreSQL and need no external artifact rebuild.
+16. Run a real backup smoke against the local dev stack. Restore that archive
+    into a uniquely named temporary database, inspect representative table
+    counts, and drop only that temporary database.
+17. Simplify the diff, run an independent pre-commit review, apply every
+    eligible P1/P2, rerun affected verification, create atomic commits, push,
+    open one PR, and watch CI to a decided state.
+
+`scripts/backup_db.sh` has one responsibility: produce one validated,
+private, custom-format archive from the configured Compose PostgreSQL service.
+It does not stop writers, schedule itself, rotate files, upload archives, or
+perform restores.
+
+`pipeline.indexer.index_documents()` remains unchanged and retains full-index
+synchronization ownership. The new `replace_documents_index()` operation owns
+the ordered clear-then-rebuild workflow. The dependency-facing clear/wait
+helper stays in `indexer_meilisearch.py`; helpers never import the indexer or
+CLI.
+
+**f) Reuse audit.** Reuse the current Compose-array convention from
+`scripts/dev_up.sh`, the existing PostgreSQL service environment, and the
+current migration backup/restore section. No backup manager, scheduler,
+configuration wrapper, restore script, Docker fake, or second credential
+source is introduced. The new command supersedes and removes the two duplicate
+inline backup command pairs in the runbook.
+
+Rejected alternatives:
+
+- Host-installed `pg_dump`: rejected because it adds a version and package
+  prerequisite while the PostgreSQL 15-compatible client already exists in
+  the database container.
+- Automatic restore script: rejected because replacement restore is
+  destructive, requires writers to be quiesced, and needs operator inspection.
+- Default timestamped destination: rejected because an implicit write location
+  would be a new silent CLI default. The operator must name the archive.
+- Fake-Docker unit test: rejected because Docker CLI substitution is not an
+  approved `docs/TESTING.MD` fake boundary.
+- A runbook-only Meilisearch deletion snippet: rejected because it would
+  duplicate SDK behavior without a tested implementation owner.
+- Filesystem-copy backup of the Postgres volume: rejected because it is not a
+  portable logical backup and can be inconsistent without storage-level
+  coordination.
+
+**g) Data contracts.**
+
+- CLI input: exactly one non-empty destination path; `-h`/`--help` prints usage
+  and exits without contacting Docker.
+- Success: exit `0`, one non-empty custom-format archive at that path, archive
+  list validation passed, mode restricted by `umask 077`, and no partial file.
+- Usage/config/archive failure: nonzero exit, contextual stderr, no completed
+  destination, and no partial file.
+- Existing destination: nonzero exit without modifying it.
+- No application API, database schema, migration revision, Celery signature,
+  environment variable, credential default, or runtime default changes.
+- `reindex_only.py --replace-all` is a new explicit maintenance option.
+  Running the CLI without it preserves current additive reindex behavior.
+
+**h) Schema/migration impact.** None. The validation restore uses a temporary
+database created from `template0`, does not alter the active database, and is
+dropped after verification. Existing Alembic migrations remain the only schema
+upgrade path after restoring an older archive.
+
+## 3. Security & Data Governance
+
+**i) Security-sensitive path.** The script handles PostgreSQL access and
+therefore crosses the backing-store credential boundary in `SECURITY.md`.
+Credentials remain inside the Compose service environment and are never passed
+as host command arguments, printed, copied into the archive name, or written to
+logs. An attacker gains no new network access. The backup contains the database
+snapshot and must be treated as sensitive local data; `umask 077` limits new
+archive access to the invoking user.
+
+`pipeline/indexer.py` handles `MEILI_MASTER_KEY`, so its focused edit also
+touches the privileged search-writer boundary. The change neither logs nor
+changes the key; it uses the existing writer client to delete and rebuild only
+the `documents` index.
+
+**j) Secrets.** No new secret, key, environment variable, or default is added.
+The script references `POSTGRES_USER` and `POSTGRES_DB` only inside the
+container. PostgreSQL authentication continues to use the existing container
+environment.
+
+**k) Person data.** The task does not create, link, aggregate, or expose new
+person data. A backup reproduces existing database contents, including any
+governed private-individual records, so operators must apply the same retention
+and access controls as the live database. G4 is unaffected.
+
+**l) Untrusted input.** The destination path is operator input. It is quoted,
+must have an existing parent, and cannot already exist. It is never evaluated
+as shell code. The archive is validated by PostgreSQL's own `pg_restore --list`
+before publication. Restore commands accept only an operator-selected local
+archive and run with writers stopped.
+
+## 4. Code Health
+
+**m) GED conformance sweep.** The script uses `set -euo pipefail`, named
+constants/variables, quoted expansions, one cleanup function, and a single exit
+trap. Errors either stop execution with context or remove incomplete output.
+The indexer receives one short ordered operation while its existing long batch
+function remains unchanged. The Meilisearch helper has typed concrete SDK
+parameters and one fail-fast responsibility. No environment config surface,
+timestamp behavior, broad exception handler, or Ruff boundary changes.
+
+**n) Antipattern scan, plan pass.**
+
+- A1/H1 corrected: current PostgreSQL and Docker Compose docs were checked for
+  custom archives, consistent snapshots, `pg_restore` validation/options,
+  repeated `-f`, and `exec -T`. Meilisearch docs and installed
+  `meilisearch==0.31.0` were checked for `delete_all_documents()`,
+  `TaskInfo.task_uid`, and `Client.wait_for_task()`.
+- A2 corrected: destination is required; no new environment variable or silent
+  path default.
+- B1/F1 corrected: one focused script extends the existing runbook; no manager,
+  registry, wrapper, or duplicate backup implementation.
+- B3 corrected: overwrite refusal, partial cleanup, and archive validation
+  protect real operator failure modes.
+- C1 corrected: migration snippets call the new command; the duplicate inline
+  dump commands are removed.
+- D1-D3 corrected: tests preserve strict behavior and avoid fake Docker or
+  private helper assertions.
+- E1-E3 corrected: only the nine owned files change and the runbook receives
+  minimal edits.
+- A3-A4, B2, C2, H2-H4: no violations planned.
+
+**o) Ratchet interaction.** `pipeline/indexer.py` and
+`pipeline/indexer_meilisearch.py` already have BLE001 allowances. This task
+leaves both unchanged because it adds no broad handler and does not modify the
+existing allowed boundaries. No selector, formatter scope, Mypy scope,
+coverage floor, or test skip changes.
+
+**p) Dead code and duplication audit.** Remove two duplicated migration
+`pg_dump`/`pg_restore --list` pairs and two duplicate in-place restore command
+blocks. Reuse the new script for backup and the new routine replacement-restore
+procedure by reference. The only production Python delta is the explicit
+Meilisearch replacement mode in the existing index owner and CLI. Expected net
+delta is one small shell command, focused contract coverage, one Full plan, and
+concise runbook/ledger text.
+
+## 5. Testing
+
+**q) Edge cases and failure scenarios.**
+
+1. No destination argument: usage error before Docker is invoked.
+2. Extra argument: usage error before Docker is invoked.
+3. Missing destination parent: fail without creating directories.
+4. Existing destination: fail without modifying it.
+5. `pg_dump` failure: exit nonzero and remove the temporary file.
+6. Empty or malformed archive: validation fails and no destination is
+   published.
+7. Successful dump: archive validates, is atomically published, and is
+   private to the invoking user.
+8. Credentials containing shell metacharacters: remain container environment
+   values and are not host-evaluated.
+9. Live writes during routine backup: PostgreSQL supplies one consistent
+   snapshot; migration backups still stop writers before the dump.
+10. Active restore with connected writers: runbook requires all Compose and
+    external writers to stop before dropping and recreating the target
+    database.
+11. Older archive: run migrations and schema parity before writer restart.
+12. Startup purge: derived rows may be cleared, source ingest remains, and
+    backups still cover the complete snapshot.
+13. Temporary restore drill: use a unique database and drop only that database.
+14. Temporary database name collision or failed creation: cleanup must never
+    drop a database the drill did not create.
+15. Restored PostgreSQL is older than Meilisearch/FAISS: delete all
+    Meilisearch documents and wait before reindex; rebuild FAISS before traffic.
+16. Meilisearch deletion task fails: stop recovery before indexing or restart.
+
+**r) Tests added or updated.**
+
+| Test | Scenarios |
+|---|---|
+| `test_backup_script_has_valid_shell_syntax` | 1-8 |
+| `test_backup_script_requires_one_destination` | 1, 2 |
+| `test_backup_script_prints_help_without_docker` | 1, 2 |
+| `test_backup_script_refuses_existing_destination` | 4 |
+| `test_backup_script_uses_private_atomic_validated_archive` | 5-8 |
+| `test_backup_runbook_covers_restore_cadence_and_startup_purge` | 9-13 |
+| `test_full_reindex_replaces_existing_meilisearch_documents` | 15 |
+| `test_full_reindex_stops_when_meilisearch_clear_fails` | 16 |
+| `test_backup_runbook_rebuilds_external_search_state` | 15, 16 |
+| Real dev-stack backup and temporary restore drill | 5-13 |
+| Existing docs-link suite | Runbook and plan links |
+| Complete Python suite | Cross-cutting regression check |
+
+The source-contract test may assert CLI and command tokens because those are
+the operator-facing shell contract. It also runs `bash -n`. Failure-path tests
+execute only pre-Docker validation branches.
+
+**s) Fakes and mocks.** Backup tests use the approved `tmp_path` filesystem
+boundary and real subprocess execution of pre-Docker script branches.
+Meilisearch replacement tests use the approved Meilisearch-client and database
+session boundaries in `pipeline.indexer`; they assert externally visible fake
+index state and raised recovery errors, not call counts. The backup success
+path uses the real Docker Compose/PostgreSQL boundary manually.
+
+**t) Verification rows.** Apply the docs-only row for `docs/**`. No existing
+matrix row names shell operator scripts, so run Ruff, Mypy, the focused backup
+contract, docs links, and the complete Python suite. The real dev-stack backup
+and temporary restore drill are required before handoff.
+
+## 6. Execution, Rollback, Docs
+
+**u) Exact commands.**
+
+```bash
+git fetch origin --prune
+git switch master
+git merge --ff-only origin/master
+git switch -c codex/t-plat-3-backup-restore
+```
+
+Tests-first red evidence:
+
+```bash
+PYTHONPATH=. .venv/bin/pytest -q tests/test_backup_db_contract.py
+```
+
+Expected: collection or assertion failure because the script and runbook
+contract do not exist yet.
+
+Final local verification:
+
+```bash
+bash -n scripts/backup_db.sh
+./.venv/bin/ruff check .
+./.venv/bin/mypy
+PYTHONPATH=. .venv/bin/pytest -q tests/test_backup_db_contract.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_indexer_logic.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py
+PYTHONPATH=. .venv/bin/pytest -q
+git diff --check
+git status --short
+```
+
+Real backup smoke:
+
+```bash
+BACKUP_SMOKE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/town-council-backup.XXXXXX")"
+BACKUP_PATH="$BACKUP_SMOKE_DIR/t_plat_3_smoke.dump"
+bash ./scripts/backup_db.sh "$BACKUP_PATH"
+docker compose exec -T postgres pg_restore --list < "$BACKUP_PATH" >/dev/null
+stat -f '%Lp %z %N' "$BACKUP_PATH"
+```
+
+Temporary restore drill:
+
+```bash
+RESTORE_DB="town_council_restore_check_$(.venv/bin/python -c \
+  'import secrets; print(secrets.token_hex(8))')"
+POSTGRES_USER="$(docker compose exec -T postgres printenv POSTGRES_USER)"
+RESTORE_DB_CREATED=false
+cleanup_restore_drill() {
+  if [[ "$RESTORE_DB_CREATED" == "true" ]]; then
+    docker compose exec -T postgres dropdb \
+      -U "$POSTGRES_USER" --if-exists "$RESTORE_DB" >/dev/null
+  fi
+  rm -rf "$BACKUP_SMOKE_DIR"
+}
+trap cleanup_restore_drill EXIT
+docker compose exec -T postgres createdb \
+  -U "$POSTGRES_USER" -T template0 "$RESTORE_DB"
+RESTORE_DB_CREATED=true
+docker compose exec -T postgres pg_restore \
+  -U "$POSTGRES_USER" -d "$RESTORE_DB" \
+  --exit-on-error --no-owner --no-privileges < "$BACKUP_PATH"
+docker compose exec -T postgres psql \
+  -U "$POSTGRES_USER" -d "$RESTORE_DB" \
+  -c "select version_num from alembic_version;
+      select 'catalog' as relation, count(*) from catalog
+      union all
+      select 'event' as relation, count(*) from event
+      order by relation"
+cleanup_restore_drill
+trap - EXIT
+```
+
+Delivery uses two commits:
+
+1. `docs(remediation): authorize T-PLAT-3 backup workflow`
+2. `feat(operations): add verified database backups`
+
+Push `codex/t-plat-3-backup-restore`, open one PR titled
+`T-PLAT-3: Add verified PostgreSQL backups`, request independent review, and
+watch CI to a decided state.
+
+**v) Rollback.** Revert the T-PLAT-3 merge commit, rerun the focused contract,
+docs links, and complete suite, and remove only the temporary smoke directory
+created under `${TMPDIR:-/tmp}`. No schema, migration, active database,
+credential, or external service state changes. If the temporary restore drill
+is interrupted, verify the generated database name and drop only that
+`town_council_restore_check_*` database.
+
+**w) Docs synchronization.**
+
+- `docs/OPERATIONS.md`: add routine backup/restore, cadence, retention,
+  archive security, fresh-database replacement restore, restore verification,
+  startup-purge interaction, and external search-state rebuild; route migration
+  backups through the script and migration rollback to the routine restore
+  procedure; update `Last updated`.
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`: version, ownership,
+  dependencies, implementation plan, acceptance, and verification.
+- `SECURITY.md`: no edit. Its checklist says backups must be configured by an
+  operator; adding a script and recommendation does not prove a schedule or
+  off-host copy exists.
+- README, ADR, architecture, testing policy, API contracts, and data-governance
+  docs: no update.
+
+## 7. Delivery Self-Audit
+
+**x) Antipattern scan, diff pass.** Re-run A-F/H. Reject a second backup path,
+automatic restore, embedded credentials, implicit destination, overwrite,
+world-readable archive, fake Docker seam, duplicated migration dump commands,
+unrelated runbook edits, new environment settings, or files outside ownership.
+
+**y) Evidence required at delivery.**
+
+- Tests-first red result.
+- `bash -n`, Ruff, Mypy, focused backup tests, docs links, complete suite, and
+  `git diff --check` outcomes.
+- Real backup path, archive size/mode, and `pg_restore --list` result.
+- Temporary restore database name, representative row counts, and confirmed
+  drop result.
+- Planning-review and pre-commit-review findings with applied fixes.
+- Commit hashes, PR URL, unresolved P1/P2 count, and final CI state.
+- Browser stage: `NOT APPLICABLE` because no UI route changes.
+
+**z) Deviations.** Expected authorized deviations are the nine-file ownership
+expansion and serial ordering before T-DD-1B's runbook edit. Any additional
+path, automatic schedule, environment variable, credential default, active
+database restore during verification, unresolved P1/P2, unrun required check,
+or remaining temporary restore database is a blocker.

--- a/docs/plans/T_PLAT_3_BACKUP_RESTORE_PLAN.md
+++ b/docs/plans/T_PLAT_3_BACKUP_RESTORE_PLAN.md
@@ -291,6 +291,8 @@ concise runbook/ledger text.
     parity prevents the failed current migration from being reapplied.
 20. Meilisearch stops responding during recovery: every maintenance request
     times out before control returns to the task or idle deadline.
+21. Recovery begins while the stack is stopped: stop remains safe, PostgreSQL
+    starts before any `docker compose exec`, and configuration reads succeed.
 
 **r) Tests added or updated.**
 
@@ -301,7 +303,7 @@ concise runbook/ledger text.
 | `test_backup_script_prints_help_without_docker` | 1, 2 |
 | `test_backup_script_refuses_existing_destination` | 4 |
 | `test_backup_script_uses_private_atomic_validated_archive` | 5-8 |
-| `test_backup_runbook_covers_restore_cadence_and_startup_purge` | 9-13 |
+| `test_backup_runbook_covers_restore_cadence_and_startup_purge` | 9-13, 21 |
 | `test_migration_rollback_selects_previous_release_before_schema_tools` | 19 |
 | `test_full_reindex_replaces_existing_meilisearch_documents` | 15 |
 | `test_full_reindex_stops_when_meilisearch_clear_fails` | 16 |

--- a/docs/plans/T_PLAT_3_BACKUP_RESTORE_PLAN.md
+++ b/docs/plans/T_PLAT_3_BACKUP_RESTORE_PLAN.md
@@ -91,6 +91,9 @@ uniquely named temporary validation database.
     `template0`, restore with error/owner/ACL controls, run migrations and
     schema parity, inspect core row counts, then restart with
     `STARTUP_PURGE_DERIVED=false`.
+    Document migration rollback separately: select the previous application
+    release before running its migration, parity, and reindex commands against
+    the restored pre-migration backup.
 13. Add one focused typed helper to existing `indexer_meilisearch.py`: delete
     every document and wait for the documented asynchronous task to succeed.
     Add a second focused helper that waits until no `documents` index task is
@@ -282,6 +285,8 @@ concise runbook/ledger text.
 18. A batch submission fails before Meilisearch accepts the asynchronous task:
     the PostgreSQL corpus count still includes those rows, so final count
     verification blocks restart.
+19. Failed schema release: selecting the rollback release before migration and
+    parity prevents the failed current migration from being reapplied.
 
 **r) Tests added or updated.**
 
@@ -293,6 +298,7 @@ concise runbook/ledger text.
 | `test_backup_script_refuses_existing_destination` | 4 |
 | `test_backup_script_uses_private_atomic_validated_archive` | 5-8 |
 | `test_backup_runbook_covers_restore_cadence_and_startup_purge` | 9-13 |
+| `test_migration_rollback_selects_previous_release_before_schema_tools` | 19 |
 | `test_full_reindex_replaces_existing_meilisearch_documents` | 15 |
 | `test_full_reindex_stops_when_meilisearch_clear_fails` | 16 |
 | `test_full_reindex_uses_maintenance_timeout_for_document_clear` | 17 |

--- a/docs/plans/T_PLAT_3_BACKUP_RESTORE_PLAN.md
+++ b/docs/plans/T_PLAT_3_BACKUP_RESTORE_PLAN.md
@@ -76,9 +76,10 @@ uniquely named temporary validation database.
 8. Run `pg_dump` inside the existing `postgres` service with the container's
    `POSTGRES_USER` and `POSTGRES_DB`. Use custom format, omit ownership and ACL
    restoration metadata, and redirect binary stdout to the temporary host file.
-9. Validate the completed archive through in-container
-   `pg_restore --list`. Atomically rename the temporary file to the requested
-   destination only after validation succeeds.
+9. Validate the completed archive through in-container `pg_restore --list`.
+   Atomically hard-link the temporary file to the requested destination only
+   after validation succeeds, then unlink the temporary name. Linking fails
+   rather than overwriting a destination created after the preflight check.
 10. Extend `docs/OPERATIONS.md` with routine backup, restore, cadence,
     retention, credential, and `STARTUP_PURGE_DERIVED` guidance.
 11. Replace the two migration-specific inline `pg_dump` and archive-list
@@ -92,11 +93,18 @@ uniquely named temporary validation database.
     `STARTUP_PURGE_DERIVED=false`.
 13. Add one focused typed helper to existing `indexer_meilisearch.py`: delete
     every document and wait for the documented asynchronous task to succeed.
+    Add a second focused helper that waits until no `documents` index task is
+    enqueued or processing.
     Add one focused `replace_documents_index()` operation to `indexer.py` that
-    calls that helper and then the unchanged `index_documents()`.
+    calls that helper and then `index_documents()`. Its new return value is the
+    PostgreSQL source-corpus count, including rows whose batch submission was
+    rejected before Meilisearch accepted a task.
 14. Extend the existing `reindex_only.py` CLI with explicit `--replace-all`.
     The default remains unchanged. Replacement mode routes to
-    `replace_documents_index()`.
+    `replace_documents_index()`. The operation waits for the rebuild queue and
+    verifies the live index settings before comparing the final Meilisearch
+    document count with the PostgreSQL corpus count returned by
+    `index_documents()`.
 15. Require the recovery runbook to rebuild Meilisearch with `--replace-all`
     before accepting traffic. When `SEMANTIC_BACKEND=faiss`, rebuild FAISS
     artifacts from the restored database too. Pgvector embeddings are restored
@@ -113,11 +121,11 @@ private, custom-format archive from the configured Compose PostgreSQL service.
 It does not stop writers, schedule itself, rotate files, upload archives, or
 perform restores.
 
-`pipeline.indexer.index_documents()` remains unchanged and retains full-index
-synchronization ownership. The new `replace_documents_index()` operation owns
-the ordered clear-then-rebuild workflow. The dependency-facing clear/wait
-helper stays in `indexer_meilisearch.py`; helpers never import the indexer or
-CLI.
+`pipeline.indexer.index_documents()` retains full-index synchronization
+ownership and returns the source-corpus count needed for recovery verification.
+The new `replace_documents_index()` operation owns the ordered
+clear-then-rebuild workflow. The dependency-facing clear/wait helper stays in
+`indexer_meilisearch.py`; helpers never import the indexer or CLI.
 
 **f) Reuse audit.** Reuse the current Compose-array convention from
 `scripts/dev_up.sh`, the existing PostgreSQL service environment, and the
@@ -189,19 +197,21 @@ and access controls as the live database. G4 is unaffected.
 
 **l) Untrusted input.** The destination path is operator input. It is quoted,
 must have an existing parent, and cannot already exist. It is never evaluated
-as shell code. The archive is validated by PostgreSQL's own `pg_restore --list`
-before publication. Restore commands accept only an operator-selected local
-archive and run with writers stopped.
+as shell code. Atomic hard-link publication also refuses a destination created
+after preflight. The archive is validated by PostgreSQL's own
+`pg_restore --list` before publication. Restore commands accept only an
+operator-selected local archive and run with writers stopped.
 
 ## 4. Code Health
 
 **m) GED conformance sweep.** The script uses `set -euo pipefail`, named
 constants/variables, quoted expansions, one cleanup function, and a single exit
 trap. Errors either stop execution with context or remove incomplete output.
-The indexer receives one short ordered operation while its existing long batch
-function remains unchanged. The Meilisearch helper has typed concrete SDK
-parameters and one fail-fast responsibility. No environment config surface,
-timestamp behavior, broad exception handler, or Ruff boundary changes.
+The indexer receives one short ordered operation, while its existing batch
+function adds only the source-corpus counter returned to recovery verification.
+The Meilisearch helper has typed concrete SDK parameters and one fail-fast
+responsibility. No environment config surface, timestamp behavior, broad
+exception handler, or Ruff boundary changes.
 
 **n) Antipattern scan, plan pass.**
 
@@ -267,6 +277,11 @@ concise runbook/ledger text.
 15. Restored PostgreSQL is older than Meilisearch/FAISS: delete all
     Meilisearch documents and wait before reindex; rebuild FAISS before traffic.
 16. Meilisearch deletion task fails: stop recovery before indexing or restart.
+17. Meilisearch rebuild task fails or stalls: queue timeout, settings mismatch,
+    or final count mismatch blocks restart.
+18. A batch submission fails before Meilisearch accepts the asynchronous task:
+    the PostgreSQL corpus count still includes those rows, so final count
+    verification blocks restart.
 
 **r) Tests added or updated.**
 
@@ -280,7 +295,11 @@ concise runbook/ledger text.
 | `test_backup_runbook_covers_restore_cadence_and_startup_purge` | 9-13 |
 | `test_full_reindex_replaces_existing_meilisearch_documents` | 15 |
 | `test_full_reindex_stops_when_meilisearch_clear_fails` | 16 |
-| `test_backup_runbook_rebuilds_external_search_state` | 15, 16 |
+| `test_full_reindex_uses_maintenance_timeout_for_document_clear` | 17 |
+| `test_full_reindex_rejects_missing_index_settings` | 17 |
+| `test_full_reindex_rejects_document_count_mismatch` | 17 |
+| `test_indexer_reports_agenda_source_count_after_batch_attempt` | 18 |
+| `test_backup_runbook_rebuilds_external_search_state` | 15-18 |
 | Real dev-stack backup and temporary restore drill | 5-13 |
 | Existing docs-link suite | Runbook and plan links |
 | Complete Python suite | Cross-cutting regression check |

--- a/docs/plans/T_PLAT_3_BACKUP_RESTORE_PLAN.md
+++ b/docs/plans/T_PLAT_3_BACKUP_RESTORE_PLAN.md
@@ -1,7 +1,7 @@
 # T-PLAT-3: Add a Verified PostgreSQL Backup and Restore Workflow
 
-`artifact_contract: ce-unified-plan/v1`  
-`artifact_readiness: implementation-ready`  
+`artifact_contract: ce-unified-plan/v1`
+`artifact_readiness: implementation-ready`
 `execution: code`
 
 ## 1. Context & Alignment
@@ -45,6 +45,8 @@ exclusive `files_owned` set before implementation to:
 - `pipeline/indexer_meilisearch.py`
 - `pipeline/reindex_only.py`
 - `tests/test_indexer_logic.py`
+- `docker-compose.yml`
+- `tests/test_docker_build_contracts.py`
 
 T-DD-1B also expects a later `docs/OPERATIONS.md` edit. The two tasks must run
 serially; T-PLAT-3 lands first and T-DD-1B rebases before implementation.
@@ -114,10 +116,21 @@ uniquely named temporary validation database.
     before accepting traffic. When `SEMANTIC_BACKEND=faiss`, rebuild FAISS
     artifacts from the restored database too. Pgvector embeddings are restored
     inside PostgreSQL and need no external artifact rebuild.
-16. Run a real backup smoke against the local dev stack. Restore that archive
+16. Make the existing `REDIS_PASSWORD` interpolation available inside the
+    Redis service environment and reference the quoted container variable from
+    the server command and healthcheck. Add one common recovery preflight that
+    requires the operator to select the exact current deployment Compose files
+    and project before any rollback checkout: stop writers, confirm the target
+    Redis service, wait for health, run authenticated
+    `FLUSHDB SYNC`, run `SAVE`, and require `DBSIZE=0`. `redis-cli -e` makes
+    authentication and command errors nonzero. The host shell never expands or
+    receives the credential, and older rollback releases do not need the new
+    Redis environment entry because clearing is complete and persisted before
+    they are selected.
+17. Run a real backup smoke against the local dev stack. Restore that archive
     into a uniquely named temporary database, inspect representative table
     counts, and drop only that temporary database.
-17. Simplify the diff, run an independent pre-commit review, apply every
+18. Simplify the diff, run an independent pre-commit review, apply every
     eligible P1/P2, rerun affected verification, create atomic commits, push,
     open one PR, and watch CI to a decided state.
 
@@ -190,10 +203,21 @@ touches the privileged search-writer boundary. The change neither logs nor
 changes the key; it uses the existing writer client to delete and rebuild only
 the `documents` index.
 
+`docker-compose.yml` is also security-sensitive under backing-store boundary 3
+and the environment-only secret policy in `SECURITY.md`. The Redis service
+receives the same existing `REDIS_PASSWORD` interpolation already used by its
+command, healthcheck, clients, and exporter. Processes already running inside
+the Redis container gain environment access to that existing credential; no
+host process, other service, port, default, or credential source gains access.
+Quoted container-side expansion prevents shell parsing from altering the server
+or healthcheck command. Existing application connection-URL character
+constraints are unchanged.
+
 **j) Secrets.** No new secret, key, environment variable, or default is added.
 The script references `POSTGRES_USER` and `POSTGRES_DB` only inside the
 container. PostgreSQL authentication continues to use the existing container
-environment.
+environment. Redis recovery reads the existing password only from the Redis
+container environment through `REDISCLI_AUTH`.
 
 **k) Person data.** The task does not create, link, aggregate, or expose new
 person data. A backup reproduces existing database contents, including any
@@ -215,7 +239,8 @@ trap. Errors either stop execution with context or remove incomplete output.
 The indexer receives one short ordered operation, while its existing batch
 function adds only the source-corpus counter returned to recovery verification.
 The Meilisearch helper has typed concrete SDK parameters and one fail-fast
-responsibility. No environment config surface, timestamp behavior, broad
+responsibility. The existing Redis credential is added to the Redis service
+environment; no environment variable, default, timestamp behavior, broad
 exception handler, or Ruff boundary changes.
 
 **n) Antipattern scan, plan pass.**
@@ -235,7 +260,7 @@ exception handler, or Ruff boundary changes.
   dump commands are removed.
 - D1-D3 corrected: tests preserve strict behavior and avoid fake Docker or
   private helper assertions.
-- E1-E3 corrected: only the nine owned files change and the runbook receives
+- E1-E3 corrected: only the eleven owned files change and the runbook receives
   minimal edits.
 - A3-A4, B2, C2, H2-H4: no violations planned.
 
@@ -266,8 +291,9 @@ concise runbook/ledger text.
    published.
 7. Successful dump: archive validates, is atomically published, and is
    private to the invoking user.
-8. Credentials containing shell metacharacters: remain container environment
-   values and are not host-evaluated.
+8. Redis credentials remain container environment values and are not expanded
+   into server or healthcheck command text. Existing application
+   connection-URL character constraints remain unchanged.
 9. Live writes during routine backup: PostgreSQL supplies one consistent
    snapshot; migration backups still stop writers before the dump.
 10. Active restore with connected writers: runbook requires all Compose and
@@ -293,6 +319,13 @@ concise runbook/ledger text.
     times out before control returns to the task or idle deadline.
 21. Recovery begins while the stack is stopped: stop remains safe, PostgreSQL
     starts before any `docker compose exec`, and configuration reads succeed.
+22. Redis contains queues, task results, or API cache entries newer than the
+    restored PostgreSQL snapshot: authenticated `FLUSHDB` clears database 0
+    after writers stop and before any recovered worker or rollback release
+    starts. `redis-cli -e` rejects authentication errors, `SAVE` persists the
+    empty state, and `DBSIZE=0` verifies completion. The server, healthcheck,
+    and recovery command read a quoted Redis container environment value;
+    application connection-URL character support is not broadened.
 
 **r) Tests added or updated.**
 
@@ -303,8 +336,9 @@ concise runbook/ledger text.
 | `test_backup_script_prints_help_without_docker` | 1, 2 |
 | `test_backup_script_refuses_existing_destination` | 4 |
 | `test_backup_script_uses_private_atomic_validated_archive` | 5-8 |
-| `test_backup_runbook_covers_restore_cadence_and_startup_purge` | 9-13, 21 |
+| `test_backup_runbook_covers_restore_cadence_and_startup_purge` | 9-13, 21, 22 |
 | `test_migration_rollback_selects_previous_release_before_schema_tools` | 19 |
+| `test_redis_service_exposes_configured_password_to_container_commands` | 8, 22 |
 | `test_full_reindex_replaces_existing_meilisearch_documents` | 15 |
 | `test_full_reindex_stops_when_meilisearch_clear_fails` | 16 |
 | `test_full_reindex_uses_maintenance_timeout_for_document_clear` | 17 |
@@ -314,6 +348,7 @@ concise runbook/ledger text.
 | `test_full_reindex_uses_one_bounded_maintenance_client` | 20 |
 | `test_backup_runbook_rebuilds_external_search_state` | 15-18 |
 | Real dev-stack backup and temporary restore drill | 5-13 |
+| Disposable Redis recovery drill | 8, 22 |
 | Existing docs-link suite | Runbook and plan links |
 | Complete Python suite | Cross-cutting regression check |
 
@@ -328,10 +363,11 @@ session boundaries in `pipeline.indexer`; they assert externally visible fake
 index state and raised recovery errors, not call counts. The backup success
 path uses the real Docker Compose/PostgreSQL boundary manually.
 
-**t) Verification rows.** Apply the docs-only row for `docs/**`. No existing
-matrix row names shell operator scripts, so run Ruff, Mypy, the focused backup
-contract, docs links, and the complete Python suite. The real dev-stack backup
-and temporary restore drill are required before handoff.
+**t) Verification rows.** Apply the docs-only row for `docs/**` and the
+security-sensitive Compose contract checks. No existing matrix row names shell
+operator scripts, so run Ruff, Mypy, the focused backup and Docker contracts,
+docs links, and the complete Python suite. The real dev-stack backup and
+temporary restore drill are required before handoff.
 
 ## 6. Execution, Rollback, Docs
 
@@ -360,6 +396,7 @@ bash -n scripts/backup_db.sh
 ./.venv/bin/ruff check .
 ./.venv/bin/mypy
 PYTHONPATH=. .venv/bin/pytest -q tests/test_backup_db_contract.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_docker_build_contracts.py
 PYTHONPATH=. .venv/bin/pytest -q tests/test_indexer_logic.py
 PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py
 PYTHONPATH=. .venv/bin/pytest -q
@@ -375,6 +412,47 @@ BACKUP_PATH="$BACKUP_SMOKE_DIR/t_plat_3_smoke.dump"
 bash ./scripts/backup_db.sh "$BACKUP_PATH"
 docker compose exec -T postgres pg_restore --list < "$BACKUP_PATH" >/dev/null
 stat -f '%Lp %z %N' "$BACKUP_PATH"
+```
+
+Disposable Redis recovery smoke:
+
+```bash
+REDIS_RECOVERY_PROJECT="tc-redis-recovery-$RANDOM"
+REDIS_PASSWORD='recovery password; not shell'
+MEILI_MASTER_KEY='test-only-meilisearch-master-key'
+export REDIS_PASSWORD MEILI_MASTER_KEY
+cleanup_redis_recovery() {
+  docker compose -p "$REDIS_RECOVERY_PROJECT" -f docker-compose.yml \
+    down -v >/dev/null 2>&1 || true
+}
+trap cleanup_redis_recovery EXIT
+docker compose -p "$REDIS_RECOVERY_PROJECT" -f docker-compose.yml up \
+  --wait --wait-timeout 60 redis
+if docker compose -p "$REDIS_RECOVERY_PROJECT" -f docker-compose.yml exec \
+  -T redis sh -eu -c \
+  'REDISCLI_AUTH="wrong password" redis-cli -e PING >/dev/null'; then
+  echo "Wrong Redis password unexpectedly succeeded" >&2
+  exit 1
+fi
+docker compose -p "$REDIS_RECOVERY_PROJECT" -f docker-compose.yml exec -T redis \
+  sh -eu -c '
+    export REDISCLI_AUTH="$REDIS_PASSWORD"
+    redis-cli -e SET recovery_probe present >/dev/null
+    redis-cli -e FLUSHDB SYNC >/dev/null
+    redis-cli -e SAVE >/dev/null
+    test "$(redis-cli -e --raw DBSIZE)" = 0
+  '
+docker compose -p "$REDIS_RECOVERY_PROJECT" -f docker-compose.yml restart redis
+docker compose -p "$REDIS_RECOVERY_PROJECT" -f docker-compose.yml up \
+  --wait --wait-timeout 60 redis
+docker compose -p "$REDIS_RECOVERY_PROJECT" -f docker-compose.yml exec -T redis \
+  sh -eu -c '
+    export REDISCLI_AUTH="$REDIS_PASSWORD"
+    test "$(redis-cli -e --raw DBSIZE)" = 0
+  '
+cleanup_redis_recovery
+trap - EXIT
+unset MEILI_MASTER_KEY REDIS_PASSWORD REDIS_RECOVERY_PROJECT
 ```
 
 Temporary restore drill:
@@ -434,6 +512,8 @@ is interrupted, verify the generated database name and drop only that
   procedure; update `Last updated`.
 - `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`: version, ownership,
   dependencies, implementation plan, acceptance, and verification.
+- `docker-compose.yml`: expose the existing Redis password interpolation to
+  commands executed inside the Redis container; no default or network change.
 - `SECURITY.md`: no edit. Its checklist says backups must be configured by an
   operator; adding a script and recommendation does not prove a schedule or
   off-host copy exists.
@@ -445,7 +525,8 @@ is interrupted, verify the generated database name and drop only that
 **x) Antipattern scan, diff pass.** Re-run A-F/H. Reject a second backup path,
 automatic restore, embedded credentials, implicit destination, overwrite,
 world-readable archive, fake Docker seam, duplicated migration dump commands,
-unrelated runbook edits, new environment settings, or files outside ownership.
+unrelated runbook edits, a new environment variable or default, or files
+outside ownership.
 
 **y) Evidence required at delivery.**
 
@@ -455,12 +536,14 @@ unrelated runbook edits, new environment settings, or files outside ownership.
 - Real backup path, archive size/mode, and `pg_restore --list` result.
 - Temporary restore database name, representative row counts, and confirmed
   drop result.
+- Disposable Redis project, wrong-password nonzero result, and zero keys after
+  restart.
 - Planning-review and pre-commit-review findings with applied fixes.
 - Commit hashes, PR URL, unresolved P1/P2 count, and final CI state.
 - Browser stage: `NOT APPLICABLE` because no UI route changes.
 
-**z) Deviations.** Expected authorized deviations are the nine-file ownership
+**z) Deviations.** Expected authorized deviations are the eleven-file ownership
 expansion and serial ordering before T-DD-1B's runbook edit. Any additional
-path, automatic schedule, environment variable, credential default, active
+path, automatic schedule, new environment variable, credential default, active
 database restore during verification, unresolved P1/P2, unrun required check,
 or remaining temporary restore database is a blocker.

--- a/pipeline/indexer.py
+++ b/pipeline/indexer.py
@@ -4,7 +4,8 @@ from collections.abc import Iterable
 
 import meilisearch
 from meilisearch.errors import MeilisearchError
-from sqlalchemy.orm import selectinload
+from meilisearch.index import Index
+from sqlalchemy.orm import Session, selectinload
 
 from pipeline.config import MEILISEARCH_BATCH_SIZE
 from pipeline.db_session import db_session
@@ -32,6 +33,22 @@ MEILI_HOST = os.getenv("MEILI_HOST", "http://meilisearch:7700")
 MEILI_MASTER_KEY = os.getenv("MEILI_MASTER_KEY", "masterKey")
 
 logger = logging.getLogger("indexer")
+MEILISEARCH_MAINTENANCE_REQUEST_TIMEOUT_SECONDS = 30
+
+
+def _report_document_truncation(
+    source_document_count: int,
+    truncated_document_count: int,
+) -> None:
+    """Expose truncation coverage without affecting recovery count checks."""
+    if not source_document_count:
+        return
+    truncation_rate = truncated_document_count / source_document_count * 100
+    print(
+        "Document truncation summary: "
+        f"{truncated_document_count}/{source_document_count} "
+        f"({truncation_rate:.1f}%) meeting docs truncated"
+    )
 
 
 def _build_meeting_search_doc(doc, catalog, event, place, organization) -> dict:
@@ -118,61 +135,115 @@ def _catalog_agenda_item_rows(session, catalog_id: int):
     )
 
 
+def _index_meeting_documents(session: Session, index: Index) -> tuple[int, int]:
+    """Index meeting records and retain the source count for recovery checks."""
+    documents_batch = []
+    submitted_document_count = 0
+    source_document_count = 0
+    truncated_document_count = 0
+
+    print("Step 1: Indexing Full Meeting Documents...")
+    for document, catalog, event, place, organization in _document_rows(session):
+        source_document_count += 1
+        _, content_truncated, _, _ = _truncate_content_for_index(catalog.content)
+        truncated_document_count += int(content_truncated)
+        documents_batch.append(
+            _build_meeting_search_doc(
+                document,
+                catalog,
+                event,
+                place,
+                organization,
+            )
+        )
+        if len(documents_batch) >= MEILISEARCH_BATCH_SIZE:
+            submitted_document_count = _flush_batch(
+                index,
+                documents_batch,
+                submitted_document_count,
+                "document",
+            )
+            documents_batch = []
+
+    submitted_document_count = _flush_batch(
+        index,
+        documents_batch,
+        submitted_document_count,
+        "document",
+    )
+    _report_document_truncation(source_document_count, truncated_document_count)
+    return submitted_document_count, source_document_count
+
+
+def _index_agenda_items(session: Session, index: Index) -> tuple[int, int]:
+    """Index agenda items and retain the source count for recovery checks."""
+    agenda_batch = []
+    submitted_agenda_count = 0
+    source_agenda_count = 0
+
+    print("Step 2: Indexing Individual Agenda Items...")
+    for agenda_item, event, place, organization in _agenda_item_rows(session):
+        source_agenda_count += 1
+        agenda_batch.append(
+            _build_agenda_item_search_doc(
+                agenda_item,
+                event,
+                place,
+                organization,
+            )
+        )
+        if len(agenda_batch) >= MEILISEARCH_BATCH_SIZE:
+            submitted_agenda_count = _flush_batch(
+                index,
+                agenda_batch,
+                submitted_agenda_count,
+                "agenda item",
+            )
+            agenda_batch = []
+
+    submitted_agenda_count = _flush_batch(
+        index,
+        agenda_batch,
+        submitted_agenda_count,
+        "agenda item",
+    )
+    return submitted_agenda_count, source_agenda_count
+
+
+def _index_documents_with_client(client: meilisearch.Client) -> int:
+    """Index the PostgreSQL corpus through the caller's Meilisearch policy."""
+    index = _ensure_documents_index(client, apply_settings=True)
+    with db_session() as session:
+        submitted_document_count, source_document_count = (
+            _index_meeting_documents(session, index)
+        )
+        submitted_agenda_count, source_agenda_count = _index_agenda_items(
+            session,
+            index,
+        )
+
+    submitted_record_count = submitted_document_count + submitted_agenda_count
+    print(f"Indexing complete. Total records indexed: {submitted_record_count}")
+    return source_document_count + source_agenda_count
+
+
 def index_documents() -> int:
-    """
-    Sync processed meetings and agenda items into Meilisearch.
-    """
+    """Sync processed meetings and agenda items into Meilisearch."""
     print(f"Connecting to Meilisearch at {MEILI_HOST}...")
     client = meilisearch.Client(MEILI_HOST, MEILI_MASTER_KEY)
-    index = _ensure_documents_index(client, apply_settings=True)
-
-    with db_session() as session:
-        documents_batch = []
-        count = 0
-        source_document_count = 0
-        indexed_meeting_docs = 0
-        truncated_meeting_docs = 0
-
-        print("Step 1: Indexing Full Meeting Documents...")
-        for doc, catalog, event, place, organization in _document_rows(session):
-            source_document_count += 1
-            _, is_content_truncated, _, _ = _truncate_content_for_index(catalog.content)
-            indexed_meeting_docs += 1
-            if is_content_truncated:
-                truncated_meeting_docs += 1
-            documents_batch.append(_build_meeting_search_doc(doc, catalog, event, place, organization))
-            if len(documents_batch) >= MEILISEARCH_BATCH_SIZE:
-                count = _flush_batch(index, documents_batch, count, "document")
-                documents_batch = []
-
-        count = _flush_batch(index, documents_batch, count, "document")
-        documents_batch = []
-        if indexed_meeting_docs:
-            print(
-                f"Document truncation summary: {truncated_meeting_docs}/{indexed_meeting_docs} "
-                f"({(truncated_meeting_docs / indexed_meeting_docs) * 100:.1f}%) meeting docs truncated"
-            )
-
-        print("Step 2: Indexing Individual Agenda Items...")
-        for item, event, place, organization in _agenda_item_rows(session):
-            source_document_count += 1
-            documents_batch.append(_build_agenda_item_search_doc(item, event, place, organization))
-            if len(documents_batch) >= MEILISEARCH_BATCH_SIZE:
-                count = _flush_batch(index, documents_batch, count, "agenda item")
-                documents_batch = []
-
-        count = _flush_batch(index, documents_batch, count, "agenda item")
-
-    print(f"Indexing complete. Total records indexed: {count}")
-    return source_document_count
+    return _index_documents_with_client(client)
 
 
 def replace_documents_index() -> None:
     """Replace search state from PostgreSQL and reject incomplete rebuilds."""
-    client = meilisearch.Client(MEILI_HOST, MEILI_MASTER_KEY)
+    client = meilisearch.Client(
+        MEILI_HOST,
+        MEILI_MASTER_KEY,
+        timeout=MEILISEARCH_MAINTENANCE_REQUEST_TIMEOUT_SECONDS,
+    )
     index = _ensure_documents_index(client, apply_settings=False)
     _clear_documents_index(client, index)
-    expected_document_count = index_documents()
+    expected_document_count = _index_documents_with_client(client)
     _wait_for_documents_index_idle(client)
     _verify_documents_index_settings(index)
     actual_document_count = int(index.get_stats().number_of_documents)

--- a/pipeline/indexer.py
+++ b/pipeline/indexer.py
@@ -18,9 +18,12 @@ from pipeline.indexer_documents import (
 )
 from pipeline.indexer_meilisearch import (
     _apply_index_settings,
+    _clear_documents_index,
     _delete_documents_by_filter,
     _flush_batch,
     _task_uid,
+    _verify_documents_index_settings,
+    _wait_for_documents_index_idle,
 )
 from pipeline.models import AgendaItem, Catalog, Document, Event, Membership, Organization, Place
 
@@ -115,7 +118,7 @@ def _catalog_agenda_item_rows(session, catalog_id: int):
     )
 
 
-def index_documents():
+def index_documents() -> int:
     """
     Sync processed meetings and agenda items into Meilisearch.
     """
@@ -126,11 +129,13 @@ def index_documents():
     with db_session() as session:
         documents_batch = []
         count = 0
+        source_document_count = 0
         indexed_meeting_docs = 0
         truncated_meeting_docs = 0
 
         print("Step 1: Indexing Full Meeting Documents...")
         for doc, catalog, event, place, organization in _document_rows(session):
+            source_document_count += 1
             _, is_content_truncated, _, _ = _truncate_content_for_index(catalog.content)
             indexed_meeting_docs += 1
             if is_content_truncated:
@@ -150,6 +155,7 @@ def index_documents():
 
         print("Step 2: Indexing Individual Agenda Items...")
         for item, event, place, organization in _agenda_item_rows(session):
+            source_document_count += 1
             documents_batch.append(_build_agenda_item_search_doc(item, event, place, organization))
             if len(documents_batch) >= MEILISEARCH_BATCH_SIZE:
                 count = _flush_batch(index, documents_batch, count, "agenda item")
@@ -158,6 +164,23 @@ def index_documents():
         count = _flush_batch(index, documents_batch, count, "agenda item")
 
     print(f"Indexing complete. Total records indexed: {count}")
+    return source_document_count
+
+
+def replace_documents_index() -> None:
+    """Replace search state from PostgreSQL and reject incomplete rebuilds."""
+    client = meilisearch.Client(MEILI_HOST, MEILI_MASTER_KEY)
+    index = _ensure_documents_index(client, apply_settings=False)
+    _clear_documents_index(client, index)
+    expected_document_count = index_documents()
+    _wait_for_documents_index_idle(client)
+    _verify_documents_index_settings(index)
+    actual_document_count = int(index.get_stats().number_of_documents)
+    if actual_document_count != expected_document_count:
+        raise RuntimeError(
+            "Meilisearch replacement count mismatch "
+            f"expected={expected_document_count} actual={actual_document_count}"
+        )
 
 
 def reindex_catalog(catalog_id: int) -> dict:

--- a/pipeline/indexer.py
+++ b/pipeline/indexer.py
@@ -22,9 +22,11 @@ from pipeline.indexer_meilisearch import (
     _clear_documents_index,
     _delete_documents_by_filter,
     _flush_batch,
+    INDEX_ALREADY_EXISTS_ERROR_CODE,
     _task_uid,
     _verify_documents_index_settings,
     _wait_for_documents_index_idle,
+    _wait_for_task_success,
 )
 from pipeline.models import AgendaItem, Catalog, Document, Event, Membership, Organization, Place
 
@@ -77,11 +79,25 @@ def _build_agenda_item_search_doc(item, event, place, organization) -> dict:
     )
 
 
-def _ensure_documents_index(client, *, apply_settings: bool):
+def _ensure_documents_index(
+    client,
+    *,
+    apply_settings: bool,
+    wait_for_creation: bool = False,
+):
     try:
-        client.create_index("documents", {"primaryKey": "id"})
+        creation_task = client.create_index("documents", {"primaryKey": "id"})
     except MeilisearchError:
-        pass
+        if wait_for_creation:
+            raise
+    else:
+        if wait_for_creation:
+            _wait_for_task_success(
+                client,
+                creation_task.task_uid,
+                "index creation",
+                accepted_failure_code=INDEX_ALREADY_EXISTS_ERROR_CODE,
+            )
     index = client.index("documents")
     if apply_settings:
         _apply_index_settings(client, index)
@@ -241,7 +257,11 @@ def replace_documents_index() -> None:
         MEILI_MASTER_KEY,
         timeout=MEILISEARCH_MAINTENANCE_REQUEST_TIMEOUT_SECONDS,
     )
-    index = _ensure_documents_index(client, apply_settings=False)
+    index = _ensure_documents_index(
+        client,
+        apply_settings=False,
+        wait_for_creation=True,
+    )
     _clear_documents_index(client, index)
     expected_document_count = _index_documents_with_client(client)
     _wait_for_documents_index_idle(client)

--- a/pipeline/indexer_meilisearch.py
+++ b/pipeline/indexer_meilisearch.py
@@ -1,8 +1,108 @@
 import logging
+import time
 
+from meilisearch import Client
 from meilisearch.errors import MeilisearchError
+from meilisearch.index import Index
 
 logger = logging.getLogger("indexer")
+
+DOCUMENTS_INDEX_UID = "documents"
+INDEX_IDLE_TIMEOUT_SECONDS = 300.0
+INDEX_IDLE_POLL_SECONDS = 0.25
+INDEX_TASK_TIMEOUT_MS = 300_000
+INDEX_TASK_POLL_INTERVAL_MS = 250
+FILTERABLE_ATTRIBUTES = (
+    "city",
+    "meeting_type",
+    "meeting_category",
+    "organization",
+    "people",
+    "date",
+    "organizations",
+    "result_type",
+    "topics",
+    "lineage_id",
+    "catalog_id",
+)
+SORTABLE_ATTRIBUTES = ("date",)
+SEARCHABLE_ATTRIBUTES = (
+    "content",
+    "event_name",
+    "title",
+    "description",
+    "filename",
+    "summary",
+    "organizations",
+    "locations",
+    "meeting_category",
+    "organization",
+    "people",
+)
+RANKING_RULES = ("sort", "words", "typo", "proximity", "attribute", "exactness")
+
+
+def _clear_documents_index(client: Client, index: Index) -> None:
+    """Remove the old corpus before a recovery rebuild can publish new rows."""
+    deletion_task = index.delete_all_documents()
+    completed_task = client.wait_for_task(
+        deletion_task.task_uid,
+        timeout_in_ms=INDEX_TASK_TIMEOUT_MS,
+        interval_in_ms=INDEX_TASK_POLL_INTERVAL_MS,
+    )
+    if completed_task.status != "succeeded":
+        raise RuntimeError(
+            "Meilisearch document deletion failed "
+            f"status={completed_task.status}"
+        )
+
+
+def _wait_for_documents_index_idle(client: Client) -> None:
+    """Keep recovery traffic stopped until every documents-index task finishes."""
+    deadline = time.monotonic() + INDEX_IDLE_TIMEOUT_SECONDS
+    while time.monotonic() < deadline:
+        pending_tasks = client.get_tasks(
+            {
+                "statuses": ["enqueued", "processing"],
+                "indexUids": [DOCUMENTS_INDEX_UID],
+            }
+        )
+        if not pending_tasks.results:
+            return
+        time.sleep(INDEX_IDLE_POLL_SECONDS)
+    raise TimeoutError("Meilisearch documents index did not become idle")
+
+
+def _verify_documents_index_settings(index: Index) -> None:
+    """Reject a recovery rebuild that lacks the search contract users rely on."""
+    documents_index_settings = (
+        (
+            "filterable_attributes",
+            list(FILTERABLE_ATTRIBUTES),
+            index.get_filterable_attributes(),
+        ),
+        (
+            "sortable_attributes",
+            list(SORTABLE_ATTRIBUTES),
+            index.get_sortable_attributes(),
+        ),
+        (
+            "searchable_attributes",
+            list(SEARCHABLE_ATTRIBUTES),
+            index.get_searchable_attributes(),
+        ),
+        ("ranking_rules", list(RANKING_RULES), index.get_ranking_rules()),
+    )
+    setting_mismatches = [
+        f"{setting_name}=expected:{expected_value!r},actual:{actual_value!r}"
+        for setting_name, expected_value, actual_value in documents_index_settings
+        if actual_value != expected_value
+    ]
+    if setting_mismatches:
+        raise RuntimeError(
+            "Meilisearch replacement settings mismatch "
+            + "; ".join(setting_mismatches)
+        )
 
 
 def _flush_batch(index, documents_batch, count, label):
@@ -40,7 +140,7 @@ def _delete_documents_by_filter(index, filter_expr: str):
     raise RuntimeError("Meilisearch client does not support filtered document deletion")
 
 
-def _apply_index_settings(client, index) -> None:
+def _apply_index_settings(client: Client, index: Index) -> None:
     """
     Apply Meilisearch index settings and wait for completion.
 
@@ -52,45 +152,19 @@ def _apply_index_settings(client, index) -> None:
 
     task_ids.append(
         _task_uid(
-            index.update_filterable_attributes(
-                [
-                    "city",
-                    "meeting_type",
-                    "meeting_category",
-                    "organization",
-                    "people",
-                    "date",
-                    "organizations",
-                    "result_type",
-                    "topics",
-                    "lineage_id",
-                    "catalog_id",
-                ]
-            )
+            index.update_filterable_attributes(list(FILTERABLE_ATTRIBUTES))
         )
     )
-    task_ids.append(_task_uid(index.update_sortable_attributes(["date"])))
+    task_ids.append(
+        _task_uid(index.update_sortable_attributes(list(SORTABLE_ATTRIBUTES)))
+    )
     task_ids.append(
         _task_uid(
-            index.update_searchable_attributes(
-                [
-                    "content",
-                    "event_name",
-                    "title",
-                    "description",
-                    "filename",
-                    "summary",
-                    "organizations",
-                    "locations",
-                    "meeting_category",
-                    "organization",
-                    "people",
-                ]
-            )
+            index.update_searchable_attributes(list(SEARCHABLE_ATTRIBUTES))
         )
     )
     task_ids.append(
-        _task_uid(index.update_ranking_rules(["sort", "words", "typo", "proximity", "attribute", "exactness"]))
+        _task_uid(index.update_ranking_rules(list(RANKING_RULES)))
     )
 
     for uid in [task_id for task_id in task_ids if isinstance(task_id, int)]:

--- a/pipeline/indexer_meilisearch.py
+++ b/pipeline/indexer_meilisearch.py
@@ -12,6 +12,7 @@ INDEX_IDLE_TIMEOUT_SECONDS = 300.0
 INDEX_IDLE_POLL_SECONDS = 0.25
 INDEX_TASK_TIMEOUT_MS = 300_000
 INDEX_TASK_POLL_INTERVAL_MS = 250
+INDEX_ALREADY_EXISTS_ERROR_CODE = "index_already_exists"
 FILTERABLE_ATTRIBUTES = (
     "city",
     "meeting_type",
@@ -42,19 +43,38 @@ SEARCHABLE_ATTRIBUTES = (
 RANKING_RULES = ("sort", "words", "typo", "proximity", "attribute", "exactness")
 
 
-def _clear_documents_index(client: Client, index: Index) -> None:
-    """Remove the old corpus before a recovery rebuild can publish new rows."""
-    deletion_task = index.delete_all_documents()
+def _wait_for_task_success(
+    client: Client,
+    task_uid: int,
+    operation: str,
+    *,
+    accepted_failure_code: str | None = None,
+) -> None:
+    """Keep recovery steps ordered and reject failed asynchronous work."""
     completed_task = client.wait_for_task(
-        deletion_task.task_uid,
+        task_uid,
         timeout_in_ms=INDEX_TASK_TIMEOUT_MS,
         interval_in_ms=INDEX_TASK_POLL_INTERVAL_MS,
     )
-    if completed_task.status != "succeeded":
-        raise RuntimeError(
-            "Meilisearch document deletion failed "
-            f"status={completed_task.status}"
-        )
+    if completed_task.status == "succeeded":
+        return
+    if accepted_failure_code is not None:
+        completed_error = completed_task.error or {}
+        if completed_error.get("code") == accepted_failure_code:
+            return
+    raise RuntimeError(
+        f"Meilisearch {operation} failed status={completed_task.status}"
+    )
+
+
+def _clear_documents_index(client: Client, index: Index) -> None:
+    """Remove the old corpus before a recovery rebuild can publish new rows."""
+    deletion_task = index.delete_all_documents()
+    _wait_for_task_success(
+        client,
+        deletion_task.task_uid,
+        "document deletion",
+    )
 
 
 def _wait_for_documents_index_idle(client: Client) -> None:

--- a/pipeline/reindex_only.py
+++ b/pipeline/reindex_only.py
@@ -12,21 +12,34 @@ Usage (Docker):
 
 import argparse
 
-from pipeline.indexer import index_documents, reindex_catalog
+from pipeline.indexer import (
+    index_documents,
+    reindex_catalog,
+    replace_documents_index,
+)
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Reindex Meilisearch from Postgres only.")
-    parser.add_argument(
+    reindex_scope = parser.add_mutually_exclusive_group()
+    reindex_scope.add_argument(
         "--catalog-id",
         type=int,
         default=None,
         help="If provided, reindex only this one catalog. Otherwise, reindex all documents and agenda items.",
     )
+    reindex_scope.add_argument(
+        "--replace-all",
+        action="store_true",
+        help="Delete the existing search corpus before rebuilding it from Postgres.",
+    )
     args = parser.parse_args()
 
     if args.catalog_id is not None:
         reindex_catalog(args.catalog_id)
+        return 0
+    if args.replace_all:
+        replace_documents_index()
         return 0
 
     index_documents()
@@ -35,4 +48,3 @@ def main() -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-

--- a/scripts/backup_db.sh
+++ b/scripts/backup_db.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+USAGE_EXIT_CODE=64
+DESTINATION_EXIT_CODE=73
+COMPOSE=(docker compose -f docker-compose.yml -f docker-compose.dev.yml)
+
+usage() {
+  printf 'Usage: %s OUTPUT_PATH\n' "$(basename "$0")"
+}
+
+cleanup_backup() {
+  if [[ -n "${backup_temp_path:-}" && -e "$backup_temp_path" ]]; then
+    rm -f "$backup_temp_path"
+  fi
+}
+
+if [[ $# -eq 1 && ( "$1" == "-h" || "$1" == "--help" ) ]]; then
+  usage
+  exit 0
+fi
+
+if [[ $# -ne 1 ]]; then
+  usage >&2
+  exit "$USAGE_EXIT_CODE"
+fi
+
+backup_path="$1"
+if [[ "$backup_path" != /* ]]; then
+  backup_path="$PWD/$backup_path"
+fi
+backup_parent="$(dirname "$backup_path")"
+
+if [[ ! -d "$backup_parent" ]]; then
+  printf '[backup_db] Parent directory does not exist: %s\n' "$backup_parent" >&2
+  exit "$DESTINATION_EXIT_CODE"
+fi
+if [[ -e "$backup_path" ]]; then
+  printf '[backup_db] Destination already exists: %s\n' "$backup_path" >&2
+  exit "$DESTINATION_EXIT_CODE"
+fi
+
+cd "$(dirname "$0")/.."
+umask 077
+backup_temp_path="$(mktemp "${backup_path}.partial.XXXXXX")"
+trap cleanup_backup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+printf '[backup_db] Creating PostgreSQL archive: %s\n' "$backup_path" >&2
+"${COMPOSE[@]}" exec -T postgres sh -ec '
+  exec pg_dump \
+    --username="$POSTGRES_USER" \
+    --dbname="$POSTGRES_DB" \
+    --format=custom \
+    --no-owner \
+    --no-privileges
+' > "$backup_temp_path"
+
+if [[ ! -s "$backup_temp_path" ]]; then
+  printf '[backup_db] PostgreSQL produced an empty archive.\n' >&2
+  exit 1
+fi
+
+"${COMPOSE[@]}" exec -T postgres pg_restore --list \
+  < "$backup_temp_path" >/dev/null
+ln "$backup_temp_path" "$backup_path"
+unlink "$backup_temp_path"
+backup_temp_path=""
+trap - EXIT INT TERM
+
+printf '[backup_db] Verified archive written: %s\n' "$backup_path" >&2

--- a/tests/test_backup_db_contract.py
+++ b/tests/test_backup_db_contract.py
@@ -119,16 +119,34 @@ def test_backup_runbook_documents_recovery_contract() -> None:
     full_recovery_guidance = recovery_guidance[
         recovery_guidance.index("For full recovery") :
     ]
+    restore_guidance = full_recovery_guidance[
+        : full_recovery_guidance.index("Confirm those counts")
+    ]
+    external_search_guidance = full_recovery_guidance[
+        full_recovery_guidance.index("restored snapshot:") :
+    ]
     writers_stopped = full_recovery_guidance.index(
         "docker compose -f docker-compose.yml -f docker-compose.dev.yml stop"
     )
+    restore_fail_fast_enabled = restore_guidance.index("set -euo pipefail")
     postgres_started = full_recovery_guidance.index(
         "docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d postgres"
     )
     postgres_environment_read = full_recovery_guidance.index(
         'POSTGRES_USER="$(docker compose exec -T postgres printenv POSTGRES_USER)"'
     )
-    assert writers_stopped < postgres_started < postgres_environment_read
+    external_search_fail_fast_enabled = external_search_guidance.index(
+        "set -euo pipefail"
+    )
+    meilisearch_started = external_search_guidance.index(
+        "up -d postgres redis meilisearch"
+    )
+    assert restore_fail_fast_enabled < writers_stopped < postgres_started
+    assert postgres_started < postgres_environment_read
+    assert external_search_fail_fast_enabled < meilisearch_started
+    assert "--rm --build --no-deps semantic python ../pipeline/reindex_semantic.py" in (
+        full_recovery_guidance
+    )
 
 
 def test_migration_rollback_selects_previous_release_before_schema_tools() -> None:
@@ -140,3 +158,26 @@ def test_migration_rollback_selects_previous_release_before_schema_tools() -> No
     assert 'git switch --detach "$ROLLBACK_REF"' in rollback_guidance
     assert "before running `db_migrate.py`" in rollback_guidance
     assert "Do not run `db_migrate.py` from the failed release" in rollback_guidance
+    assert "both reindex" in rollback_guidance
+    assert "rollback release" in rollback_guidance
+    assert "Checkout-based rollback" in rollback_guidance
+    prebuilt_image_guidance = rollback_guidance[
+        rollback_guidance.index("Prebuilt-image rollback") :
+    ]
+    assert 'ROLLBACK_COMPOSE_FILE="<ROLLBACK_COMPOSE_FILE>"' in (
+        prebuilt_image_guidance
+    )
+    assert "--rm --no-deps pipeline python db_migrate.py" in prebuilt_image_guidance
+    assert (
+        "--rm --no-deps semantic python ../pipeline/reindex_semantic.py"
+        in prebuilt_image_guidance
+    )
+    prebuilt_image_commands = prebuilt_image_guidance.split("```bash", maxsplit=1)[
+        1
+    ].split("```", maxsplit=1)[0]
+    rollback_compose_command = 'docker compose -f "$ROLLBACK_COMPOSE_FILE"'
+    assert "set -euo pipefail" in prebuilt_image_commands
+    assert "--build" not in prebuilt_image_commands
+    assert prebuilt_image_commands.count(
+        rollback_compose_command
+    ) == prebuilt_image_commands.count("docker compose")

--- a/tests/test_backup_db_contract.py
+++ b/tests/test_backup_db_contract.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BACKUP_SCRIPT = REPO_ROOT / "scripts" / "backup_db.sh"
+OPERATIONS_RUNBOOK = REPO_ROOT / "docs" / "OPERATIONS.md"
+PRE_DOCKER_PATH = "/usr/bin:/bin"
+
+
+def _run_backup_preflight(*arguments: str) -> subprocess.CompletedProcess[str]:
+    backup_environment = {**os.environ, "PATH": PRE_DOCKER_PATH}
+    return subprocess.run(
+        ["bash", str(BACKUP_SCRIPT), *arguments],
+        cwd=REPO_ROOT,
+        env=backup_environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_backup_db_script_has_valid_bash_syntax() -> None:
+    syntax_check = subprocess.run(
+        ["bash", "-n", str(BACKUP_SCRIPT)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert syntax_check.returncode == 0, syntax_check.stderr
+
+
+def test_backup_db_cli_requires_one_output_path() -> None:
+    missing_destination = _run_backup_preflight()
+    extra_destination = _run_backup_preflight("first.dump", "second.dump")
+
+    assert missing_destination.returncode != 0
+    assert "usage:" in missing_destination.stderr.lower()
+    assert extra_destination.returncode != 0
+    assert "usage:" in extra_destination.stderr.lower()
+
+
+def test_backup_db_cli_prints_help_without_docker() -> None:
+    help_result = _run_backup_preflight("--help")
+
+    assert help_result.returncode == 0
+    assert "usage:" in help_result.stdout.lower()
+
+
+def test_backup_db_cli_refuses_existing_destination(tmp_path: Path) -> None:
+    backup_destination = tmp_path / "existing.dump"
+    original_contents = b"keep-this-content"
+    backup_destination.write_bytes(original_contents)
+
+    backup_result = _run_backup_preflight(str(backup_destination))
+
+    assert backup_result.returncode != 0
+    assert "already exists" in backup_result.stderr.lower()
+    assert backup_destination.read_bytes() == original_contents
+
+
+def test_backup_db_cli_rejects_missing_parent(tmp_path: Path) -> None:
+    missing_parent = tmp_path / "missing" / "town-council.dump"
+
+    backup_result = _run_backup_preflight(str(missing_parent))
+
+    assert backup_result.returncode != 0
+    assert "parent directory" in backup_result.stderr.lower()
+    assert not missing_parent.parent.exists()
+
+
+def test_backup_db_script_secures_and_atomically_publishes_archive() -> None:
+    backup_source = BACKUP_SCRIPT.read_text(encoding="utf-8")
+
+    assert "umask 077" in backup_source
+    assert "mktemp" in backup_source
+    assert "trap cleanup_backup" in backup_source
+    assert "--format=custom" in backup_source
+    assert "--no-owner" in backup_source
+    assert "--no-privileges" in backup_source
+    assert "pg_restore --list" in backup_source
+    assert '\"$POSTGRES_USER\"' in backup_source
+    assert '\"$POSTGRES_DB\"' in backup_source
+    assert "POSTGRES_PASSWORD" not in backup_source
+    assert backup_source.index("pg_restore --list") < backup_source.index("ln ")
+    assert backup_source.index("ln ") < backup_source.index("unlink ")
+
+
+def test_backup_runbook_documents_recovery_contract() -> None:
+    operations = OPERATIONS_RUNBOOK.read_text(encoding="utf-8")
+    routine_backup_start = operations.index("#### Routine database backup and recovery")
+    migration_start = operations.index("#### Schema migration workflow")
+    recovery_guidance = operations[routine_backup_start:migration_start]
+
+    assert "scripts/backup_db.sh" in recovery_guidance
+    assert "daily" in recovery_guidance
+    assert "weekly" in recovery_guidance
+    assert "encrypted" in recovery_guidance
+    assert "template0" in recovery_guidance
+    assert "--exit-on-error" in recovery_guidance
+    assert "select 'catalog' as relation" in recovery_guidance
+    assert "select 'event' as relation" in recovery_guidance
+    assert "STARTUP_PURGE_DERIVED=false" in recovery_guidance
+    assert "reindex_only.py --replace-all" in recovery_guidance
+    assert "reindex_semantic.py" in recovery_guidance

--- a/tests/test_backup_db_contract.py
+++ b/tests/test_backup_db_contract.py
@@ -102,8 +102,27 @@ def test_backup_runbook_documents_recovery_contract() -> None:
     assert "encrypted" in recovery_guidance
     assert "template0" in recovery_guidance
     assert "--exit-on-error" in recovery_guidance
+    assert "RESTORE_DB_CREATED=false" in recovery_guidance
+    assert "trap cleanup_restore_drill EXIT" in recovery_guidance
+    assert "createdb" in recovery_guidance
+    assert "pg_restore" in recovery_guidance
+    assert "dropdb" in recovery_guidance
     assert "select 'catalog' as relation" in recovery_guidance
     assert "select 'event' as relation" in recovery_guidance
     assert "STARTUP_PURGE_DERIVED=false" in recovery_guidance
     assert "reindex_only.py --replace-all" in recovery_guidance
     assert "reindex_semantic.py" in recovery_guidance
+    assert recovery_guidance.index("createdb") < recovery_guidance.index(
+        "RESTORE_DB_CREATED=true"
+    )
+
+
+def test_migration_rollback_selects_previous_release_before_schema_tools() -> None:
+    operations = OPERATIONS_RUNBOOK.read_text(encoding="utf-8")
+    rollback_start = operations.index("##### Roll back a failed schema release")
+    historical_migration_start = operations.index("#### Historical timezone migration v10")
+    rollback_guidance = operations[rollback_start:historical_migration_start]
+
+    assert 'git switch --detach "$ROLLBACK_REF"' in rollback_guidance
+    assert "before running `db_migrate.py`" in rollback_guidance
+    assert "Do not run `db_migrate.py` from the failed release" in rollback_guidance

--- a/tests/test_backup_db_contract.py
+++ b/tests/test_backup_db_contract.py
@@ -158,13 +158,37 @@ def test_migration_rollback_selects_previous_release_before_schema_tools() -> No
     assert 'git switch --detach "$ROLLBACK_REF"' in rollback_guidance
     assert "before running `db_migrate.py`" in rollback_guidance
     assert "Do not run `db_migrate.py` from the failed release" in rollback_guidance
-    assert "both reindex" in rollback_guidance
     assert "rollback release" in rollback_guidance
     assert "Checkout-based rollback" in rollback_guidance
+    assert "--replace-all" not in rollback_guidance
+    assert "from urllib.request import Request, urlopen" in rollback_guidance
+    assert '"/indexes/documents/documents"' in rollback_guidance
+    rollback_index_clear = rollback_guidance.index('"/indexes/documents/documents"')
+    rollback_additive_reindex = rollback_guidance.index("python reindex_only.py")
+    assert rollback_index_clear < rollback_additive_reindex
+    rollback_task_wait = rollback_guidance.index(
+        "Meilisearch rollback reindex completed"
+    )
+    assert rollback_additive_reindex < rollback_task_wait
+    assert 'in {"failed", "canceled"}' in rollback_guidance
+    assert 'task["type"] == "indexCreation"' in rollback_guidance
+    assert 'task["error"]["code"] == "index_already_exists"' in rollback_guidance
+    assert "TASK_TIMEOUT_SECONDS" in rollback_guidance
+    checkout_image_guidance = rollback_guidance[
+        rollback_guidance.index("Checkout-based rollback") :
+        rollback_guidance.index("Prebuilt-image rollback")
+    ]
+    assert (
+        'docker compose "${ROLLBACK_COMPOSE_FILES[@]}" build\n'
+        in checkout_image_guidance
+    )
     prebuilt_image_guidance = rollback_guidance[
         rollback_guidance.index("Prebuilt-image rollback") :
     ]
     assert 'ROLLBACK_COMPOSE_FILE="<ROLLBACK_COMPOSE_FILE>"' in (
+        prebuilt_image_guidance
+    )
+    assert 'ROLLBACK_COMPOSE_FILES=(-f "$ROLLBACK_COMPOSE_FILE")' in (
         prebuilt_image_guidance
     )
     assert "--rm --no-deps pipeline python db_migrate.py" in prebuilt_image_guidance
@@ -175,9 +199,47 @@ def test_migration_rollback_selects_previous_release_before_schema_tools() -> No
     prebuilt_image_commands = prebuilt_image_guidance.split("```bash", maxsplit=1)[
         1
     ].split("```", maxsplit=1)[0]
-    rollback_compose_command = 'docker compose -f "$ROLLBACK_COMPOSE_FILE"'
+    rollback_compose_command = 'docker compose "${ROLLBACK_COMPOSE_FILES[@]}"'
     assert "set -euo pipefail" in prebuilt_image_commands
-    assert "--build" not in prebuilt_image_commands
-    assert prebuilt_image_commands.count(
+    assert prebuilt_image_guidance.count("set -euo pipefail") == 2
+    assert "--build" not in prebuilt_image_guidance
+    assert prebuilt_image_guidance.count(
         rollback_compose_command
-    ) == prebuilt_image_commands.count("docker compose")
+    ) == prebuilt_image_guidance.count("docker compose")
+
+
+def test_rollback_task_classifier_accepts_only_existing_index_failure() -> None:
+    operations = OPERATIONS_RUNBOOK.read_text(encoding="utf-8")
+    classifier_start = operations.index("def task_allows_rollback_reindex")
+    classifier_end = operations.index("\n\ndef request_json", classifier_start)
+    classifier_source = operations[classifier_start:classifier_end]
+    classifier_contract = """
+assert task_allows_rollback_reindex({"status": "succeeded"})
+assert task_allows_rollback_reindex({
+    "status": "failed",
+    "type": "indexCreation",
+    "error": {"code": "index_already_exists"},
+})
+assert not task_allows_rollback_reindex({
+    "status": "failed",
+    "type": "indexCreation",
+    "error": {"code": "internal_error"},
+})
+assert not task_allows_rollback_reindex({
+    "status": "failed",
+    "type": "documentAdditionOrUpdate",
+    "error": {"code": "index_already_exists"},
+})
+assert not task_allows_rollback_reindex({"status": "canceled"})
+assert not task_allows_rollback_reindex({"status": "processing"})
+"""
+    classifier_check = subprocess.run(
+        [str(REPO_ROOT / ".venv" / "bin" / "python"), "-"],
+        cwd=REPO_ROOT,
+        input=f"{classifier_source}\n{classifier_contract}",
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert classifier_check.returncode == 0, classifier_check.stderr

--- a/tests/test_backup_db_contract.py
+++ b/tests/test_backup_db_contract.py
@@ -116,6 +116,20 @@ def test_backup_runbook_documents_recovery_contract() -> None:
         "RESTORE_DB_CREATED=true"
     )
 
+    full_recovery_guidance = recovery_guidance[
+        recovery_guidance.index("For full recovery") :
+    ]
+    writers_stopped = full_recovery_guidance.index(
+        "docker compose -f docker-compose.yml -f docker-compose.dev.yml stop"
+    )
+    postgres_started = full_recovery_guidance.index(
+        "docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d postgres"
+    )
+    postgres_environment_read = full_recovery_guidance.index(
+        'POSTGRES_USER="$(docker compose exec -T postgres printenv POSTGRES_USER)"'
+    )
+    assert writers_stopped < postgres_started < postgres_environment_read
+
 
 def test_migration_rollback_selects_previous_release_before_schema_tools() -> None:
     operations = OPERATIONS_RUNBOOK.read_text(encoding="utf-8")

--- a/tests/test_backup_db_contract.py
+++ b/tests/test_backup_db_contract.py
@@ -116,6 +116,40 @@ def test_backup_runbook_documents_recovery_contract() -> None:
         "RESTORE_DB_CREATED=true"
     )
 
+    redis_preflight_guidance = recovery_guidance[
+        recovery_guidance.index("Before full recovery") :
+        recovery_guidance.index("For full recovery")
+    ]
+    assert (
+        "RECOVERY_COMPOSE=(docker compose -f docker-compose.yml "
+        "-f docker-compose.dev.yml)" in redis_preflight_guidance
+    )
+    assert (
+        'RECOVERY_COMPOSE=(docker compose -p "<CURRENT_DEPLOYMENT_PROJECT>" '
+        '-f "<CURRENT_DEPLOYMENT_COMPOSE_FILE>")' in redis_preflight_guidance
+    )
+    assert redis_preflight_guidance.count('"${RECOVERY_COMPOSE[@]}"') == 3
+    redis_writers_stopped = redis_preflight_guidance.index(
+        '"${RECOVERY_COMPOSE[@]}" stop'
+    )
+    redis_started = redis_preflight_guidance.index(
+        "--wait --wait-timeout 60 redis"
+    )
+    redis_flushed = redis_preflight_guidance.index("redis-cli -e FLUSHDB SYNC")
+    redis_saved = redis_preflight_guidance.index("redis-cli -e SAVE")
+    redis_verified = redis_preflight_guidance.index(
+        'test "$(redis-cli -e --raw DBSIZE)" = 0'
+    )
+    assert (
+        redis_writers_stopped
+        < redis_started
+        < redis_flushed
+        < redis_saved
+        < redis_verified
+    )
+    assert 'REDISCLI_AUTH="$REDIS_PASSWORD"' in redis_preflight_guidance
+    assert 'REDISCLI_AUTH="${REDIS_PASSWORD' not in redis_preflight_guidance
+
     full_recovery_guidance = recovery_guidance[
         recovery_guidance.index("For full recovery") :
     ]
@@ -141,9 +175,13 @@ def test_backup_runbook_documents_recovery_contract() -> None:
     meilisearch_started = external_search_guidance.index(
         "up -d postgres redis meilisearch"
     )
+    replacement_reindex_started = external_search_guidance.index(
+        "python reindex_only.py --replace-all"
+    )
     assert restore_fail_fast_enabled < writers_stopped < postgres_started
     assert postgres_started < postgres_environment_read
     assert external_search_fail_fast_enabled < meilisearch_started
+    assert meilisearch_started < replacement_reindex_started
     assert "--rm --build --no-deps semantic python ../pipeline/reindex_semantic.py" in (
         full_recovery_guidance
     )
@@ -160,6 +198,15 @@ def test_migration_rollback_selects_previous_release_before_schema_tools() -> No
     assert "Do not run `db_migrate.py` from the failed release" in rollback_guidance
     assert "rollback release" in rollback_guidance
     assert "Checkout-based rollback" in rollback_guidance
+    redis_preflight_required = rollback_guidance.index(
+        "Run the Redis recovery preflight above"
+    )
+    rollback_checkout_selected = rollback_guidance.index(
+        'git switch --detach "$ROLLBACK_REF"'
+    )
+    assert redis_preflight_required < rollback_checkout_selected
+    checkout_fail_fast_enabled = rollback_guidance.index("set -euo pipefail")
+    assert checkout_fail_fast_enabled < rollback_checkout_selected
     assert "--replace-all" not in rollback_guidance
     assert "from urllib.request import Request, urlopen" in rollback_guidance
     assert '"/indexes/documents/documents"' in rollback_guidance

--- a/tests/test_docker_build_contracts.py
+++ b/tests/test_docker_build_contracts.py
@@ -208,6 +208,23 @@ def test_base_compose_requires_meilisearch_master_key() -> None:
     assert "MEILI_MASTER_KEY must be set" in completed_process.stderr
 
 
+def test_redis_service_exposes_configured_password_to_container_commands(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    redis_password_sentinel = "compose redis; password with spaces"
+    monkeypatch.setenv("REDIS_PASSWORD", redis_password_sentinel)
+
+    redis_service = _compose_services("docker-compose.yml")["redis"]
+    redis_command = " ".join(redis_service["command"])
+    redis_healthcheck = " ".join(redis_service["healthcheck"]["test"])
+
+    assert redis_service["environment"]["REDIS_PASSWORD"] == redis_password_sentinel
+    assert redis_password_sentinel not in redis_command
+    assert redis_password_sentinel not in redis_healthcheck
+    assert '"$$REDIS_PASSWORD"' in redis_command
+    assert '"$$REDIS_PASSWORD"' in redis_healthcheck
+
+
 def test_dev_overlay_mounts_reader_source_without_repository_secrets() -> None:
     development_services = _compose_services("docker-compose.yml", "docker-compose.dev.yml")
     expected_targets = {

--- a/tests/test_indexer_logic.py
+++ b/tests/test_indexer_logic.py
@@ -1,6 +1,7 @@
 import pytest
 import sys
 import os
+import subprocess
 from types import SimpleNamespace
 from contextlib import contextmanager
 from unittest.mock import MagicMock
@@ -8,6 +9,245 @@ from unittest.mock import MagicMock
 # Ensure the pipeline directory is in the path for indexer imports
 sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'pipeline'))
 from pipeline import indexer
+
+
+class EmptyIndexQuery:
+    def join(self, *args, **kwargs):
+        return self
+
+    def outerjoin(self, *args, **kwargs):
+        return self
+
+    def filter(self, *args, **kwargs):
+        return self
+
+    def options(self, *args, **kwargs):
+        return self
+
+    def yield_per(self, *args, **kwargs):
+        return []
+
+
+class ReplacementIndex:
+    def __init__(
+        self,
+        index_events,
+        indexed_document_count,
+        *,
+        settings_valid=True,
+    ):
+        self.index_events = index_events
+        self.indexed_document_count = indexed_document_count
+        self.settings_valid = settings_valid
+
+    def delete_all_documents(self):
+        self.index_events.append("delete_enqueued")
+        return SimpleNamespace(task_uid=91)
+
+    def update_filterable_attributes(self, attributes):
+        return {"taskUid": 1}
+
+    def update_sortable_attributes(self, attributes):
+        return {"taskUid": 2}
+
+    def update_searchable_attributes(self, attributes):
+        return {"taskUid": 3}
+
+    def update_ranking_rules(self, rules):
+        return {"taskUid": 4}
+
+    def get_stats(self):
+        self.index_events.append("stats_checked")
+        return SimpleNamespace(number_of_documents=self.indexed_document_count)
+
+    def get_filterable_attributes(self):
+        self.index_events.append("filterable_settings_checked")
+        if not self.settings_valid:
+            return []
+        return [
+            "city",
+            "meeting_type",
+            "meeting_category",
+            "organization",
+            "people",
+            "date",
+            "organizations",
+            "result_type",
+            "topics",
+            "lineage_id",
+            "catalog_id",
+        ]
+
+    def get_sortable_attributes(self):
+        return ["date"]
+
+    def get_searchable_attributes(self):
+        return [
+            "content",
+            "event_name",
+            "title",
+            "description",
+            "filename",
+            "summary",
+            "organizations",
+            "locations",
+            "meeting_category",
+            "organization",
+            "people",
+        ]
+
+    def get_ranking_rules(self):
+        return ["sort", "words", "typo", "proximity", "attribute", "exactness"]
+
+
+class ReplacementClient:
+    def __init__(
+        self,
+        deletion_status,
+        indexed_document_count=0,
+        *,
+        settings_valid=True,
+    ):
+        self.deletion_status = deletion_status
+        self.index_events = []
+        self.deletion_timeout_ms = None
+        self.deletion_poll_interval_ms = None
+        self.documents_index = ReplacementIndex(
+            self.index_events,
+            indexed_document_count,
+            settings_valid=settings_valid,
+        )
+
+    def create_index(self, index_name, index_options):
+        return None
+
+    def index(self, index_name):
+        return self.documents_index
+
+    def wait_for_task(
+        self,
+        task_uid,
+        timeout_in_ms=5000,
+        interval_in_ms=50,
+    ):
+        if task_uid == 91:
+            self.deletion_timeout_ms = timeout_in_ms
+            self.deletion_poll_interval_ms = interval_in_ms
+            self.index_events.append(f"delete_{self.deletion_status}")
+            return SimpleNamespace(status=self.deletion_status)
+        self.index_events.append(f"settings_{task_uid}")
+        return SimpleNamespace(status="succeeded")
+
+    def get_tasks(self, task_filters):
+        self.index_events.append("queue_idle")
+        return SimpleNamespace(results=[])
+
+
+def _empty_index_session():
+    session = MagicMock()
+    session.query.return_value = EmptyIndexQuery()
+    return session
+
+
+def test_full_reindex_replaces_existing_meilisearch_documents(mocker):
+    replacement_client = ReplacementClient("succeeded")
+
+    @contextmanager
+    def fake_db_session():
+        yield _empty_index_session()
+
+    mocker.patch.object(indexer, "db_session", fake_db_session)
+    mocker.patch.object(indexer.meilisearch, "Client", return_value=replacement_client)
+
+    indexer.replace_documents_index()
+
+    assert replacement_client.index_events[:2] == [
+        "delete_enqueued",
+        "delete_succeeded",
+    ]
+    assert replacement_client.index_events[-3:] == [
+        "queue_idle",
+        "filterable_settings_checked",
+        "stats_checked",
+    ]
+
+
+def test_full_reindex_uses_maintenance_timeout_for_document_clear(mocker):
+    replacement_client = ReplacementClient("failed")
+    mocker.patch.object(indexer.meilisearch, "Client", return_value=replacement_client)
+
+    with pytest.raises(RuntimeError, match="failed"):
+        indexer.replace_documents_index()
+
+    assert replacement_client.deletion_timeout_ms == 300_000
+    assert replacement_client.deletion_poll_interval_ms == 250
+
+
+def test_full_reindex_stops_when_meilisearch_clear_fails(mocker):
+    replacement_client = ReplacementClient("failed")
+    mocker.patch.object(indexer.meilisearch, "Client", return_value=replacement_client)
+
+    with pytest.raises(RuntimeError, match="failed"):
+        indexer.replace_documents_index()
+
+    assert replacement_client.index_events == ["delete_enqueued", "delete_failed"]
+
+
+def test_full_reindex_rejects_document_count_mismatch(mocker):
+    replacement_client = ReplacementClient(
+        "succeeded",
+        indexed_document_count=1,
+    )
+
+    @contextmanager
+    def fake_db_session():
+        yield _empty_index_session()
+
+    mocker.patch.object(indexer, "db_session", fake_db_session)
+    mocker.patch.object(indexer.meilisearch, "Client", return_value=replacement_client)
+
+    with pytest.raises(RuntimeError, match="expected=0 actual=1"):
+        indexer.replace_documents_index()
+
+    assert replacement_client.index_events[-3:] == [
+        "queue_idle",
+        "filterable_settings_checked",
+        "stats_checked",
+    ]
+
+
+def test_full_reindex_rejects_missing_index_settings(mocker):
+    replacement_client = ReplacementClient(
+        "succeeded",
+        settings_valid=False,
+    )
+
+    @contextmanager
+    def fake_db_session():
+        yield _empty_index_session()
+
+    mocker.patch.object(indexer, "db_session", fake_db_session)
+    mocker.patch.object(indexer.meilisearch, "Client", return_value=replacement_client)
+
+    with pytest.raises(RuntimeError, match="filterable_attributes"):
+        indexer.replace_documents_index()
+
+    assert replacement_client.index_events[-2:] == [
+        "queue_idle",
+        "filterable_settings_checked",
+    ]
+
+
+def test_reindex_cli_exposes_explicit_replace_mode():
+    cli_help = subprocess.run(
+        [sys.executable, "-m", "pipeline.reindex_only", "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert cli_help.returncode == 0, cli_help.stderr
+    assert "--replace-all" in cli_help.stdout
 
 def test_meeting_category_normalization():
     """
@@ -36,7 +276,15 @@ def test_meeting_category_normalization():
     assert get_category("") == "Other"
 
 
-def test_indexer_flushes_agenda_final_batch_once(mocker):
+@pytest.mark.parametrize(
+    "batch_submission_fails",
+    [False, True],
+    ids=["submitted", "provider-error"],
+)
+def test_indexer_reports_agenda_source_count_after_batch_attempt(
+    mocker,
+    batch_submission_fails,
+):
     """
     Regression: remaining agenda items should be sent once after the loop.
     """
@@ -81,19 +329,23 @@ def test_indexer_flushes_agenda_final_batch_once(mocker):
     fake_index.update_sortable_attributes.return_value = {"taskUid": 2}
     fake_index.update_searchable_attributes.return_value = {"taskUid": 3}
     fake_index.update_ranking_rules.return_value = {"taskUid": 4}
+    if batch_submission_fails:
+        fake_index.add_documents.side_effect = indexer.MeilisearchError("boom")
     fake_client = MagicMock()
     fake_client.index.return_value = fake_index
     mocker.patch.object(indexer, "db_session", fake_db_session)
     mocker.patch.object(indexer.meilisearch, "Client", return_value=fake_client)
     mocker.patch.object(indexer, "MEILISEARCH_BATCH_SIZE", 2)
 
-    indexer.index_documents()
+    source_document_count = indexer.index_documents()
 
+    assert source_document_count == 2
     fake_index.update_sortable_attributes.assert_called_with(["date"])
     assert fake_client.wait_for_task.call_count == 4
     assert fake_index.add_documents.call_count == 1
-    sent_batch = fake_index.add_documents.call_args[0][0]
-    assert len(sent_batch) == 2
+    if not batch_submission_fails:
+        sent_batch = fake_index.add_documents.call_args[0][0]
+        assert len(sent_batch) == 2
 
 
 def test_flush_batch_updates_count(mocker):

--- a/tests/test_indexer_logic.py
+++ b/tests/test_indexer_logic.py
@@ -183,6 +183,34 @@ def test_full_reindex_uses_maintenance_timeout_for_document_clear(mocker):
     assert replacement_client.deletion_poll_interval_ms == 250
 
 
+def test_full_reindex_uses_one_bounded_maintenance_client(mocker):
+    replacement_client = ReplacementClient("succeeded")
+    maintenance_request_timeouts = []
+
+    def create_replacement_client(
+        meilisearch_host,
+        meilisearch_key,
+        timeout=None,
+    ):
+        maintenance_request_timeouts.append(timeout)
+        return replacement_client
+
+    @contextmanager
+    def fake_db_session():
+        yield _empty_index_session()
+
+    mocker.patch.object(indexer, "db_session", fake_db_session)
+    mocker.patch.object(
+        indexer.meilisearch,
+        "Client",
+        side_effect=create_replacement_client,
+    )
+
+    indexer.replace_documents_index()
+
+    assert maintenance_request_timeouts == [30]
+
+
 def test_full_reindex_stops_when_meilisearch_clear_fails(mocker):
     replacement_client = ReplacementClient("failed")
     mocker.patch.object(indexer.meilisearch, "Client", return_value=replacement_client)

--- a/tests/test_indexer_logic.py
+++ b/tests/test_indexer_logic.py
@@ -106,8 +106,10 @@ class ReplacementClient:
         deletion_status,
         indexed_document_count=0,
         *,
+        creation_error_code="index_already_exists",
         settings_valid=True,
     ):
+        self.creation_error_code = creation_error_code
         self.deletion_status = deletion_status
         self.index_events = []
         self.deletion_timeout_ms = None
@@ -119,7 +121,8 @@ class ReplacementClient:
         )
 
     def create_index(self, index_name, index_options):
-        return None
+        self.index_events.append("create_enqueued")
+        return SimpleNamespace(task_uid=77)
 
     def index(self, index_name):
         return self.documents_index
@@ -130,6 +133,15 @@ class ReplacementClient:
         timeout_in_ms=5000,
         interval_in_ms=50,
     ):
+        if task_uid == 77:
+            if self.creation_error_code is None:
+                self.index_events.append("create_succeeded")
+                return SimpleNamespace(status="succeeded", error=None)
+            self.index_events.append(f"create_{self.creation_error_code}")
+            return SimpleNamespace(
+                status="failed",
+                error={"code": self.creation_error_code},
+            )
         if task_uid == 91:
             self.deletion_timeout_ms = timeout_in_ms
             self.deletion_poll_interval_ms = interval_in_ms
@@ -141,6 +153,15 @@ class ReplacementClient:
     def get_tasks(self, task_filters):
         self.index_events.append("queue_idle")
         return SimpleNamespace(results=[])
+
+
+class SynchronousCreationFailureClient(ReplacementClient):
+    def create_index(self, index_name, index_options):
+        self.index_events.append("create_rejected")
+        raise indexer.MeilisearchError("provider unavailable")
+
+    def index(self, index_name):
+        raise AssertionError("recovery continued after synchronous create failure")
 
 
 def _empty_index_session():
@@ -161,7 +182,9 @@ def test_full_reindex_replaces_existing_meilisearch_documents(mocker):
 
     indexer.replace_documents_index()
 
-    assert replacement_client.index_events[:2] == [
+    assert replacement_client.index_events[:4] == [
+        "create_enqueued",
+        "create_index_already_exists",
         "delete_enqueued",
         "delete_succeeded",
     ]
@@ -170,6 +193,55 @@ def test_full_reindex_replaces_existing_meilisearch_documents(mocker):
         "filterable_settings_checked",
         "stats_checked",
     ]
+
+
+def test_full_reindex_waits_for_fresh_index_before_clearing(mocker):
+    replacement_client = ReplacementClient(
+        "succeeded",
+        creation_error_code=None,
+    )
+
+    @contextmanager
+    def fake_db_session():
+        yield _empty_index_session()
+
+    mocker.patch.object(indexer, "db_session", fake_db_session)
+    mocker.patch.object(indexer.meilisearch, "Client", return_value=replacement_client)
+
+    indexer.replace_documents_index()
+
+    assert replacement_client.index_events[:4] == [
+        "create_enqueued",
+        "create_succeeded",
+        "delete_enqueued",
+        "delete_succeeded",
+    ]
+
+
+def test_full_reindex_stops_when_fresh_index_creation_fails(mocker):
+    replacement_client = ReplacementClient(
+        "succeeded",
+        creation_error_code="internal",
+    )
+    mocker.patch.object(indexer.meilisearch, "Client", return_value=replacement_client)
+
+    with pytest.raises(RuntimeError, match="index creation failed status=failed"):
+        indexer.replace_documents_index()
+
+    assert replacement_client.index_events == [
+        "create_enqueued",
+        "create_internal",
+    ]
+
+
+def test_full_reindex_stops_when_index_creation_is_rejected(mocker):
+    replacement_client = SynchronousCreationFailureClient("succeeded")
+    mocker.patch.object(indexer.meilisearch, "Client", return_value=replacement_client)
+
+    with pytest.raises(indexer.MeilisearchError, match="provider unavailable"):
+        indexer.replace_documents_index()
+
+    assert replacement_client.index_events == ["create_rejected"]
 
 
 def test_full_reindex_uses_maintenance_timeout_for_document_clear(mocker):
@@ -218,7 +290,12 @@ def test_full_reindex_stops_when_meilisearch_clear_fails(mocker):
     with pytest.raises(RuntimeError, match="failed"):
         indexer.replace_documents_index()
 
-    assert replacement_client.index_events == ["delete_enqueued", "delete_failed"]
+    assert replacement_client.index_events == [
+        "create_enqueued",
+        "create_index_already_exists",
+        "delete_enqueued",
+        "delete_failed",
+    ]
 
 
 def test_full_reindex_rejects_document_count_mismatch(mocker):
@@ -360,6 +437,7 @@ def test_indexer_reports_agenda_source_count_after_batch_attempt(
     if batch_submission_fails:
         fake_index.add_documents.side_effect = indexer.MeilisearchError("boom")
     fake_client = MagicMock()
+    fake_client.create_index.return_value = SimpleNamespace(task_uid=77)
     fake_client.index.return_value = fake_index
     mocker.patch.object(indexer, "db_session", fake_db_session)
     mocker.patch.object(indexer.meilisearch, "Client", return_value=fake_client)
@@ -495,6 +573,7 @@ def test_reindex_catalog_skips_schema_updates_and_reindexes_agenda_items(mocker)
     fake_index = MagicMock()
     fake_index.delete_documents.return_value = {"taskUid": 88}
     fake_client = MagicMock()
+    fake_client.create_index.return_value = SimpleNamespace(task_uid=77)
     fake_client.index.return_value = fake_index
     mocker.patch.object(indexer, "db_session", fake_db_session)
     mocker.patch.object(indexer.meilisearch, "Client", return_value=fake_client)
@@ -507,6 +586,7 @@ def test_reindex_catalog_skips_schema_updates_and_reindexes_agenda_items(mocker)
         filter='catalog_id = 9 AND result_type = "agenda_item"'
     )
     fake_index.add_documents.assert_called_once()
+    fake_client.wait_for_task.assert_called_once_with(88)
     sent = fake_index.add_documents.call_args.args[0]
     assert {doc["result_type"] for doc in sent} == {"meeting", "agenda_item"}
     assert result["agenda_item_documents"] == 1


### PR DESCRIPTION
## What changed

- adds `scripts/backup_db.sh` for private, validated, no-overwrite custom-format PostgreSQL archives
- documents routine cadence, a complete disposable restore drill, replacement recovery, schema and row-count checks, startup-purge handling, and external search recovery
- makes failed-schema rollback select the previous application release before migration, parity, or reindex commands
- adds explicit `reindex_only.py --replace-all` recovery mode
- rejects failed, hung, or incomplete Meilisearch recovery through bounded requests, ordered index creation/deletion waits, live settings, PostgreSQL source count, and final index count

## Why

PostgreSQL is Town Council's system of record, but the repository had no reusable backup command or complete restore drill. Recovery also needed a safe way to prevent newer Meilisearch or FAISS state from surviving an older database restore without accidentally reapplying a failed migration.

## Risk and compatibility

- no runtime default, schema, migration, API, Celery, or query behavior changes
- backup destination is required and existing files are never overwritten
- archives contain governed data and remain operator-managed; this PR does not claim scheduling or off-host retention is configured
- destructive database recovery remains manual; destructive search replacement is explicit maintenance-only behavior
- routine and targeted indexing retain their existing creation-wait and request policy

## Verification

- PASS: `bash -n scripts/backup_db.sh`
- PASS: `./.venv/bin/ruff check .`
- PASS: `./.venv/bin/mypy`
- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_indexer_logic.py tests/test_docs_links.py` (`21 passed`)
- PASS: `PYTHONPATH=. .venv/bin/pytest -q` (`1537 passed, 17 skipped`)
- PASS: `git diff --check`
- PASS: live backup archive validated with `pg_restore --list`, mode `600`, size `48185` bytes
- PASS: archive restored into a uniquely named disposable database; Alembic revision `0001_v10_baseline`, catalog `0`, event `0`; temporary database and archive removed
- PASS: current-head Python Guardrails, Frontend Tests, and CodeQL checks
- PASS: final independent review found no P1/P2

## Review findings resolved

- extended the delete wait from the SDK's 5-second default to the 5-minute maintenance window
- bounded every recovery Meilisearch HTTP request at 30 seconds and reused one client across the operation
- verified live Meilisearch settings so failed asynchronous settings tasks cannot pass on document count alone
- compared the final index against all PostgreSQL source rows, including synchronous batch submission failures
- added executable full-recovery row-count checks and a guarded disposable restore drill
- required selection of the previous release before restored migration/parity work
- started PostgreSQL before reading restore credentials
- waited for fresh-index creation before deletion; accepted only asynchronous `index_already_exists` and propagated all other creation failures

## Remaining deficits

- operators must still configure and test an actual schedule, retention policy, encryption, and off-host copy before closing the `SECURITY.md` backup checklist
- browser testing is not applicable because no UI route changed