### PR TITLE
T-DC-1: Give API startup one state owner

### DIFF
--- a/api/app_setup.py
+++ b/api/app_setup.py
@@ -1,6 +1,5 @@
 import hmac
 import logging
-import os
 from collections.abc import AsyncIterator, Iterator
 from contextlib import asynccontextmanager
 from ipaddress import ip_address
@@ -28,7 +27,6 @@ HEADER_UNSAFE_API_AUTH_KEY_MESSAGE = (
     "API_AUTH_KEY must contain printable ASCII characters without leading or trailing whitespace."
 )
 DATABASE_UNAVAILABLE_DETAIL = "Database service is unavailable"
-SEMANTIC_SERVICE_URL = os.getenv("SEMANTIC_SERVICE_URL", "http://semantic:8010").rstrip("/")
 API_KEY_HEADER = "x-api-key"
 FORWARDED_CLIENT_HEADER = "x-forwarded-for"
 
@@ -110,20 +108,6 @@ async def verify_api_key(request: Request, x_api_key: str = Header(None)) -> Non
         raise HTTPException(status_code=401, detail="Invalid or missing API Key")
 
 
-def _semantic_enabled_from_facade() -> bool:
-    try:
-        from api import main as api_main
-    except ImportError:
-        return bool(SEMANTIC_ENABLED)
-    return bool(getattr(api_main, "SEMANTIC_ENABLED", SEMANTIC_ENABLED))
-
-
-def _semantic_healthcheck_from_facade() -> dict:
-    from api import main as api_main
-
-    return api_main._semantic_service_healthcheck()
-
-
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     _ = app
@@ -142,7 +126,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         raise RuntimeError(HEADER_UNSAFE_API_AUTH_KEY_MESSAGE)
     if api_auth_key == DEFAULT_API_AUTH_KEY:
         logger.critical("SECURITY WARNING: You are using the default API Key. Please set API_AUTH_KEY in production.")
-    from api.search import support_core
+    from api.search import semantic_support, support_core
 
     if support_core.MEILI_MASTER_KEY == DEVELOPMENT_MEILI_SEARCH_KEY:
         logger.warning(MEILI_SEARCH_KEY_FALLBACK_WARNING)
@@ -152,10 +136,10 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     # Startup purge is lock-protected. If another service already purged, we skip.
     purge_result = run_startup_purge_if_enabled()
     logger.info("startup_purge_result=%s", purge_result)
-    if _semantic_enabled_from_facade():
+    if SEMANTIC_ENABLED:
         try:
             # The API image only verifies the internal semantic service boundary.
-            health = _semantic_healthcheck_from_facade()
+            health = semantic_support._semantic_service_healthcheck()
             logger.info("semantic_backend_health=%s", health)
         except RuntimeError as exc:
             logger.critical("Semantic service misconfiguration: %s", exc)

--- a/api/main.py
+++ b/api/main.py
@@ -1,10 +1,8 @@
 import logging
 import os
 import sys
-from contextlib import asynccontextmanager
-from typing import Any
 
-from fastapi import Depends, FastAPI, Header, HTTPException, Request
+from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import ORJSONResponse
 from sqlalchemy.orm import Session as SQLAlchemySession
@@ -12,8 +10,7 @@ from slowapi.errors import RateLimitExceeded
 from sqlalchemy import text
 from slowapi import _rate_limit_exceeded_handler
 
-from api import app_setup
-from api.app_setup import SEMANTIC_SERVICE_URL as SEMANTIC_SERVICE_URL
+from api.app_setup import get_db, lifespan, limiter, verify_api_key
 from api.catalog_routes import (
     _summary_doc_kind_and_hashes as _summary_doc_kind_and_hashes,
     build_catalog_router,
@@ -21,34 +18,18 @@ from api.catalog_routes import (
 from api.lineage_routes import _lineage_rows as _lineage_rows
 from api.lineage_routes import build_lineage_router
 from api.people_routes import build_people_router
-from api.reporting_routes import IssueReport as IssueReport
 from api.reporting_routes import build_reporting_router
 from api.search import support_core as search_support_core
 from api.search_routes import (
-    MEILI_HOST as MEILI_HOST,
-    MEILI_MASTER_KEY as MEILI_MASTER_KEY,
-    _build_filter_values as _build_filter_values,
     _build_meilisearch_filter_clauses as _build_meilisearch_filter_clauses,
     _collect_meeting_docs as _collect_meeting_docs,
-    _count_topics_from_docs as _count_topics_from_docs,
-    _facet_topics as _facet_topics,
-    _iter_time_buckets as _iter_time_buckets,
-    _normalize_city_or_400 as _normalize_city_or_400,
-    _normalize_filters_or_400 as _normalize_filters_or_400,
-    _parse_iso_date as _parse_iso_date,
-    _require_trends_feature as _require_trends_feature,
     _semantic_service_get_json as _semantic_service_get_json,
-    _semantic_service_healthcheck as _semantic_service_healthcheck,
     client as client,
-    normalize_city_filter as normalize_city_filter,
     router as search_router,
-    search_documents as search_documents,
     search_documents_semantic as search_documents_semantic,
-    validate_date_format as validate_date_format,
 )
 from api.task_routes import (
     AsyncResult as AsyncResult,
-    _CeleryTaskProxy as _CeleryTaskProxy,
     _enqueue_task as _enqueue_task,
     build_task_router,
     extract_text_task as extract_text_task,
@@ -69,73 +50,7 @@ from api.metrics import instrument_app
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 logger = logging.getLogger("town-council-api")
 
-limiter = app_setup.limiter
-hmac = app_setup.hmac
-sessionmaker = app_setup.sessionmaker
-db_connect = app_setup.db_connect
-SessionLocal = app_setup.SessionLocal
-_db_init_error = app_setup._db_init_error
-
-from pipeline.models import AgendaItem as AgendaItem  # noqa: F401
-from pipeline.models import Catalog as Catalog  # noqa: F401
-from pipeline.models import DataIssue as DataIssue  # noqa: F401
-from pipeline.models import Document as Document  # noqa: F401
-from pipeline.models import Event as Event  # noqa: F401
-from pipeline.models import IssueType as IssueType  # noqa: F401
-from pipeline.models import Membership as Membership  # noqa: F401
-from pipeline.models import Organization as Organization  # noqa: F401
-from pipeline.models import Person as Person  # noqa: F401
-from pipeline.models import Place as Place  # noqa: F401
 from pipeline.agenda_resolver import agenda_items_look_low_quality as agenda_items_look_low_quality
-
-
-def _sync_app_setup_from_facade() -> None:
-    app_setup.SessionLocal = SessionLocal
-    app_setup._db_init_error = _db_init_error
-    app_setup.db_connect = db_connect
-    app_setup.sessionmaker = sessionmaker
-
-
-def _sync_facade_from_app_setup() -> None:
-    globals()["SessionLocal"] = app_setup.SessionLocal
-    globals()["_db_init_error"] = app_setup._db_init_error
-
-
-def initialize_database() -> Any:
-    _sync_app_setup_from_facade()
-    try:
-        return app_setup.initialize_database()
-    finally:
-        _sync_facade_from_app_setup()
-
-
-def is_db_ready() -> bool:
-    _sync_app_setup_from_facade()
-    try:
-        return app_setup.is_db_ready()
-    finally:
-        _sync_facade_from_app_setup()
-
-
-def get_db():
-    _sync_app_setup_from_facade()
-    try:
-        yield from app_setup.get_db()
-    finally:
-        _sync_facade_from_app_setup()
-
-
-async def verify_api_key(request: Request, x_api_key: str = Header(None)):
-    return await app_setup.verify_api_key(request, x_api_key=x_api_key)
-
-
-@asynccontextmanager
-async def lifespan(app: FastAPI):
-    _sync_app_setup_from_facade()
-    async with app_setup.lifespan(app):
-        _sync_facade_from_app_setup()
-        yield
-    _sync_facade_from_app_setup()
 
 
 app = FastAPI(
@@ -165,16 +80,6 @@ async def catch_exceptions_middleware(request: Request, call_next):
             status_code=500,
             content={"detail": "Internal Server Error. Our team has been notified."}
         )
-
-def get_local_ai():
-    """
-    Legacy dependency hook preserved for older tests.
-
-    Why this exists:
-    The API no longer instantiates the local LLM directly, but several targeted
-    tests still import and override this symbol.
-    """
-    return None
 
 # SECURITY: Restrict CORS (Cross-Origin Resource Sharing)
 # We load the allowed domains from the environment.

--- a/api/search/semantic_support.py
+++ b/api/search/semantic_support.py
@@ -3,12 +3,18 @@ from typing import Any
 import httpx
 from fastapi import HTTPException
 
-from api.app_setup import SEMANTIC_SERVICE_URL
 from api.search.support_core import (
     SEMANTIC_HEALTHCHECK_TIMEOUT_SECONDS,
     SEMANTIC_SEARCH_TIMEOUT_SECONDS,
     SEMANTIC_SERVICE_ERROR_DETAIL,
 )
+from pipeline.config_env import env_raw
+
+
+SEMANTIC_SERVICE_URL = env_raw(
+    "SEMANTIC_SERVICE_URL",
+    "http://semantic:8010",
+).rstrip("/")
 
 
 def _semantic_service_healthcheck() -> dict[str, Any]:

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,6 +1,6 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 3.63
+version: 3.64
 generated: 2026-07-26
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
@@ -10,6 +10,13 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v3.64:** Marks T-DD-1B complete after PR #156 merged the characterized
+  event-graph mutation owner with shared-catalog, rollback, idempotency, and
+  CLI parity coverage. Activates P1 T-DC-1 with exact ownership for removing
+  copied startup state, forwarding wrappers, stdlib rebinding, and the
+  `app_setup -> api.main` semantic startup dependency. Test-only model, search,
+  task, and reporting re-exports are removed in the same task; only aliases
+  resolved by assembled task, lineage, and search routes remain.
 - **v3.63:** Marks T-PLAT-3 complete after PR #155 merged with verified backup,
   disposable restore, rollback, search rebuild, and Redis recovery contracts.
   Activates T-DD-1B with exact ownership for a tests-first extraction of only
@@ -306,10 +313,10 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 | State | Tasks |
 |---|---|
-| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2, T-SEC-3, T-SEC-3C, T-SEC-4, T-SEC-4A, T-SEC-5, T-SEC-6, T-TIME-1, T-TIME-2, T-TIME-3, T-CRAWL-1, T-CRAWL-2, T-PLAT-1, T-PLAT-1A, T-PLAT-2A, T-PLAT-2B, T-PLAT-3, T-GOV-1, T-GOV-3A, T-GOV-4, T-GOV-5, T-DA-1, T-DB-1A, T-DB-1, T-DB-1B, T-DD-1A |
+| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2, T-SEC-3, T-SEC-3C, T-SEC-4, T-SEC-4A, T-SEC-5, T-SEC-6, T-TIME-1, T-TIME-2, T-TIME-3, T-CRAWL-1, T-CRAWL-2, T-PLAT-1, T-PLAT-1A, T-PLAT-2A, T-PLAT-2B, T-PLAT-3, T-GOV-1, T-GOV-3A, T-GOV-4, T-GOV-5, T-DA-1, T-DB-1A, T-DB-1, T-DB-1B, T-DD-1A, T-DD-1B |
 | **Partially landed; acceptance incomplete** | T-GOV-3, T-GOV-6 |
-| **Active** | T-DD-1B |
-| **Pending** | T-DC-1, T-DE-1, T-PLAT-2, T-PLAT-4, T-GOV-2, T-GOV-3B |
+| **Active** | T-DC-1 |
+| **Pending** | T-DE-1, T-PLAT-2, T-PLAT-4, T-GOV-2, T-GOV-3B |
 
 ---
 
@@ -1141,19 +1148,40 @@ files (GED-5 grant).
 
 ### T-DC-1: Remove the api.main <-> app_setup sync machinery
 - priority: P1
+- status: active
 - must_not_run_concurrently_with: any SEC task
-- files_owned: api/main.py, api/app_setup.py, tests/conftest.py,
-  tests/test_*api*
-- do: app_setup owns SessionLocal/_db_init_error/verify_api_key/lifespan as
-  the single authority. Delete `_sync_app_setup_from_facade`,
+- implementation_plan: `docs/plans/T_DC_1_APP_STARTUP_OWNERSHIP_PLAN.md`
+- files_owned: the implementation plan and ledger; `api/main.py`;
+  `api/app_setup.py`; `api/search/semantic_support.py`
+  (`SEMANTIC_SERVICE_URL` ownership only); `tests/conftest.py`;
+  `tests/test_api.py` (database startup, direct model imports, and dead AI
+  override only);
+  `tests/test_api_key_compare_digest.py`;
+  `tests/test_api_startup_security.py`;
+  `tests/test_city_slug_normalization.py`;
+  `tests/test_semantic_search_api.py` (dead semantic health patches only)
+- do: `api.app_setup` owns
+  `SessionLocal`/`_db_init_error`/`verify_api_key`/`lifespan` as the single
+  authority. Delete `_sync_app_setup_from_facade`,
   `_sync_facade_from_app_setup`, the wrapper defs in main.py, the
   `hmac = app_setup.hmac` rebind, and the `X as X` re-export blocks whose
-  only consumers are tests. Repoint tests (conftest.py "api.main.db_connect"
-  patch -> pipeline/app_setup target).
-- accept: main.py contains no bidirectional sync functions; no stdlib
-  re-exports; suite green.
+  only consumers are tests. Delete the inert `get_local_ai` test hook and
+  override. Repoint tests from `api.main.db_connect` to `api.app_setup.db_connect`,
+  model and normalization imports to their implementation modules, and remove
+  dead semantic health facade patches. Move the semantic service URL to its
+  semantic implementation owner so startup no longer imports back through
+  `api.main`.
+- preserve: Direct runtime assembly names for FastAPI lifespan, authentication,
+  and database dependency; task, lineage, and search facade aliases used by
+  routers; all auth, startup, fail-fast, route, and response behavior.
+- accept: `main.py` contains no bidirectional sync functions, copied mutable
+  startup state, forwarding startup wrappers, or stdlib re-exports;
+  `app_setup.py` does not import `api.main`; focused security/API behavior,
+  coverage, complete suite, and boot smoke pass.
 - risk: Highest-touch task in the plan. Land as one PR; do not interleave.
-- verify: Full suite + a manual `uvicorn api.main:app` boot smoke.
+- verify: Follow the Full T-DC-1 plan; Ruff, Mypy, focused security/API/search
+  tests, docs links, coverage, complete suite, and manual
+  `uvicorn api.main:app` boot smoke pass.
 
 ### T-DD-1A: Consolidate worker health probes
 - priority: P2
@@ -1178,7 +1206,7 @@ files (GED-5 grant).
 
 ### T-DD-1B: Evaluate city-state mutation consolidation
 - priority: P2
-- status: active
+- status: complete and verified 2026-07-26 (PR #156)
 - depends_on: T-DD-1A (satisfied by PR #153)
 - implementation_plan: `docs/plans/T_DD_1B_CITY_STATE_MUTATION_PLAN.md`
 - files_owned: the implementation plan and ledger;

--- a/docs/plans/T_DC_1_APP_STARTUP_OWNERSHIP_PLAN.md
+++ b/docs/plans/T_DC_1_APP_STARTUP_OWNERSHIP_PLAN.md
@@ -1,0 +1,372 @@
+# T-DC-1: Give API Startup One State Owner
+
+`artifact_contract: ce-unified-plan/v1`  
+`artifact_readiness: implementation-ready`  
+`execution: code`
+
+## 1. Context & Alignment
+
+**a) Driver.** `api.main` and `api.app_setup` currently copy database startup
+state in both directions. Tests mutate the facade copies, so every database
+operation must synchronize `SessionLocal`, `_db_init_error`, `db_connect`, and
+`sessionmaker` before and after delegating. `app_setup` also imports back
+through `api.main` for semantic startup policy. T-DC-1 removes this cycle
+without changing authentication, startup validation, database failure
+responses, semantic fail-fast behavior, or route contracts.
+
+**b) Canonical documents consulted.**
+
+- `AGENTS.md` hierarchy, known-antipatterns, security-sensitive paths,
+  verification matrix, and testing policy require one state owner, direct
+  implementation patch targets, a trust-boundary report, and full verification.
+- `docs/TESTING.MD` requires tests to patch implementation modules or use
+  FastAPI dependency overrides rather than preserving facade globals.
+- `SECURITY.md` requires non-development API-key rejection, secret redaction,
+  scoped client identity, and semantic startup fail-fast behavior.
+- `docs/ENGINEERING_GUARDRAILS.md` treats helper-to-facade imports and
+  bidirectional synchronization as structural debt.
+- `docs/ADR.md`, “Start API main cleanup with lifecycle and search route
+  boundaries,” assigns lifecycle, session, auth, and limiter ownership to
+  `api/app_setup.py`. Its temporary test-seam preservation was superseded by
+  the accepted G3 ADR.
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md` names T-DC-1 as the remaining
+  P1 architecture task and prohibits concurrent security work.
+- `docs/reviews/architecture-review-2026-07-19.html`, “Give application startup
+  one state owner,” confirms `app_setup` as the implementation boundary.
+
+**c) Remediation alignment.** T-DC-1 owns exactly:
+
+- `docs/plans/T_DC_1_APP_STARTUP_OWNERSHIP_PLAN.md`
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`
+- `api/main.py`
+- `api/app_setup.py`
+- `api/search/semantic_support.py` (`SEMANTIC_SERVICE_URL` ownership only)
+- `tests/conftest.py`
+- `tests/test_api.py` (database startup, direct model imports, and dead AI
+  override only)
+- `tests/test_api_key_compare_digest.py`
+- `tests/test_api_startup_security.py`
+- `tests/test_city_slug_normalization.py`
+- `tests/test_semantic_search_api.py` (dead semantic health patches only)
+
+The task marks T-DD-1B complete after PR #156 and activates T-DC-1 before
+implementation. No security task runs concurrently. Only task, lineage, and
+search aliases resolved by assembled routers remain; test-only re-exports are
+deleted in this task.
+
+**d) Decision gates.** G3 is satisfied and authorizes removal of test-only
+patch seams. G1, G2, G4, and G5 are unaffected. No open gate blocks this task.
+
+## 2. Design
+
+**e) Step-by-step approach.**
+
+1. Update the remediation ledger to version 3.64, mark T-DD-1B complete, and
+   activate T-DC-1 with exact ownership and acceptance criteria.
+2. Add failing tests before production edits:
+   - assembled application behavior continues through the `app_setup`
+     lifespan, DB dependency, and API-key dependency;
+   - copied startup globals and synchronization functions are absent from
+     `api.main`;
+   - semantic startup reads `app_setup.SEMANTIC_ENABLED` and calls the
+     implementation health boundary without importing `api.main`;
+   - database failure and recovery tests patch only `api.app_setup`;
+   - test-only model, reporting, task, and search exports are absent.
+3. Remove from `api.main`:
+   - `_sync_app_setup_from_facade` and `_sync_facade_from_app_setup`;
+   - wrapper definitions for `initialize_database`, `is_db_ready`, `get_db`,
+     `verify_api_key`, and `lifespan`;
+   - copied `SessionLocal`, `_db_init_error`, `db_connect`, `sessionmaker`, and
+     `hmac` globals;
+   - the unused `SEMANTIC_SERVICE_URL` facade export;
+   - imports made dead by those removals.
+4. Import `get_db`, `verify_api_key`, `lifespan`, and `limiter` directly from
+   `api.app_setup` because application assembly consumes those callables at
+   runtime. Their names remain part of application assembly and FastAPI
+   dependency override identity; mutable facade state and forwarding wrappers
+   do not.
+5. Move `SEMANTIC_SERVICE_URL` from `app_setup` to
+   `api.search.semantic_support`, its only runtime consumer. Remove
+   `app_setup` helpers that import `api.main`; `lifespan` reads its own
+   `SEMANTIC_ENABLED` setting and calls the semantic implementation. Import
+   direction becomes `main -> app_setup -> semantic_support`, with no reverse
+   semantic import into startup.
+6. Repoint tests:
+   - shared DB fixture patches only `api.app_setup.db_connect`;
+   - database startup tests exercise `api.app_setup` and assert HTTP/session
+     outcomes rather than synchronized private copies or call counts;
+   - constant-time comparison test patches `api.app_setup.hmac.compare_digest`;
+   - catalog and agenda-item models import from `pipeline.models`;
+   - city normalization imports from `api.search.query_builder`;
+   - dead semantic health patches and the inert local-AI dependency override
+     are removed.
+7. Delete test-only `api.main` exports. Preserve this explicit runtime
+   allowlist:
+   - task routes: `AsyncResult`, `_enqueue_task`, `extract_text_task`,
+     `extract_votes_task`, `generate_summary_task`, `generate_topics_task`,
+     `segment_agenda_task`, `agenda_items_look_low_quality`, and
+     `_summary_doc_kind_and_hashes`;
+   - lineage routes: `_lineage_rows`;
+   - search routes: `client`, `_build_meilisearch_filter_clauses`,
+     `_collect_meeting_docs`, `_semantic_service_get_json`,
+     `search_documents_semantic`, `SEMANTIC_ENABLED`, and
+     `FEATURE_TRENDS_DASHBOARD`;
+   - application assembly imports and router builders.
+8. Run targeted tests, API/search verification rows, security startup tests,
+   direct import/boot smoke, Ruff, Mypy, coverage, and the complete suite.
+9. Run simplification and independent pre-commit review. Apply every eligible
+   P1/P2, commit in two logical changes, push, open a PR, request Codex review,
+   and watch CI to a decided state.
+
+No new production module or helper is introduced.
+
+**f) Reuse audit.** Extend `api.app_setup` as the already-established owner.
+Reuse FastAPI’s direct lifespan callable and dependency-overrides mechanism,
+SQLAlchemy’s existing `sessionmaker`, and current semantic health helper.
+Nothing new duplicates route or startup logic. The synchronized facade
+implementation is deleted, not renamed or retained.
+
+Rejected alternatives:
+
+- Keep one-way synchronization: rejected because it preserves duplicated
+  mutable state and stale test patch points.
+- Add setters or a startup-state registry: rejected as unrequested machinery.
+- Pass semantic callables into `lifespan`: rejected because injectable
+  callables are a banned test seam.
+- Remove every `api.main` alias now: rejected because the explicit task,
+  lineage, and search allowlist is still resolved at runtime by assembled
+  routers.
+- Leave `SEMANTIC_SERVICE_URL` in `app_setup` and import semantic support only
+  during lifespan: rejected because it delays but does not remove the two-way
+  module dependency.
+
+**g) Data contracts.** No new application payload. Existing contracts remain:
+
+- `get_db` yields one SQLAlchemy session and closes it.
+- unavailable database initialization returns sanitized HTTP 503.
+- `verify_api_key` returns no value on success and raises HTTP 401 on failure.
+- `lifespan` rejects unsafe production keys before database work, warns without
+  logging secrets, runs startup purge, and fails fast on semantic
+  misconfiguration.
+- `api.main.app` retains all current routes, middleware, dependencies, and
+  response formats.
+- `api.main.get_db`, `verify_api_key`, and `lifespan` remain runtime assembly
+  names bound directly to implementation callables, not wrappers or mutable
+  test seams.
+
+**h) Schema/migrations.** None. No database definition, migration, timestamp,
+or stored value changes.
+
+## 3. Security & Data Governance
+
+**i) Security boundary.** `api/app_setup.py` is security-sensitive. This task
+changes ownership, not policy. An attacker gains no route, credential,
+permission, or bypass. `SECURITY.md` controls for API-key fail-fast validation,
+constant-time comparison, secret-free logging, client identity, database
+failure sanitization, and semantic startup checks remain enforced by targeted
+tests. `api.main` remains the public ASGI assembly boundary.
+
+**j) Secrets.** No credential, environment variable, key, or default changes.
+No secret moves into a browser-visible or logged surface.
+
+**k) Person data.** No person record is created, linked, aggregated, or
+exposed. G4 is unaffected.
+
+**l) Untrusted input.** API headers and client address metadata remain
+validated in `app_setup`. No scraped content, HTML, provider response, or new
+input parser is introduced.
+
+## 4. Code Health
+
+**m) GED conformance.** Deletion reduces functions, globals, imports, and
+module coupling. No new nesting, environment read, exception handler,
+timestamp, mutable default, or broad exception is added. Existing startup
+errors continue to take meaningful action: typed HTTP failure, contextual log,
+or re-raise.
+
+**n) Antipattern scan, plan pass.**
+
+- A1/H1: FastAPI current docs verify async-context-manager lifespan,
+  `Depends`, dependency overrides, and `TestClient` lifespan execution.
+  SQLAlchemy 2.0 docs verify module-owned `sessionmaker`, factory invocation,
+  and `Session.close`.
+- B1/B2/C1: no registry, compatibility shim, wrapper, or old synchronized path.
+- B3: no new validation or retry.
+- C2: tests move to the implementation owner rather than preserving facade
+  patch targets.
+- D1-D3: no assertion weakening, skips, call-count contracts, or mocked unit
+  under test.
+- E1-E3: only eleven owned files change; no broad formatting.
+- F1/F2: existing startup logic remains in one module.
+- H2-H4: no type suppression, alternative contract, or new import-time
+  engine/client/network work.
+
+**o) Ratchet interaction.** `api/main.py` remains in the BLE001 allowlist for
+its middleware and endpoint boundaries; this task neither adds nor widens an
+entry. T-GOV-3B will later enforce the generic synchronization ban after
+T-DC-1 and T-DE-1 merge.
+
+**p) Dead code and duplication.** Delete two synchronization functions, five
+facade wrappers, six copied globals/stdlib bindings, two reverse semantic
+helpers, 27 test-only exports/hooks, and their dead imports. Expected production
+delta is materially negative. No superseded code survives.
+
+## 5. Testing
+
+**q) Edge cases and failure scenarios.**
+
+1. First database connection attempt fails; request receives sanitized 503.
+2. Later database attempt succeeds; session is yielded and closed.
+3. Unsafe non-development API key stops startup before database work.
+4. Invalid key uses constant-time comparison and returns 401 without logging
+   the key.
+5. Default development key warning omits the key value.
+6. Semantic startup disabled skips semantic health.
+7. Semantic startup enabled checks health and re-raises misconfiguration.
+8. Meilisearch fallback warning omits search and master key values.
+9. FastAPI application behavior uses implementation-owned lifespan/auth/DB
+   logic.
+10. No copied startup state, sync function, stdlib rebind, or reverse
+    `app_setup -> api.main` dependency remains.
+11. API routes, dependency overrides, task dispatch, search, lineage, and
+    response contracts remain unchanged.
+12. Test-only model, reporting, task, and search exports are absent from
+    `api.main`; explicit runtime-resolved aliases remain.
+
+**r) Tests mapped to scenarios.**
+
+| Test | Scenarios |
+|---|---|
+| Updated database startup tests in `tests/test_api.py` | 1, 2 |
+| Updated `tests/test_api_key_compare_digest.py` | 4 |
+| Existing and extended `tests/test_api_startup_security.py` | 3, 5-10, 12 |
+| Updated direct imports and semantic patch targets | 11, 12 |
+| Shared fixture collection/full-suite execution | 2, 11 |
+| Existing API/search/query verification rows | 11 |
+| Manual Uvicorn boot and `/health` smoke | 2, 9, 11 |
+
+Tests are written and run red before production edits. Existing 65 focused
+tests establish the pre-change behavior baseline.
+
+**s) Fakes/mocks.** Tests fake only approved boundaries:
+
+- database engine creation at `api.app_setup.db_connect`;
+- SQLAlchemy session factory at `api.app_setup.sessionmaker`;
+- semantic HTTP boundary at `api.search.semantic_support`;
+- FastAPI dependency overrides for route-level DB behavior.
+
+Changed startup tests patch no facade or re-export. Existing tests still patch
+the task, lineage, and search aliases in the explicit runtime allowlist; that
+debt remains until those route families stop resolving through `api.main`.
+Structural assertions are limited to explicitly prohibited synchronization
+functions, copied mutable globals, stdlib rebinding, reverse imports, and
+test-only exports; runtime behavior is asserted through FastAPI and session
+outcomes.
+
+**t) Verification rows.** Apply security-sensitive trust-boundary reporting,
+API/search behavior, and broad cross-cutting rows. Run the complete Python
+suite and coverage gate because application assembly and shared fixtures
+change.
+
+## 6. Execution, Rollback, Docs
+
+**u) Exact commands.**
+
+```bash
+git fetch origin --prune
+test "$(git branch --show-current)" = "codex/t-dc-1-app-startup-ownership"
+git merge-base --is-ancestor origin/master HEAD
+```
+
+Tests-first:
+
+```bash
+PYTHONPATH=. .venv/bin/pytest -q \
+  tests/test_api.py::test_get_db_returns_sanitized_503_when_database_init_fails \
+  tests/test_api.py::test_initialize_database_recovers_after_transient_failure \
+  tests/test_api_key_compare_digest.py \
+  tests/test_api_startup_security.py
+```
+
+Final:
+
+```bash
+./.venv/bin/ruff check .
+./.venv/bin/mypy
+PYTHONPATH=. .venv/bin/pytest -q tests/test_api_startup_security.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_api.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_api_key_compare_digest.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_api_auth_logging.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_semantic_search_api.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_query_builder_filters.py
+PYTHONPATH=. .venv/bin/pytest -q \
+  tests/test_query_builder_parity_search_vs_trends.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py
+PYTHONPATH=. .venv/bin/python -m pytest -q \
+  --cov --cov-config=.coveragerc --cov-report=term-missing:skip-covered tests/
+PYTHONPATH=. .venv/bin/pytest -q
+git diff --check
+```
+
+Boot smoke uses the existing API image because Uvicorn is a runtime dependency,
+not a local development dependency. It binds only to loopback:
+
+```bash
+cleanup() {
+  docker stop "$smoke_container" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+smoke_container=$(
+  docker compose -f docker-compose.yml -f docker-compose.dev.yml run \
+    -d --rm --no-deps \
+    -p 127.0.0.1:8019:8000 \
+    -e DATABASE_URL=sqlite:////tmp/tc-t-dc-1-smoke.sqlite \
+    -e APP_ENV=dev \
+    -e STARTUP_PURGE_DERIVED=false \
+    -e SEMANTIC_ENABLED=false \
+    api uvicorn main:app --host 0.0.0.0 --port 8000 --no-proxy-headers
+)
+
+for attempt in 1 2 3 4 5; do
+  curl -fsS http://127.0.0.1:8019/health && break
+  sleep 1
+done
+curl -fsS http://127.0.0.1:8019/health
+```
+
+**v) Rollback.** Revert the T-DC-1 merge commit, rerun Ruff, Mypy, focused API
+and security tests, coverage, and the complete suite, then boot-smoke the
+restored application. No migration, data repair, credential rotation, or
+external-state cleanup is required. Rollback knowingly restores duplicated
+startup state and facade test seams.
+
+**w) Docs sync.**
+
+- Remediation ledger: version 3.64, T-DD-1B completion, T-DC-1 activation,
+  exact ownership, behavior boundary, and verification.
+- This implementation plan.
+- `SECURITY.md`, `ARCHITECTURE.md`, `docs/ADR.md`, `docs/OPERATIONS.md`,
+  `docs/TESTING.MD`, README, API contracts, and data-governance docs: no
+  update. Their current ownership and security statements remain accurate;
+  historical ADR text is not rewritten.
+
+## 7. Delivery Self-Audit
+
+**x) Diff scan.** Re-run A-F/H. Reject facade wrappers, synchronized globals,
+reverse `app_setup -> api.main` imports, test-only aliases, callable injection,
+new config, auth changes, route changes, type suppression, unrelated alias
+cleanup, or files outside ownership.
+
+**y) Evidence.** Report tests-first red output; FastAPI/SQLAlchemy documentation
+verification; Ruff, Mypy, focused API/security/search tests, coverage, complete
+suite, and boot smoke results; planning and pre-commit review findings; commit
+hashes; PR URL; current-head review; CI state; and unresolved-thread count.
+Mark every unrun check `NOT VERIFIED`.
+
+**z) Deviations.** Expected deviation is the remediation ownership expansion
+to include this plan, ledger, semantic URL owner, and six exact test files.
+Any other changed
+path, removed runtime facade used by task/search/lineage routers, security
+policy change, new compatibility seam, skipped review, unresolved P1/P2, or
+unrun required check blocks delivery.

--- a/docs/plans/T_DC_1_APP_STARTUP_OWNERSHIP_PLAN.md
+++ b/docs/plans/T_DC_1_APP_STARTUP_OWNERSHIP_PLAN.md
@@ -1,7 +1,7 @@
 # T-DC-1: Give API Startup One State Owner
 
-`artifact_contract: ce-unified-plan/v1`  
-`artifact_readiness: implementation-ready`  
+`artifact_contract: ce-unified-plan/v1`
+`artifact_readiness: implementation-ready`
 `execution: code`
 
 ## 1. Context & Alignment

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,7 +56,6 @@ def mock_db_connect(monkeypatch, shared_engine):
         "pipeline.promote_stage.db_connect",
         "pipeline.downloader.db_connect",
         "api.app_setup.db_connect",
-        "api.main.db_connect"
     ]
     for target in targets:
         try:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -16,11 +16,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'api'))
 # Mock heavy AI dependency before importing api.main
 sys.modules["llama_cpp"] = MagicMock()
 
-from api.main import app, get_local_ai, agenda_items_look_low_quality
-
-# Override the AI dependency for the entire test module
-mock_ai = MagicMock()
-app.dependency_overrides[get_local_ai] = lambda: mock_ai
+from api.main import agenda_items_look_low_quality, app
 
 client = TestClient(app)
 VALID_KEY = "dev_secret_key_change_me"
@@ -336,48 +332,63 @@ def test_api_database_unavailable(mocker):
 
 
 def test_get_db_returns_sanitized_503_when_database_init_fails(mocker):
-    import api.main as api_main
+    from api import app_setup
 
-    mocker.patch.object(api_main, "db_connect", side_effect=RuntimeError("DATABASE_URL is not set"))
-    api_main.SessionLocal = None
-    api_main._db_init_error = None
+    mocker.patch.object(
+        app_setup,
+        "db_connect",
+        side_effect=RuntimeError("DATABASE_URL is not set"),
+    )
+    app_setup.SessionLocal = None
+    app_setup._db_init_error = None
 
     try:
         with pytest.raises(HTTPException) as excinfo:
-            next(api_main.get_db())
+            next(app_setup.get_db())
         assert excinfo.value.status_code == 503
         assert excinfo.value.detail == "Database service is unavailable"
-        assert isinstance(api_main._db_init_error, RuntimeError)
     finally:
-        api_main.SessionLocal = None
-        api_main._db_init_error = None
+        app_setup.SessionLocal = None
+        app_setup._db_init_error = None
 
 
 def test_initialize_database_recovers_after_transient_failure(mocker):
-    import api.main as api_main
+    from api import app_setup
 
+    class _ClosableSession:
+        closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    fake_session = _ClosableSession()
     fake_engine = MagicMock()
-    fake_session_factory = MagicMock()
-    db_connect = mocker.patch.object(
-        api_main,
+    mocker.patch.object(
+        app_setup,
         "db_connect",
         side_effect=[RuntimeError("first failure"), fake_engine],
     )
-    sessionmaker = mocker.patch.object(api_main, "sessionmaker", return_value=fake_session_factory)
-    api_main.SessionLocal = None
-    api_main._db_init_error = None
+    mocker.patch.object(
+        app_setup,
+        "sessionmaker",
+        return_value=lambda: fake_session,
+    )
+    app_setup.SessionLocal = None
+    app_setup._db_init_error = None
 
     try:
-        assert api_main.initialize_database() is None
-        assert isinstance(api_main._db_init_error, RuntimeError)
-        assert api_main.initialize_database() is fake_session_factory
-        assert api_main._db_init_error is None
-        assert api_main.is_db_ready() is True
-        assert db_connect.call_count == 2
-        sessionmaker.assert_called_once_with(bind=fake_engine, autoflush=False, autocommit=False)
+        with pytest.raises(HTTPException) as excinfo:
+            next(app_setup.get_db())
+        assert excinfo.value.status_code == 503
+
+        session_dependency = app_setup.get_db()
+        assert next(session_dependency) is fake_session
+        with pytest.raises(StopIteration):
+            next(session_dependency)
+        assert fake_session.closed is True
     finally:
-        api_main.SessionLocal = None
-        api_main._db_init_error = None
+        app_setup.SessionLocal = None
+        app_setup._db_init_error = None
 
 
 def test_task_status_rejects_invalid_uuid():
@@ -462,7 +473,8 @@ def test_segment_force_bypasses_cache(mocker):
     """
     If cached agenda items exist, `force=true` should still enqueue regeneration.
     """
-    from api.main import get_db, Catalog, AgendaItem
+    from api.main import get_db
+    from pipeline.models import AgendaItem, Catalog
 
     catalog = MagicMock(id=401, content="City council meeting discussed budget updates and adopted multiple motions after public comment.")
 

--- a/tests/test_api_key_compare_digest.py
+++ b/tests/test_api_key_compare_digest.py
@@ -1,11 +1,10 @@
 import asyncio
-import pytest
 
 
 def test_verify_api_key_uses_compare_digest(mocker):
-    from api import main
+    from api import app_setup
 
-    spy = mocker.patch("api.main.hmac.compare_digest", return_value=False)
+    mocker.patch("api.app_setup.hmac.compare_digest", return_value=True)
 
     class _Client:
         host = "127.0.0.1"
@@ -17,8 +16,4 @@ def test_verify_api_key_uses_compare_digest(mocker):
     req.client = _Client()
     req.url = _URL()
 
-    with pytest.raises(main.HTTPException) as exc:
-        asyncio.run(main.verify_api_key(req, x_api_key="bad"))
-
-    assert exc.value.status_code == 401
-    spy.assert_called_once()
+    assert asyncio.run(app_setup.verify_api_key(req, x_api_key="bad")) is None

--- a/tests/test_api_startup_security.py
+++ b/tests/test_api_startup_security.py
@@ -1,4 +1,5 @@
 import logging
+from pathlib import Path
 from typing import Never
 
 import h11
@@ -20,6 +21,35 @@ CONFIGURED_API_KEY = "Configured Production Key_123"
 CONFIGURED_MEILI_SEARCH_KEY = "Configured Search Key_123"
 MEILI_FALLBACK_WARNING = "Meilisearch reader is using the development fallback key"
 MASTER_KEY_SENTINEL = "master-key-must-not-appear-in-logs"
+TEST_ONLY_API_MAIN_EXPORTS = (
+    "get_local_ai",
+    "IssueReport",
+    "_CeleryTaskProxy",
+    "Place",
+    "Event",
+    "Document",
+    "Catalog",
+    "AgendaItem",
+    "DataIssue",
+    "IssueType",
+    "Membership",
+    "Organization",
+    "Person",
+    "MEILI_HOST",
+    "MEILI_MASTER_KEY",
+    "_build_filter_values",
+    "_count_topics_from_docs",
+    "_facet_topics",
+    "_iter_time_buckets",
+    "_normalize_city_or_400",
+    "_normalize_filters_or_400",
+    "_parse_iso_date",
+    "_require_trends_feature",
+    "_semantic_service_healthcheck",
+    "normalize_city_filter",
+    "search_documents",
+    "validate_date_format",
+)
 
 
 class _HealthySemanticResponse:
@@ -41,6 +71,55 @@ def _fail_database_initialization() -> Never:
 
 def _protected_status() -> dict[str, str]:
     return {"status": "ok"}
+
+
+def test_api_startup_has_one_implementation_owner() -> None:
+    from api import main as api_main
+
+    main_source = Path(api_main.__file__).read_text(encoding="utf-8")
+    app_setup_source = Path(app_setup.__file__).read_text(encoding="utf-8")
+
+    assert "_sync_app_setup_from_facade" not in main_source
+    assert "_sync_facade_from_app_setup" not in main_source
+    assert "hmac = app_setup.hmac" not in main_source
+    assert "from api import main" not in app_setup_source
+    assert not hasattr(api_main, "SessionLocal")
+    assert not hasattr(api_main, "_db_init_error")
+    assert not hasattr(api_main, "db_connect")
+    assert not hasattr(api_main, "sessionmaker")
+    assert not hasattr(api_main, "initialize_database")
+    assert not hasattr(api_main, "is_db_ready")
+    assert not hasattr(app_setup, "SEMANTIC_SERVICE_URL")
+    assert semantic_support.SEMANTIC_SERVICE_URL
+    assert not {
+        export_name
+        for export_name in TEST_ONLY_API_MAIN_EXPORTS
+        if hasattr(api_main, export_name)
+    }
+
+
+def test_semantic_startup_uses_app_setup_policy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    semantic_failure = "semantic startup owner reached"
+
+    def fail_semantic_healthcheck() -> dict[str, str]:
+        raise RuntimeError(semantic_failure)
+
+    monkeypatch.setenv("APP_ENV", "dev")
+    monkeypatch.setenv("API_AUTH_KEY", CONFIGURED_API_KEY)
+    monkeypatch.setenv("STARTUP_PURGE_DERIVED", "false")
+    monkeypatch.setattr(app_setup, "SEMANTIC_ENABLED", True)
+    monkeypatch.setattr(
+        semantic_support,
+        "_semantic_service_healthcheck",
+        fail_semantic_healthcheck,
+    )
+    application = FastAPI(lifespan=app_setup.lifespan)
+
+    with pytest.raises(RuntimeError, match=semantic_failure):
+        with TestClient(application):
+            pass
 
 
 @pytest.mark.parametrize(

--- a/tests/test_city_slug_normalization.py
+++ b/tests/test_city_slug_normalization.py
@@ -1,4 +1,4 @@
-from api.main import normalize_city_filter
+from api.search.query_builder import normalize_city_filter
 
 
 def test_city_slug_normalization_defaults_to_ca_prefix():

--- a/tests/test_semantic_search_api.py
+++ b/tests/test_semantic_search_api.py
@@ -11,7 +11,6 @@ VALID_KEY = "dev_secret_key_change_me"
 
 def test_semantic_search_success_with_filters(mocker):
     mocker.patch("api.main.SEMANTIC_ENABLED", True)
-    mocker.patch("api.main._semantic_service_healthcheck", return_value={"status": "healthy"})
     mocker.patch(
         "api.main._semantic_service_get_json",
         return_value={
@@ -33,7 +32,6 @@ def test_semantic_search_success_with_filters(mocker):
 
 def test_semantic_search_missing_artifacts_returns_503(mocker):
     mocker.patch("api.main.SEMANTIC_ENABLED", True)
-    mocker.patch("api.main._semantic_service_healthcheck", return_value={"status": "healthy"})
     mocker.patch(
         "api.main._semantic_service_get_json",
         side_effect=HTTPException(


### PR DESCRIPTION
## What changed

- Made `api.app_setup` the sole owner of database startup state, authentication, limiter, and lifespan behavior.
- Removed bidirectional sync functions, forwarding wrappers, stdlib rebinding, the inert local-AI hook, and 26 other test-only `api.main` exports.
- Moved semantic service URL ownership to `api.search.semantic_support` and removed the reverse startup import through `api.main`.
- Repointed affected tests to implementation modules while preserving the explicit task, lineage, and search aliases resolved by assembled routers.
- Registered the implementation-ready T-DC-1 plan and exact ownership in the remediation ledger.

## Why

The synchronized facade duplicated mutable startup state and required tests to patch public assembly exports rather than implementation boundaries. T-DC-1 removes that architectural cycle without changing route contracts or runtime policy.

## Security and compatibility

`api/app_setup.py` is security-sensitive. This PR changes ownership, not policy: API-key fail-fast validation, constant-time comparison, secret-free logging, forwarded-client handling, sanitized database failures, startup purge, semantic fail-fast behavior, and route dependencies remain covered. An attacker gains no route, credential, permission, or bypass. No API, schema, migration, environment default, model policy, or soak policy changes.

## Verification

- PASS: tests-first startup-owner regression failed on the synchronized implementation.
- PASS: alias regression failed on the 26 remaining test-only exports.
- PASS: inert `get_local_ai` regression failed before removal.
- PASS: `./.venv/bin/ruff check .`
- PASS: `./.venv/bin/mypy` (68 source files)
- PASS: focused API/security/search/task/lineage suite (119 passed)
- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py` (2 passed)
- PASS: coverage suite (1,544 passed, 17 skipped; 82.94%, floor 71%)
- PASS: complete suite (1,544 passed, 17 skipped)
- PASS: Docker Uvicorn boot smoke and `GET /health` on loopback returned `{"status":"healthy","database":"connected"}`.
- PASS: `git diff --check origin/master..HEAD`
- PASS: independent pre-commit review found no remaining P1/P2 after fixes.

## Remaining deficits

Runtime task, lineage, and search aliases intentionally remain because assembled routers still resolve them. Their removal belongs to the owned route-family remediation work, not T-DC-1.
