### PR TITLE
T-DE-1: Remove reverse provider facade imports

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -272,6 +272,10 @@ Primary owners:
 - Transport is abstracted behind `InferenceProvider`:
   - `InProcessLlamaProvider`
   - `HttpInferenceProvider`
+- HTTP retry orchestration stays in `pipeline/http_inference_attempts.py`;
+  in-process locking and reset behavior stays adapter-local.
+- Provider implementations import configuration and metrics from their owners,
+  never backward through the provider compatibility facade.
 - Providers emit typed errors (`ProviderTimeoutError`, `ProviderUnavailableError`, `ProviderResponseError`) so orchestration can distinguish retryable paths from deterministic fallback paths.
 - Under prefork workers, provider telemetry is mirrored to Redis-backed aggregates so `tc_provider_*` series remain visible.
 
@@ -287,8 +291,10 @@ Future direction (Experimental, non-baseline):
 Primary owners:
 - `pipeline/llm.py` facade plus focused `pipeline/local_ai_*` helpers
 - `pipeline/agenda_extraction.py`
-- `pipeline/llm_provider.py`
-- `pipeline/http_inference_provider.py` facade plus focused `pipeline/http_inference_*` helpers
+- `pipeline/llm_provider.py` (provider class, protocol, field, and typed-error
+  import compatibility only)
+- `pipeline/http_inference_provider.py` adapter plus focused
+  `pipeline/http_inference_*` helpers
 - `pipeline/inprocess_inference_provider.py`
 - `pipeline/inference_provider_contract.py`
 - `pipeline/config.py` facade plus focused `pipeline/config_*` loaders
@@ -325,7 +331,7 @@ Primary owners:
 - Ingestion and promotion: `council_crawler/`, `crawler/promote_stage.py`
 - Canonical extraction/content hashing: `pipeline/extraction_service.py`, `pipeline/content_hash.py`
 - Async orchestration and writes: `pipeline/tasks.py` facade plus focused `pipeline/task_*` helpers, vote extraction through `pipeline/vote_extractor.py` plus focused `pipeline/vote_extraction_*` helpers
-- Inference abstraction and provider telemetry: `pipeline/llm.py` facade plus focused `pipeline/local_ai_*` helpers, `pipeline/agenda_extraction.py`, `pipeline/llm_provider.py`, `pipeline/http_inference_provider.py` facade plus focused `pipeline/http_inference_*` helpers, `pipeline/inprocess_inference_provider.py`, `pipeline/provider_telemetry.py`, `pipeline/metrics.py`, `pipeline/metrics_provider_recorders.py`, `pipeline/metrics_redis_backend.py`
+- Inference abstraction and provider telemetry: `pipeline/llm.py` facade plus focused `pipeline/local_ai_*` helpers, `pipeline/agenda_extraction.py`, `pipeline/llm_provider.py` import compatibility, `pipeline/http_inference_provider.py` adapter plus focused `pipeline/http_inference_*` helpers, `pipeline/inprocess_inference_provider.py`, `pipeline/provider_telemetry.py`, `pipeline/metrics.py`, `pipeline/metrics_provider_recorders.py`, `pipeline/metrics_redis_backend.py`
 - API surface and auth: `api/main.py`, `api/app_setup.py`, `api/search_routes.py`, `api/search_read_routes.py` facade plus focused `api/search_read_*` helpers, `api/task_routes.py` facade plus focused `api/task_*` helpers, `api/search_support.py` facade plus focused `api/search/*_support.py` helpers, `api/search/query_builder.py`, `api/metrics.py`
 - Semantic retrieval and embeddings: `semantic_service/main.py` route facade plus focused `semantic_service/*` helpers, `pipeline/semantic_index.py`, `pipeline/semantic_faiss_backend.py`, `pipeline/semantic_pgvector_backend.py`, focused semantic backend helpers, `pipeline/models.py` facade plus focused `pipeline/model_*` modules
 - Frontend query/task UX: `frontend/app/page.js`, `frontend/state/search-state.js`, `frontend/components/ResultCard.js`
@@ -369,7 +375,10 @@ Primary owners:
 ### Extension Points and Safe Customization Seams
 
 - Add new generation capability: add route in `api/task_routes.py` + task in `pipeline/tasks.py` + UI task-state wiring.
-- Add provider transport: implement the `InferenceProvider` contract from `pipeline/inference_provider_contract.py`, expose it through `pipeline/llm_provider.py`, and preserve typed errors plus metrics.
+- Add provider transport: implement the `InferenceProvider` contract from
+  `pipeline/inference_provider_contract.py`, keep transport policy in the
+  adapter, and preserve typed errors plus metrics. Add facade imports only when
+  they are an explicit runtime compatibility contract.
 - Extend query behavior: modify `api/search/query_builder.py` to avoid search/trend filter drift.
 - Add enrichment stage: append explicit stage in pipeline orchestration with deterministic write contract.
 
@@ -396,7 +405,8 @@ Owners:
 - `pipeline/llm.py`
 - `pipeline/agenda_extraction.py`
 - `pipeline/llm_provider.py`
-- `pipeline/http_inference_provider.py` facade plus focused `pipeline/http_inference_*` helpers
+- `pipeline/http_inference_provider.py` adapter plus focused
+  `pipeline/http_inference_*` helpers
 - `pipeline/inprocess_inference_provider.py`
 - `pipeline/inference_provider_contract.py`
 - `pipeline/config.py` facade plus focused `pipeline/config_*` loaders
@@ -423,7 +433,6 @@ Owners:
 - `pipeline/metrics_task_recorders.py`
 - `pipeline/metrics_celery_signals.py`
 - `pipeline/metrics_profile_events.py`
-- `pipeline/llm_provider.py`
 - `pipeline/provider_telemetry.py`
 
 ### API Behavior Contract
@@ -457,7 +466,7 @@ Owners:
 |---|---|---|
 | API service metrics | `GET /metrics` on API | `api/metrics.py`, `api/main.py` |
 | Worker service metrics | `GET /metrics` on worker exporter | `pipeline/metrics.py`, `pipeline/metrics_definitions.py`, `pipeline/metrics_task_recorders.py`, `pipeline/metrics_celery_signals.py`, `pipeline/metrics_profile_events.py` |
-| Provider transport telemetry | `tc_provider_*` (requests, duration, retries, timeouts, TTFT/TPS, token counters) | `pipeline/provider_telemetry.py`, `pipeline/llm_provider.py`, `pipeline/metrics.py`, `pipeline/metrics_provider_keys.py`, `pipeline/metrics_provider_recorders.py`, `pipeline/metrics_redis_backend.py` |
+| Provider transport telemetry | `tc_provider_*` (requests, duration, retries, timeouts, TTFT/TPS, token counters) | `pipeline/provider_telemetry.py`, `pipeline/metrics.py`, `pipeline/metrics_provider_keys.py`, `pipeline/metrics_provider_recorders.py`, `pipeline/metrics_redis_backend.py` |
 | Prefork-safe provider visibility | Redis-backed provider metric aggregates | `pipeline/metrics.py`, `pipeline/metrics_provider_keys.py`, `pipeline/metrics_provider_collector.py`, `pipeline/metrics_redis_backend.py` |
 
 ### Security and Reliability Controls

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -223,10 +223,18 @@ Why this exists:
 - `pipeline/local_ai_agenda_compat.py`, `pipeline/local_ai_provider_calls.py`: focused LocalAI compatibility and provider-call helpers
 - `pipeline/agenda_extraction.py`: agenda-extraction facade for prompt/parser/fallback compatibility
 - `pipeline/agenda_extraction_parser.py`, `pipeline/agenda_extraction_fallback.py`, `pipeline/agenda_extraction_acceptance.py`, `pipeline/agenda_extraction_pages.py`, `pipeline/agenda_extraction_noise.py`, `pipeline/agenda_extraction_numbered.py`, `pipeline/agenda_extraction_paragraphs.py`, `pipeline/agenda_extraction_diagnostics.py`: focused agenda-extraction implementation modules
-- `pipeline/llm_provider.py`: provider compatibility facade for imports, patch seams, and config overrides
-- `pipeline/http_inference_provider.py`: HTTP/Ollama transport facade backed by focused `pipeline/http_inference_*` helpers
+- `pipeline/llm_provider.py`: provider class, protocol, response-field, and
+  typed-error import compatibility
+- `pipeline/http_inference_provider.py`: HTTP/Ollama transport adapter backed by
+  focused `pipeline/http_inference_*` helpers
 - `pipeline/inprocess_inference_provider.py`: in-process llama transport abstraction
 - `pipeline/inference_provider_contract.py`: provider protocol and typed error contract
+- `pipeline/provider_telemetry.py`: provider telemetry formatting and direct
+  metric-recorder invocation
+
+HTTP retries remain transport-local in `pipeline/http_inference_attempts.py`.
+Tests patch HTTP, configuration, and telemetry names at their implementation
+modules rather than through `pipeline/llm_provider.py`.
 
 ### Typed provider errors
 - `ProviderTimeoutError`
@@ -332,8 +340,11 @@ Use these files as primary references:
 - Agenda extraction: `pipeline/agenda_extraction.py` facade plus `pipeline/agenda_extraction_*` implementation modules
 - Runtime agenda summaries: `pipeline/agenda_summary.py` facade plus `pipeline/agenda_summary_items.py`, `pipeline/agenda_summary_scaffold.py`, `pipeline/agenda_summary_prompting.py`, `pipeline/agenda_summary_rendering.py`, `pipeline/agenda_summary_counters.py`, and `pipeline/agenda_summary_pipeline.py`
 - Agenda-summary maintenance: `pipeline/agenda_summary_fallback.py` routes maintenance requests; `pipeline/agenda_summary_contracts.py` and `pipeline/agenda_summary_inputs.py` own contracts and inputs; `pipeline/agenda_summary_batch.py` and `pipeline/non_agenda_summary_fallback.py` own deterministic writes; `pipeline/agenda_summary_side_effects.py` owns post-commit effects
-- Provider facade: `pipeline/llm_provider.py`
-- Provider transport + typed errors: `pipeline/http_inference_provider.py` facade plus focused `pipeline/http_inference_*` helpers, `pipeline/inprocess_inference_provider.py`, `pipeline/inference_provider_contract.py`
+- Provider import compatibility: `pipeline/llm_provider.py`
+- Provider transport + typed errors: `pipeline/http_inference_provider.py`
+  adapter plus focused `pipeline/http_inference_*` helpers,
+  `pipeline/inprocess_inference_provider.py`,
+  `pipeline/inference_provider_contract.py`
 - Extraction freshness/hash: `pipeline/extraction_service.py`, `pipeline/content_hash.py`
 - Metrics: `pipeline/metrics.py` (facade), `pipeline/metrics_definitions.py`, `pipeline/metrics_provider_keys.py`, `pipeline/metrics_redis_backend.py`, `pipeline/metrics_provider_recorders.py`, `pipeline/metrics_provider_collector.py`, `pipeline/metrics_task_recorders.py`, `pipeline/metrics_celery_signals.py`, `pipeline/metrics_profile_events.py`
 - Summary text runtime: `pipeline/text_generation.py` facade plus `pipeline/summary_text_formatting.py`, `pipeline/summary_text_prompting.py`, `pipeline/summary_source_quality.py`, `pipeline/summary_grounding.py`, and `pipeline/summary_backfill_*` helpers

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,6 +1,6 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 3.64
+version: 3.65
 generated: 2026-07-26
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
@@ -10,6 +10,12 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v3.65:** Marks T-DC-1 complete after PR #157 removed copied startup state,
+  reverse startup imports, forwarding wrappers, stdlib rebinding, and test-only
+  API re-exports. Activates a corrected T-DE-1 after independent review found
+  that retry orchestration is already transport-local. T-DE-1 now removes
+  reverse imports through the provider compatibility facade, repoints tests to
+  implementation owners, and preserves HTTP retry and in-process reset policy.
 - **v3.64:** Marks T-DD-1B complete after PR #156 merged the characterized
   event-graph mutation owner with shared-catalog, rollback, idempotency, and
   CLI parity coverage. Activates P1 T-DC-1 with exact ownership for removing
@@ -313,10 +319,10 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 | State | Tasks |
 |---|---|
-| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2, T-SEC-3, T-SEC-3C, T-SEC-4, T-SEC-4A, T-SEC-5, T-SEC-6, T-TIME-1, T-TIME-2, T-TIME-3, T-CRAWL-1, T-CRAWL-2, T-PLAT-1, T-PLAT-1A, T-PLAT-2A, T-PLAT-2B, T-PLAT-3, T-GOV-1, T-GOV-3A, T-GOV-4, T-GOV-5, T-DA-1, T-DB-1A, T-DB-1, T-DB-1B, T-DD-1A, T-DD-1B |
+| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2, T-SEC-3, T-SEC-3C, T-SEC-4, T-SEC-4A, T-SEC-5, T-SEC-6, T-TIME-1, T-TIME-2, T-TIME-3, T-CRAWL-1, T-CRAWL-2, T-PLAT-1, T-PLAT-1A, T-PLAT-2A, T-PLAT-2B, T-PLAT-3, T-GOV-1, T-GOV-3A, T-GOV-4, T-GOV-5, T-DA-1, T-DB-1A, T-DB-1, T-DB-1B, T-DC-1, T-DD-1A, T-DD-1B |
 | **Partially landed; acceptance incomplete** | T-GOV-3, T-GOV-6 |
-| **Active** | T-DC-1 |
-| **Pending** | T-DE-1, T-PLAT-2, T-PLAT-4, T-GOV-2, T-GOV-3B |
+| **Active** | T-DE-1 |
+| **Pending** | T-PLAT-2, T-PLAT-4, T-GOV-2, T-GOV-3B |
 
 ---
 
@@ -383,7 +389,7 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 | DEDUP-B   | agent-db   | pipeline/summary_backfill*.py, pipeline/task_summary_generation*.py, pipeline/task_summary_empty_agenda.py, pipeline/task_summary_side_effects.py, pipeline/task_facade_helpers.py, pipeline/tasks.py, pipeline/run_pipeline.py (T-DB-1 only), pipeline/backlog_maintenance.py (T-DB-1B only), pipeline/agenda_summary_maintenance.py (T-DB-1B only), pipeline/agenda_summary_fallback.py (T-DB-1B only), pipeline/non_agenda_summary_fallback.py (T-DB-1B only), pipeline/agenda_summary_batch.py (T-DB-1B only), scripts/backfill_summaries.py, scripts/staged_hydrate_cities.py, scripts/profile_pipeline_selection.py, scripts/staged_hydration_runner.py (T-DB-1B only), ARCHITECTURE.md and docs/PIPELINE.md (T-DB-1B agenda-summary maintenance map only), tests/test_*backfill*, tests/test_summary_generation_operation.py (new), tests/test_agenda_summary_payload_budget.py, tests/test_summary_blocking.py, tests/test_task_provider_retry_semantics.py, tests/test_async_flow.py, tests/test_task_facade_cleanup.py, tests/test_repository_guardrails.py (T-DB tasks only), tests/test_pipeline_batching.py, tests/test_run_pipeline_orchestration.py, tests/test_staged_hydrate_cities.py, tests/test_tasks_agenda_summary_format.py, tests/test_profile_pipeline_cli.py |
 | DEDUP-C   | agent-dc   | api/main.py, api/app_setup.py, tests/conftest.py, tests/test_*api* (Phase 2 only) |
 | DEDUP-D   | agent-dd   | scripts/flush_city_pipeline_state.py, scripts/reset_city_verification_state.py, scripts/worker_health_probes.py, scripts/*_healthcheck.py, tests for same |
-| DEDUP-E   | agent-de   | pipeline/http_inference_provider.py, pipeline/inprocess_inference_provider.py, pipeline/inference_provider_contract.py, tests for same |
+| DEDUP-E   | agent-de   | pipeline/http_inference_provider.py, pipeline/http_inference_attempts.py (verify-only), pipeline/inprocess_inference_provider.py (verify-only), pipeline/inference_provider_contract.py (verify-only), pipeline/llm_provider.py, pipeline/provider_telemetry.py, pipeline/agenda_segmentation_maintenance.py, ARCHITECTURE.md, docs/PIPELINE.md, docs/plans/T_DE_1_PROVIDER_BOUNDARY_PLAN.md, docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md (T-DE-1 only), tests/test_inference_provider_protocol_contract.py, tests/test_http_provider_telemetry_metrics.py, tests/test_http_provider_operation_retry_budgets.py, tests/test_http_provider_ttft_tps_computation.py, tests/test_http_provider_token_metrics_parsing.py, tests/test_hydrate_repaired_city_catalogs.py |
 | PLAT      | agent-plat | alembic/** (new), alembic.ini (new), pipeline/requirements*.txt, pipeline/db_init.py (T-PLAT-1 only), pipeline/db_migrate.py (T-PLAT-1 only, after TIME), pipeline/db_migration_alembic.py (new, T-PLAT-1 only), pipeline/db_migration_backfills.py (T-PLAT-1 shared transaction only), pipeline/db_migration_runner.py (T-PLAT-1 strict legacy path only), pipeline/db_schema_contracts.py (new, T-PLAT-1 only), pipeline/db_migration_columns.py (T-PLAT-1 legacy parity only), pipeline/migrate_v8.py (T-PLAT-1 frozen transaction adapter only), pipeline/migration_pgvector_semantic_embeddings.py (T-PLAT-1 frozen metadata only), pipeline/migrate_v9.py and pipeline/migration_catalog_lineage_columns.py (T-PLAT-1 shared transaction only), pipeline/migrate_v10.py (T-PLAT-1 shared transaction only), pipeline/seed_places.py (T-PLAT-1 schema handoff only), pipeline/promote_stage.py (T-PLAT-1 schema handoff only), scripts/check_schema_parity.py (new, T-PLAT-1 only), scripts/dev_up.sh (T-PLAT-1 only), README.md (T-PLAT-1 setup section only), ARCHITECTURE.md (T-PLAT-1 migration map only), api/requirements.txt, semantic_service/requirements.txt, constraints.txt (new), .github/dependabot.yml (new), .github/workflows/python-guardrails.yml (T-PLAT-1 PostgreSQL migration service/step only), ruff.toml (T-PLAT-1 stale db_migration_runner.py BLE001 selector removal only), docs/OPERATIONS.md (migration and backup sections only), docs/PIPELINE.md (T-PLAT-1 migration section only), docs/CONTRIBUTING_CITIES.md (T-PLAT-1 seed prerequisite only), docs/plans/T_PLAT_1_ALEMBIC_BASELINE_PLAN.md (new), docs/plans/G5_ALEMBIC_ADOPTION_DECISION_PLAN.md (T-PLAT-1 status only), docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md (T-PLAT-1 only), tests/test_alembic_migrations.py (new), tests/test_db_init.py (T-PLAT-1 only), tests/test_db_migrate.py (T-PLAT-1 only), tests/test_docker_build_contracts.py (T-PLAT-1 fresh-DB contract only), tests/test_migrate_v8_pgvector_order.py (T-PLAT-1 only), tests/test_migrate_v9.py (T-PLAT-1 only), tests/test_migrate_v10.py (T-PLAT-1 only), tests/test_seed_places.py (T-PLAT-1 schema handoff only), tests/test_seed_places_includes_cupertino.py (T-PLAT-1 schema handoff only), tests/test_database.py (T-PLAT-1 promotion schema handoff only), tests/test_pipeline_idempotency.py (T-PLAT-1 promotion schema handoff only), tests/test_pipeline_integration.py (T-PLAT-1 promotion schema handoff only), tests/test_repository_guardrails.py (T-PLAT-1 migration CI and BLE001 ratchet only), tests/test_run_pipeline_orchestration.py (T-PLAT-1 migration-prelude contract only), api/cache.py |
 | GOV       | agent-gov  | docs/ADR.md, docs/ENGINEERING_GUARDRAILS.md, AGENTS.md, SECURITY.md (new), docs/TESTING.md (new), docs/DATA_GOVERNANCE.md (new), tests/test_repository_guardrails.py (Phase 3 only) |
 
@@ -1148,7 +1154,7 @@ files (GED-5 grant).
 
 ### T-DC-1: Remove the api.main <-> app_setup sync machinery
 - priority: P1
-- status: active
+- status: complete and verified 2026-07-26 (PR #157)
 - must_not_run_concurrently_with: any SEC task
 - implementation_plan: `docs/plans/T_DC_1_APP_STARTUP_OWNERSHIP_PLAN.md`
 - files_owned: the implementation plan and ledger; `api/main.py`;
@@ -1231,18 +1237,39 @@ files (GED-5 grant).
   persisted-state and onboarding contracts, Ruff, Mypy, docs links, coverage,
   and the complete suite pass.
 
-### T-DE-1: Shared provider retry/telemetry
+### T-DE-1: Remove reverse provider-facade dependencies
 - priority: P2
-- files_owned: http_inference_provider.py, inprocess_inference_provider.py,
-  inference_provider_contract.py, tests for same
-- do: Move the 23 duplicated windows (retry/telemetry scaffolding) into the
-  contract module or a small shared helper; providers call it. No behavior
-  change: error mapping and fail-fast semantics are covered by
-  tests/test_provider_error_mapping_retry_vs_fallback.py — it must pass
-  unmodified.
-- accept: Duplication between providers ~0; that guardrail test green
-  UNCHANGED.
-- verify: Full suite.
+- implementation_plan: `docs/plans/T_DE_1_PROVIDER_BOUNDARY_PLAN.md`
+- files_owned: the implementation plan and ledger; `ARCHITECTURE.md`;
+  `docs/PIPELINE.md`; `pipeline/http_inference_provider.py`;
+  `pipeline/llm_provider.py`;
+  `pipeline/provider_telemetry.py`;
+  `pipeline/agenda_segmentation_maintenance.py`;
+  `tests/test_inference_provider_protocol_contract.py`;
+  `tests/test_http_provider_telemetry_metrics.py`;
+  `tests/test_http_provider_operation_retry_budgets.py`;
+  `tests/test_http_provider_ttft_tps_computation.py`;
+  `tests/test_http_provider_token_metrics_parsing.py`;
+  `tests/test_hydrate_repaired_city_catalogs.py`
+- do: Remove implementation imports through `pipeline.llm_provider`. HTTP
+  transport reads config and calls `requests` at its implementation owner;
+  provider telemetry calls metric recorders at its implementation owner;
+  maintenance timeout overrides patch the HTTP owner. Repoint affected tests
+  from facade monkeypatches. Keep HTTP retry orchestration in
+  `pipeline/http_inference_attempts.py`; in-process locking/reset behavior
+  remains distinct.
+- preserve: `pipeline.llm_provider` runtime import compatibility; provider
+  classes, protocol, operation labels, response fields, and typed errors;
+  retry budgets, timeout values, metric labels, local-first defaults,
+  fail-fast behavior, and model/fallback policy. Remove test-only config,
+  `requests`, and metric-recorder re-exports rather than leaving inert names.
+- accept: Provider implementations do not import their compatibility facade;
+  tests patch implementation or approved fake boundaries; temporary timeout
+  overrides still restore prior values and provider state; the unchanged
+  provider error-mapping test remains green.
+- verify: Follow the Full T-DE-1 plan; focused inference, telemetry, and
+  maintenance tests, Ruff, Mypy, docs links, coverage, and the complete Python
+  suite pass.
 
 ---
 

--- a/docs/plans/T_DE_1_PROVIDER_BOUNDARY_PLAN.md
+++ b/docs/plans/T_DE_1_PROVIDER_BOUNDARY_PLAN.md
@@ -1,7 +1,7 @@
 # T-DE-1: Remove Reverse Provider-Facade Dependencies
 
-`artifact_contract: ce-unified-plan/v1`  
-`artifact_readiness: implementation-ready`  
+`artifact_contract: ce-unified-plan/v1`
+`artifact_readiness: implementation-ready`
 `execution: code`
 
 ## 1. Context & Alignment

--- a/docs/plans/T_DE_1_PROVIDER_BOUNDARY_PLAN.md
+++ b/docs/plans/T_DE_1_PROVIDER_BOUNDARY_PLAN.md
@@ -1,0 +1,315 @@
+# T-DE-1: Remove Reverse Provider-Facade Dependencies
+
+`artifact_contract: ce-unified-plan/v1`  
+`artifact_readiness: implementation-ready`  
+`execution: code`
+
+## 1. Context & Alignment
+
+**a) Driver.** The current remediation entry incorrectly treats HTTP retry and
+telemetry policy as duplicated across both inference adapters. Current code
+shows that HTTP retry orchestration is already isolated in
+`pipeline/http_inference_attempts.py`, while the in-process adapter has no retry
+loop and instead owns model locking and reset behavior. The actual defect is
+that HTTP transport and telemetry implementations import backward through
+`pipeline/llm_provider.py`, preserving a test-driven facade cycle. T-DE-1 must
+remove those reverse imports without changing inference behavior.
+
+**b) Canonical documents consulted.**
+
+- `AGENTS.md` `<known_antipatterns>`, `<workflow_contract>`, and
+  `<verification_matrix>` prohibit test-seam re-exports, require implementation
+  patch targets, and define the inference verification row.
+- `docs/TESTING.MD` "The core rule" and "Patch-target rules" require tests to
+  fake the inference and outbound-HTTP boundaries at implementation modules.
+- `docs/ADR.md` "Test patch points are not a public API" authorizes the
+  domain-scoped removal of test-only facade seams while preserving runtime
+  import contracts not explicitly retired.
+- `docs/ADR.md` "Split inference provider implementation behind the existing
+  facade" remains historical context. G3 supersedes its test-patch preservation
+  clauses, but not its runtime import compatibility decision.
+- `docs/reviews/architecture-review-2026-07-19.html` Candidate 04 requires
+  reverse-facade removal and explicitly rejects moving HTTP retry policy into
+  the shared contract.
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md` assigns T-DE-1 to the DEDUP-E
+  lane and requires provider failure mapping to remain unchanged.
+
+**c) Remediation alignment.** Revise T-DE-1 and own exactly:
+
+- `docs/plans/T_DE_1_PROVIDER_BOUNDARY_PLAN.md`
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`
+- `ARCHITECTURE.md`
+- `docs/PIPELINE.md`
+- `pipeline/http_inference_provider.py`
+- `pipeline/llm_provider.py`
+- `pipeline/provider_telemetry.py`
+- `pipeline/agenda_segmentation_maintenance.py`
+- `tests/test_inference_provider_protocol_contract.py`
+- `tests/test_http_provider_telemetry_metrics.py`
+- `tests/test_http_provider_operation_retry_budgets.py`
+- `tests/test_http_provider_ttft_tps_computation.py`
+- `tests/test_http_provider_token_metrics_parsing.py`
+- `tests/test_hydrate_repaired_city_catalogs.py`
+
+`pipeline/http_inference_attempts.py`, `pipeline/inprocess_inference_provider.py`, and
+`pipeline/inference_provider_contract.py` are read-only in this task. The facade
+retains provider class, protocol, operation-label, response-field, and typed
+error imports. Its config, `requests`, and metric-recorder exports are
+test-only rebinding seams and are removed. Deleting the tracked facade file
+remains outside this task and requires separate operator authorization.
+
+**d) Decision gates.** G3 is accepted and authorizes domain-scoped test seam
+removal. No open G1-G5 gate is required or foreclosed. Runtime defaults, retry
+budgets, timeout values, fail-fast policy, error mapping, and soak comparability
+remain unchanged.
+
+## 2. Design
+
+**e) Step-by-step approach.**
+
+1. Record T-DC-1 as complete and replace the stale T-DE-1 ledger entry with
+   this corrected scope.
+2. Add failing tests before implementation:
+   - provider construction reads configuration from
+     `pipeline.http_inference_provider`;
+   - outbound HTTP patches target `pipeline.http_inference_provider.requests`;
+   - metric patches target `pipeline.provider_telemetry`;
+   - in-process success and failure still emit request metrics through the
+     telemetry implementation owner;
+   - maintenance timeout overrides change the HTTP implementation owner;
+   - provider implementation modules do not import `pipeline.llm_provider`.
+3. In `pipeline/http_inference_provider.py`, import HTTP configuration directly
+   from `pipeline.config`, use its direct `requests` import, and remove
+   `_provider_facade()`.
+4. In `pipeline/provider_telemetry.py`, import provider metric recorders
+   directly from `pipeline.metrics` and remove `_provider_facade()`.
+5. In `pipeline/agenda_segmentation_maintenance.py`, apply temporary timeout
+   overrides to `pipeline.http_inference_provider`, where provider instances now
+   read the values. Preserve provider reset and restoration behavior.
+6. In `pipeline/llm_provider.py`, remove config, `requests`, and metric-recorder
+   re-exports that existed only for facade patching. Preserve provider classes,
+   protocol symbols, operation labels, response fields, and typed errors.
+7. Repoint affected tests from `pipeline.llm_provider` patches to the modules
+   where names are looked up. Preserve the provider-class facade identity test
+   because that runtime import compatibility is not retired here.
+8. Update architecture and pipeline docs to state that HTTP retries remain
+   transport-local and implementation modules do not import through the
+   compatibility facade.
+9. Run simplification, independent pre-commit review, all verification gates,
+   atomic commits, PR review, and CI watch.
+
+No new production function or module is introduced.
+
+**f) Reuse audit.** Reuse `pipeline.http_inference_attempts` for HTTP retry
+orchestration, `pipeline.inference_provider_contract` for typed errors and the
+provider protocol, `pipeline.provider_telemetry` for telemetry formatting, and
+`pipeline.metrics` for metric recording. No retry helper, adapter base class,
+registry, wrapper, or alternate contract is added.
+
+Rejected alternatives:
+
+- Move retry policy into `inference_provider_contract.py`: rejected because
+  retry is HTTP transport policy and the in-process adapter intentionally has
+  different locking/reset behavior.
+- Delete `pipeline/llm_provider.py`: rejected because provider class, protocol,
+  operation-label, response-field, and typed-error imports remain runtime
+  compatibility contracts, and tracked-file deletion requires separate
+  operator authorization. Test-only config, HTTP client, and metric re-exports
+  are removed instead.
+- Leave maintenance overrides on the facade: rejected because direct
+  implementation configuration would make those overrides inert.
+- Preserve facade patch targets with synchronization: rejected by G3 and the
+  repository's known-antipattern rules.
+
+**g) Data contracts.** The existing `InferenceProvider` protocol and typed
+provider errors remain unchanged. Telemetry dataclasses and metric labels remain
+unchanged. No raw-dictionary contract, API payload, Celery signature, CLI, or
+environment variable changes. Import compatibility narrows only by removing
+test-only config, `requests`, and metric-recorder facade names.
+
+**h) Schema/migration impact.** None.
+
+## 3. Security & Data Governance
+
+**i) Security boundary.** No `AGENTS.md` security-sensitive path changes.
+Outbound inference remains local-first and uses the same configured base URL,
+timeouts, typed failures, and fail-fast behavior.
+
+**j) Secrets.** No credential, key, environment default, or log field changes.
+
+**k) Person data.** No person-level data is created, linked, aggregated, or
+exposed.
+
+**l) Untrusted input.** Provider HTTP responses remain parsed at the existing
+HTTP payload boundary. This task changes import ownership only, not response
+validation or rendering.
+
+## 4. Code Health
+
+**m) Conformance.** Removing `_provider_facade()` eliminates dependency
+rebinding and backward imports. No new nesting, broad exception, timestamp,
+environment read, or magic policy value is added. Existing configuration
+constants continue to come from `pipeline.config`.
+
+**n) Antipattern scan, plan pass.**
+
+- A1/H1: no external API changes; current `requests` and pytest monkeypatch
+  behavior are already exercised by installed tests.
+- B1/F1: no new abstraction or duplicate retry implementation.
+- B2/C1/C2: the old facade patch path is removed from implementation tests; no
+  synchronization or compatibility shim replaces it.
+- D1-D3: assertions remain behavioral; the unchanged error-mapping suite guards
+  retry and fallback semantics.
+- E1-E3: edits remain within the owned provider family, tests, and canonical
+  docs.
+- A2-A4, B3, F2, H2-H4: no planned violations.
+
+**o) Ratchet interaction.** No Ruff selector, BLE001 boundary, type-check scope,
+coverage threshold, runtime gate, or soak policy changes. T-GOV-3B may later
+register the now-clean dependency direction.
+
+**p) Dead code and duplication audit.** Delete two `_provider_facade()`
+functions, their `ModuleType` imports, test patches that rely on the facade as a
+rebinding seam, and the facade's config, HTTP-client, and metric-recorder
+re-exports. Keep one provider-class facade identity assertion for active runtime
+import compatibility. Expected production delta is negative.
+
+## 5. Testing
+
+**q) Edge and failure scenarios.**
+
+1. HTTP provider configuration changes at its implementation owner are applied
+   to newly constructed providers.
+2. HTTP request fakes at the outbound HTTP call site affect generation and
+   health checks.
+3. Metric recorder fakes at the telemetry owner receive request, retry,
+   timeout, TTFT, TPS, and token events.
+4. Conservative profiles remain one-shot and balanced profiles retain their
+   retry budget.
+5. Provider response, timeout, unavailable, and fallback mappings remain
+   unchanged.
+6. Temporary segment and summary timeout overrides affect only the context and
+   restore prior values and provider state afterward.
+7. In-process locking/reset behavior remains unchanged.
+8. In-process success and failure continue to emit provider request telemetry.
+9. The implementation modules do not import the compatibility facade.
+10. Existing callers importing provider classes and errors through
+   `pipeline.llm_provider` remain compatible.
+11. Removed config, HTTP-client, and metric-recorder facade names are absent
+    rather than inert.
+
+**r) Test mapping.**
+
+| Tests | Scenarios |
+|---|---|
+| `test_inference_provider_protocol_contract.py` | 1, 2, 7-11 |
+| `test_http_provider_telemetry_metrics.py` | 2-5 |
+| `test_http_provider_operation_retry_budgets.py` | 2, 4, 5 |
+| `test_http_provider_ttft_tps_computation.py` | 2, 3 |
+| `test_http_provider_token_metrics_parsing.py` | 2, 3 |
+| `test_hydrate_repaired_city_catalogs.py` | 6 |
+| Unchanged `test_provider_error_mapping_retry_vs_fallback.py` | 4, 5 |
+| Unchanged in-process protocol tests | 7 |
+| Complete Python suite and coverage gate | 1-11 |
+
+**s) Fakes and mocks.** Outbound HTTP is patched at
+`pipeline.http_inference_provider.requests`, the approved outbound-HTTP
+boundary. Provider metrics are patched where looked up in
+`pipeline.provider_telemetry`. No facade, re-export, private sequence, or
+unapproved boundary is patched.
+
+**t) Verification rows.** Apply the inference backend/provider/policy row and
+docs-only row. Run focused telemetry and maintenance tests, Ruff, Mypy,
+coverage, and the complete Python suite because the change crosses provider,
+telemetry, and maintenance boundaries.
+
+## 6. Execution, Rollback, Docs
+
+**u) Exact commands.**
+
+```bash
+git fetch origin --prune
+git switch master
+git merge --ff-only origin/master
+git switch -c codex/t-de-1-provider-boundary
+```
+
+Tests-first evidence:
+
+```bash
+PYTHONPATH=. .venv/bin/pytest -q \
+  tests/test_inference_provider_protocol_contract.py \
+  tests/test_http_provider_telemetry_metrics.py \
+  tests/test_http_provider_operation_retry_budgets.py \
+  tests/test_http_provider_ttft_tps_computation.py \
+  tests/test_http_provider_token_metrics_parsing.py \
+  tests/test_hydrate_repaired_city_catalogs.py
+```
+
+Final verification:
+
+```bash
+./.venv/bin/ruff check .
+./.venv/bin/mypy
+PYTHONPATH=. .venv/bin/pytest -q \
+  tests/test_inference_provider_protocol_contract.py \
+  tests/test_provider_error_mapping_retry_vs_fallback.py \
+  tests/test_llm_backend_parity_*.py \
+  tests/test_runtime_profiles_defaults.py
+PYTHONPATH=. .venv/bin/pytest -q \
+  tests/test_http_provider_telemetry_metrics.py \
+  tests/test_http_provider_operation_retry_budgets.py \
+  tests/test_http_provider_operation_timeout_selection.py \
+  tests/test_http_provider_ttft_tps_computation.py \
+  tests/test_http_provider_token_metrics_parsing.py \
+  tests/test_hydrate_repaired_city_catalogs.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py
+PYTHONPATH=. .venv/bin/python -m pytest -q --cov \
+  --cov-config=.coveragerc \
+  --cov-report=term-missing:skip-covered \
+  tests/
+PYTHONPATH=. .venv/bin/pytest -q
+git diff --check
+git status --short
+```
+
+Delivery uses two commits:
+
+1. `docs(remediation): correct T-DE-1 provider ownership`
+2. `refactor(inference): remove reverse provider facade imports`
+
+Push `codex/t-de-1-provider-boundary`, open one PR, request Codex review, and
+watch required CI and review threads to a decided state.
+
+**v) Rollback.** Revert the T-DE-1 merge commit and rerun the inference,
+telemetry, maintenance, docs-link, coverage, and complete-suite commands. No
+migration, data repair, environment rollback, or external-state cleanup exists.
+Rollback knowingly restores test-driven reverse facade imports.
+
+**w) Docs synchronization.**
+
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`: close T-DC-1, activate corrected
+  T-DE-1, and replace the false shared-retry premise.
+- `ARCHITECTURE.md`: document provider dependency direction and transport-local
+  retry ownership.
+- `docs/PIPELINE.md`: distinguish the runtime compatibility facade from
+  implementation patch and configuration owners.
+- `AGENTS.md`, README, ADR, operations, performance, security, and data
+  governance: no change.
+
+## 7. Delivery Self-Audit
+
+**x) Diff scan.** Re-run A-F/H. Reject retry-policy movement, new provider
+abstractions, facade synchronization, runtime default changes, error-map drift,
+metrics-label drift, unowned files, weakened tests, type suppression, or
+unrelated formatting.
+
+**y) Evidence required.** Report the tests-first failure, every command from
+6u with PASS/FAIL, exact suite counts, coverage result, independent planning
+and pre-commit findings, commit hashes, PR URL, unresolved-thread count, and CI
+state. Browser testing is not applicable because no UI path changes.
+
+**z) Deviations.** Expected deviations from remediation plan v3.64 are the
+corrected T-DE-1 premise and expanded ownership. Any tracked-file deletion,
+runtime import break, retry/timeout/model-policy change, added dependency,
+skipped review, unresolved P1/P2, or unrun required check is a blocker.

--- a/pipeline/agenda_segmentation_maintenance.py
+++ b/pipeline/agenda_segmentation_maintenance.py
@@ -10,7 +10,7 @@ from typing import Any
 from sqlalchemy.exc import SQLAlchemyError
 
 from pipeline import llm as llm_mod
-from pipeline import llm_provider as llm_provider_mod
+from pipeline import http_inference_provider as http_inference_provider_mod
 from pipeline.agenda_resolver import has_viable_structured_agenda_source, resolve_agenda_items
 from pipeline.agenda_service import persist_agenda_items
 from pipeline.db_session import db_session
@@ -30,23 +30,23 @@ def provider_timeout_override(
         yield
         return
 
-    previous_segment_timeout = llm_provider_mod.LOCAL_AI_HTTP_TIMEOUT_SEGMENT_SECONDS
-    previous_summary_timeout = llm_provider_mod.LOCAL_AI_HTTP_TIMEOUT_SUMMARY_SECONDS
+    previous_segment_timeout = http_inference_provider_mod.LOCAL_AI_HTTP_TIMEOUT_SEGMENT_SECONDS
+    previous_summary_timeout = http_inference_provider_mod.LOCAL_AI_HTTP_TIMEOUT_SUMMARY_SECONDS
     previous_instance = llm_mod.LocalAI._instance
     previous_provider = getattr(previous_instance, "_provider", None) if previous_instance else None
     previous_backend = getattr(previous_instance, "_provider_backend", None) if previous_instance else None
     if segment_timeout_seconds is not None:
-        llm_provider_mod.LOCAL_AI_HTTP_TIMEOUT_SEGMENT_SECONDS = int(segment_timeout_seconds)
+        http_inference_provider_mod.LOCAL_AI_HTTP_TIMEOUT_SEGMENT_SECONDS = int(segment_timeout_seconds)
     if summary_timeout_seconds is not None:
-        llm_provider_mod.LOCAL_AI_HTTP_TIMEOUT_SUMMARY_SECONDS = int(summary_timeout_seconds)
+        http_inference_provider_mod.LOCAL_AI_HTTP_TIMEOUT_SUMMARY_SECONDS = int(summary_timeout_seconds)
     if previous_instance is not None:
         previous_instance._provider = None
         previous_instance._provider_backend = None
     try:
         yield
     finally:
-        llm_provider_mod.LOCAL_AI_HTTP_TIMEOUT_SEGMENT_SECONDS = previous_segment_timeout
-        llm_provider_mod.LOCAL_AI_HTTP_TIMEOUT_SUMMARY_SECONDS = previous_summary_timeout
+        http_inference_provider_mod.LOCAL_AI_HTTP_TIMEOUT_SEGMENT_SECONDS = previous_segment_timeout
+        http_inference_provider_mod.LOCAL_AI_HTTP_TIMEOUT_SUMMARY_SECONDS = previous_summary_timeout
         current_instance = llm_mod.LocalAI._instance
         if current_instance is not None:
             current_instance._provider = previous_provider

--- a/pipeline/http_inference_provider.py
+++ b/pipeline/http_inference_provider.py
@@ -1,10 +1,21 @@
 from __future__ import annotations
 
 import logging
-from types import ModuleType
 
 import requests
 
+from pipeline.config import (
+    LLM_CONTEXT_WINDOW,
+    LOCAL_AI_HTTP_API,
+    LOCAL_AI_HTTP_BASE_URL,
+    LOCAL_AI_HTTP_MAX_RETRIES,
+    LOCAL_AI_HTTP_MODEL,
+    LOCAL_AI_HTTP_PROFILE,
+    LOCAL_AI_HTTP_TIMEOUT_SECONDS,
+    LOCAL_AI_HTTP_TIMEOUT_SEGMENT_SECONDS,
+    LOCAL_AI_HTTP_TIMEOUT_SUMMARY_SECONDS,
+    LOCAL_AI_HTTP_TIMEOUT_TOPICS_SECONDS,
+)
 from pipeline.http_inference_attempts import HttpOperationContext, ProviderAttemptResult, run_attempt, run_operation
 from pipeline.http_inference_errors import raise_provider_error_from_last_error
 from pipeline.http_inference_payloads import (
@@ -45,21 +56,20 @@ class HttpInferenceProvider:
     name = HTTP_PROVIDER_NAME
 
     def __init__(self):
-        facade = _provider_facade()
-        self.base_url = facade.LOCAL_AI_HTTP_BASE_URL
-        self.http_api = facade.LOCAL_AI_HTTP_API
-        self.timeout_seconds = max(MINIMUM_HTTP_TIMEOUT_SECONDS, facade.LOCAL_AI_HTTP_TIMEOUT_SECONDS)
-        self.timeout_segment_seconds = max(MINIMUM_HTTP_TIMEOUT_SECONDS, facade.LOCAL_AI_HTTP_TIMEOUT_SEGMENT_SECONDS)
-        self.timeout_summary_seconds = max(MINIMUM_HTTP_TIMEOUT_SECONDS, facade.LOCAL_AI_HTTP_TIMEOUT_SUMMARY_SECONDS)
-        self.timeout_topics_seconds = max(MINIMUM_HTTP_TIMEOUT_SECONDS, facade.LOCAL_AI_HTTP_TIMEOUT_TOPICS_SECONDS)
-        self.max_retries = max(0, facade.LOCAL_AI_HTTP_MAX_RETRIES)
-        self.model_name = facade.LOCAL_AI_HTTP_MODEL
-        self.context_window = max(0, facade.LLM_CONTEXT_WINDOW)
+        self.base_url = LOCAL_AI_HTTP_BASE_URL
+        self.http_api = LOCAL_AI_HTTP_API
+        self.timeout_seconds = max(MINIMUM_HTTP_TIMEOUT_SECONDS, LOCAL_AI_HTTP_TIMEOUT_SECONDS)
+        self.timeout_segment_seconds = max(MINIMUM_HTTP_TIMEOUT_SECONDS, LOCAL_AI_HTTP_TIMEOUT_SEGMENT_SECONDS)
+        self.timeout_summary_seconds = max(MINIMUM_HTTP_TIMEOUT_SECONDS, LOCAL_AI_HTTP_TIMEOUT_SUMMARY_SECONDS)
+        self.timeout_topics_seconds = max(MINIMUM_HTTP_TIMEOUT_SECONDS, LOCAL_AI_HTTP_TIMEOUT_TOPICS_SECONDS)
+        self.max_retries = max(0, LOCAL_AI_HTTP_MAX_RETRIES)
+        self.model_name = LOCAL_AI_HTTP_MODEL
+        self.context_window = max(0, LLM_CONTEXT_WINDOW)
 
     def health_check(self) -> bool:
         health_path = "/health" if self.http_api == OPENAI_COMPAT_HTTP_API else "/api/tags"
         try:
-            response = _provider_facade().requests.get(
+            response = requests.get(
                 f"{self.base_url}{health_path}",
                 timeout=min(HEALTH_CHECK_TIMEOUT_SECONDS, self.timeout_seconds),
             )
@@ -80,7 +90,7 @@ class HttpInferenceProvider:
         return max_retries_for_operation(
             operation,
             max_retries=self.max_retries,
-            profile_name=_provider_facade().LOCAL_AI_HTTP_PROFILE,
+            profile_name=LOCAL_AI_HTTP_PROFILE,
         )
 
     def _build_request_payload(self, prompt: str, *, max_tokens: int, temperature: float) -> dict[str, object]:
@@ -101,7 +111,7 @@ class HttpInferenceProvider:
 
     def _post_generate_request(self, payload: dict[str, object], *, timeout_seconds: int) -> requests.Response:
         endpoint_path = "/v1/chat/completions" if self.http_api == OPENAI_COMPAT_HTTP_API else "/api/generate"
-        return _provider_facade().requests.post(
+        return requests.post(
             f"{self.base_url}{endpoint_path}",
             json=payload,
             timeout=timeout_seconds,
@@ -128,7 +138,7 @@ class HttpInferenceProvider:
         return ProviderTelemetryIdentity(
             provider_name=self.name,
             model_name=self.model_name,
-            profile_name=_provider_facade().LOCAL_AI_HTTP_PROFILE,
+            profile_name=LOCAL_AI_HTTP_PROFILE,
             api_name=self.http_api,
         )
 
@@ -232,9 +242,3 @@ class HttpInferenceProvider:
 
     def generate_json(self, prompt: str, *, max_tokens: int) -> str | None:
         return self._run_operation(OPERATION_GENERATE_JSON, prompt, max_tokens=max_tokens, temperature=0.0)
-
-
-def _provider_facade() -> ModuleType:
-    from pipeline import llm_provider
-
-    return llm_provider

--- a/pipeline/llm_provider.py
+++ b/pipeline/llm_provider.py
@@ -1,19 +1,5 @@
 from __future__ import annotations
 
-import requests
-
-from pipeline.config import (
-    LOCAL_AI_HTTP_API,
-    LOCAL_AI_HTTP_BASE_URL,
-    LOCAL_AI_HTTP_MAX_RETRIES,
-    LOCAL_AI_HTTP_MODEL,
-    LOCAL_AI_HTTP_PROFILE,
-    LOCAL_AI_HTTP_TIMEOUT_SECONDS,
-    LOCAL_AI_HTTP_TIMEOUT_SEGMENT_SECONDS,
-    LOCAL_AI_HTTP_TIMEOUT_SUMMARY_SECONDS,
-    LOCAL_AI_HTTP_TIMEOUT_TOPICS_SECONDS,
-    LLM_CONTEXT_WINDOW,
-)
 from pipeline.http_inference_provider import HttpInferenceProvider
 from pipeline.inference_provider_contract import (
     EVAL_COUNT_FIELD,
@@ -35,14 +21,6 @@ from pipeline.inference_provider_contract import (
     ProviderUnavailableError,
 )
 from pipeline.inprocess_inference_provider import InProcessLlamaProvider
-from pipeline.metrics import (
-    record_provider_request,
-    record_provider_retry,
-    record_provider_timeout,
-    record_provider_token_counts,
-    record_provider_tokens_per_sec,
-    record_provider_ttft,
-)
 
 
 __all__ = [
@@ -51,16 +29,6 @@ __all__ = [
     "HttpInferenceProvider",
     "InferenceProvider",
     "InProcessLlamaProvider",
-    "LOCAL_AI_HTTP_BASE_URL",
-    "LOCAL_AI_HTTP_API",
-    "LOCAL_AI_HTTP_MAX_RETRIES",
-    "LOCAL_AI_HTTP_MODEL",
-    "LOCAL_AI_HTTP_PROFILE",
-    "LOCAL_AI_HTTP_TIMEOUT_SECONDS",
-    "LOCAL_AI_HTTP_TIMEOUT_SEGMENT_SECONDS",
-    "LOCAL_AI_HTTP_TIMEOUT_SUMMARY_SECONDS",
-    "LOCAL_AI_HTTP_TIMEOUT_TOPICS_SECONDS",
-    "LLM_CONTEXT_WINDOW",
     "OPERATION_EXTRACT_AGENDA",
     "OPERATION_GENERATE_JSON",
     "OPERATION_GENERATE_TOPICS",
@@ -75,11 +43,4 @@ __all__ = [
     "ProviderUnavailableError",
     "RESPONSE_FIELD_NAME",
     "TOTAL_DURATION_FIELD",
-    "record_provider_request",
-    "record_provider_retry",
-    "record_provider_timeout",
-    "record_provider_token_counts",
-    "record_provider_tokens_per_sec",
-    "record_provider_ttft",
-    "requests",
 ]

--- a/pipeline/provider_telemetry.py
+++ b/pipeline/provider_telemetry.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from types import ModuleType
 
 from pipeline.inference_provider_contract import (
     EVAL_COUNT_FIELD,
@@ -10,6 +9,14 @@ from pipeline.inference_provider_contract import (
     PROMPT_EVAL_COUNT_FIELD,
     PROMPT_EVAL_DURATION_FIELD,
     TOTAL_DURATION_FIELD,
+)
+from pipeline.metrics import (
+    record_provider_request,
+    record_provider_retry,
+    record_provider_timeout,
+    record_provider_token_counts,
+    record_provider_tokens_per_sec,
+    record_provider_ttft,
 )
 
 
@@ -154,7 +161,7 @@ def record_provider_retry_event(
         retry_telemetry.timeout_seconds,
         retry_telemetry.error.__class__.__name__,
     )
-    _provider_facade().record_provider_retry(
+    record_provider_retry(
         identity.provider_name,
         retry_telemetry.operation,
         identity.model_name,
@@ -188,8 +195,7 @@ def record_provider_attempt_event(
         _format_metric(token_metrics[TOKEN_METRIC_PROMPT_EVAL_DURATION_MS], precision=2),
         _format_metric(token_metrics[TOKEN_METRIC_EVAL_DURATION_MS], precision=2),
     )
-    facade = _provider_facade()
-    facade.record_provider_request(
+    record_provider_request(
         identity.provider_name,
         attempt_telemetry.operation,
         identity.model_name,
@@ -198,7 +204,7 @@ def record_provider_attempt_event(
     )
     ttft_ms = token_metrics[TOKEN_METRIC_TTFT_MS]
     if ttft_ms is not None:
-        facade.record_provider_ttft(
+        record_provider_ttft(
             identity.provider_name,
             attempt_telemetry.operation,
             identity.model_name,
@@ -207,7 +213,7 @@ def record_provider_attempt_event(
         )
     tokens_per_sec = token_metrics[TOKEN_METRIC_TOKENS_PER_SEC]
     if tokens_per_sec is not None:
-        facade.record_provider_tokens_per_sec(
+        record_provider_tokens_per_sec(
             identity.provider_name,
             attempt_telemetry.operation,
             identity.model_name,
@@ -217,7 +223,7 @@ def record_provider_attempt_event(
     prompt_tokens = token_metrics[TOKEN_METRIC_PROMPT_TOKENS]
     completion_tokens = token_metrics[TOKEN_METRIC_COMPLETION_TOKENS]
     if prompt_tokens is not None and completion_tokens is not None:
-        facade.record_provider_token_counts(
+        record_provider_token_counts(
             identity.provider_name,
             attempt_telemetry.operation,
             identity.model_name,
@@ -234,11 +240,11 @@ def record_inprocess_provider_request(
     outcome: str,
     duration_ms: float,
 ) -> None:
-    _provider_facade().record_provider_request(provider_name, operation, model_name, outcome, duration_ms)
+    record_provider_request(provider_name, operation, model_name, outcome, duration_ms)
 
 
 def record_provider_timeout_event(provider_name: str, operation: str, model_name: str) -> None:
-    _provider_facade().record_provider_timeout(provider_name, operation, model_name)
+    record_provider_timeout(provider_name, operation, model_name)
 
 
 def _format_metric(metric_value: float | int | None, *, precision: int | None = None) -> str:
@@ -247,9 +253,3 @@ def _format_metric(metric_value: float | int | None, *, precision: int | None = 
     if precision is None:
         return str(metric_value)
     return f"{metric_value:.{precision}f}"
-
-
-def _provider_facade() -> ModuleType:
-    from pipeline import llm_provider
-
-    return llm_provider

--- a/tests/test_http_provider_operation_retry_budgets.py
+++ b/tests/test_http_provider_operation_retry_budgets.py
@@ -1,7 +1,8 @@
 import requests
 
-import pipeline.llm_provider as llm_provider
-from pipeline.llm_provider import HttpInferenceProvider, ProviderTimeoutError
+import pipeline.http_inference_provider as http_inference_provider
+from pipeline.http_inference_provider import HttpInferenceProvider
+from pipeline.inference_provider_contract import ProviderTimeoutError
 
 
 def test_extract_agenda_uses_zero_http_retries(monkeypatch):
@@ -12,7 +13,7 @@ def test_extract_agenda_uses_zero_http_retries(monkeypatch):
         attempts["count"] += 1
         raise requests.exceptions.Timeout("timed out")
 
-    monkeypatch.setattr("pipeline.llm_provider.requests.post", _always_timeout)
+    monkeypatch.setattr("pipeline.http_inference_provider.requests.post", _always_timeout)
 
     try:
         provider.extract_agenda("prompt", temperature=0.1, max_tokens=64)
@@ -25,7 +26,7 @@ def test_extract_agenda_uses_zero_http_retries(monkeypatch):
 
 
 def test_summarize_agenda_items_uses_zero_http_retries_in_conservative_profile(monkeypatch):
-    monkeypatch.setattr(llm_provider, "LOCAL_AI_HTTP_PROFILE", "conservative")
+    monkeypatch.setattr(http_inference_provider, "LOCAL_AI_HTTP_PROFILE", "conservative")
     provider = HttpInferenceProvider()
     attempts = {"count": 0}
 
@@ -33,7 +34,7 @@ def test_summarize_agenda_items_uses_zero_http_retries_in_conservative_profile(m
         attempts["count"] += 1
         raise requests.exceptions.Timeout("timed out")
 
-    monkeypatch.setattr("pipeline.llm_provider.requests.post", _always_timeout)
+    monkeypatch.setattr("pipeline.http_inference_provider.requests.post", _always_timeout)
 
     try:
         provider.summarize_agenda_items("prompt", temperature=0.1, max_tokens=64)
@@ -46,7 +47,7 @@ def test_summarize_agenda_items_uses_zero_http_retries_in_conservative_profile(m
 
 
 def test_summarize_agenda_items_keeps_retry_budget_in_balanced_profile(monkeypatch):
-    monkeypatch.setattr(llm_provider, "LOCAL_AI_HTTP_PROFILE", "balanced")
+    monkeypatch.setattr(http_inference_provider, "LOCAL_AI_HTTP_PROFILE", "balanced")
     provider = HttpInferenceProvider()
     attempts = {"count": 0}
 
@@ -54,7 +55,7 @@ def test_summarize_agenda_items_keeps_retry_budget_in_balanced_profile(monkeypat
         attempts["count"] += 1
         raise requests.exceptions.Timeout("timed out")
 
-    monkeypatch.setattr("pipeline.llm_provider.requests.post", _always_timeout)
+    monkeypatch.setattr("pipeline.http_inference_provider.requests.post", _always_timeout)
 
     try:
         provider.summarize_agenda_items("prompt", temperature=0.1, max_tokens=64)

--- a/tests/test_http_provider_telemetry_metrics.py
+++ b/tests/test_http_provider_telemetry_metrics.py
@@ -1,9 +1,9 @@
 import pytest
 import requests
 
-import pipeline.llm_provider as llm_provider
-from pipeline.llm_provider import (
-    HttpInferenceProvider,
+import pipeline.http_inference_provider as http_inference_provider
+from pipeline.http_inference_provider import HttpInferenceProvider
+from pipeline.inference_provider_contract import (
     ProviderResponseError,
     ProviderTimeoutError,
     ProviderUnavailableError,
@@ -13,14 +13,22 @@ from pipeline.llm_provider import (
 def test_http_provider_timeout_emits_single_attempt_metrics_in_conservative_profile(monkeypatch):
     events = {"timeout": 0, "retry": 0, "request": 0}
 
-    monkeypatch.setattr(llm_provider, "LOCAL_AI_HTTP_PROFILE", "conservative")
-    monkeypatch.setattr("pipeline.llm_provider.record_provider_timeout", lambda *args, **kwargs: events.__setitem__("timeout", events["timeout"] + 1))
-    monkeypatch.setattr("pipeline.llm_provider.record_provider_retry", lambda *args, **kwargs: events.__setitem__("retry", events["retry"] + 1))
-    monkeypatch.setattr("pipeline.llm_provider.record_provider_request", lambda *args, **kwargs: events.__setitem__("request", events["request"] + 1))
+    monkeypatch.setattr(http_inference_provider, "LOCAL_AI_HTTP_PROFILE", "conservative")
+    monkeypatch.setattr(
+        "pipeline.provider_telemetry.record_provider_timeout",
+        lambda *args, **kwargs: events.__setitem__("timeout", events["timeout"] + 1),
+    )
+    monkeypatch.setattr(
+        "pipeline.provider_telemetry.record_provider_retry",
+        lambda *args, **kwargs: events.__setitem__("retry", events["retry"] + 1),
+    )
+    monkeypatch.setattr(
+        "pipeline.provider_telemetry.record_provider_request",
+        lambda *args, **kwargs: events.__setitem__("request", events["request"] + 1),
+    )
 
     monkeypatch.setattr(
-        requests,
-        "post",
+        "pipeline.http_inference_provider.requests.post",
         lambda *args, **kwargs: (_ for _ in ()).throw(requests.exceptions.Timeout("slow")),
     )
 
@@ -42,14 +50,22 @@ def test_http_provider_timeout_emits_single_attempt_metrics_in_conservative_prof
 def test_http_provider_timeout_emits_retry_metrics_in_balanced_profile(monkeypatch):
     events = {"timeout": 0, "retry": 0, "request": 0}
 
-    monkeypatch.setattr(llm_provider, "LOCAL_AI_HTTP_PROFILE", "balanced")
-    monkeypatch.setattr("pipeline.llm_provider.record_provider_timeout", lambda *args, **kwargs: events.__setitem__("timeout", events["timeout"] + 1))
-    monkeypatch.setattr("pipeline.llm_provider.record_provider_retry", lambda *args, **kwargs: events.__setitem__("retry", events["retry"] + 1))
-    monkeypatch.setattr("pipeline.llm_provider.record_provider_request", lambda *args, **kwargs: events.__setitem__("request", events["request"] + 1))
+    monkeypatch.setattr(http_inference_provider, "LOCAL_AI_HTTP_PROFILE", "balanced")
+    monkeypatch.setattr(
+        "pipeline.provider_telemetry.record_provider_timeout",
+        lambda *args, **kwargs: events.__setitem__("timeout", events["timeout"] + 1),
+    )
+    monkeypatch.setattr(
+        "pipeline.provider_telemetry.record_provider_retry",
+        lambda *args, **kwargs: events.__setitem__("retry", events["retry"] + 1),
+    )
+    monkeypatch.setattr(
+        "pipeline.provider_telemetry.record_provider_request",
+        lambda *args, **kwargs: events.__setitem__("request", events["request"] + 1),
+    )
 
     monkeypatch.setattr(
-        requests,
-        "post",
+        "pipeline.http_inference_provider.requests.post",
         lambda *args, **kwargs: (_ for _ in ()).throw(requests.exceptions.Timeout("slow")),
     )
 
@@ -87,24 +103,23 @@ def test_http_provider_missing_stats_skips_token_metrics(monkeypatch):
     events = {"ttft": 0, "tps": 0, "tokens": 0, "request": 0}
 
     monkeypatch.setattr(
-        "pipeline.llm_provider.record_provider_request",
+        "pipeline.provider_telemetry.record_provider_request",
         lambda *args, **kwargs: events.__setitem__("request", events["request"] + 1),
     )
     monkeypatch.setattr(
-        "pipeline.llm_provider.record_provider_ttft",
+        "pipeline.provider_telemetry.record_provider_ttft",
         lambda *args, **kwargs: events.__setitem__("ttft", events["ttft"] + 1),
     )
     monkeypatch.setattr(
-        "pipeline.llm_provider.record_provider_tokens_per_sec",
+        "pipeline.provider_telemetry.record_provider_tokens_per_sec",
         lambda *args, **kwargs: events.__setitem__("tps", events["tps"] + 1),
     )
     monkeypatch.setattr(
-        "pipeline.llm_provider.record_provider_token_counts",
+        "pipeline.provider_telemetry.record_provider_token_counts",
         lambda *args, **kwargs: events.__setitem__("tokens", events["tokens"] + 1),
     )
     monkeypatch.setattr(
-        requests,
-        "post",
+        "pipeline.http_inference_provider.requests.post",
         lambda *args, **kwargs: _FakeResponse({"response": "ok"}),
     )
 
@@ -120,12 +135,17 @@ def test_http_provider_missing_stats_skips_token_metrics(monkeypatch):
 def test_http_provider_empty_response_payload_is_response_error_without_retry(monkeypatch):
     events = {"retry": 0, "request": 0}
 
-    monkeypatch.setattr("pipeline.llm_provider.record_provider_retry", lambda *args, **kwargs: events.__setitem__("retry", events["retry"] + 1))
-    monkeypatch.setattr("pipeline.llm_provider.record_provider_request", lambda *args, **kwargs: events.__setitem__("request", events["request"] + 1))
+    monkeypatch.setattr(
+        "pipeline.provider_telemetry.record_provider_retry",
+        lambda *args, **kwargs: events.__setitem__("retry", events["retry"] + 1),
+    )
+    monkeypatch.setattr(
+        "pipeline.provider_telemetry.record_provider_request",
+        lambda *args, **kwargs: events.__setitem__("request", events["request"] + 1),
+    )
 
     monkeypatch.setattr(
-        requests,
-        "post",
+        "pipeline.http_inference_provider.requests.post",
         lambda *args, **kwargs: _FakeResponse({"response": "   "}),
     )
 
@@ -149,8 +169,11 @@ def test_http_provider_invalid_json_is_response_error_without_retry(monkeypatch)
         def json(self):
             raise ValueError("bad json")
 
-    monkeypatch.setattr("pipeline.llm_provider.record_provider_retry", lambda *args, **kwargs: events.__setitem__("retry", events["retry"] + 1))
-    monkeypatch.setattr(requests, "post", lambda *args, **kwargs: _BadJsonResponse())
+    monkeypatch.setattr(
+        "pipeline.provider_telemetry.record_provider_retry",
+        lambda *args, **kwargs: events.__setitem__("retry", events["retry"] + 1),
+    )
+    monkeypatch.setattr("pipeline.http_inference_provider.requests.post", lambda *args, **kwargs: _BadJsonResponse())
 
     provider = HttpInferenceProvider()
     provider.max_retries = 2
@@ -165,10 +188,10 @@ def test_http_provider_malformed_response_payload_is_response_error_without_retr
     events = {"retry": 0}
 
     monkeypatch.setattr(
-        "pipeline.llm_provider.record_provider_retry",
+        "pipeline.provider_telemetry.record_provider_retry",
         lambda *args, **kwargs: events.__setitem__("retry", events["retry"] + 1),
     )
-    monkeypatch.setattr(requests, "post", lambda *args, **kwargs: _FakeResponse(payload))
+    monkeypatch.setattr("pipeline.http_inference_provider.requests.post", lambda *args, **kwargs: _FakeResponse(payload))
 
     provider = HttpInferenceProvider()
     provider.max_retries = 2
@@ -188,8 +211,11 @@ def test_http_provider_client_http_error_is_response_error_without_retry(monkeyp
         response = _ClientErrorResponse()
         raise requests.exceptions.HTTPError("bad request", response=response)
 
-    monkeypatch.setattr("pipeline.llm_provider.record_provider_retry", lambda *args, **kwargs: events.__setitem__("retry", events["retry"] + 1))
-    monkeypatch.setattr(requests, "post", _raise_http_error)
+    monkeypatch.setattr(
+        "pipeline.provider_telemetry.record_provider_retry",
+        lambda *args, **kwargs: events.__setitem__("retry", events["retry"] + 1),
+    )
+    monkeypatch.setattr("pipeline.http_inference_provider.requests.post", _raise_http_error)
 
     provider = HttpInferenceProvider()
     provider.max_retries = 2
@@ -201,8 +227,7 @@ def test_http_provider_client_http_error_is_response_error_without_retry(monkeyp
 
 def test_http_provider_request_exception_maps_to_unavailable(monkeypatch):
     monkeypatch.setattr(
-        requests,
-        "post",
+        "pipeline.http_inference_provider.requests.post",
         lambda *args, **kwargs: (_ for _ in ()).throw(requests.exceptions.ConnectionError("down")),
     )
 
@@ -216,11 +241,11 @@ def test_http_provider_unexpected_transport_failure_maps_to_unavailable_with_err
     outcomes = []
 
     monkeypatch.setattr(
-        "pipeline.llm_provider.record_provider_request",
+        "pipeline.provider_telemetry.record_provider_request",
         lambda provider, operation, model, outcome, duration_ms: outcomes.append(outcome),
     )
     monkeypatch.setattr(
-        "pipeline.llm_provider.requests.post",
+        "pipeline.http_inference_provider.requests.post",
         lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("patched transport blew up")),
     )
 
@@ -236,11 +261,11 @@ def test_http_provider_metric_parse_failure_maps_to_unavailable_with_error_outco
     outcomes = []
 
     monkeypatch.setattr(
-        "pipeline.llm_provider.record_provider_request",
+        "pipeline.provider_telemetry.record_provider_request",
         lambda provider, operation, model, outcome, duration_ms: outcomes.append(outcome),
     )
     monkeypatch.setattr(
-        "pipeline.llm_provider.requests.post",
+        "pipeline.http_inference_provider.requests.post",
         lambda *args, **kwargs: _FakeResponse({"response": "ok"}),
     )
 
@@ -258,17 +283,17 @@ def test_http_provider_memory_failure_maps_to_unavailable_with_error_outcome(mon
     outcomes = []
 
     monkeypatch.setattr(
-        "pipeline.llm_provider.record_provider_request",
+        "pipeline.provider_telemetry.record_provider_request",
         lambda provider, operation, model, outcome, duration_ms: outcomes.append(outcome),
     )
     if failure_source == "request":
         monkeypatch.setattr(
-            "pipeline.llm_provider.requests.post",
+            "pipeline.http_inference_provider.requests.post",
             lambda *args, **kwargs: (_ for _ in ()).throw(MemoryError("request memory failed")),
         )
     else:
         monkeypatch.setattr(
-            "pipeline.llm_provider.requests.post",
+            "pipeline.http_inference_provider.requests.post",
             lambda *args, **kwargs: _MemoryErrorResponse(),
         )
 
@@ -281,19 +306,19 @@ def test_http_provider_memory_failure_maps_to_unavailable_with_error_outcome(mon
     assert outcomes == ["error"]
 
 
-def test_http_provider_uses_llm_provider_facade_request_patch(monkeypatch):
+def test_http_provider_uses_outbound_http_call_site_patch(monkeypatch):
     monkeypatch.setattr(
-        "pipeline.llm_provider.requests.post",
-        lambda *args, **kwargs: _FakeResponse({"response": "ok from facade"}),
+        "pipeline.http_inference_provider.requests.post",
+        lambda *args, **kwargs: _FakeResponse({"response": "ok from call site"}),
     )
 
     provider = HttpInferenceProvider()
-    assert provider.summarize_text("hello", temperature=0.1, max_tokens=16) == "ok from facade"
+    assert provider.summarize_text("hello", temperature=0.1, max_tokens=16) == "ok from call site"
 
 
 def test_http_provider_health_check_handles_request_failure(monkeypatch):
     monkeypatch.setattr(
-        "pipeline.llm_provider.requests.get",
+        "pipeline.http_inference_provider.requests.get",
         lambda *args, **kwargs: (_ for _ in ()).throw(requests.exceptions.ConnectionError("down")),
     )
 

--- a/tests/test_http_provider_token_metrics_parsing.py
+++ b/tests/test_http_provider_token_metrics_parsing.py
@@ -1,6 +1,4 @@
-import requests
-
-from pipeline.llm_provider import HttpInferenceProvider
+from pipeline.http_inference_provider import HttpInferenceProvider
 
 
 class _FakeResponse:
@@ -25,20 +23,20 @@ def test_http_provider_emits_token_metrics_when_stats_exist(monkeypatch):
         "eval_duration": 3_000_000_000,
     }
 
-    monkeypatch.setattr(requests, "post", lambda *args, **kwargs: _FakeResponse(payload))
-    monkeypatch.setattr("pipeline.llm_provider.record_provider_request", lambda *args, **kwargs: None)
-    monkeypatch.setattr("pipeline.llm_provider.record_provider_timeout", lambda *args, **kwargs: None)
-    monkeypatch.setattr("pipeline.llm_provider.record_provider_retry", lambda *args, **kwargs: None)
+    monkeypatch.setattr("pipeline.http_inference_provider.requests.post", lambda *args, **kwargs: _FakeResponse(payload))
+    monkeypatch.setattr("pipeline.provider_telemetry.record_provider_request", lambda *args, **kwargs: None)
+    monkeypatch.setattr("pipeline.provider_telemetry.record_provider_timeout", lambda *args, **kwargs: None)
+    monkeypatch.setattr("pipeline.provider_telemetry.record_provider_retry", lambda *args, **kwargs: None)
     monkeypatch.setattr(
-        "pipeline.llm_provider.record_provider_ttft",
+        "pipeline.provider_telemetry.record_provider_ttft",
         lambda provider, operation, model, outcome, ttft_ms: seen.__setitem__("ttft", ttft_ms),
     )
     monkeypatch.setattr(
-        "pipeline.llm_provider.record_provider_tokens_per_sec",
+        "pipeline.provider_telemetry.record_provider_tokens_per_sec",
         lambda provider, operation, model, outcome, tokens_per_sec: seen.__setitem__("tps", tokens_per_sec),
     )
     monkeypatch.setattr(
-        "pipeline.llm_provider.record_provider_token_counts",
+        "pipeline.provider_telemetry.record_provider_token_counts",
         lambda provider, operation, model, outcome, prompt_tokens, completion_tokens: seen.__setitem__(
             "counts", (prompt_tokens, completion_tokens)
         ),

--- a/tests/test_http_provider_ttft_tps_computation.py
+++ b/tests/test_http_provider_ttft_tps_computation.py
@@ -1,6 +1,4 @@
-import requests
-
-from pipeline.llm_provider import HttpInferenceProvider
+from pipeline.http_inference_provider import HttpInferenceProvider
 
 
 class _FakeResponse:
@@ -25,20 +23,20 @@ def test_http_provider_omits_tps_when_eval_duration_is_zero(monkeypatch):
         "eval_duration": 0,
     }
 
-    monkeypatch.setattr(requests, "post", lambda *args, **kwargs: _FakeResponse(payload))
-    monkeypatch.setattr("pipeline.llm_provider.record_provider_request", lambda *args, **kwargs: None)
-    monkeypatch.setattr("pipeline.llm_provider.record_provider_timeout", lambda *args, **kwargs: None)
-    monkeypatch.setattr("pipeline.llm_provider.record_provider_retry", lambda *args, **kwargs: None)
+    monkeypatch.setattr("pipeline.http_inference_provider.requests.post", lambda *args, **kwargs: _FakeResponse(payload))
+    monkeypatch.setattr("pipeline.provider_telemetry.record_provider_request", lambda *args, **kwargs: None)
+    monkeypatch.setattr("pipeline.provider_telemetry.record_provider_timeout", lambda *args, **kwargs: None)
+    monkeypatch.setattr("pipeline.provider_telemetry.record_provider_retry", lambda *args, **kwargs: None)
     monkeypatch.setattr(
-        "pipeline.llm_provider.record_provider_ttft",
+        "pipeline.provider_telemetry.record_provider_ttft",
         lambda *args, **kwargs: seen.__setitem__("ttft", seen["ttft"] + 1),
     )
     monkeypatch.setattr(
-        "pipeline.llm_provider.record_provider_tokens_per_sec",
+        "pipeline.provider_telemetry.record_provider_tokens_per_sec",
         lambda *args, **kwargs: seen.__setitem__("tps", seen["tps"] + 1),
     )
     monkeypatch.setattr(
-        "pipeline.llm_provider.record_provider_token_counts",
+        "pipeline.provider_telemetry.record_provider_token_counts",
         lambda provider, operation, model, outcome, prompt_tokens, completion_tokens: seen.__setitem__(
             "tokens", (prompt_tokens, completion_tokens)
         ),

--- a/tests/test_hydrate_repaired_city_catalogs.py
+++ b/tests/test_hydrate_repaired_city_catalogs.py
@@ -6,9 +6,9 @@ from pathlib import Path
 
 from pipeline import (
     agenda_segmentation_maintenance,
+    http_inference_provider,
     indexer,
     llm as llm_module,
-    llm_provider as llm_provider_module,
     semantic_tasks,
 )
 from pipeline.models import AgendaItem, Catalog, Document, Event, Place
@@ -416,14 +416,15 @@ def test_segment_timeout_override_is_scoped(mocker):
     previous_provider = object()
     previous_instance = type("Instance", (), {"_provider": previous_provider, "_provider_backend": "http"})()
     mocker.patch.object(llm_module.LocalAI, "_instance", previous_instance)
-    previous_timeout = llm_provider_module.LOCAL_AI_HTTP_TIMEOUT_SEGMENT_SECONDS
+    previous_timeout = http_inference_provider.LOCAL_AI_HTTP_TIMEOUT_SEGMENT_SECONDS
 
     with agenda_segmentation_maintenance.segment_timeout_override(17):
-        assert llm_provider_module.LOCAL_AI_HTTP_TIMEOUT_SEGMENT_SECONDS == 17
+        assert http_inference_provider.LOCAL_AI_HTTP_TIMEOUT_SEGMENT_SECONDS == 17
+        assert http_inference_provider.HttpInferenceProvider().timeout_segment_seconds == 17
         assert previous_instance._provider is None
         assert previous_instance._provider_backend is None
 
-    assert llm_provider_module.LOCAL_AI_HTTP_TIMEOUT_SEGMENT_SECONDS == previous_timeout
+    assert http_inference_provider.LOCAL_AI_HTTP_TIMEOUT_SEGMENT_SECONDS == previous_timeout
     assert previous_instance._provider is previous_provider
     assert previous_instance._provider_backend == "http"
 
@@ -558,14 +559,15 @@ def test_summary_timeout_override_is_scoped(mocker):
     previous_provider = object()
     previous_instance = type("Instance", (), {"_provider": previous_provider, "_provider_backend": "http"})()
     mocker.patch.object(llm_module.LocalAI, "_instance", previous_instance)
-    previous_timeout = llm_provider_module.LOCAL_AI_HTTP_TIMEOUT_SUMMARY_SECONDS
+    previous_timeout = http_inference_provider.LOCAL_AI_HTTP_TIMEOUT_SUMMARY_SECONDS
 
     with agenda_segmentation_maintenance.summary_timeout_override(29):
-        assert llm_provider_module.LOCAL_AI_HTTP_TIMEOUT_SUMMARY_SECONDS == 29
+        assert http_inference_provider.LOCAL_AI_HTTP_TIMEOUT_SUMMARY_SECONDS == 29
+        assert http_inference_provider.HttpInferenceProvider().timeout_summary_seconds == 29
         assert previous_instance._provider is None
         assert previous_instance._provider_backend is None
 
-    assert llm_provider_module.LOCAL_AI_HTTP_TIMEOUT_SUMMARY_SECONDS == previous_timeout
+    assert http_inference_provider.LOCAL_AI_HTTP_TIMEOUT_SUMMARY_SECONDS == previous_timeout
     assert previous_instance._provider is previous_provider
     assert previous_instance._provider_backend == "http"
 

--- a/tests/test_inference_provider_protocol_contract.py
+++ b/tests/test_inference_provider_protocol_contract.py
@@ -1,11 +1,13 @@
 import threading
+from pathlib import Path
 
 from pipeline import llm as llm_mod
-from pipeline import llm_provider
+from pipeline import http_inference_provider, llm_provider, provider_telemetry
 from pipeline.http_inference_payloads import parse_openai_compatible_response_payload
 from pipeline.http_inference_provider import HttpInferenceProvider as DirectHttpInferenceProvider
-from pipeline.llm_provider import InferenceProvider, InProcessLlamaProvider, HttpInferenceProvider
-from pipeline.llm_provider import ProviderResponseError
+from pipeline.inference_provider_contract import InferenceProvider, ProviderResponseError
+from pipeline.inprocess_inference_provider import InProcessLlamaProvider
+from pipeline.llm_provider import HttpInferenceProvider
 from pipeline.provider_telemetry import TOKEN_METRIC_COMPLETION_TOKENS, TOKEN_METRIC_PROMPT_TOKENS
 
 
@@ -107,9 +109,25 @@ def test_inprocess_provider_satisfies_protocol():
     assert provider.summarize_text("x", temperature=0.0, max_tokens=8) == "ok"
 
 
+def test_inprocess_provider_emits_success_request_metric(monkeypatch):
+    provider_requests = []
+    monkeypatch.setattr(
+        provider_telemetry,
+        "record_provider_request",
+        lambda provider, operation, model, outcome, duration_ms: provider_requests.append(
+            (provider, operation, model, outcome, duration_ms)
+        ),
+    )
+
+    InProcessLlamaProvider(_DummyOwner()).summarize_text("x", temperature=0.0, max_tokens=8)
+
+    assert len(provider_requests) == 1
+    assert provider_requests[0][:4] == ("inprocess", "summarize_text", "inprocess-llama", "ok")
+
+
 def test_http_provider_payload_includes_configured_context_window(monkeypatch):
-    monkeypatch.setattr(llm_provider, "LOCAL_AI_HTTP_API", "ollama")
-    monkeypatch.setattr(llm_provider, "LLM_CONTEXT_WINDOW", 8192)
+    monkeypatch.setattr(http_inference_provider, "LOCAL_AI_HTTP_API", "ollama")
+    monkeypatch.setattr(http_inference_provider, "LLM_CONTEXT_WINDOW", 8192)
     provider = DirectHttpInferenceProvider()
 
     payload = provider._build_request_payload("summarize this", max_tokens=128, temperature=0.2)
@@ -120,8 +138,8 @@ def test_http_provider_payload_includes_configured_context_window(monkeypatch):
 
 
 def test_http_provider_openai_compatible_payload_uses_chat_completion_shape(monkeypatch):
-    monkeypatch.setattr(llm_provider, "LOCAL_AI_HTTP_API", "openai_compat")
-    monkeypatch.setattr(llm_provider, "LOCAL_AI_HTTP_MODEL", "mlx-community/test-model")
+    monkeypatch.setattr(http_inference_provider, "LOCAL_AI_HTTP_API", "openai_compat")
+    monkeypatch.setattr(http_inference_provider, "LOCAL_AI_HTTP_MODEL", "mlx-community/test-model")
     provider = DirectHttpInferenceProvider()
 
     payload = provider._build_request_payload("summarize this", max_tokens=128, temperature=0.2)
@@ -142,9 +160,13 @@ def test_http_provider_openai_compatible_health_check_uses_health_endpoint(monke
         requested_urls.append((url, timeout))
         return _OkResponse()
 
-    monkeypatch.setattr(llm_provider, "LOCAL_AI_HTTP_API", "openai_compat")
-    monkeypatch.setattr(llm_provider, "LOCAL_AI_HTTP_BASE_URL", "http://host.docker.internal:8080")
-    monkeypatch.setattr(llm_provider.requests, "get", fake_get)
+    monkeypatch.setattr(http_inference_provider, "LOCAL_AI_HTTP_API", "openai_compat")
+    monkeypatch.setattr(
+        http_inference_provider,
+        "LOCAL_AI_HTTP_BASE_URL",
+        "http://host.docker.internal:8080",
+    )
+    monkeypatch.setattr(http_inference_provider.requests, "get", fake_get)
     provider = DirectHttpInferenceProvider()
 
     assert provider.health_check() is True
@@ -217,6 +239,29 @@ def test_inprocess_provider_maps_backend_failure_and_resets_model():
     assert owner.llm.reset_count == 1
 
 
+def test_inprocess_provider_emits_failure_request_metric(monkeypatch):
+    provider_requests = []
+    monkeypatch.setattr(
+        provider_telemetry,
+        "record_provider_request",
+        lambda provider, operation, model, outcome, duration_ms: provider_requests.append(
+            (provider, operation, model, outcome, duration_ms)
+        ),
+    )
+    owner = _DummyOwner()
+    owner.llm = _FailingLlama()
+
+    try:
+        InProcessLlamaProvider(owner).summarize_text("x", temperature=0.0, max_tokens=8)
+    except ProviderResponseError:
+        pass
+    else:  # pragma: no cover - defensive
+        raise AssertionError("expected ProviderResponseError")
+
+    assert len(provider_requests) == 1
+    assert provider_requests[0][:4] == ("inprocess", "summarize_text", "inprocess-llama", "error")
+
+
 def test_inprocess_provider_maps_model_assertion_failure_to_response_error():
     owner = _DummyOwner()
     owner.llm = _AssertionFailingLlama()
@@ -275,6 +320,42 @@ def test_http_provider_has_protocol_methods():
 def test_http_provider_import_contract_preserves_llm_provider_facade():
     assert llm_provider.HttpInferenceProvider is DirectHttpInferenceProvider
     assert HttpInferenceProvider is DirectHttpInferenceProvider
+
+
+def test_provider_facade_excludes_test_only_rebinding_names():
+    removed_names = {
+        "LOCAL_AI_HTTP_BASE_URL",
+        "LOCAL_AI_HTTP_API",
+        "LOCAL_AI_HTTP_MAX_RETRIES",
+        "LOCAL_AI_HTTP_MODEL",
+        "LOCAL_AI_HTTP_PROFILE",
+        "LOCAL_AI_HTTP_TIMEOUT_SECONDS",
+        "LOCAL_AI_HTTP_TIMEOUT_SEGMENT_SECONDS",
+        "LOCAL_AI_HTTP_TIMEOUT_SUMMARY_SECONDS",
+        "LOCAL_AI_HTTP_TIMEOUT_TOPICS_SECONDS",
+        "LLM_CONTEXT_WINDOW",
+        "record_provider_request",
+        "record_provider_retry",
+        "record_provider_timeout",
+        "record_provider_token_counts",
+        "record_provider_tokens_per_sec",
+        "record_provider_ttft",
+        "requests",
+    }
+
+    assert removed_names.isdisjoint(llm_provider.__all__)
+    assert all(not hasattr(llm_provider, name) for name in removed_names)
+
+
+def test_provider_implementation_modules_do_not_import_compatibility_facade():
+    provider_implementation_paths = (
+        Path("pipeline/http_inference_provider.py"),
+        Path("pipeline/provider_telemetry.py"),
+        Path("pipeline/agenda_segmentation_maintenance.py"),
+    )
+
+    for provider_implementation_path in provider_implementation_paths:
+        assert "llm_provider" not in provider_implementation_path.read_text()
 
 
 def test_local_ai_defaults_to_http_provider_when_backend_unset(monkeypatch):


### PR DESCRIPTION
## What changed
- corrected T-DE-1's false shared-retry premise and closed merged T-DC-1 in the ledger
- removed HTTP transport, telemetry, and maintenance imports through `pipeline.llm_provider`
- kept HTTP retry policy in `pipeline/http_inference_attempts.py`
- removed test-only config, `requests`, and metric-recorder exports from the provider facade
- preserved provider classes, protocol symbols, response fields, typed errors, retry budgets, timeout values, metric labels, and model/fallback policy
- repointed tests to HTTP and telemetry implementation boundaries

## Why
The provider adapters already have intentionally different behavior. The actual architecture defect was implementation code importing backward through a compatibility facade, which made test monkeypatch paths part of runtime design.

## Risk and compatibility
Low-to-moderate import-boundary risk. Runtime provider class/error imports remain compatible. Removed facade names were test-only rebinding seams. No API, schema, environment, model default, retry, timeout, fallback, or soak-policy change.

## Verification
- PASS `./.venv/bin/ruff check .`
- PASS `./.venv/bin/mypy` (68 source files)
- PASS focused provider/telemetry/maintenance suite (63 passed)
- PASS unchanged provider error mapping and inference contract suite (41 passed)
- PASS `PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py` (2 passed)
- PASS `PYTHONPATH=. .venv/bin/pytest -q` (1,548 passed, 17 skipped)
- PASS coverage gate (82.93%, required 71%)
- PASS `git diff --check origin/master...HEAD`

Tests-first evidence: the repointed boundary tests failed in 19 expected places before implementation, covering configuration, HTTP, telemetry, timeout overrides, facade exports, and reverse imports.

## Review
Independent planning review found and resolved two P1s and three P2s. Independent pre-commit review found and resolved two P2s. Final follow-up review reported no unresolved P1/P2 findings.
