### PR TITLE
T-DD-1B: Consolidate city event-graph mutation

### DIFF
--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -990,6 +990,7 @@ docker compose start api worker frontend monitor
 - The rewind deletes only city-scoped verification-era state:
   - `event`
   - linked `document`
+  - linked `data_issue`
   - unreferenced `catalog`
   - linked derived agenda/embedding rows via existing cascades
 - Example shape:

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,6 +1,6 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 3.62
+version: 3.63
 generated: 2026-07-26
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
@@ -10,6 +10,12 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v3.63:** Marks T-PLAT-3 complete after PR #155 merged with verified backup,
+  disposable restore, rollback, search rebuild, and Redis recovery contracts.
+  Activates T-DD-1B with exact ownership for a tests-first extraction of only
+  the identical selected-event reference and deletion policy. Stage behavior,
+  temporal selection, validation, command defaults, transaction ownership, and
+  reports remain command-local.
 - **v3.62:** Expands active T-PLAT-3 ownership to the Redis service definition
   and its Compose contract test. Recovery must clear persistent Redis database
   0 after writers stop and before workers restart, using the service's existing
@@ -300,10 +306,10 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 | State | Tasks |
 |---|---|
-| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2, T-SEC-3, T-SEC-3C, T-SEC-4, T-SEC-4A, T-SEC-5, T-SEC-6, T-TIME-1, T-TIME-2, T-TIME-3, T-CRAWL-1, T-CRAWL-2, T-PLAT-1, T-PLAT-1A, T-PLAT-2A, T-PLAT-2B, T-GOV-1, T-GOV-3A, T-GOV-4, T-GOV-5, T-DA-1, T-DB-1A, T-DB-1, T-DB-1B, T-DD-1A |
+| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2, T-SEC-3, T-SEC-3C, T-SEC-4, T-SEC-4A, T-SEC-5, T-SEC-6, T-TIME-1, T-TIME-2, T-TIME-3, T-CRAWL-1, T-CRAWL-2, T-PLAT-1, T-PLAT-1A, T-PLAT-2A, T-PLAT-2B, T-PLAT-3, T-GOV-1, T-GOV-3A, T-GOV-4, T-GOV-5, T-DA-1, T-DB-1A, T-DB-1, T-DB-1B, T-DD-1A |
 | **Partially landed; acceptance incomplete** | T-GOV-3, T-GOV-6 |
-| **Active** | T-PLAT-3 |
-| **Pending** | T-DC-1, T-DD-1B, T-DE-1, T-PLAT-2, T-PLAT-4, T-GOV-2, T-GOV-3B |
+| **Active** | T-DD-1B |
+| **Pending** | T-DC-1, T-DE-1, T-PLAT-2, T-PLAT-4, T-GOV-2, T-GOV-3B |
 
 ---
 
@@ -1172,18 +1178,30 @@ files (GED-5 grant).
 
 ### T-DD-1B: Evaluate city-state mutation consolidation
 - priority: P2
-- status: pending
+- status: active
 - depends_on: T-DD-1A (satisfied by PR #153)
-- files_owned: `scripts/flush_city_pipeline_state.py`,
-  `scripts/reset_city_verification_state.py`, and focused tests to be named in
-  a separate Full plan
+- implementation_plan: `docs/plans/T_DD_1B_CITY_STATE_MUTATION_PLAN.md`
+- files_owned: the implementation plan and ledger;
+  `docs/OPERATIONS.md` (pending-city rewind deletion list only);
+  `scripts/city_state_mutation.py` (new);
+  `scripts/flush_city_pipeline_state.py`;
+  `scripts/reset_city_verification_state.py`;
+  `tests/test_city_state_mutation_cli.py` (new);
+  `tests/test_flush_city_pipeline_state.py`;
+  `tests/test_reset_city_verification_baseline.py` (new);
+  `tests/test_reset_city_verification_state.py`
 - do: Characterize the exact shared event-graph deletion invariant before
-  extracting code. Preserve each command's distinct stage-row behavior,
-  defaults, temporal selection, output, and dry-run contract.
+  extracting code. Move only selected-event ID accounting, shared-catalog
+  protection, and live event-graph deletion into one implementation owner.
+  Preserve each command's distinct stage-row behavior, defaults, temporal
+  selection, validation, output, commit ownership, and dry-run contract.
 - accept: Consolidate only proven identical mutation policy; do not force
-  shallow reuse when semantics differ.
-- verify: Separate tests-first Full plan, CLI parity, targeted tests, and the
-  complete suite.
+  shallow reuse when semantics differ. Both commands retain their CLI and
+  persisted-state behavior, and the shared module never imports either CLI or
+  commits the caller-owned transaction.
+- verify: Follow the Full T-DD-1B plan; CLI characterization, focused
+  persisted-state and onboarding contracts, Ruff, Mypy, docs links, coverage,
+  and the complete suite pass.
 
 ### T-DE-1: Shared provider retry/telemetry
 - priority: P2
@@ -1388,7 +1406,7 @@ files (GED-5 grant).
 
 ### T-PLAT-3: Backup/restore runbook
 - priority: P1
-- status: active
+- status: complete and verified 2026-07-26 (PR #155)
 - implementation_plan: `docs/plans/T_PLAT_3_BACKUP_RESTORE_PLAN.md`
 - must_not_run_concurrently_with: T-DD-1B
 - files_owned: `docs/plans/T_PLAT_3_BACKUP_RESTORE_PLAN.md`,

--- a/docs/plans/T_DD_1B_CITY_STATE_MUTATION_PLAN.md
+++ b/docs/plans/T_DD_1B_CITY_STATE_MUTATION_PLAN.md
@@ -1,0 +1,281 @@
+# T-DD-1B: Consolidate City Event-Graph Mutation
+
+`artifact_contract: ce-unified-plan/v1`
+`artifact_readiness: implementation-ready`
+`execution: code`
+
+## 1. Context & Alignment
+
+**a) Driver.** The full city flush and verification-window reset independently
+implement the same live event-graph accounting, shared-catalog protection, and
+deletion policy. Their event selection, stage-table behavior, safety defaults,
+validation, and reports are intentionally different. T-DD-1B removes only the
+proven duplicate mutation policy so future fixes cannot protect shared catalogs
+in one command but not the other.
+
+**b) Canonical documents consulted.**
+
+- `AGENTS.md`: preserve command behavior, use the database boundary, avoid
+  facade compatibility seams, and run complete verification for cross-cutting
+  refactors.
+- `docs/TESTING.MD`: assert persisted database and CLI outcomes; do not add
+  helper-call assertions or production seams for tests.
+- `docs/ENGINEERING_GUARDRAILS.md`: Ruff owns lint scope and exception policy.
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`: DEDUP-D owns the two commands
+  and requires proof of identical policy before extraction.
+- `docs/reviews/architecture-review-2026-07-19.html`, Candidate 05: separate
+  city mutation from health probes, keep CLI interfaces stable, and extract
+  only the identical reference-deletion invariant.
+- `docs/OPERATIONS.md`: flush is dry-run by default and deletes stage state;
+  pending-city rewind is dry-run through its supported wrapper and preserves
+  stage state.
+- `SECURITY.md` and `docs/DATA_GOVERNANCE.md`: no security-sensitive or person
+  data boundary is affected.
+
+**c) Remediation alignment.** T-DD-1B owns exactly:
+
+- `docs/plans/T_DD_1B_CITY_STATE_MUTATION_PLAN.md`
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`
+- `docs/OPERATIONS.md` (pending-city rewind deletion list only)
+- `scripts/city_state_mutation.py` (new)
+- `scripts/flush_city_pipeline_state.py`
+- `scripts/reset_city_verification_state.py`
+- `tests/test_city_state_mutation_cli.py` (new)
+- `tests/test_flush_city_pipeline_state.py`
+- `tests/test_reset_city_verification_baseline.py` (new)
+- `tests/test_reset_city_verification_state.py`
+
+T-PLAT-3 is complete, so the former runbook serialization constraint is
+satisfied. No task with overlapping ownership may run concurrently.
+
+**d) Decision-gate check.** No G1-G5 gate is required or foreclosed. Runtime
+defaults, city rollout policy, schema, and soak comparability remain unchanged.
+
+## 2. Design
+
+**e) Step-by-step approach.**
+
+1. Register this Full plan, exact ownership, T-PLAT-3 completion, and T-DD-1B
+   activation in the remediation ledger before implementation edits.
+2. Decompose the touched reset test file before adding cases: move its
+   timestamp formatting, baseline capture, and record-date anchor tests into
+   `tests/test_reset_city_verification_baseline.py`. Keep local database setup
+   in each focused file rather than creating a fixture framework.
+3. Add characterization tests before refactoring. Prove both command defaults
+   and JSON contracts through subprocess execution against a temporary SQLite
+   database.
+4. Strengthen persisted-state tests for catalogs shared outside the selected
+   event set, linked and unrelated data issues, documents without catalogs,
+   stage-row asymmetry, idempotency, and transactional rollback. Use a SQLite
+   `BEFORE DELETE ON catalog` trigger that raises `ABORT` to prove a late
+   failure restores every earlier stage/live/data-issue mutation.
+5. Add `scripts/city_state_mutation.py` as the single owner of:
+   - the selected event-graph ID contract;
+   - total-versus-selected catalog reference accounting;
+   - deletion of selected data issues, events/documents, and catalogs no
+     longer referenced outside the selected event set.
+6. Keep event selection in each command. Flush selects every city event;
+   reset retains its `scraped_datetime` and optional `record_date` anchor.
+7. Keep stage discovery and deletion only in the flush command.
+8. Keep city validation, CLI flags, dry-run defaults, output fields, remaining
+   summaries, and transaction commit in their current command owners.
+9. The shared mutation function changes the caller-owned SQLAlchemy session
+   but never commits. This keeps flush stage and live deletion atomic.
+10. Delete both duplicate live-graph implementations and their duplicate
+   dataclasses in the same change.
+11. Run simplification, a fresh independent pre-commit review, all verification,
+    atomic commits, PR delivery, and bounded review/CI repair.
+
+New functions have one responsibility:
+
+- `city_ocd_division_id(city)`: build the existing California place ID.
+- `collect_event_graph_mutation(session, selected_events)`: collect affected
+  IDs and determine which catalogs have no references outside the selection.
+- `delete_event_graph(session, mutation)`: apply the shared live-row mutation
+  without committing.
+
+The shared module imports models and SQLAlchemy only. It never imports either
+CLI. Both CLIs import the shared module rather than copied symbols.
+
+**f) Reuse audit.** Move the existing reference-count and deletion blocks
+rather than rewriting them. Existing SQLAlchemy `Session.query`,
+`selectinload`, grouped counts, `Query.delete(synchronize_session=False)`,
+`Session.delete`, and `Session.commit` behavior remains unchanged. No existing
+module owns this maintenance mutation policy; metrics and generic city-scope
+modules do not own database deletion.
+
+Rejected alternatives:
+
+- Extract all command logic: rejected because stage and temporal policies
+  differ materially.
+- Share only the OCD identifier helper: rejected as too shallow to justify a
+  module.
+- Put mutation logic in one CLI and import it from the other: rejected because
+  it makes one command a facade for another.
+- Generalize a maintenance framework: rejected as unrequested machinery.
+
+**g) Data contracts.** A frozen `CityEventGraphMutation` dataclass carries
+event, document, referenced-catalog, unreferenced-catalog, and data-issue IDs.
+Each command retains its existing JSON dictionary contract. No raw external
+input crosses a new boundary.
+
+**h) Schema/migration impact.** None. Existing cascade and transaction behavior
+remain authoritative.
+
+## 3. Security & Data Governance
+
+**i) Security-sensitive paths.** None. The commands remain local maintenance
+tools and add no endpoint or privilege. Apply operations retain the documented
+writer-quiescence requirement.
+
+**j) Secrets.** No credentials, keys, environment variables, or defaults
+change.
+
+**k) Person data.** No person-level data is created, linked, aggregated, or
+exposed. G4 is unaffected.
+
+**l) Untrusted input.** City slugs and timestamp strings remain parsed by the
+same command boundaries. Database content remains trusted only after SQLAlchemy
+model loading. No scraped content is rendered or newly parsed.
+
+## 4. Code Health
+
+**m) GED conformance sweep.** New functions use domain names, complete type
+annotations, at most two parameters, one responsibility, and no nesting beyond
+two levels. The shared module adds no environment reads, timestamps, broad
+handlers, or import-time side effects. Callers retain commit and rollback
+ownership.
+
+**n) Antipattern scan, plan pass.**
+
+- A1/H1: SQLAlchemy 2.0.38 is pinned. Context7 `/websites/sqlalchemy_en_20_orm`
+  verifies the retained legacy query, eager-load, bulk-delete, object-delete,
+  and commit semantics.
+- B1/F1: one focused mutation owner replaces two proven duplicate blocks; no
+  manager, registry, base class, or `utils` module.
+- B2/C1/C2: no compatibility export, wrapper, old implementation, or new patch
+  seam survives.
+- D1-D3: tests assert CLI JSON and persisted rows; no skip, tolerance change,
+  helper call count, or private-symbol assertion.
+- E1-E3: only ten owned files change; no unrelated formatting.
+- A2-A4, B3, F2, H2-H4: no planned violation.
+
+**o) Ratchet interaction.** Neither command has a dedicated Ruff exception.
+No rule, allowlist, source scope, coverage floor, or typed-subtree boundary
+changes.
+
+**p) Dead code and duplication audit.** Delete `RewindCounts`, duplicate live
+fields from `FlushCounts`, both repeated reference-count blocks, both repeated
+live deletion blocks, and one duplicate city-ID helper. Event selection,
+stage mutation, reports, and timestamp helpers remain local. Production lines
+should decrease overall despite the new focused module.
+
+## 5. Testing
+
+**q) Edge and failure scenarios.**
+
+1. A selected event shares a catalog with an unselected event in the same city.
+2. A selected event shares a catalog with another city.
+3. A selected document has no catalog.
+4. Selected data issues are deleted; unrelated issues remain.
+5. Flush deletes stage rows; reset preserves them.
+6. Flush defaults to dry-run; direct reset defaults to apply.
+7. Reset timestamp and record-date boundaries remain exact.
+8. Both commands remain idempotent.
+9. A late database error rolls back the complete caller-owned transaction.
+10. Empty selections return zero counts and stable JSON fields.
+
+**r) Test mapping.**
+
+| Test area | Scenarios |
+|---|---|
+| New subprocess CLI characterization | 6, 10 |
+| Updated flush database tests | 2-5, 8-9 |
+| Updated reset database tests | 1, 3-5, 7-9 |
+| Split reset baseline tests | 7 |
+| Existing onboarding runner contracts | 5-8 |
+| Ruff, Mypy, coverage, and complete suite | 1-10 regression check |
+
+Tests are committed to the working tree and run before implementation.
+Characterization is expected to pass because this is a behavior-preserving
+refactor; failures stop implementation.
+
+**s) Fakes and mocks.** Database tests use the approved SQLite/sessionmaker
+boundary. CLI tests use real subprocesses and a temporary database. No facade,
+re-export, helper-call patch, or injectable callable is introduced.
+
+**t) Verification rows.** No named row covers these maintenance scripts. Run
+focused command tests, affected onboarding orchestration tests, Ruff, Mypy,
+docs links, the coverage gate because a production module is added, and the
+complete suite before handoff.
+
+## 6. Execution, Rollback, Docs
+
+**u) Exact commands.**
+
+```bash
+git fetch origin --prune
+git switch master
+git merge --ff-only origin/master
+git switch -c codex/t-dd-1b-city-state-mutation
+
+PYTHONPATH=. .venv/bin/pytest -q \
+  tests/test_city_state_mutation_cli.py \
+  tests/test_flush_city_pipeline_state.py \
+  tests/test_reset_city_verification_baseline.py \
+  tests/test_reset_city_verification_state.py
+
+./.venv/bin/ruff check .
+./.venv/bin/mypy
+./.venv/bin/mypy scripts/city_state_mutation.py
+PYTHONPATH=. .venv/bin/pytest -q \
+  tests/test_city_state_mutation_cli.py \
+  tests/test_flush_city_pipeline_state.py \
+  tests/test_reset_city_verification_baseline.py \
+  tests/test_reset_city_verification_state.py \
+  tests/test_city_onboarding_runner.py \
+  tests/test_city_onboarding_wave_script_contract.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py
+PYTHONPATH=. .venv/bin/python -m pytest -q --cov \
+  --cov-config=.coveragerc \
+  --cov-report=term-missing:skip-covered \
+  tests/
+PYTHONPATH=. .venv/bin/pytest -q
+git diff --check
+git status --short
+```
+
+Delivery:
+
+```bash
+git push -u origin codex/t-dd-1b-city-state-mutation
+gh pr create --base master --head codex/t-dd-1b-city-state-mutation \
+  --title "T-DD-1B: Consolidate city event-graph mutation"
+```
+
+**v) Rollback.** Revert the T-DD-1B merge commit and rerun focused command
+tests, onboarding contracts, Ruff, Mypy, docs links, coverage, and the complete
+suite. No migration, data repair, config restoration, or external cleanup is
+required.
+
+**w) Docs sync.** Update this plan, the remediation ledger, and only the
+pending-city rewind deletion list in `docs/OPERATIONS.md` so its existing
+`data_issue` deletion is explicit. Command names, flags, defaults, and safety
+requirements remain unchanged. README, ADR, architecture review, testing
+policy, guardrails, API contracts, security, and governance docs remain
+unchanged.
+
+## 7. Delivery Self-Audit
+
+**x) Antipattern scan, diff pass.** Re-run A-F/H. Reject shared stage or event
+selection, helper commits, compatibility exports, CLI-to-CLI imports, generic
+frameworks, changed flags/defaults/JSON, widened exceptions, weakened tests,
+or edits outside ownership.
+
+**y) Evidence.** Report characterization results, all commands in 6u,
+planning/pre-commit findings, applied fixes, commit hashes, PR URL, unresolved
+threads, and final CI state. Mark anything unrun `NOT VERIFIED`.
+
+**z) Deviations.** Expected result is none. Any additional file, altered
+operator contract, schema/runtime change, unowned refactor, skipped review,
+unresolved P1/P2, or unrun required check is a blocker.

--- a/scripts/city_state_mutation.py
+++ b/scripts/city_state_mutation.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session, selectinload
+
+from pipeline.models import Catalog, DataIssue, Document, Event
+
+
+@dataclass(frozen=True)
+class CityEventGraphMutation:
+    event_ids: list[int]
+    document_ids: list[int]
+    catalog_ids: list[int]
+    unreferenced_catalog_ids: list[int]
+    data_issue_ids: list[int]
+
+
+def city_ocd_division_id(city: str) -> str:
+    return f"ocd-division/country:us/state:ca/place:{city}"
+
+
+def _catalog_reference_counts(
+    session: Session,
+    catalog_ids: list[int],
+    document_ids: list[int],
+) -> tuple[dict[int, int], dict[int, int]]:
+    reference_counts = {
+        row.catalog_id: row.ref_count
+        for row in (
+            session.query(
+                Document.catalog_id,
+                func.count(Document.id).label("ref_count"),
+            )
+            .filter(Document.catalog_id.in_(catalog_ids))
+            .group_by(Document.catalog_id)
+            .all()
+        )
+    }
+    selected_counts = {
+        row.catalog_id: row.ref_count
+        for row in (
+            session.query(
+                Document.catalog_id,
+                func.count(Document.id).label("ref_count"),
+            )
+            .filter(Document.id.in_(document_ids))
+            .group_by(Document.catalog_id)
+            .all()
+        )
+    }
+    return reference_counts, selected_counts
+
+
+def _unreferenced_catalog_ids(
+    session: Session,
+    catalog_ids: list[int],
+    document_ids: list[int],
+) -> list[int]:
+    if not catalog_ids:
+        return []
+
+    reference_counts, selected_counts = _catalog_reference_counts(
+        session,
+        catalog_ids,
+        document_ids,
+    )
+    return sorted(
+        catalog_id
+        for catalog_id in catalog_ids
+        if reference_counts.get(catalog_id, 0) == selected_counts.get(catalog_id, 0)
+    )
+
+
+def collect_event_graph_mutation(
+    session: Session,
+    selected_events: list[Event],
+) -> CityEventGraphMutation:
+    event_ids = [int(event.id) for event in selected_events]
+    document_ids = [
+        int(document.id)
+        for event in selected_events
+        for document in event.documents
+    ]
+    catalog_ids = sorted(
+        {
+            int(document.catalog_id)
+            for event in selected_events
+            for document in event.documents
+            if document.catalog_id is not None
+        }
+    )
+    data_issue_ids = (
+        [
+            row[0]
+            for row in (
+                session.query(DataIssue.id)
+                .filter(DataIssue.event_id.in_(event_ids))
+                .all()
+            )
+        ]
+        if event_ids
+        else []
+    )
+    return CityEventGraphMutation(
+        event_ids=event_ids,
+        document_ids=document_ids,
+        catalog_ids=catalog_ids,
+        unreferenced_catalog_ids=_unreferenced_catalog_ids(
+            session,
+            catalog_ids,
+            document_ids,
+        ),
+        data_issue_ids=data_issue_ids,
+    )
+
+
+def delete_event_graph(
+    session: Session,
+    mutation: CityEventGraphMutation,
+) -> None:
+    if mutation.data_issue_ids:
+        (
+            session.query(DataIssue)
+            .filter(DataIssue.id.in_(mutation.data_issue_ids))
+            .delete(synchronize_session=False)
+        )
+
+    if mutation.event_ids:
+        events = (
+            session.query(Event)
+            .options(selectinload(Event.documents))
+            .filter(Event.id.in_(mutation.event_ids))
+            .all()
+        )
+        for event in events:
+            session.delete(event)
+
+    if mutation.unreferenced_catalog_ids:
+        catalogs = (
+            session.query(Catalog)
+            .filter(Catalog.id.in_(mutation.unreferenced_catalog_ids))
+            .all()
+        )
+        for catalog in catalogs:
+            session.delete(catalog)

--- a/scripts/flush_city_pipeline_state.py
+++ b/scripts/flush_city_pipeline_state.py
@@ -9,8 +9,9 @@ from sqlalchemy import func
 from sqlalchemy.orm import selectinload
 
 from pipeline.db_session import db_session
-from pipeline.models import Catalog, DataIssue, Document, Event, EventStage, UrlStage, UrlStageHist
+from pipeline.models import Catalog, Document, Event, EventStage, UrlStage, UrlStageHist
 from pipeline.rollout_registry import CITY_SLUG_RE
+from scripts import city_state_mutation
 
 
 @dataclass(frozen=True)
@@ -18,15 +19,7 @@ class FlushCounts:
     event_stage_ids: list[int]
     url_stage_ids: list[int]
     url_stage_hist_ids: list[int]
-    event_ids: list[int]
-    document_ids: list[int]
-    catalog_ids: list[int]
-    unreferenced_catalog_ids: list[int]
-    data_issue_ids: list[int]
-
-
-def _ocd_division_id_for_city(city: str) -> str:
-    return f"ocd-division/country:us/state:ca/place:{city}"
+    event_graph: city_state_mutation.CityEventGraphMutation
 
 
 def _validate_city_slug(city: str) -> None:
@@ -35,7 +28,7 @@ def _validate_city_slug(city: str) -> None:
 
 
 def _collect_stage_ids(session, city: str) -> tuple[list[int], list[int], list[int]]:
-    ocd_division_id = _ocd_division_id_for_city(city)
+    ocd_division_id = city_state_mutation.city_ocd_division_id(city)
     event_stage_ids = [row[0] for row in session.query(EventStage.id).filter(EventStage.ocd_division_id == ocd_division_id).all()]
     url_stage_ids = [row[0] for row in session.query(UrlStage.id).filter(UrlStage.ocd_division_id == ocd_division_id).all()]
     url_stage_hist_ids = [
@@ -45,70 +38,29 @@ def _collect_stage_ids(session, city: str) -> tuple[list[int], list[int], list[i
     return event_stage_ids, url_stage_ids, url_stage_hist_ids
 
 
-def _collect_live_ids(session, city: str) -> tuple[list[int], list[int], list[int], list[int], list[int]]:
-    ocd_division_id = _ocd_division_id_for_city(city)
+def _collect_live_graph(session, city: str) -> city_state_mutation.CityEventGraphMutation:
+    ocd_division_id = city_state_mutation.city_ocd_division_id(city)
     events = (
         session.query(Event)
         .options(selectinload(Event.documents))
         .filter(Event.ocd_division_id == ocd_division_id)
         .all()
     )
-    event_ids = [event.id for event in events]
-    document_ids = [document.id for event in events for document in event.documents]
-    catalog_ids = sorted(
-        {document.catalog_id for event in events for document in event.documents if document.catalog_id is not None}
-    )
-    data_issue_ids = (
-        [row[0] for row in session.query(DataIssue.id).filter(DataIssue.event_id.in_(event_ids)).all()] if event_ids else []
-    )
-
-    unreferenced_catalog_ids: list[int] = []
-    if catalog_ids:
-        # A city flush should not delete a catalog that is still linked to another city.
-        ref_counts = {
-            row.catalog_id: row.ref_count
-            for row in (
-                session.query(Document.catalog_id, func.count(Document.id).label("ref_count"))
-                .filter(Document.catalog_id.in_(catalog_ids))
-                .group_by(Document.catalog_id)
-                .all()
-            )
-        }
-        targeted_counts = {
-            row.catalog_id: row.ref_count
-            for row in (
-                session.query(Document.catalog_id, func.count(Document.id).label("ref_count"))
-                .filter(Document.id.in_(document_ids))
-                .group_by(Document.catalog_id)
-                .all()
-            )
-        }
-        unreferenced_catalog_ids = sorted(
-            catalog_id
-            for catalog_id in catalog_ids
-            if ref_counts.get(catalog_id, 0) == targeted_counts.get(catalog_id, 0)
-        )
-
-    return event_ids, document_ids, catalog_ids, unreferenced_catalog_ids, data_issue_ids
+    return city_state_mutation.collect_event_graph_mutation(session, events)
 
 
 def _collect_flush_counts(session, city: str) -> FlushCounts:
     event_stage_ids, url_stage_ids, url_stage_hist_ids = _collect_stage_ids(session, city)
-    event_ids, document_ids, catalog_ids, unreferenced_catalog_ids, data_issue_ids = _collect_live_ids(session, city)
     return FlushCounts(
         event_stage_ids=event_stage_ids,
         url_stage_ids=url_stage_ids,
         url_stage_hist_ids=url_stage_hist_ids,
-        event_ids=event_ids,
-        document_ids=document_ids,
-        catalog_ids=catalog_ids,
-        unreferenced_catalog_ids=unreferenced_catalog_ids,
-        data_issue_ids=data_issue_ids,
+        event_graph=_collect_live_graph(session, city),
     )
 
 
 def _remaining_summary(session, city: str) -> dict[str, int]:
-    ocd_division_id = _ocd_division_id_for_city(city)
+    ocd_division_id = city_state_mutation.city_ocd_division_id(city)
     remaining_event_count = session.query(func.count(Event.id)).filter(Event.ocd_division_id == ocd_division_id).scalar() or 0
     remaining_document_count = (
         session.query(func.count(Document.id))
@@ -148,22 +100,21 @@ def flush_city_pipeline_state(city: str, *, dry_run: bool = True) -> dict[str, i
     _validate_city_slug(city)
     with db_session() as session:
         counts = _collect_flush_counts(session, city)
+        event_graph = counts.event_graph
         summary: dict[str, int | str | bool] = {
             "city": city,
             "dry_run": dry_run,
             "deleted_event_stage_count": len(counts.event_stage_ids),
             "deleted_url_stage_count": len(counts.url_stage_ids),
             "deleted_url_stage_hist_count": len(counts.url_stage_hist_ids),
-            "deleted_event_count": len(counts.event_ids),
-            "deleted_document_count": len(counts.document_ids),
-            "deleted_catalog_count": len(counts.unreferenced_catalog_ids),
-            "catalog_reference_count": len(counts.catalog_ids),
-            "deleted_data_issue_count": len(counts.data_issue_ids),
+            "deleted_event_count": len(event_graph.event_ids),
+            "deleted_document_count": len(event_graph.document_ids),
+            "deleted_catalog_count": len(event_graph.unreferenced_catalog_ids),
+            "catalog_reference_count": len(event_graph.catalog_ids),
+            "deleted_data_issue_count": len(event_graph.data_issue_ids),
         }
 
         if not dry_run:
-            if counts.data_issue_ids:
-                session.query(DataIssue).filter(DataIssue.id.in_(counts.data_issue_ids)).delete(synchronize_session=False)
             if counts.event_stage_ids:
                 session.query(EventStage).filter(EventStage.id.in_(counts.event_stage_ids)).delete(synchronize_session=False)
             if counts.url_stage_ids:
@@ -172,17 +123,7 @@ def flush_city_pipeline_state(city: str, *, dry_run: bool = True) -> dict[str, i
                 session.query(UrlStageHist).filter(UrlStageHist.id.in_(counts.url_stage_hist_ids)).delete(
                     synchronize_session=False
                 )
-            if counts.event_ids:
-                for event in (
-                    session.query(Event)
-                    .options(selectinload(Event.documents))
-                    .filter(Event.id.in_(counts.event_ids))
-                    .all()
-                ):
-                    session.delete(event)
-            if counts.unreferenced_catalog_ids:
-                for catalog in session.query(Catalog).filter(Catalog.id.in_(counts.unreferenced_catalog_ids)).all():
-                    session.delete(catalog)
+            city_state_mutation.delete_event_graph(session, event_graph)
             session.commit()
 
         summary.update(_remaining_summary(session, city))

--- a/scripts/reset_city_verification_state.py
+++ b/scripts/reset_city_verification_state.py
@@ -10,19 +10,11 @@ from sqlalchemy import and_, func, or_
 from sqlalchemy.orm import selectinload
 
 from pipeline.db_session import db_session
-from pipeline.models import Catalog, DataIssue, Document, Event
+from pipeline.models import Event
+from scripts import city_state_mutation
 
 
 ISO_FMT = "%Y-%m-%dT%H:%M:%SZ"
-
-
-@dataclass(frozen=True)
-class RewindCounts:
-    event_ids: list[int]
-    document_ids: list[int]
-    catalog_ids: list[int]
-    unreferenced_catalog_ids: list[int]
-    data_issue_ids: list[int]
 
 
 @dataclass(frozen=True)
@@ -42,55 +34,12 @@ def _format_iso_utc(value: datetime) -> str:
     return aware_value.astimezone(UTC).strftime(ISO_FMT)
 
 
-def _ocd_division_id_for_city(city: str) -> str:
-    return f"ocd-division/country:us/state:ca/place:{city}"
-
-
-def _rewind_counts_from_events(session, events: list[Event]) -> RewindCounts:
-    event_ids = [event.id for event in events]
-    document_ids = [document.id for event in events for document in event.documents]
-    catalog_ids = sorted({document.catalog_id for event in events for document in event.documents if document.catalog_id is not None})
-    data_issue_ids = [row[0] for row in session.query(DataIssue.id).filter(DataIssue.event_id.in_(event_ids)).all()] if event_ids else []
-
-    unreferenced_catalog_ids: list[int] = []
-    if catalog_ids:
-        # Catalog rows may survive document deletion in the DB, so only remove
-        # catalogs whose entire reference set belongs to the rewound city window.
-        ref_counts = {
-            row.catalog_id: row.ref_count
-            for row in (
-                session.query(Document.catalog_id, func.count(Document.id).label("ref_count"))
-                .filter(Document.catalog_id.in_(catalog_ids))
-                .group_by(Document.catalog_id)
-                .all()
-            )
-        }
-        targeted_counts = {
-            row.catalog_id: row.ref_count
-            for row in (
-                session.query(Document.catalog_id, func.count(Document.id).label("ref_count"))
-                .filter(Document.id.in_(document_ids))
-                .group_by(Document.catalog_id)
-                .all()
-            )
-        }
-        unreferenced_catalog_ids = sorted(
-            catalog_id
-            for catalog_id in catalog_ids
-            if ref_counts.get(catalog_id, 0) == targeted_counts.get(catalog_id, 0)
-        )
-
-    return RewindCounts(
-        event_ids=event_ids,
-        document_ids=document_ids,
-        catalog_ids=catalog_ids,
-        unreferenced_catalog_ids=unreferenced_catalog_ids,
-        data_issue_ids=data_issue_ids,
-    )
-
-
-def _collect_rewind_counts(session, city: str, since_dt: datetime) -> RewindCounts:
-    ocd_division_id = _ocd_division_id_for_city(city)
+def _collect_rewind_counts(
+    session,
+    city: str,
+    since_dt: datetime,
+) -> city_state_mutation.CityEventGraphMutation:
+    ocd_division_id = city_state_mutation.city_ocd_division_id(city)
     events = (
         session.query(Event)
         .options(selectinload(Event.documents))
@@ -100,7 +49,7 @@ def _collect_rewind_counts(session, city: str, since_dt: datetime) -> RewindCoun
         )
         .all()
     )
-    return _rewind_counts_from_events(session, events)
+    return city_state_mutation.collect_event_graph_mutation(session, events)
 
 
 def _collect_anchor_rewind_counts(
@@ -108,8 +57,8 @@ def _collect_anchor_rewind_counts(
     city: str,
     since_dt: datetime,
     baseline_record_date: date | None,
-) -> RewindCounts:
-    ocd_division_id = _ocd_division_id_for_city(city)
+) -> city_state_mutation.CityEventGraphMutation:
+    ocd_division_id = city_state_mutation.city_ocd_division_id(city)
     query = session.query(Event).options(selectinload(Event.documents)).filter(Event.ocd_division_id == ocd_division_id)
     if baseline_record_date is None:
         events = query.filter(Event.scraped_datetime >= since_dt).all()
@@ -123,12 +72,12 @@ def _collect_anchor_rewind_counts(
                 ),
             )
         ).all()
-    return _rewind_counts_from_events(session, events)
+    return city_state_mutation.collect_event_graph_mutation(session, events)
 
 
 def capture_city_verification_baseline(city: str) -> dict[str, str | int | None]:
     with db_session() as session:
-        ocd_division_id = _ocd_division_id_for_city(city)
+        ocd_division_id = city_state_mutation.city_ocd_division_id(city)
         max_record_date, max_scraped_datetime, event_count = (
             session.query(
                 func.max(Event.record_date),
@@ -157,7 +106,7 @@ def capture_city_verification_baseline(city: str) -> dict[str, str | int | None]
 
 
 def _remaining_anchor_summary(session, city: str) -> dict[str, str | int | None]:
-    ocd_division_id = _ocd_division_id_for_city(city)
+    ocd_division_id = city_state_mutation.city_ocd_division_id(city)
     max_record_date, max_scraped_datetime, remaining_event_count = (
         session.query(
             func.max(Event.record_date),
@@ -202,24 +151,7 @@ def reset_city_verification_state(
         }
 
         if not dry_run:
-            if counts.data_issue_ids:
-                session.query(DataIssue).filter(DataIssue.id.in_(counts.data_issue_ids)).delete(
-                    synchronize_session=False
-                )
-
-            if counts.event_ids:
-                for event in (
-                    session.query(Event)
-                    .options(selectinload(Event.documents))
-                    .filter(Event.id.in_(counts.event_ids))
-                    .all()
-                ):
-                    session.delete(event)
-
-            if counts.unreferenced_catalog_ids:
-                for catalog in session.query(Catalog).filter(Catalog.id.in_(counts.unreferenced_catalog_ids)).all():
-                    session.delete(catalog)
-
+            city_state_mutation.delete_event_graph(session, counts)
             session.commit()
 
         summary.update(_remaining_anchor_summary(session, city))

--- a/tests/test_city_state_mutation_cli.py
+++ b/tests/test_city_state_mutation_cli.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from sqlalchemy import create_engine
+
+from pipeline.models import Base
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FLUSH_SCRIPT = ROOT / "scripts/flush_city_pipeline_state.py"
+RESET_SCRIPT = ROOT / "scripts/reset_city_verification_state.py"
+
+
+def _create_empty_database(database_path: Path) -> None:
+    engine = create_engine(f"sqlite:///{database_path}")
+    Base.metadata.create_all(engine)
+    engine.dispose()
+
+
+def _run_city_state_command(
+    script_path: Path,
+    arguments: list[str],
+    database_path: Path,
+) -> dict[str, int | str | bool | None]:
+    environment = os.environ.copy()
+    environment["DATABASE_URL"] = f"sqlite:///{database_path}"
+    environment["PYTHONPATH"] = str(ROOT)
+    completed = subprocess.run(
+        [sys.executable, str(script_path), *arguments],
+        cwd=ROOT,
+        env=environment,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+    return json.loads(completed.stdout)
+
+
+def test_city_state_clis_preserve_distinct_defaults_and_json_contracts(tmp_path: Path) -> None:
+    database_path = tmp_path / "city_state_cli.sqlite"
+    _create_empty_database(database_path)
+
+    flush_summary = _run_city_state_command(
+        FLUSH_SCRIPT,
+        ["--city", "fremont"],
+        database_path,
+    )
+    reset_summary = _run_city_state_command(
+        RESET_SCRIPT,
+        ["--city", "fremont", "--since", "2026-03-15T13:21:09Z"],
+        database_path,
+    )
+
+    assert flush_summary == {
+        "catalog_reference_count": 0,
+        "city": "fremont",
+        "deleted_catalog_count": 0,
+        "deleted_data_issue_count": 0,
+        "deleted_document_count": 0,
+        "deleted_event_count": 0,
+        "deleted_event_stage_count": 0,
+        "deleted_url_stage_count": 0,
+        "deleted_url_stage_hist_count": 0,
+        "dry_run": True,
+        "remaining_catalog_count": 0,
+        "remaining_document_count": 0,
+        "remaining_event_count": 0,
+        "remaining_event_stage_count": 0,
+        "remaining_url_stage_count": 0,
+        "remaining_url_stage_hist_count": 0,
+    }
+    assert reset_summary == {
+        "baseline_record_date": None,
+        "catalog_reference_count": 0,
+        "city": "fremont",
+        "deleted_catalog_count": 0,
+        "deleted_data_issue_count": 0,
+        "deleted_document_count": 0,
+        "deleted_event_count": 0,
+        "dry_run": False,
+        "remaining_event_count": 0,
+        "remaining_max_record_date": None,
+        "remaining_max_scraped_datetime": None,
+        "since": "2026-03-15T13:21:09Z",
+    }

--- a/tests/test_flush_city_pipeline_state.py
+++ b/tests/test_flush_city_pipeline_state.py
@@ -1,15 +1,20 @@
 from __future__ import annotations
 
-from datetime import date, datetime
+from datetime import UTC, date, datetime
 from pathlib import Path
 
 import pytest
 from sqlalchemy import create_engine
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import sessionmaker
 
 import pipeline.db_session as db_session_module
 from pipeline.models import Base, Catalog, DataIssue, Document, Event, EventStage, Place, UrlStage, UrlStageHist
 from scripts.flush_city_pipeline_state import flush_city_pipeline_state
+
+
+TEST_SCRAPED_AT = datetime(2026, 4, 4, 12, tzinfo=UTC)
 
 
 def _setup_session(db_path: Path, monkeypatch) -> sessionmaker:
@@ -34,7 +39,13 @@ def test_flush_city_pipeline_state_dry_run_reports_counts_without_deleting(tmp_p
         session.add(place)
         session.flush()
 
-        session.add(EventStage(ocd_division_id=place.ocd_division_id, name="Stage", scraped_datetime=datetime.utcnow()))
+        session.add(
+            EventStage(
+                ocd_division_id=place.ocd_division_id,
+                name="Stage",
+                scraped_datetime=TEST_SCRAPED_AT,
+            )
+        )
         session.add(UrlStage(ocd_division_id=place.ocd_division_id, event="Stage", event_date=date(2026, 4, 4), url="https://example.com/a.pdf", url_hash="a", category="agenda"))
         session.add(UrlStageHist(ocd_division_id=place.ocd_division_id, event="Stage", event_date=date(2026, 4, 4), url="https://example.com/a.pdf", url_hash="a", category="agenda"))
 
@@ -42,7 +53,7 @@ def test_flush_city_pipeline_state_dry_run_reports_counts_without_deleting(tmp_p
             ocd_id="event-1",
             ocd_division_id=place.ocd_division_id,
             place_id=place.id,
-            scraped_datetime=datetime.utcnow(),
+            scraped_datetime=TEST_SCRAPED_AT,
             record_date=date(2026, 4, 4),
             source="san_leandro",
             source_url="https://example.com/event",
@@ -101,8 +112,16 @@ def test_flush_city_pipeline_state_apply_deletes_city_scoped_stage_and_live_rows
 
         session.add_all(
             [
-                EventStage(ocd_division_id=target_place.ocd_division_id, name="Target", scraped_datetime=datetime.utcnow()),
-                EventStage(ocd_division_id=other_place.ocd_division_id, name="Other", scraped_datetime=datetime.utcnow()),
+                EventStage(
+                    ocd_division_id=target_place.ocd_division_id,
+                    name="Target",
+                    scraped_datetime=TEST_SCRAPED_AT,
+                ),
+                EventStage(
+                    ocd_division_id=other_place.ocd_division_id,
+                    name="Other",
+                    scraped_datetime=TEST_SCRAPED_AT,
+                ),
                 UrlStage(ocd_division_id=target_place.ocd_division_id, event="Target", event_date=date(2026, 4, 4), url="https://example.com/target.pdf", url_hash="target-stage", category="agenda"),
                 UrlStage(ocd_division_id=other_place.ocd_division_id, event="Other", event_date=date(2026, 4, 4), url="https://example.com/other.pdf", url_hash="other-stage", category="agenda"),
                 UrlStageHist(ocd_division_id=target_place.ocd_division_id, event="Target", event_date=date(2026, 4, 4), url="https://example.com/target.pdf", url_hash="target-stage", category="agenda"),
@@ -114,7 +133,7 @@ def test_flush_city_pipeline_state_apply_deletes_city_scoped_stage_and_live_rows
             ocd_id="target-event",
             ocd_division_id=target_place.ocd_division_id,
             place_id=target_place.id,
-            scraped_datetime=datetime.utcnow(),
+            scraped_datetime=TEST_SCRAPED_AT,
             record_date=date(2026, 4, 4),
             source="san_leandro",
             source_url="https://example.com/target-event",
@@ -124,7 +143,7 @@ def test_flush_city_pipeline_state_apply_deletes_city_scoped_stage_and_live_rows
             ocd_id="other-event",
             ocd_division_id=other_place.ocd_division_id,
             place_id=other_place.id,
-            scraped_datetime=datetime.utcnow(),
+            scraped_datetime=TEST_SCRAPED_AT,
             record_date=date(2026, 4, 4),
             source="berkeley",
             source_url="https://example.com/other-event",
@@ -139,9 +158,15 @@ def test_flush_city_pipeline_state_apply_deletes_city_scoped_stage_and_live_rows
                 Document(place_id=target_place.id, event_id=target_event.id, catalog_id=shared_catalog.id, url_hash="shared"),
                 Document(place_id=other_place.id, event_id=other_event.id, catalog_id=shared_catalog.id, url_hash="shared"),
                 Document(place_id=target_place.id, event_id=target_event.id, catalog_id=target_only_catalog.id, url_hash="target-only"),
+                Document(place_id=target_place.id, event_id=target_event.id, catalog_id=None, url_hash="catalogless"),
             ]
         )
-        session.add(DataIssue(event_id=target_event.id, issue_type="broken_link"))
+        session.add_all(
+            [
+                DataIssue(event_id=target_event.id, issue_type="broken_link"),
+                DataIssue(event_id=other_event.id, issue_type="other_city_issue"),
+            ]
+        )
         session.commit()
 
     result = flush_city_pipeline_state("san_leandro", dry_run=False)
@@ -151,7 +176,7 @@ def test_flush_city_pipeline_state_apply_deletes_city_scoped_stage_and_live_rows
     assert result["deleted_url_stage_count"] == 1
     assert result["deleted_url_stage_hist_count"] == 1
     assert result["deleted_event_count"] == 1
-    assert result["deleted_document_count"] == 2
+    assert result["deleted_document_count"] == 3
     assert result["deleted_catalog_count"] == 1
     assert result["catalog_reference_count"] == 2
     assert result["deleted_data_issue_count"] == 1
@@ -178,7 +203,74 @@ def test_flush_city_pipeline_state_apply_deletes_city_scoped_stage_and_live_rows
         assert session.query(Document).count() == 1
         assert session.query(Catalog).count() == 1
         assert session.query(Catalog).one().url_hash == "shared"
-        assert session.query(DataIssue).count() == 0
+        assert session.query(DataIssue).count() == 1
+        assert session.query(DataIssue).one().issue_type == "other_city_issue"
+
+
+def test_flush_city_pipeline_state_rolls_back_stage_and_live_deletes_on_late_failure(tmp_path, monkeypatch):
+    Session = _setup_session(tmp_path / "flush_rollback.sqlite", monkeypatch)
+
+    with Session() as session:
+        place = Place(
+            name="San Leandro",
+            state="CA",
+            country="us",
+            display_name="San Leandro, CA",
+            ocd_division_id="ocd-division/country:us/state:ca/place:san_leandro",
+        )
+        session.add(place)
+        session.flush()
+        event = Event(
+            ocd_id="rollback-event",
+            ocd_division_id=place.ocd_division_id,
+            place_id=place.id,
+            scraped_datetime=TEST_SCRAPED_AT,
+            record_date=date(2026, 4, 4),
+            source="san_leandro",
+            source_url="https://example.com/rollback",
+            name="Rollback meeting",
+        )
+        catalog = Catalog(url_hash="rollback", location="/tmp/rollback.pdf")
+        session.add_all(
+            [
+                EventStage(
+                    ocd_division_id=place.ocd_division_id,
+                    name="Rollback stage",
+                    scraped_datetime=TEST_SCRAPED_AT,
+                ),
+                event,
+                catalog,
+            ]
+        )
+        session.flush()
+        session.add(
+            Document(
+                place_id=place.id,
+                event_id=event.id,
+                catalog_id=catalog.id,
+                url_hash="rollback",
+            )
+        )
+        session.add(DataIssue(event_id=event.id, issue_type="rollback_issue"))
+        session.commit()
+        session.execute(
+            text(
+                "CREATE TRIGGER abort_catalog_delete "
+                "BEFORE DELETE ON catalog "
+                "BEGIN SELECT RAISE(ABORT, 'catalog delete blocked'); END"
+            )
+        )
+        session.commit()
+
+    with pytest.raises(IntegrityError, match="catalog delete blocked"):
+        flush_city_pipeline_state("san_leandro", dry_run=False)
+
+    with Session() as session:
+        assert session.query(EventStage).count() == 1
+        assert session.query(Event).count() == 1
+        assert session.query(Document).count() == 1
+        assert session.query(Catalog).count() == 1
+        assert session.query(DataIssue).count() == 1
 
 
 def test_flush_city_pipeline_state_rejects_invalid_city_slug():

--- a/tests/test_reset_city_verification_baseline.py
+++ b/tests/test_reset_city_verification_baseline.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from datetime import UTC, date, datetime, timedelta, timezone
+from pathlib import Path
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+import pipeline.db_session as db_session_module
+from pipeline.models import Base, Catalog, Document, Event, Place
+from scripts import reset_city_verification_state as reset_module
+from scripts.reset_city_verification_state import (
+    capture_city_verification_baseline,
+    reset_city_verification_state,
+)
+
+
+def _setup_city_graph(db_path: Path, monkeypatch) -> sessionmaker:
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+    db_session_module._SessionLocal = None
+    engine = create_engine(f"sqlite:///{db_path}")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)
+
+
+def test_verification_reset_parser_returns_aware_utc():
+    parsed_at = reset_module._parse_iso_utc("2026-03-15T13:21:09Z")
+
+    assert parsed_at == datetime(2026, 3, 15, 13, 21, 9, tzinfo=UTC)
+    assert parsed_at.utcoffset() == timedelta(0)
+
+
+def test_verification_artifacts_normalize_offset_timestamps_to_utc(monkeypatch, mocker):
+    offset_timestamp = datetime(
+        2026,
+        7,
+        25,
+        5,
+        30,
+        tzinfo=timezone(timedelta(hours=-7)),
+    )
+    session = mocker.MagicMock()
+    session.query.return_value.filter.return_value.one.return_value = (
+        date(2026, 7, 25),
+        offset_timestamp,
+        1,
+    )
+
+    @contextmanager
+    def verification_session():
+        yield session
+
+    monkeypatch.setattr(reset_module, "db_session", verification_session)
+
+    baseline = reset_module.capture_city_verification_baseline("sunnyvale")
+    remaining = reset_module._remaining_anchor_summary(session, "sunnyvale")
+
+    assert baseline["baseline_max_scraped_datetime"] == "2026-07-25T12:30:00Z"
+    assert remaining["remaining_max_scraped_datetime"] == "2026-07-25T12:30:00Z"
+
+
+def test_capture_city_verification_baseline_reports_city_anchor(tmp_path, monkeypatch):
+    Session = _setup_city_graph(tmp_path / "baseline.sqlite", monkeypatch)
+    now = datetime.now(UTC).replace(tzinfo=None, microsecond=0)
+
+    with Session() as session:
+        place = Place(
+            name="Sunnyvale",
+            state="CA",
+            country="us",
+            display_name="Sunnyvale, CA",
+            ocd_division_id="ocd-division/country:us/state:ca/place:sunnyvale",
+        )
+        session.add(place)
+        session.flush()
+        session.add_all(
+            [
+                Event(
+                    ocd_id="early",
+                    ocd_division_id=place.ocd_division_id,
+                    place_id=place.id,
+                    scraped_datetime=now,
+                    record_date=date(2026, 3, 1),
+                    source="sunnyvale",
+                    source_url="https://example.com/early",
+                    name="Early meeting",
+                ),
+                Event(
+                    ocd_id="late",
+                    ocd_division_id=place.ocd_division_id,
+                    place_id=place.id,
+                    scraped_datetime=now + timedelta(days=1),
+                    record_date=date(2026, 3, 7),
+                    source="sunnyvale",
+                    source_url="https://example.com/late",
+                    name="Late meeting",
+                ),
+            ]
+        )
+        session.commit()
+
+    result = capture_city_verification_baseline("sunnyvale")
+
+    assert result["city"] == "sunnyvale"
+    assert result["baseline_event_count"] == 2
+    assert result["baseline_max_record_date"] == "2026-03-07"
+    assert result["baseline_max_scraped_datetime"] == (now + timedelta(days=1)).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+
+
+def test_reset_city_verification_state_rewinds_to_baseline_record_date(tmp_path, monkeypatch):
+    Session = _setup_city_graph(tmp_path / "anchor_reset.sqlite", monkeypatch)
+    campaign_started_at = datetime(2026, 3, 15, 13, 21, 9)
+
+    with Session() as session:
+        place = Place(
+            name="Sunnyvale",
+            state="CA",
+            country="us",
+            display_name="Sunnyvale, CA",
+            ocd_division_id="ocd-division/country:us/state:ca/place:sunnyvale",
+        )
+        session.add(place)
+        session.flush()
+
+        preserved_same_day = Event(
+            ocd_id="baseline-same-day",
+            ocd_division_id=place.ocd_division_id,
+            place_id=place.id,
+            scraped_datetime=campaign_started_at - timedelta(days=1),
+            record_date=date(2026, 3, 10),
+            source="sunnyvale",
+            source_url="https://example.com/baseline-same-day",
+            name="Baseline same-day meeting",
+        )
+        future_event = Event(
+            ocd_id="future-run-one",
+            ocd_division_id=place.ocd_division_id,
+            place_id=place.id,
+            scraped_datetime=campaign_started_at + timedelta(minutes=2),
+            record_date=date(2026, 5, 18),
+            source="sunnyvale",
+            source_url="https://example.com/future",
+            name="Future meeting",
+        )
+        same_day_run_one = Event(
+            ocd_id="same-day-run-one",
+            ocd_division_id=place.ocd_division_id,
+            place_id=place.id,
+            scraped_datetime=campaign_started_at + timedelta(minutes=3),
+            record_date=date(2026, 3, 10),
+            source="sunnyvale",
+            source_url="https://example.com/same-day-run-one",
+            name="Same day run-one meeting",
+        )
+        session.add_all([preserved_same_day, future_event, same_day_run_one])
+        session.flush()
+
+        future_catalog = Catalog(url_hash="future", location="/tmp/future.pdf")
+        same_day_catalog = Catalog(url_hash="same-day", location="/tmp/same-day.pdf")
+        session.add_all([future_catalog, same_day_catalog])
+        session.flush()
+        session.add_all(
+            [
+                Document(
+                    place_id=place.id,
+                    event_id=future_event.id,
+                    catalog_id=future_catalog.id,
+                    url_hash="future",
+                ),
+                Document(
+                    place_id=place.id,
+                    event_id=same_day_run_one.id,
+                    catalog_id=same_day_catalog.id,
+                    url_hash="same-day",
+                ),
+            ]
+        )
+        session.commit()
+
+    result = reset_city_verification_state(
+        "sunnyvale",
+        campaign_started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        baseline_record_date="2026-03-10",
+    )
+
+    assert result["deleted_event_count"] == 2
+    assert result["deleted_document_count"] == 2
+    assert result["deleted_catalog_count"] == 2
+    assert result["remaining_event_count"] == 1
+    assert result["remaining_max_record_date"] == "2026-03-10"
+    assert result["remaining_max_scraped_datetime"] == (
+        campaign_started_at - timedelta(days=1)
+    ).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    with Session() as session:
+        remaining_events = session.query(Event).all()
+        assert [event.ocd_id for event in remaining_events] == ["baseline-same-day"]

--- a/tests/test_reset_city_verification_state.py
+++ b/tests/test_reset_city_verification_state.py
@@ -2,18 +2,18 @@ from __future__ import annotations
 
 import importlib.util
 import sys
-from contextlib import contextmanager
-from datetime import UTC, date, datetime, timedelta, timezone
+from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
 
 import pytest
 from sqlalchemy import create_engine
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import sessionmaker
 
 import pipeline.db_session as db_session_module
-from pipeline.models import Base, Catalog, Document, Event, EventStage, Place, UrlStage, UrlStageHist
-from scripts.reset_city_verification_state import capture_city_verification_baseline, reset_city_verification_state
-from scripts import reset_city_verification_state as reset_module
+from pipeline.models import Base, Catalog, DataIssue, Document, Event, EventStage, Place, UrlStage, UrlStageHist
+from scripts.reset_city_verification_state import reset_city_verification_state
 
 
 def _load_rewind_module():
@@ -32,42 +32,6 @@ def _setup_city_graph(db_path: Path, monkeypatch) -> sessionmaker:
     engine = create_engine(f"sqlite:///{db_path}")
     Base.metadata.create_all(engine)
     return sessionmaker(bind=engine)
-
-
-def test_verification_reset_parser_returns_aware_utc():
-    parsed_at = reset_module._parse_iso_utc("2026-03-15T13:21:09Z")
-
-    assert parsed_at == datetime(2026, 3, 15, 13, 21, 9, tzinfo=UTC)
-    assert parsed_at.utcoffset() == timedelta(0)
-
-
-def test_verification_artifacts_normalize_offset_timestamps_to_utc(monkeypatch, mocker):
-    offset_timestamp = datetime(
-        2026,
-        7,
-        25,
-        5,
-        30,
-        tzinfo=timezone(timedelta(hours=-7)),
-    )
-    session = mocker.MagicMock()
-    session.query.return_value.filter.return_value.one.return_value = (
-        date(2026, 7, 25),
-        offset_timestamp,
-        1,
-    )
-
-    @contextmanager
-    def verification_session():
-        yield session
-
-    monkeypatch.setattr(reset_module, "db_session", verification_session)
-
-    baseline = reset_module.capture_city_verification_baseline("sunnyvale")
-    remaining = reset_module._remaining_anchor_summary(session, "sunnyvale")
-
-    assert baseline["baseline_max_scraped_datetime"] == "2026-07-25T12:30:00Z"
-    assert remaining["remaining_max_scraped_datetime"] == "2026-07-25T12:30:00Z"
 
 
 def test_reset_city_verification_state_dry_run_preserves_rows(tmp_path, monkeypatch):
@@ -165,7 +129,15 @@ def test_reset_city_verification_state_deletes_only_events_in_window_and_unrefer
         session.add_all(
             [
                 Document(place_id=place.id, event_id=old_event.id, catalog_id=preserved_catalog.id, url="https://example.com/old.pdf", url_hash="preserved"),
+                Document(place_id=place.id, event_id=new_event.id, catalog_id=preserved_catalog.id, url="https://example.com/new-shared.pdf", url_hash="new-shared"),
                 Document(place_id=place.id, event_id=new_event.id, catalog_id=exclusive_catalog.id, url="https://example.com/new-exclusive.pdf", url_hash="exclusive"),
+                Document(place_id=place.id, event_id=new_event.id, catalog_id=None, url="https://example.com/catalogless.pdf", url_hash="catalogless"),
+            ]
+        )
+        session.add_all(
+            [
+                DataIssue(event_id=old_event.id, issue_type="preserved_issue"),
+                DataIssue(event_id=new_event.id, issue_type="deleted_issue"),
             ]
         )
         session.commit()
@@ -174,18 +146,28 @@ def test_reset_city_verification_state_deletes_only_events_in_window_and_unrefer
 
     assert result["city"] == "fremont"
     assert result["deleted_event_count"] == 1
-    assert result["deleted_document_count"] == 1
+    assert result["deleted_document_count"] == 3
     assert result["deleted_catalog_count"] == 1
-    assert result["catalog_reference_count"] == 1
+    assert result["catalog_reference_count"] == 2
+    assert result["deleted_data_issue_count"] == 1
+
+    second = reset_city_verification_state("fremont", now.strftime("%Y-%m-%dT%H:%M:%SZ"))
+    assert second["deleted_event_count"] == 0
+    assert second["deleted_document_count"] == 0
+    assert second["deleted_catalog_count"] == 0
+    assert second["deleted_data_issue_count"] == 0
 
     with Session() as session:
         assert session.query(Event).count() == 1
         assert session.query(Document).count() == 1
         assert session.query(Catalog).count() == 1
+        assert session.query(DataIssue).count() == 1
         remaining_event = session.query(Event).one()
         remaining_catalog = session.query(Catalog).one()
+        remaining_issue = session.query(DataIssue).one()
         assert remaining_event.ocd_id == "old-event"
         assert remaining_catalog.url_hash == "preserved"
+        assert remaining_issue.issue_type == "preserved_issue"
 
 
 def test_rewind_pending_city_onboarding_rejects_enabled_or_pass_city(mocker):
@@ -198,132 +180,6 @@ def test_rewind_pending_city_onboarding_rejects_enabled_or_pass_city(mocker):
 
     with pytest.raises(ValueError, match="disabled cities"):
         mod._validate_city_is_rewindable("hayward")
-
-
-def test_capture_city_verification_baseline_reports_city_anchor(tmp_path, monkeypatch):
-    Session = _setup_city_graph(tmp_path / "baseline.sqlite", monkeypatch)
-    now = datetime.now(UTC).replace(tzinfo=None, microsecond=0)
-
-    with Session() as session:
-        place = Place(
-            name="Sunnyvale",
-            state="CA",
-            country="us",
-            display_name="Sunnyvale, CA",
-            ocd_division_id="ocd-division/country:us/state:ca/place:sunnyvale",
-        )
-        session.add(place)
-        session.flush()
-        session.add_all(
-            [
-                Event(
-                    ocd_id="early",
-                    ocd_division_id=place.ocd_division_id,
-                    place_id=place.id,
-                    scraped_datetime=now,
-                    record_date=date(2026, 3, 1),
-                    source="sunnyvale",
-                    source_url="https://example.com/early",
-                    name="Early meeting",
-                ),
-                Event(
-                    ocd_id="late",
-                    ocd_division_id=place.ocd_division_id,
-                    place_id=place.id,
-                    scraped_datetime=now + timedelta(days=1),
-                    record_date=date(2026, 3, 7),
-                    source="sunnyvale",
-                    source_url="https://example.com/late",
-                    name="Late meeting",
-                ),
-            ]
-        )
-        session.commit()
-
-    result = capture_city_verification_baseline("sunnyvale")
-
-    assert result["city"] == "sunnyvale"
-    assert result["baseline_event_count"] == 2
-    assert result["baseline_max_record_date"] == "2026-03-07"
-    assert result["baseline_max_scraped_datetime"] == (now + timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
-
-
-def test_reset_city_verification_state_rewinds_to_baseline_record_date(tmp_path, monkeypatch):
-    Session = _setup_city_graph(tmp_path / "anchor_reset.sqlite", monkeypatch)
-    campaign_started_at = datetime(2026, 3, 15, 13, 21, 9)
-
-    with Session() as session:
-        place = Place(
-            name="Sunnyvale",
-            state="CA",
-            country="us",
-            display_name="Sunnyvale, CA",
-            ocd_division_id="ocd-division/country:us/state:ca/place:sunnyvale",
-        )
-        session.add(place)
-        session.flush()
-
-        preserved_same_day = Event(
-            ocd_id="baseline-same-day",
-            ocd_division_id=place.ocd_division_id,
-            place_id=place.id,
-            scraped_datetime=campaign_started_at - timedelta(days=1),
-            record_date=date(2026, 3, 10),
-            source="sunnyvale",
-            source_url="https://example.com/baseline-same-day",
-            name="Baseline same-day meeting",
-        )
-        future_event = Event(
-            ocd_id="future-run-one",
-            ocd_division_id=place.ocd_division_id,
-            place_id=place.id,
-            scraped_datetime=campaign_started_at + timedelta(minutes=2),
-            record_date=date(2026, 5, 18),
-            source="sunnyvale",
-            source_url="https://example.com/future",
-            name="Future meeting",
-        )
-        same_day_run_one = Event(
-            ocd_id="same-day-run-one",
-            ocd_division_id=place.ocd_division_id,
-            place_id=place.id,
-            scraped_datetime=campaign_started_at + timedelta(minutes=3),
-            record_date=date(2026, 3, 10),
-            source="sunnyvale",
-            source_url="https://example.com/same-day-run-one",
-            name="Same day run-one meeting",
-        )
-        session.add_all([preserved_same_day, future_event, same_day_run_one])
-        session.flush()
-
-        future_catalog = Catalog(url_hash="future", location="/tmp/future.pdf")
-        same_day_catalog = Catalog(url_hash="same-day", location="/tmp/same-day.pdf")
-        session.add_all([future_catalog, same_day_catalog])
-        session.flush()
-        session.add_all(
-            [
-                Document(place_id=place.id, event_id=future_event.id, catalog_id=future_catalog.id, url_hash="future"),
-                Document(place_id=place.id, event_id=same_day_run_one.id, catalog_id=same_day_catalog.id, url_hash="same-day"),
-            ]
-        )
-        session.commit()
-
-    result = reset_city_verification_state(
-        "sunnyvale",
-        campaign_started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
-        baseline_record_date="2026-03-10",
-    )
-
-    assert result["deleted_event_count"] == 2
-    assert result["deleted_document_count"] == 2
-    assert result["deleted_catalog_count"] == 2
-    assert result["remaining_event_count"] == 1
-    assert result["remaining_max_record_date"] == "2026-03-10"
-    assert result["remaining_max_scraped_datetime"] == (campaign_started_at - timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
-
-    with Session() as session:
-        remaining_events = session.query(Event).all()
-        assert [event.ocd_id for event in remaining_events] == ["baseline-same-day"]
 
 
 def test_reset_city_verification_state_does_not_delete_stage_rows(tmp_path, monkeypatch):
@@ -363,3 +219,59 @@ def test_reset_city_verification_state_does_not_delete_stage_rows(tmp_path, monk
         assert session.query(EventStage).count() == 1
         assert session.query(UrlStage).count() == 1
         assert session.query(UrlStageHist).count() == 1
+
+
+def test_reset_city_verification_state_rolls_back_live_deletes_on_late_failure(tmp_path, monkeypatch):
+    Session = _setup_city_graph(tmp_path / "reset_rollback.sqlite", monkeypatch)
+    since = datetime(2026, 3, 15, 13, 21, 9)
+
+    with Session() as session:
+        place = Place(
+            name="Fremont",
+            state="CA",
+            country="us",
+            display_name="Fremont, CA",
+            ocd_division_id="ocd-division/country:us/state:ca/place:fremont",
+        )
+        session.add(place)
+        session.flush()
+        event = Event(
+            ocd_id="rollback-event",
+            ocd_division_id=place.ocd_division_id,
+            place_id=place.id,
+            scraped_datetime=since + timedelta(minutes=1),
+            record_date=date(2026, 4, 4),
+            source="fremont",
+            source_url="https://example.com/rollback",
+            name="Rollback meeting",
+        )
+        catalog = Catalog(url_hash="rollback", location="/tmp/rollback.pdf")
+        session.add_all([event, catalog])
+        session.flush()
+        session.add(
+            Document(
+                place_id=place.id,
+                event_id=event.id,
+                catalog_id=catalog.id,
+                url_hash="rollback",
+            )
+        )
+        session.add(DataIssue(event_id=event.id, issue_type="rollback_issue"))
+        session.commit()
+        session.execute(
+            text(
+                "CREATE TRIGGER abort_catalog_delete "
+                "BEFORE DELETE ON catalog "
+                "BEGIN SELECT RAISE(ABORT, 'catalog delete blocked'); END"
+            )
+        )
+        session.commit()
+
+    with pytest.raises(IntegrityError, match="catalog delete blocked"):
+        reset_city_verification_state("fremont", since.strftime("%Y-%m-%dT%H:%M:%SZ"))
+
+    with Session() as session:
+        assert session.query(Event).count() == 1
+        assert session.query(Document).count() == 1
+        assert session.query(Catalog).count() == 1
+        assert session.query(DataIssue).count() == 1


### PR DESCRIPTION
## What changed
- moved duplicate city event/document/catalog/data-issue accounting into one transaction-neutral helper
- preserved flush and verification-reset selection rules, defaults, reports, and stage-row behavior
- added shared-catalog, catalogless-document, data-issue, idempotency, rollback, and CLI contract coverage
- registered the T-DD-1B plan and updated the operator runbook

## Why
The two destructive maintenance commands implemented the same live graph deletion policy independently. Consolidating that policy prevents fixes in one command from leaving the other unsafe or inconsistent.

## Risk and compatibility
- no schema, API, runtime-default, Celery, or model-policy changes
- each caller still owns its transaction and commits only after its command-specific mutations
- shared catalogs remain protected when any unselected document references them
- writers must remain stopped during destructive maintenance, as documented

## Verification
- PASS: `./.venv/bin/ruff check .`
- PASS: `./.venv/bin/mypy`
- PASS: `./.venv/bin/mypy scripts/city_state_mutation.py`
- PASS: focused/onboarding tests, 23 passed
- PASS: docs links, 2 passed
- PASS: coverage suite, 1,542 passed and 17 skipped, 82.89%
- PASS: complete Python suite, 1,542 passed and 17 skipped
- PASS: `git diff --check`
- PASS: independent pre-commit review, no remaining P1/P2

## Remaining deficits
None within T-DD-1B. Existing dependency deprecation warnings remain outside this task.
