### PR TITLE
Group duplicate Python dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,9 @@ updates:
       - /semantic_service
     schedule:
       interval: weekly
+    groups:
+      python-dependencies:
+        group-by: dependency-name
 
   - package-ecosystem: npm
     directory: /frontend

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -1270,7 +1270,7 @@ def _run_workflow_script(
     )
 
 
-def test_dependabot_checks_every_dependency_manifest_weekly() -> None:
+def test_dependabot_checks_every_dependency_manifest_weekly_and_groups_python_updates() -> None:
     dependabot_contract = yaml.load(
         (ROOT / ".github" / "dependabot.yml").read_text(encoding="utf-8"),
         Loader=yaml.BaseLoader,
@@ -1288,6 +1288,11 @@ def test_dependabot_checks_every_dependency_manifest_weekly() -> None:
                 "/semantic_service",
             ],
             "schedule": {"interval": "weekly"},
+            "groups": {
+                "python-dependencies": {
+                    "group-by": "dependency-name",
+                },
+            },
         },
         {
             "package-ecosystem": "npm",


### PR DESCRIPTION
## What changed
- group compatible Python Dependabot updates by dependency name across configured directories
- enforce the grouping policy in the existing exact Dependabot contract test

## Why
The first weekly run created root and directory-specific duplicates because each pip directory resolves the shared root constraints file. GitHub documents `group-by: dependency-name` as the monorepo consolidation mechanism.

## Risk and compatibility
Low. This changes version-update PR grouping only. Security-update grouping is unchanged, and incompatible constraints may still require separate PRs. Operational behavior is confirmed on the next scheduled Dependabot run.

## Verification
- PASS: `.venv/bin/ruff check .`
- PASS: `.venv/bin/mypy`
- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_repository_guardrails.py` (373 passed)
- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py` (2 passed)
- PASS: `PYTHONPATH=. .venv/bin/python -m pytest -q tests/` (1571 passed, 19 skipped)
- PASS: `git diff --check`
- PASS: independent review, no P1/P2 findings