### PR TITLE
T-GOV-2: Adopt roster-gated person minimization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,11 @@ Do:
 - Treat optional remote acceleration as personal opt-in only.
 - Fail fast when remote inference is unreachable.
 - Preserve soak comparability unless the task explicitly changes baseline policy.
+- Create person entities and people-facing records only from independently
+  authoritative official membership data scoped to municipality, governing
+  body, and meeting date. Title inference, source-document mentions, and
+  linker-created memberships are not roster authority. Do not start City
+  Coverage Expansion before T-GOV-2A is complete and verified.
 
 Don't:
 - Do not silently fall back from remote to local inference.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -145,6 +145,9 @@ Existing spider coverage should be promoted before new provider families. City
 membership and enabled status should come from the rollout registry, not from
 hardcoded roadmap lists.
 
+Start criteria:
+- T-GOV-2A roster-gated person linking is complete and verified.
+
 Quality gates stay outcome-based:
 - crawl success is high enough for repeatable ingestion;
 - extraction is non-empty for the expected document set;

--- a/docs/ADR.md
+++ b/docs/ADR.md
@@ -8,6 +8,41 @@ Use each entry to record:
 - the affected boundary or contract
 - links to the canonical docs that carry the ongoing operational or architecture detail
 
+## 2026-07-26: Roster-gated person linking
+
+- Status: Accepted
+- Decision:
+  - Only names matched to independently authoritative official membership data
+    for the relevant municipality, governing body, and meeting date may become
+    person entities, profiles, memberships, or vote attributions.
+  - Title inference, source-document mentions, and linker-created memberships
+    are not roster authority.
+  - Non-roster names remain searchable municipal source text, but they do not
+    become people metadata or cross-document person aggregation.
+  - Outside enrichment of private individuals remains prohibited.
+  - Corrections remove or repair derived records and indexes. Source documents
+    are not modified.
+- Why:
+  - Public-record status does not justify turning incidental names into
+    persistent, cross-document person records.
+  - Independent roster authority keeps the civic-accountability product
+    focused on officials acting in public roles.
+  - Preserving source text maintains the municipal record while minimizing
+    derived exposure.
+- Current state:
+  - Town Council does not yet enforce this policy. Existing entity linking can
+    create mention-only people and infer memberships from document content.
+  - T-GOV-2A owns authoritative roster input, runtime gating, existing
+    derived-data remediation, reindexing, and prevention of re-derivation.
+  - City Coverage Expansion remains blocked until T-GOV-2A is complete.
+- Affected boundaries:
+  - This decision governs person creation, people metadata, profiles,
+    memberships, vote attribution, correction, and derived-data retention.
+  - Municipal source documents and searchable source text remain unchanged.
+- Canonical references:
+  - [Data governance policy](DATA_GOVERNANCE.md)
+  - [Town Council remediation plan](plans/TOWN_COUNCIL_REMEDIATION_PLAN.md)
+
 ## 2026-07-25: Maintenance hydration operations own runtime dependencies
 
 - Status: Accepted

--- a/docs/DATA_GOVERNANCE.md
+++ b/docs/DATA_GOVERNANCE.md
@@ -6,8 +6,8 @@ itself justify every derived use: aggregation, entity linking, and search
 change the accessibility of information about identifiable people. This
 document states the project's handling policy.
 
-Status: initial version. Section 3 carries the open decision (gate G4);
-everything else is effective policy on merge.
+Status: effective. Decision G4 was approved on 2026-07-26. Runtime enforcement
+remains pending under T-GOV-2A.
 
 ## 1. Data classes
 
@@ -34,26 +34,26 @@ everything else is effective policy on merge.
   public record and are not edited; corrections apply to derived data
   (links, profiles, summaries, index entries).
 
-## 3. Person-entity treatment for private individuals (DECISION G4 — open)
+## 3. Roster-gated person entities
 
-Options under consideration; exactly one will be adopted by ADR:
+Only names matched to independently authoritative official membership data
+for the relevant municipality, governing body, and meeting date may become
+person entities. Covered officials may receive profiles, memberships, and vote
+attribution only after that match.
 
-- Option A (roster-gated linking): `person_linker` creates/links Person
-  entities only for names matching official membership rosters. Private
-  individuals remain plain text in documents — searchable in full text, but
-  never entity-linked, never in people metadata, never profiled.
-- Option B (index-but-no-profile): names are indexed and may appear in
-  people metadata on search hits, but profile pages and cross-document
-  person aggregation are roster-gated.
-- Option C (status quo + process): current extraction behavior, with the
-  Section 4 takedown/correction process as the sole safeguard.
+Title inference, source-document mentions, and memberships created by the
+entity linker are derived evidence, not roster authority. They cannot
+authorize person creation or people-facing records.
 
-Working default until the ADR lands: build nothing new that expands
-person-level aggregation of non-officials, and treat Option A as the design
-target for City Coverage Expansion planning.
+Non-roster names remain searchable source text. They do not become person
+entities, people metadata, profiles, memberships, vote attribution, or
+cross-document aggregation. Outside enrichment of private individuals remains
+forbidden.
 
-Decision owner: repository owner. Record the outcome in `docs/ADR.md` and
-replace this section with the adopted policy.
+Corrections apply to derived records and indexes. Source documents are not
+modified. Current runtime behavior does not yet enforce this policy; T-GOV-2A
+owns authoritative roster input, runtime gating, existing derived-data
+remediation, reindexing, and prevention of re-derivation.
 
 ## 4. Correction and takedown
 
@@ -78,10 +78,9 @@ so decisions are auditable.
 
 - Source documents and extraction outputs: retained indefinitely (archival
   civic record).
-- Derived person-level data for private individuals: retained only while
-  policy in Section 3 permits its existence; removals under Section 4 are
-  permanent (re-derivation must respect a suppression list — implementation
-  task to be filed with the G4 ADR).
+- Derived person-level data for non-roster people: not retained. Existing
+  records remain remediation debt until T-GOV-2A removes them and prevents
+  re-derivation through roster gating.
 - Operational telemetry: per `docs/OPERATIONS.md`; no person-level data in
   metrics.
 

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,6 +1,6 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 3.69
+version: 3.70
 generated: 2026-07-26
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
@@ -10,6 +10,10 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v3.70:** Completes T-GOV-2 by recording the approved roster-gated person
+  policy in the ADR and Data Governance document. Runtime enforcement remains
+  explicitly pending under T-GOV-2A, and City Coverage Expansion stays
+  blocked.
 - **v3.69:** Marks T-PLAT-2 complete after PR #160 merged with all required
   checks green, activates T-GOV-2, and records the exact policy-only ownership
   needed to adopt the operator-approved G4 roster-gated decision without
@@ -336,9 +340,8 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 | State | Tasks |
 |---|---|
-| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2, T-SEC-3, T-SEC-3C, T-SEC-4, T-SEC-4A, T-SEC-5, T-SEC-6, T-TIME-1, T-TIME-2, T-TIME-3, T-CRAWL-1, T-CRAWL-2, T-PLAT-1, T-PLAT-1A, T-PLAT-2, T-PLAT-2A, T-PLAT-2B, T-PLAT-3, T-GOV-1, T-GOV-3A, T-GOV-4, T-GOV-5, T-GOV-6, T-DA-1, T-DB-1A, T-DB-1, T-DB-1B, T-DC-1, T-DD-1A, T-DD-1B, T-DE-1 |
+| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2, T-SEC-3, T-SEC-3C, T-SEC-4, T-SEC-4A, T-SEC-5, T-SEC-6, T-TIME-1, T-TIME-2, T-TIME-3, T-CRAWL-1, T-CRAWL-2, T-PLAT-1, T-PLAT-1A, T-PLAT-2, T-PLAT-2A, T-PLAT-2B, T-PLAT-3, T-GOV-1, T-GOV-2, T-GOV-3A, T-GOV-4, T-GOV-5, T-GOV-6, T-DA-1, T-DB-1A, T-DB-1, T-DB-1B, T-DC-1, T-DD-1A, T-DD-1B, T-DE-1 |
 | **Partially landed; acceptance incomplete** | T-GOV-3 |
-| **Active** | T-GOV-2 |
 | **Pending** | T-PLAT-4, T-GOV-2A, T-GOV-3B |
 
 ---
@@ -1579,7 +1582,7 @@ files (GED-5 grant).
 
 ### T-GOV-2: ADR — Person-entity minimization & takedown (gate G4)
 - priority: P1
-- status: active; G4 decision approved 2026-07-26
+- status: complete and verified 2026-07-29
 - implementation_plan:
   `docs/plans/T_GOV_2_PERSON_MINIMIZATION_PLAN.md`
 - scope_authorization: The operator approved G4 Option A and directed continued

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,6 +1,6 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 3.71
+version: 3.72
 generated: 2026-07-26
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
@@ -10,6 +10,9 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v3.72:** Expands T-GOV-2 ownership to `AGENTS.md`, synchronizes the binding
+  roster-authority and T-GOV-2A expansion invariant, and extends guardrails to
+  reject contradictions in the ADR or agent policy.
 - **v3.71:** Expands T-GOV-2 ownership to the roadmap after review, makes
   T-GOV-2A completion an explicit City Coverage Expansion start criterion,
   and strengthens the non-roster prohibition contract.
@@ -1592,7 +1595,7 @@ files (GED-5 grant).
   remediation execution through completion.
 - files_owned: `docs/plans/T_GOV_2_PERSON_MINIMIZATION_PLAN.md`,
   `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`, `docs/ADR.md`,
-  `docs/DATA_GOVERNANCE.md`, `ROADMAP.md`,
+  `docs/DATA_GOVERNANCE.md`, `AGENTS.md`, `ROADMAP.md`,
   `tests/test_repository_guardrails.py`
   (G4 and T-GOV-2 policy contracts only)
 - do: Record roster-gated person linking as an Accepted ADR. Replace the live
@@ -1607,9 +1610,10 @@ files (GED-5 grant).
   current derived memberships as roster authority; edits outside
   `files_owned`.
 - accept: ADR and Data Governance agree on the approved policy; live G4 option
-  and working-default language is gone; T-GOV-2A is pending; City Coverage
-  Expansion names verified T-GOV-2A completion as a start criterion; repository
-  guardrails, docs links, and the complete suite pass.
+  and working-default language is gone; AGENTS names the binding roster
+  authority and T-GOV-2A expansion gate; T-GOV-2A is pending; City Coverage
+  Expansion names verified T-GOV-2A completion as a start criterion;
+  repository guardrails, docs links, and the complete suite pass.
 - verify: Follow the Full T-GOV-2 plan; Ruff, Mypy, repository guardrails, docs
   links, complete Python suite, independent review, and PR CI.
 

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,6 +1,6 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 3.68
+version: 3.69
 generated: 2026-07-26
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
@@ -10,6 +10,10 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v3.69:** Marks T-PLAT-2 complete after PR #160 merged with all required
+  checks green, activates T-GOV-2, and records the exact policy-only ownership
+  needed to adopt the operator-approved G4 roster-gated decision without
+  overstating current runtime enforcement.
 - **v3.68:** Closes T-PLAT-2 audit parity gaps found during review and CI.
   The CI-only scikit-learn pin now lives in the audited development manifest,
   while the semantic manifest exposes Torch's upstream version and Docker's
@@ -332,10 +336,10 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 | State | Tasks |
 |---|---|
-| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2, T-SEC-3, T-SEC-3C, T-SEC-4, T-SEC-4A, T-SEC-5, T-SEC-6, T-TIME-1, T-TIME-2, T-TIME-3, T-CRAWL-1, T-CRAWL-2, T-PLAT-1, T-PLAT-1A, T-PLAT-2A, T-PLAT-2B, T-PLAT-3, T-GOV-1, T-GOV-3A, T-GOV-4, T-GOV-5, T-GOV-6, T-DA-1, T-DB-1A, T-DB-1, T-DB-1B, T-DC-1, T-DD-1A, T-DD-1B, T-DE-1 |
+| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2, T-SEC-3, T-SEC-3C, T-SEC-4, T-SEC-4A, T-SEC-5, T-SEC-6, T-TIME-1, T-TIME-2, T-TIME-3, T-CRAWL-1, T-CRAWL-2, T-PLAT-1, T-PLAT-1A, T-PLAT-2, T-PLAT-2A, T-PLAT-2B, T-PLAT-3, T-GOV-1, T-GOV-3A, T-GOV-4, T-GOV-5, T-GOV-6, T-DA-1, T-DB-1A, T-DB-1, T-DB-1B, T-DC-1, T-DD-1A, T-DD-1B, T-DE-1 |
 | **Partially landed; acceptance incomplete** | T-GOV-3 |
-| **Active** | T-PLAT-2 |
-| **Pending** | T-PLAT-4, T-GOV-2, T-GOV-3B |
+| **Active** | T-GOV-2 |
+| **Pending** | T-PLAT-4, T-GOV-2A, T-GOV-3B |
 
 ---
 
@@ -382,8 +386,12 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
   at approved architectural boundaries; historical test patch targets are not
   public API. Phase 2 is unblocked, subject to each task's own sequencing and
   ownership.
-- G4 pii_policy: Ratify ADR on person-entity minimization for non-officials
-  (T-GOV-2). BLOCKS nothing in this plan, but blocks City Coverage Expansion.
+- G4 pii_policy: **Approved 2026-07-26.** Use roster-gated person linking.
+  Only names matched to independently authoritative official membership data
+  may become person entities or people-facing derived records. Title inference
+  and linker-created memberships are not roster authority. T-GOV-2 records
+  the decision; T-GOV-2A implements and remediates it. City Coverage Expansion
+  remains blocked until T-GOV-2A completes.
 - G5 migration_tooling: **Approved 2026-07-24.** Adopt Alembic through
   T-PLAT-1 after T-TIME-1 and T-TIME-2. Freeze the readable `migrate_v*`
   chain after the baseline; author all later schema changes as Alembic
@@ -1464,7 +1472,7 @@ files (GED-5 grant).
 
 ### T-PLAT-2: Dependency hygiene
 - priority: P2
-- status: active; implementation authorized 2026-07-26
+- status: complete and verified 2026-07-27 (PR #160)
 - implementation_plan:
   `docs/plans/T_PLAT_2_DEPENDENCY_HYGIENE_PLAN.md`
 - scope_authorization: Operator-approved 2026-07-26.
@@ -1571,14 +1579,48 @@ files (GED-5 grant).
 
 ### T-GOV-2: ADR — Person-entity minimization & takedown (gate G4)
 - priority: P1
-- files_owned: docs/ADR.md
-- do: Draft decision options for the user: (a) entity-link only persons
-  matching official rosters (person_linker gate), (b) index commenter names
-  but exclude from people profiles/metadata, (c) status quo + documented
-  takedown SLA via the existing report-issue path. Include retention stance
-  and correction workflow. Users selects; agent records.
-- accept: ADR merged with a selected option; follow-up implementation task
-  filed (out of scope here).
+- status: active; G4 decision approved 2026-07-26
+- implementation_plan:
+  `docs/plans/T_GOV_2_PERSON_MINIMIZATION_PLAN.md`
+- scope_authorization: The operator approved G4 Option A and directed continued
+  remediation execution through completion.
+- files_owned: `docs/plans/T_GOV_2_PERSON_MINIMIZATION_PLAN.md`,
+  `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`, `docs/ADR.md`,
+  `docs/DATA_GOVERNANCE.md`, `tests/test_repository_guardrails.py`
+  (G4 and T-GOV-2 policy contracts only)
+- do: Record roster-gated person linking as an Accepted ADR. Replace the live
+  option list in Data Governance with the adopted policy. Define roster
+  authority as independently authoritative official membership data, not title
+  inference or linker-created memberships. Preserve source-document text and
+  correction of derived records. Register T-GOV-2A for runtime enforcement,
+  existing derived-data remediation, reindexing, and prevention of
+  re-derivation.
+- forbidden: Runtime, schema, API, crawler, search, inference, or migration
+  changes; claiming current behavior is compliant; treating inferred titles or
+  current derived memberships as roster authority; edits outside
+  `files_owned`.
+- accept: ADR and Data Governance agree on the approved policy; live G4 option
+  and working-default language is gone; T-GOV-2A is pending; City Coverage
+  Expansion remains blocked until implementation; repository guardrails, docs
+  links, and the complete suite pass.
+- verify: Follow the Full T-GOV-2 plan; Ruff, Mypy, repository guardrails, docs
+  links, complete Python suite, independent review, and PR CI.
+
+### T-GOV-2A: Enforce roster-gated person linking
+- priority: P1
+- status: pending
+- depends_on: T-GOV-2
+- files_owned: to be named in a separate Full plan after authoritative roster
+  inputs and current derived person records are inventoried
+- do: Establish independently authoritative roster input; gate person creation
+  and people-facing derived records; remediate existing non-roster entities and
+  memberships; reindex affected catalogs; and prevent re-derivation.
+- forbidden: Inferring roster authority from titles, source-document mentions,
+  or linker-generated memberships; deleting or rewriting municipal source
+  records; implementing without an approved Full person-data plan.
+- accept: Runtime behavior and existing derived data conform to the accepted G4
+  policy; correction and reindexing are repeatable; City Coverage Expansion is
+  unblocked only after verification.
 
 ### T-GOV-3: Redesign the guardrail regime
 - priority: P2
@@ -1704,8 +1746,9 @@ files (GED-5 grant).
   pending — that is intentional, update checkboxes as tasks merge).
   TESTING.md is active with the G3 ADR (T-GOV-1) as its operational companion.
   All three canonical documents are linked from the README Documentation Map.
-  DATA_GOVERNANCE.md Section 3 stays in "options + working default" form until
-  T-GOV-2 records and implements the approved G4 policy.
+  DATA_GOVERNANCE.md Section 3 remains in its historical
+  "options + working default" form only until T-GOV-2 records the approved G4
+  policy; T-GOV-2A owns runtime implementation.
 - do: Keep the three governance documents linked from the README and keep the
   G1 deployment posture synchronized between SECURITY.md and this ledger.
 - forbidden: Resolving G2/G4 by editing defaults; adding further new documents
@@ -1732,9 +1775,11 @@ Phase 2: agent-da || agent-db [T-DB-1A, then T-DB-1, then T-DB-1B] || agent-dd |
          then agent-dc (exclusive on api/*)
 Phase 3: agent-plat [T-PLAT-1 after T-TIME-1 and T-TIME-2, T-PLAT-1A
          closure, T-PLAT-2B security patch, then T-PLAT-2..4]
-         || agent-gov [T-GOV-2, T-GOV-3A, then T-GOV-3B after T-DC-1 and
-         revised T-DE-1; T-GOV-5 complete]
-Anytime: T-GOV-6 complete; T-GOV-2 records the approved G4 policy
+         || agent-gov [T-GOV-2 records G4 policy, T-GOV-2A implements after
+         authoritative roster approval; T-GOV-3A, then T-GOV-3B after T-DC-1
+         and revised T-DE-1; T-GOV-5 complete]
+Anytime: T-GOV-6 complete; T-GOV-2 records approved G4, while T-GOV-2A
+         implements it only after authoritative roster-source approval
 ```
 
 Merge policy: one task = one PR, except operator-approved T-TIME-1 +

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,6 +1,6 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 3.70
+version: 3.71
 generated: 2026-07-26
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
@@ -10,6 +10,9 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v3.71:** Expands T-GOV-2 ownership to the roadmap after review, makes
+  T-GOV-2A completion an explicit City Coverage Expansion start criterion,
+  and strengthens the non-roster prohibition contract.
 - **v3.70:** Completes T-GOV-2 by recording the approved roster-gated person
   policy in the ADR and Data Governance document. Runtime enforcement remains
   explicitly pending under T-GOV-2A, and City Coverage Expansion stays
@@ -1589,7 +1592,8 @@ files (GED-5 grant).
   remediation execution through completion.
 - files_owned: `docs/plans/T_GOV_2_PERSON_MINIMIZATION_PLAN.md`,
   `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`, `docs/ADR.md`,
-  `docs/DATA_GOVERNANCE.md`, `tests/test_repository_guardrails.py`
+  `docs/DATA_GOVERNANCE.md`, `ROADMAP.md`,
+  `tests/test_repository_guardrails.py`
   (G4 and T-GOV-2 policy contracts only)
 - do: Record roster-gated person linking as an Accepted ADR. Replace the live
   option list in Data Governance with the adopted policy. Define roster
@@ -1604,8 +1608,8 @@ files (GED-5 grant).
   `files_owned`.
 - accept: ADR and Data Governance agree on the approved policy; live G4 option
   and working-default language is gone; T-GOV-2A is pending; City Coverage
-  Expansion remains blocked until implementation; repository guardrails, docs
-  links, and the complete suite pass.
+  Expansion names verified T-GOV-2A completion as a start criterion; repository
+  guardrails, docs links, and the complete suite pass.
 - verify: Follow the Full T-GOV-2 plan; Ruff, Mypy, repository guardrails, docs
   links, complete Python suite, independent review, and PR CI.
 

--- a/docs/plans/T_GOV_2_PERSON_MINIMIZATION_PLAN.md
+++ b/docs/plans/T_GOV_2_PERSON_MINIMIZATION_PLAN.md
@@ -1,7 +1,7 @@
 # T-GOV-2: Record Roster-Gated Person Minimization
 
-`artifact_contract: ce-unified-plan/v1`  
-`artifact_readiness: implementation-ready`  
+`artifact_contract: ce-unified-plan/v1`
+`artifact_readiness: implementation-ready`
 `execution: docs-and-tests`
 
 ## 1. Context & Alignment

--- a/docs/plans/T_GOV_2_PERSON_MINIMIZATION_PLAN.md
+++ b/docs/plans/T_GOV_2_PERSON_MINIMIZATION_PLAN.md
@@ -40,6 +40,7 @@ Its exact `files_owned` set is:
 - `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`
 - `docs/ADR.md`
 - `docs/DATA_GOVERNANCE.md`
+- `ROADMAP.md`
 - `tests/test_repository_guardrails.py`
 
 The remediation ledger update is limited to the changelog, task table,
@@ -142,7 +143,7 @@ membership, derived record, and reindexing.
 - D1: no skip, xfail, weakened assertion, or widened tolerance.
 - D3: exact decision and task states are observable governance contracts;
   tests avoid full-document snapshots.
-- E1-E3: edits remain within the five owned files and do not rewrite
+- E1-E3: edits remain within the six owned files and do not rewrite
   historical ADR entries.
 - H2-H4: no type suppression, alternate trust-boundary model, or import-time
   behavior.
@@ -184,7 +185,7 @@ contracts. Expected production-code delta is zero.
 |---|---|
 | G4 contradiction detector positive and negative fixtures | 1-3 |
 | Cross-document roster-gated policy contract | 4-7, 10 |
-| T-GOV-2/T-GOV-2A ledger contract | 5, 8, 9, 10 |
+| T-GOV-2/T-GOV-2A ledger and roadmap contract | 5, 8, 9, 10 |
 | Existing repository guardrail suite | 1-10 |
 | Docs-link test | Canonical references |
 | Complete Python suite | Regression coverage |
@@ -250,9 +251,11 @@ policy and keeps City Coverage Expansion blocked.
 - `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`: version, changelog, task
   states, T-PLAT-2 completion, G4, T-GOV-2, T-GOV-2A, T-GOV-6 sequencing,
   and execution order.
+- `ROADMAP.md`: add verified T-GOV-2A completion to City Coverage Expansion
+  start criteria.
 - New T-GOV-2 Full plan.
 - README, architecture, operations, performance, engineering guardrails,
-  testing policy, security policy, API contracts, and roadmap: no changes.
+  testing policy, security policy, and API contracts: no changes.
 
 ## 7. Delivery Self-Audit
 
@@ -267,7 +270,8 @@ pre-commit-review findings, commit hashes, PR URL, unresolved-thread count,
 and final CI state. Mark unrun evidence `NOT VERIFIED`.
 
 **z) Deviations.** The authorized scope expansion from the ledger's original
-single ADR file to the five-file set above is required to keep the canonical
-policy, task states, implementation follow-up, and durable contract aligned.
+single ADR file to the six-file set above is required to keep the canonical
+policy, roadmap start criterion, task states, implementation follow-up, and
+durable contract aligned.
 Any runtime file, schema change, new dependency, new governance document,
 skipped review, unresolved P1/P2, or unrun required check is a blocker.

--- a/docs/plans/T_GOV_2_PERSON_MINIMIZATION_PLAN.md
+++ b/docs/plans/T_GOV_2_PERSON_MINIMIZATION_PLAN.md
@@ -40,6 +40,7 @@ Its exact `files_owned` set is:
 - `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`
 - `docs/ADR.md`
 - `docs/DATA_GOVERNANCE.md`
+- `AGENTS.md`
 - `ROADMAP.md`
 - `tests/test_repository_guardrails.py`
 
@@ -143,7 +144,7 @@ membership, derived record, and reindexing.
 - D1: no skip, xfail, weakened assertion, or widened tolerance.
 - D3: exact decision and task states are observable governance contracts;
   tests avoid full-document snapshots.
-- E1-E3: edits remain within the six owned files and do not rewrite
+- E1-E3: edits remain within the seven owned files and do not rewrite
   historical ADR entries.
 - H2-H4: no type suppression, alternate trust-boundary model, or import-time
   behavior.
@@ -178,15 +179,17 @@ contracts. Expected production-code delta is zero.
 8. T-GOV-2 is complete without a pending runtime follow-up.
 9. City Coverage Expansion is unblocked before T-GOV-2A completes.
 10. ADR, governance policy, and remediation ledger disagree.
+11. `AGENTS.md` omits the official-roster-only exclusions or contradicts the
+    canonical policy.
 
 **r) Tests.**
 
 | Test | Scenarios |
 |---|---|
 | G4 contradiction detector positive and negative fixtures | 1-3 |
-| Cross-document roster-gated policy contract | 4-7, 10 |
+| Cross-document roster-gated policy contract | 4-7, 10-11 |
 | T-GOV-2/T-GOV-2A ledger and roadmap contract | 5, 8, 9, 10 |
-| Existing repository guardrail suite | 1-10 |
+| Existing repository guardrail suite | 1-11 |
 | Docs-link test | Canonical references |
 | Complete Python suite | Regression coverage |
 
@@ -248,6 +251,8 @@ policy and keeps City Coverage Expansion blocked.
 - `docs/ADR.md`: add the Accepted G4 decision.
 - `docs/DATA_GOVERNANCE.md`: activate the document and replace Section 3's
   open options with the adopted policy.
+- `AGENTS.md`: reference the binding roster authority and T-GOV-2A expansion
+  gate.
 - `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`: version, changelog, task
   states, T-PLAT-2 completion, G4, T-GOV-2, T-GOV-2A, T-GOV-6 sequencing,
   and execution order.
@@ -270,8 +275,8 @@ pre-commit-review findings, commit hashes, PR URL, unresolved-thread count,
 and final CI state. Mark unrun evidence `NOT VERIFIED`.
 
 **z) Deviations.** The authorized scope expansion from the ledger's original
-single ADR file to the six-file set above is required to keep the canonical
-policy, roadmap start criterion, task states, implementation follow-up, and
-durable contract aligned.
+single ADR file to the seven-file set above is required to keep the canonical
+policy, agent invariant, roadmap start criterion, task states, implementation
+follow-up, and durable contract aligned.
 Any runtime file, schema change, new dependency, new governance document,
 skipped review, unresolved P1/P2, or unrun required check is a blocker.

--- a/docs/plans/T_GOV_2_PERSON_MINIMIZATION_PLAN.md
+++ b/docs/plans/T_GOV_2_PERSON_MINIMIZATION_PLAN.md
@@ -1,0 +1,273 @@
+# T-GOV-2: Record Roster-Gated Person Minimization
+
+`artifact_contract: ce-unified-plan/v1`  
+`artifact_readiness: implementation-ready`  
+`execution: docs-and-tests`
+
+## 1. Context & Alignment
+
+**a) Driver.** The operator approved G4 Option A, but the canonical governance
+documents still describe G4 as open. Town Council currently persists and
+exposes mention-only people, so this task must record the selected
+roster-gated policy without falsely claiming runtime compliance. A separate
+T-GOV-2A implementation task will own roster authority, runtime enforcement,
+derived-data remediation, and reindexing before City Coverage Expansion may
+resume.
+
+**b) Canonical documents consulted.**
+
+- `AGENTS.md` `<hierarchy_of_truth>`, `<workflow_contract>`,
+  `<verification_matrix>`, and `<docs_sync_rules>` require current policy,
+  exact evidence, docs-link verification, and no duplicated configuration
+  inventories.
+- `docs/DATA_GOVERNANCE.md` Sections 1-5 define data classes, minimization,
+  source-record preservation, correction, and retention. Section 3 is the open
+  G4 decision this task replaces.
+- `docs/ADR.md` supplies the established Accepted-decision format.
+- `docs/TESTING.MD` permits direct filesystem contracts without a production
+  test seam.
+- `SECURITY.md` confirms this task changes no authentication, credential, or
+  network boundary.
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md` makes T-GOV-2 the G4 decision
+  task and requires a separate implementation follow-up.
+- `docs/reviews/architecture-review-2026-07-19.html` identifies person-level
+  aggregation as a governance concern rather than ordinary search behavior.
+
+**c) Remediation alignment.** T-GOV-2 is the governance-lane decision task.
+Its exact `files_owned` set is:
+
+- `docs/plans/T_GOV_2_PERSON_MINIMIZATION_PLAN.md`
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`
+- `docs/ADR.md`
+- `docs/DATA_GOVERNANCE.md`
+- `tests/test_repository_guardrails.py`
+
+The remediation ledger update is limited to the changelog, task table,
+T-PLAT-2 completion, G4, T-GOV-2, new T-GOV-2A registration, T-GOV-6's
+superseded sequencing note, and execution order. No runtime or schema file may
+change.
+
+**d) Decision-gate check.** G4 is already approved as Option A:
+roster-gated person linking. This task records that decision and does not
+reopen it. G1, G2, G3, and G5 are unaffected. City Coverage Expansion remains
+blocked until T-GOV-2A is complete.
+
+## 2. Design
+
+**e) Step-by-step approach.**
+
+1. Register this Full plan, exact ownership, acceptance criteria, and
+   sequencing in the remediation ledger.
+2. Add failing repository contract tests before changing the ADR or governance
+   policy.
+3. Add an Accepted ADR entry dated 2026-07-26 that:
+   - selects roster-gated person linking;
+   - defines a roster as independently authoritative official membership data;
+   - rejects inferred titles and linker-created memberships as roster proof;
+   - preserves source-document text and source records;
+   - records that current runtime behavior is not yet compliant; and
+   - delegates runtime enforcement and remediation to T-GOV-2A.
+4. Replace `docs/DATA_GOVERNANCE.md` Section 3's option list and working
+   default with the adopted policy:
+   - covered officials may receive person entities, profiles, memberships, and
+     vote attribution only after authoritative roster matching;
+   - non-roster names remain searchable source text but do not become person
+     entities, people metadata, profiles, or cross-document aggregation;
+   - outside enrichment of private individuals remains forbidden; and
+   - correction changes derived records and indexes, never source documents.
+5. Update the ledger so G4 and T-GOV-2 are complete and T-GOV-2A is pending.
+   T-GOV-2A must own authoritative roster input, selection rules, runtime
+   gating, existing derived-data remediation, reindexing, and prevention of
+   re-derivation.
+6. Run the docs and guardrail gates, simplify the diff, and obtain a fresh
+   subagent pre-commit review.
+7. Commit the planning authorization separately from the policy and contract
+   implementation, push one branch, open one PR, request remote review, and
+   wait for required CI.
+
+No production function or module is added.
+
+**f) Reuse audit.** Reuse the existing ADR format, Data Governance sections,
+remediation task-state table, Markdown section helper, and cross-document
+policy-contract pattern in `tests/test_repository_guardrails.py`. Do not add a
+Markdown parser, policy registry, runtime compatibility path, or duplicate
+governance document.
+
+**g) Data contracts.** This task changes policy contracts only. The policy
+distinguishes independently authoritative roster records from title inference,
+linker output, source-document mentions, and derived person records. No API
+payload, database model, Celery signature, CLI, environment variable, or
+runtime default changes.
+
+**h) Schema/migration impact.** None. T-GOV-2A must separately plan any
+schema or data-remediation work after inspecting authoritative roster inputs
+and existing derived records.
+
+## 3. Security & Data Governance
+
+**i) Security-sensitive paths.** None. No authentication, proxy, container,
+credential, CORS, or backing-store path changes.
+
+**j) Secrets.** None.
+
+**k) Person data.** This task directly governs person-level data and therefore
+uses the Full template. The accepted policy minimizes aggregation: non-roster
+people remain only in municipal source text and cannot be promoted into
+persistent person entities or people-facing derived products. The policy does
+not delete or rewrite public source records.
+
+**l) Untrusted input.** No scraped or user input is parsed by new code.
+Repository tests read checked-in Markdown through the existing filesystem
+boundary.
+
+## 4. Code Health
+
+**m) GED conformance sweep.** The implementation is docs and one focused
+contract test. No runtime functions, nesting, timestamps, environment reads,
+exception handlers, or dependency calls change. Policy terms use Town Council
+domain vocabulary: source document, official roster, person entity,
+membership, derived record, and reindexing.
+
+**n) Antipattern scan, plan pass.**
+
+- A1/H1: no external API or library call is introduced.
+- A2-A4: no setting, silent default, placeholder, or unsupported completion
+  claim.
+- B1-B3/F1-F2: no parser framework, registry, wrapper, compatibility path, or
+  duplicate policy implementation.
+- C1: active open/options wording is replaced, not retained as a second live
+  policy.
+- C2/D2: no test seam, facade patch, call-count assertion, or mocked unit under
+  test.
+- D1: no skip, xfail, weakened assertion, or widened tolerance.
+- D3: exact decision and task states are observable governance contracts;
+  tests avoid full-document snapshots.
+- E1-E3: edits remain within the five owned files and do not rewrite
+  historical ADR entries.
+- H2-H4: no type suppression, alternate trust-boundary model, or import-time
+  behavior.
+
+Independent planning review found two required corrections incorporated here:
+the roster must be independently authoritative rather than created by the
+linker, and the policy task must state that runtime enforcement remains
+pending.
+
+**o) Ratchet interaction.** Ruff selectors, BLE001 boundaries, formatter
+scope, typed scope, coverage, and CI gates remain unchanged.
+
+**p) Dead code and duplication audit.** Delete the active G4 option list,
+working-default prose, and stale ledger wording. Add one ADR entry, one adopted
+policy section, one implementation follow-up registration, and focused
+contracts. Expected production-code delta is zero.
+
+## 5. Testing
+
+**q) Edge cases and failure scenarios.**
+
+1. A canonical document still calls G4 open, pending, unresolved, or a working
+   default.
+2. Option B, Option C, or status quo remains presented as a live choice.
+3. Historical descriptions are incorrectly treated as active policy.
+4. A title inferred from source text or a linker-created membership is treated
+   as authoritative roster evidence.
+5. Policy claims current runtime already enforces roster gating.
+6. Non-roster names are allowed into person entities, metadata, profiles, or
+   cross-document aggregation.
+7. Correction language permits editing municipal source records.
+8. T-GOV-2 is complete without a pending runtime follow-up.
+9. City Coverage Expansion is unblocked before T-GOV-2A completes.
+10. ADR, governance policy, and remediation ledger disagree.
+
+**r) Tests.**
+
+| Test | Scenarios |
+|---|---|
+| G4 contradiction detector positive and negative fixtures | 1-3 |
+| Cross-document roster-gated policy contract | 4-7, 10 |
+| T-GOV-2/T-GOV-2A ledger contract | 5, 8, 9, 10 |
+| Existing repository guardrail suite | 1-10 |
+| Docs-link test | Canonical references |
+| Complete Python suite | Regression coverage |
+
+Tests are written and run red before policy edits. Historical ADR text is
+outside the live-policy scan so accepted decisions remain append-only.
+
+**s) Fakes and mocks.** None. Tests use the approved filesystem boundary and
+existing Markdown section helper. No production symbol is patched.
+
+**t) Verification rows.** Apply the docs-only and guardrail/tooling rows, then
+run the complete Python suite because the policy contract is cross-document.
+
+## 6. Execution, Rollback, Docs
+
+**u) Exact commands.**
+
+```bash
+git fetch origin --prune
+git worktree add -b codex/t-gov-2-person-minimization \
+  <TEMP_WORKTREE> origin/master
+```
+
+Tests-first red evidence:
+
+```bash
+PYTHONPATH=. .venv/bin/pytest -q \
+  tests/test_repository_guardrails.py::test_g4_contradiction_detection_covers_equivalent_wording \
+  tests/test_repository_guardrails.py::test_g4_roster_gated_policy_is_aligned
+```
+
+Final verification:
+
+```bash
+./.venv/bin/ruff check .
+./.venv/bin/mypy
+PYTHONPATH=. .venv/bin/pytest -q tests/test_repository_guardrails.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py
+PYTHONPATH=. .venv/bin/pytest -q
+git diff --check
+git status --short
+```
+
+Delivery uses two commits:
+
+1. `docs(remediation): authorize T-GOV-2 person minimization`
+2. `docs(governance): adopt roster-gated person linking`
+
+Push `codex/t-gov-2-person-minimization`, open one PR titled
+`T-GOV-2: Adopt roster-gated person linking`, request Codex review, and wait
+for all required checks.
+
+**v) Rollback.** Revert the T-GOV-2 merge commit, rerun repository guardrails,
+docs links, and the complete Python suite. No migration, data restoration, or
+external-state cleanup applies. Rollback knowingly returns G4 to an unresolved
+policy and keeps City Coverage Expansion blocked.
+
+**w) Docs synchronization.**
+
+- `docs/ADR.md`: add the Accepted G4 decision.
+- `docs/DATA_GOVERNANCE.md`: activate the document and replace Section 3's
+  open options with the adopted policy.
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`: version, changelog, task
+  states, T-PLAT-2 completion, G4, T-GOV-2, T-GOV-2A, T-GOV-6 sequencing,
+  and execution order.
+- New T-GOV-2 Full plan.
+- README, architecture, operations, performance, engineering guardrails,
+  testing policy, security policy, API contracts, and roadmap: no changes.
+
+## 7. Delivery Self-Audit
+
+**x) Antipattern scan, diff pass.** Re-run A-F/H. Reject a runtime-compliance
+claim, circular roster authority, a second live option list, policy parser
+machinery, implementation edits, historical ADR rewrites, unrelated
+formatting, or files outside ownership.
+
+**y) Evidence.** Report the tests-first red result, Ruff, Mypy, repository
+guardrails, docs links, complete-suite counts, planning-review findings,
+pre-commit-review findings, commit hashes, PR URL, unresolved-thread count,
+and final CI state. Mark unrun evidence `NOT VERIFIED`.
+
+**z) Deviations.** The authorized scope expansion from the ledger's original
+single ADR file to the five-file set above is required to keep the canonical
+policy, task states, implementation follow-up, and durable contract aligned.
+Any runtime file, schema change, new dependency, new governance document,
+skipped review, unresolved P1/P2, or unrun required check is a blocker.

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2857,7 +2857,9 @@ G4_DERIVED_PERSON_TARGET = re.compile(
     re.IGNORECASE,
 )
 G4_DERIVED_PASSIVE_PERSON_PROMOTION = re.compile(
-    r"\b(?:person entities|people-facing records)\b[^.!?;]{0,40}"
+    r"\b(?:person entities|people-facing records|profiles|memberships|"
+    r"people metadata|vote attribution|cross-document aggregation)\b"
+    r"[^.!?;]{0,60}"
     r"\b(?:may|can|will|must|should)\s+be\s+"
     r"(?:authorized|created|produced)\s+from\s+"
     r"(?:title inference|source-document mentions?|linker-created memberships?"
@@ -2927,6 +2929,10 @@ G4_SOURCE_PASSIVE_ACTION = re.compile(
 )
 G4_SOURCE_RECORD_TARGET = re.compile(
     r"\b(?:municipal\s+)?source (?:documents?|records?|text)\b",
+    re.IGNORECASE,
+)
+G4_EXTERNAL_SOURCE_CUSTODIAN = re.compile(
+    r"\b(?:originating municipality|source municipality|records? custodian)\b",
     re.IGNORECASE,
 )
 G4_SOURCE_ACTION_BARRIER = re.compile(
@@ -3207,6 +3213,10 @@ def _segment_allows_active_source_edit(
         ]
         if (
             G4_SOURCE_ACTION_BARRIER.search(action_target_text) is None
+            and G4_EXTERNAL_SOURCE_CUSTODIAN.search(
+                policy_segment[: source_action.start()]
+            )
+            is None
             and G4_SOURCE_TARGET_PRESERVATION.match(
                 policy_segment[source_target.end() :]
             )
@@ -3427,6 +3437,15 @@ def test_g2_policy_contradiction_detection_allows_approved_wording(
         ("Town Council deletes source documents.", True),
         ("Source-document mentions may become person entities.", True),
         ("Person entities may be created from source-document mentions.", True),
+        (
+            "Profiles for non-roster names may be created from "
+            "source-document mentions.",
+            True,
+        ),
+        (
+            "Memberships may be created from linker-created memberships.",
+            True,
+        ),
         ("Title inference may produce people-facing records.", True),
         ("Source-document mentions may not become person entities.", False),
         (
@@ -3481,6 +3500,11 @@ def test_g2_policy_contradiction_detection_allows_approved_wording(
         ("Staff cannot edit and delete source records.", False),
         ("Staff are deleting source documents.", True),
         ("Staff may redact municipal source documents.", True),
+        (
+            "The originating municipality may edit its source records before "
+            "publication.",
+            False,
+        ),
         ("Corrections remove entity links to source documents.", False),
         (
             "Corrections modify annotations linked to municipal source records.",

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2895,11 +2895,14 @@ G4_NON_ROSTER_PERSON_CREATION_POLICY = re.compile(
     r"\bnon-roster (?:names?|people)\b"
     r"(?![^.!?;]{0,80}\bwhile\b)"
     r"[^.!?;]{0,80}\b(?:(?:may|can)\s+"
-    r"(?:become|create|produce|appear in|be retained as|receive)"
+    r"(?:become|create|produce|appear in|be retained as|receive|"
+    r"(?:be\s+)?link(?:ed|ing)?\s+to)"
     r"|are\s+allowed\s+to\s+"
-    r"(?:become|create|produce|appear in|be retained as|receive)"
+    r"(?:become|create|produce|appear in|be retained as|receive|"
+    r"(?:be\s+)?link(?:ed|ing)?\s+to)"
     r"|(?<!not )(?<!never )(?<!cannot )"
-    r"(?:become|create|produce|appear in|are retained as|receive))"
+    r"(?:become|create|produce|appear in|are retained as|receive|"
+    r"(?:are\s+)?link(?:ed|ing|s)?\s+to))"
     r"(?![^.!?;]{0,40}\bnot\b)[^.!?;]{0,40}"
     r"\b(?:person entities|people metadata|profiles|memberships|"
     r"vote attribution|cross-document aggregation)\b",
@@ -2908,7 +2911,8 @@ G4_NON_ROSTER_PERSON_CREATION_POLICY = re.compile(
 G4_NON_ROSTER_WHILE_CONTINUATION_POLICY = re.compile(
     r"\bnon-roster (?:names?|people)\b[^.!?;]{0,80}"
     r"\bwhile\s+they\s+(?:(?:may|can)\s+)?"
-    r"(?:become|create|produce|appear in|are retained as|receive)\b"
+    r"(?:become|create|produce|appear in|are retained as|receive|"
+    r"(?:be\s+|are\s+)?link(?:ed|ing|s)?\s+to)\b"
     r"(?![^.!?;]{0,40}\bnot\b)[^.!?;]{0,40}"
     r"\b(?:person entities|people metadata|profiles|memberships|"
     r"vote attribution|cross-document aggregation)\b",
@@ -2932,8 +2936,10 @@ G4_SOURCE_RECORD_TARGET = re.compile(
     r"\b(?:municipal\s+)?source (?:documents?|records?|text)\b",
     re.IGNORECASE,
 )
-G4_EXTERNAL_SOURCE_CUSTODIAN = re.compile(
-    r"\b(?:originating municipality|source municipality|records? custodian)\b",
+G4_EXTERNAL_SOURCE_CUSTODIAN_ACTIVE_ACTOR = re.compile(
+    r"\b(?:the\s+)?"
+    r"(?:originating municipality|source municipality|records? custodian)\b"
+    r"(?:\s+(?:may|can|will|must|should|does|is|are))?\s*$",
     re.IGNORECASE,
 )
 G4_EXTERNAL_SOURCE_CUSTODIAN_ACTOR = re.compile(
@@ -3232,7 +3238,7 @@ def _segment_allows_active_source_edit(
         ]
         if (
             G4_SOURCE_ACTION_BARRIER.search(action_target_text) is None
-            and G4_EXTERNAL_SOURCE_CUSTODIAN.search(
+            and G4_EXTERNAL_SOURCE_CUSTODIAN_ACTIVE_ACTOR.search(
                 policy_segment[: source_action.start()]
             )
             is None
@@ -3353,6 +3359,9 @@ def test_g2_policy_contradiction_detection_allows_approved_wording(
         ("Linker-created memberships are roster authority.", True),
         ("Memberships created by the entity linker are roster authority.", True),
         ("Non-roster names may become person entities.", True),
+        ("Non-roster names may be linked to person entities.", True),
+        ("Non-roster names link to person entities.", True),
+        ("Non-roster names are linked to person entities.", True),
         ("Non-roster names become person entities.", True),
         ("Non-roster names can appear in people metadata.", True),
         ("Non-roster names may appear in source text, not profiles.", False),
@@ -3531,6 +3540,11 @@ def test_g2_policy_contradiction_detection_allows_approved_wording(
             "The originating municipality may edit its source records before "
             "publication.",
             False,
+        ),
+        (
+            "At the originating municipality's request, Town Council may edit "
+            "source records.",
+            True,
         ),
         (
             "Deletion of source records by the originating municipality is "

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2853,14 +2853,15 @@ G4_DERIVED_PERSON_ACTION = re.compile(
     re.IGNORECASE,
 )
 G4_DERIVED_PERSON_TARGET = re.compile(
-    r"\b(?:person creation|person entities|people-facing records)\b",
+    r"\b(?:person creation|person entities|people-facing records|profiles|"
+    r"memberships|people metadata|vote attribution|cross-document aggregation)\b",
     re.IGNORECASE,
 )
 G4_DERIVED_PASSIVE_PERSON_PROMOTION = re.compile(
     r"\b(?:person entities|people-facing records|profiles|memberships|"
     r"people metadata|vote attribution|cross-document aggregation)\b"
     r"[^.!?;]{0,60}"
-    r"\b(?:may|can|will|must|should)\s+be\s+"
+    r"\b(?:(?:may|can|will|must|should)\s+be|is|are)\s+"
     r"(?:authorized|created|produced)\s+from\s+"
     r"(?:title inference|source-document mentions?|linker-created memberships?"
     r"|memberships created by the entity linker)\b",
@@ -3007,6 +3008,9 @@ G4_PREMATURE_CITY_EXPANSION_POLICY = re.compile(
     r"[^.!?;]{0,160}\b(?:(?<!not )(?<!never )before|without)\b"
     r"|\bt-gov-2a\b[^.!?;]{0,80}\b(?:is|becomes|remains)\s+optional\b"
     r"[^.!?;]{0,80}\bbefore\b[^.!?;]{0,80}\bcity coverage expansion\b"
+    r"|\bt-gov-2a\b[^.!?;]{0,40}\bneed(?:s)?\s+not\s+"
+    r"(?:be\s+)?complete\b[^.!?;]{0,80}\bbefore\b[^.!?;]{0,80}"
+    r"\bcity coverage expansion\b"
     r"|\bbefore\b[^.!?;]{0,80}\bt-gov-2a\b[^.!?;]{0,80}"
     r"\bcity coverage expansion\b[^.!?;]{0,80}"
     r"(?:(?:may|can)\s+(?:start|begin|proceed|resume)"
@@ -3167,6 +3171,7 @@ def _g4_policy_allows_source_record_modification(g4_policy: str) -> bool:
     for policy_sentence in _g4_policy_clauses(g4_policy):
         if any(
             nominal_action.group("negated") is None
+            and G4_EXTERNAL_SOURCE_CUSTODIAN.search(policy_sentence) is None
             for nominal_action in G4_SOURCE_NOMINAL_AUTHORIZATION.finditer(
                 policy_sentence
             )
@@ -3436,7 +3441,10 @@ def test_g2_policy_contradiction_detection_allows_approved_wording(
         ("Staff may edit municipal source records.", True),
         ("Town Council deletes source documents.", True),
         ("Source-document mentions may become person entities.", True),
+        ("Source-document mentions may create profiles.", True),
+        ("Title inference may produce memberships.", True),
         ("Person entities may be created from source-document mentions.", True),
+        ("Profiles are created from source-document mentions.", True),
         (
             "Profiles for non-roster names may be created from "
             "source-document mentions.",
@@ -3503,6 +3511,11 @@ def test_g2_policy_contradiction_detection_allows_approved_wording(
         (
             "The originating municipality may edit its source records before "
             "publication.",
+            False,
+        ),
+        (
+            "Deletion of source records by the originating municipality is "
+            "permitted under local retention law.",
             False,
         ),
         ("Corrections remove entity links to source documents.", False),
@@ -3582,6 +3595,10 @@ def test_g2_policy_contradiction_detection_allows_approved_wording(
         ("Town Council does not yet enforce this policy.", False),
         ("Runtime enforcement remains pending under T-GOV-2A.", False),
         ("T-GOV-2A must complete before City Coverage Expansion starts.", False),
+        (
+            "T-GOV-2A need not complete before City Coverage Expansion proceeds.",
+            True,
+        ),
     ),
 )
 def test_g4_contradiction_detection_covers_equivalent_wording(

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2840,6 +2840,19 @@ G4_LIVE_OPTIONS_POLICY = re.compile(
     r"|\bworking\s+default\s+until\s+(?:the\s+)?adr\s+lands\b)",
     re.IGNORECASE,
 )
+G4_DERIVED_ROSTER_AUTHORITY_POLICY = re.compile(
+    r"\b(?:title inference|source-document mentions?|linker-created memberships?"
+    r"|memberships created by the entity linker)\b"
+    r".{0,80}\b(?:(?:may|can)\s+(?:be|become|constitute|establish|serve as)"
+    r"|(?:is|are)(?:\s+valid)?)\s+roster authority\b",
+    re.IGNORECASE,
+)
+G4_NON_ROSTER_PERSON_CREATION_POLICY = re.compile(
+    r"\bnon-roster names?\b.{0,80}\b(?:may|can)\s+(?:become|create|produce)"
+    r".{0,40}\b(?:person entities|people metadata|profiles|memberships|"
+    r"vote attribution|cross-document aggregation)\b",
+    re.IGNORECASE,
+)
 OPERATOR_AUTH_APPROVAL_POLICY = re.compile(
     r"\boperator(?:-only)?(?: proxy)? authentication\s+(?:is\s+)?(?:approved|pending)\b",
     re.IGNORECASE,
@@ -2869,9 +2882,12 @@ def _g2_policy_has_contradiction(g2_policy: str) -> bool:
 
 
 def _g4_policy_has_contradiction(g4_policy: str) -> bool:
+    normalized_g4_policy = " ".join(g4_policy.split())
     return bool(
-        G4_UNRESOLVED_POLICY.search(g4_policy)
-        or G4_LIVE_OPTIONS_POLICY.search(g4_policy)
+        G4_UNRESOLVED_POLICY.search(normalized_g4_policy)
+        or G4_LIVE_OPTIONS_POLICY.search(normalized_g4_policy)
+        or G4_DERIVED_ROSTER_AUTHORITY_POLICY.search(normalized_g4_policy)
+        or G4_NON_ROSTER_PERSON_CREATION_POLICY.search(normalized_g4_policy)
     )
 
 
@@ -2913,9 +2929,17 @@ def test_g2_policy_contradiction_detection_allows_approved_wording(
         ("DECISION G4 - unresolved", True),
         ("Options under consideration; exactly one will be adopted by ADR.", True),
         ("Working default until the ADR lands.", True),
+        ("Title inference may establish roster authority.", True),
+        ("Title inference\nmay establish roster authority.", True),
+        ("Linker-created memberships are roster authority.", True),
+        ("Memberships created by the entity linker are roster authority.", True),
+        ("Non-roster names may become person entities.", True),
+        ("Non-roster names\nmay become person entities.", True),
         ("G4 is approved; T-GOV-2A remains pending.", False),
         ("Runtime enforcement is pending T-GOV-2A.", False),
         ("The historical alternatives were superseded by approved G4.", False),
+        ("Title inference and linker-created memberships are not roster authority.", False),
+        ("Non-roster names do not become person entities.", False),
     ),
 )
 def test_g4_contradiction_detection_covers_equivalent_wording(
@@ -2926,6 +2950,7 @@ def test_g4_contradiction_detection_covers_equivalent_wording(
 
 
 def test_g4_roster_gated_policy_is_aligned() -> None:
+    agent_policy = (ROOT / "AGENTS.md").read_text(encoding="utf-8")
     architecture_decisions = (ROOT / "docs" / "ADR.md").read_text(encoding="utf-8")
     data_governance = (ROOT / "docs" / "DATA_GOVERNANCE.md").read_text(
         encoding="utf-8"
@@ -2968,8 +2993,12 @@ def test_g4_roster_gated_policy_is_aligned() -> None:
     assert "- Status: Accepted" in g4_decision
     assert "independently authoritative official membership data" in g4_decision
     assert "municipality, governing body, and meeting date" in g4_decision
-    assert "Title inference" in g4_decision
-    assert "linker-created memberships" in g4_decision
+    normalized_g4_decision = " ".join(g4_decision.split())
+    assert (
+        "Title inference, source-document mentions, and linker-created memberships "
+        "are not roster authority."
+        in normalized_g4_decision
+    )
     assert "does not yet enforce" in g4_decision
     assert "T-GOV-2A" in g4_decision
 
@@ -2978,6 +3007,12 @@ def test_g4_roster_gated_policy_is_aligned() -> None:
     assert "municipality, governing body, and meeting date" in person_policy
     normalized_person_policy = " ".join(person_policy.split())
     assert (
+        "Title inference, source-document mentions, and memberships created by the "
+        "entity linker are derived evidence, not roster authority. They cannot "
+        "authorize person creation or people-facing records."
+        in normalized_person_policy
+    )
+    assert (
         "Non-roster names remain searchable source text. They do not become "
         "person entities, people metadata, profiles, memberships, vote attribution, "
         "or cross-document aggregation."
@@ -2985,7 +3020,18 @@ def test_g4_roster_gated_policy_is_aligned() -> None:
     )
     assert "Source documents are not modified" in person_policy
 
-    active_g4_policy = f"{person_policy} {g4_entry} {t_gov_2_entry}"
+    normalized_agent_policy = " ".join(agent_policy.split())
+    assert (
+        "Create person entities and people-facing records only from independently "
+        "authoritative official membership data scoped to municipality, governing "
+        "body, and meeting date. Title inference, source-document mentions, and "
+        "linker-created memberships are not roster authority. Do not start City "
+        "Coverage Expansion before T-GOV-2A is complete and verified."
+        in normalized_agent_policy
+    )
+    active_g4_policy = " ".join(
+        (agent_policy, g4_decision, person_policy, g4_entry, t_gov_2_entry)
+    )
     assert not _g4_policy_has_contradiction(active_g4_policy)
     assert "status: complete and verified" in t_gov_2_entry
     assert "status: pending" in t_gov_2a_entry

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2849,7 +2849,7 @@ G4_DERIVED_EVIDENCE_SOURCE = re.compile(
 )
 G4_DERIVED_PERSON_ACTION = re.compile(
     r"(?<!-)\b(?:authoriz(?:e|es|ed|ing)|becom(?:e|es|ing)|"
-    r"creat(?:e|es|ed|ing)|produc(?:e|es|ed|ing))\b",
+    r"creat(?:e|es|ed|ing)|generat(?:e|es|ed|ing)|produc(?:e|es|ed|ing))\b",
     re.IGNORECASE,
 )
 G4_DERIVED_PERSON_TARGET = re.compile(
@@ -2862,7 +2862,7 @@ G4_DERIVED_PASSIVE_PERSON_PROMOTION = re.compile(
     r"people metadata|vote attribution|cross-document aggregation)\b"
     r"[^.!?;]{0,60}"
     r"\b(?:(?:may|can|will|must|should)\s+be|is|are)\s+"
-    r"(?:authorized|created|produced)\s+from\s+"
+    r"(?:authorized|created|generated|produced)\s+from\s+"
     r"(?:title inference|source-document mentions?|linker-created memberships?"
     r"|memberships created by the entity linker)\b",
     re.IGNORECASE,
@@ -2895,13 +2895,13 @@ G4_NON_ROSTER_PERSON_CREATION_POLICY = re.compile(
     r"\bnon-roster (?:names?|people)\b"
     r"(?![^.!?;]{0,80}\bwhile\b)"
     r"[^.!?;]{0,80}\b(?:(?:may|can)\s+"
-    r"(?:become|create|produce|appear in|be retained as|receive|"
+    r"(?:become|create|generate|produce|appear in|be retained as|receive|"
     r"(?:be\s+)?link(?:ed|ing)?\s+to)"
     r"|are\s+allowed\s+to\s+"
-    r"(?:become|create|produce|appear in|be retained as|receive|"
+    r"(?:become|create|generate|produce|appear in|be retained as|receive|"
     r"(?:be\s+)?link(?:ed|ing)?\s+to)"
     r"|(?<!not )(?<!never )(?<!cannot )"
-    r"(?:become|create|produce|appear in|are retained as|receive|"
+    r"(?:become|create|generate|produce|appear in|are retained as|receive|"
     r"(?:are\s+)?link(?:ed|ing|s)?\s+to))"
     r"(?![^.!?;]{0,40}\bnot\s+(?:person entities|people metadata|profiles|"
     r"memberships|vote attribution|cross-document aggregation)\b)"
@@ -2913,7 +2913,7 @@ G4_NON_ROSTER_PERSON_CREATION_POLICY = re.compile(
 G4_NON_ROSTER_WHILE_CONTINUATION_POLICY = re.compile(
     r"\bnon-roster (?:names?|people)\b[^.!?;]{0,80}"
     r"\bwhile\s+they\s+(?:(?:may|can)\s+)?"
-    r"(?:become|create|produce|appear in|are retained as|receive|"
+    r"(?:become|create|generate|produce|appear in|are retained as|receive|"
     r"(?:be\s+|are\s+)?link(?:ed|ing|s)?\s+to)\b"
     r"(?![^.!?;]{0,40}\bnot\s+(?:person entities|people metadata|profiles|"
     r"memberships|vote attribution|cross-document aggregation)\b)"
@@ -2986,6 +2986,7 @@ G4_SOURCE_NOMINAL_AUTHORIZATION = re.compile(
 )
 G4_SOURCE_NEGATION_CUE = re.compile(
     r"\b(?:not(?:\s+(?:allowed|permitted|authorized)(?:\s+to)?)?|never|cannot|"
+    r"prevent(?:s|ed|ing)?|refus(?:e|es|ed|ing)|"
     r"prohibit(?:s|ed)?|forbid(?:s|den)?|prohibited|forbidden)\b",
     re.IGNORECASE,
 )
@@ -3030,7 +3031,9 @@ G4_PREMATURE_CITY_EXPANSION_POLICY = re.compile(
     r"\b(?:t-gov-2a|roster enforcement|roster-gated person linking)\b"
     r"|prior\s+to\s+(?:the\s+)?completion\s+of\s+t-gov-2a\b"
     r"|without\b[^.!?;]{0,40}\b(?:completion\s+of|completing)\s+t-gov-2a\b)"
-    r"|\bt-gov-2a\b[^.!?;]{0,80}\b(?:is|becomes|remains)\s+optional\b"
+    r"|\bt-gov-2a\b[^.!?;]{0,80}\b(?:is|becomes|remains)\s+"
+    r"(?:optional|unnecessary|not\s+(?:required|mandatory)|"
+    r"no\s+longer\s+(?:required|mandatory))\b"
     r"[^.!?;]{0,80}\bbefore\b[^.!?;]{0,80}\bcity coverage expansion\b"
     r"|\bt-gov-2a\b[^.!?;]{0,40}\b"
     r"(?:need(?:s)?\s+not|do(?:es)?\s+not\s+need\s+to)\s+"
@@ -3469,6 +3472,7 @@ def test_g2_policy_contradiction_detection_allows_approved_wording(
         ("Deletion of source records is authorized for takedowns.", True),
         ("Deletion of source records is not authorized for takedowns.", False),
         ("Corrections prohibit editing source documents.", False),
+        ("Correction controls prevent editing municipal source records.", False),
         (
             "Corrections remove derived records and source documents remain unchanged.",
             False,
@@ -3507,10 +3511,12 @@ def test_g2_policy_contradiction_detection_allows_approved_wording(
         ("Source-document mentions may create profiles.", True),
         ("Source-document mentions may create a profile.", True),
         ("Source-document mentions may create a membership.", True),
+        ("Source-document mentions may generate profiles.", True),
         ("Source-document mentions may create links to profiles.", True),
         ("Title inference may produce memberships.", True),
         ("Person entities may be created from source-document mentions.", True),
         ("Profiles are created from source-document mentions.", True),
+        ("Profiles are generated from source-document mentions.", True),
         (
             "Neither profiles nor memberships are created from "
             "source-document mentions.",
@@ -3722,6 +3728,10 @@ def test_g2_policy_contradiction_detection_allows_approved_wording(
         (
             "T-GOV-2A does not need to be complete before City Coverage "
             "Expansion proceeds.",
+            True,
+        ),
+        (
+            "T-GOV-2A is not required before City Coverage Expansion proceeds.",
             True,
         ),
     ),

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2868,7 +2868,7 @@ G4_DERIVED_AUTHORITY_ACTION = re.compile(
 )
 G4_DERIVED_AUTHORITY_TARGET = re.compile(r"\broster authority\b", re.IGNORECASE)
 G4_DERIVED_AUTHORITY_RELATION_BARRIER = re.compile(
-    r"\b(?:rather than|instead of)\b",
+    r"\b(?:rather than|instead of|rejected as)\b",
     re.IGNORECASE,
 )
 G4_AUTHORITATIVE_ROSTER_SUBJECT = re.compile(
@@ -2997,7 +2997,9 @@ G4_PREMATURE_ENFORCEMENT_POLICY = re.compile(
     r"(?:\btown council\b[^.!?;]{0,80}\b(?:currently|already|now)\s+"
     r"enforces?\s+(?:this|the)\s+(?:g4\s+)?policy\b"
     r"|\bruntime enforcement\b[^.!?;]{0,80}\b"
-    r"(?:is|has been)\s+(?:complete|implemented|verified)\b)",
+    r"(?:is|has been)\s+(?:complete|implemented|verified)\b"
+    r"|\broster gating\b[^.!?;]{0,40}\b(?:is|has been)\s+"
+    r"(?:(?:already|currently|now)\s+)?(?:enforced|implemented|complete|verified)\b)",
     re.IGNORECASE,
 )
 OPERATOR_AUTH_APPROVAL_POLICY = re.compile(
@@ -3323,6 +3325,7 @@ def test_g2_policy_contradiction_detection_allows_approved_wording(
         ("Corrections apply to derived records while they remove source documents.", True),
         ("Before T-GOV-2A completes, City Coverage Expansion may proceed.", True),
         ("Town Council currently enforces this policy.", True),
+        ("Roster gating is already enforced.", True),
         ("Runtime enforcement is complete.", True),
         ("G4 is approved; T-GOV-2A remains pending.", False),
         ("Runtime enforcement is pending T-GOV-2A.", False),
@@ -3485,6 +3488,7 @@ def test_g2_policy_contradiction_detection_allows_approved_wording(
             True,
         ),
         ("Title inference may count as roster authority.", True),
+        ("Title inference is rejected as roster authority.", False),
         (
             "Neither title inference nor source-document mentions provide "
             "roster authority.",

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2853,12 +2853,12 @@ G4_DERIVED_PERSON_ACTION = re.compile(
     re.IGNORECASE,
 )
 G4_DERIVED_PERSON_TARGET = re.compile(
-    r"\b(?:person creation|person entities|people-facing records|profiles|"
-    r"memberships|people metadata|vote attribution|cross-document aggregation)\b",
+    r"\b(?:person creation|person entities|people-facing records|profiles?|"
+    r"memberships?|people metadata|vote attribution|cross-document aggregation)\b",
     re.IGNORECASE,
 )
 G4_DERIVED_PASSIVE_PERSON_PROMOTION = re.compile(
-    r"\b(?:person entities|people-facing records|profiles|memberships|"
+    r"\b(?:person entities|people-facing records|profiles?|memberships?|"
     r"people metadata|vote attribution|cross-document aggregation)\b"
     r"[^.!?;]{0,60}"
     r"\b(?:(?:may|can|will|must|should)\s+be|is|are)\s+"
@@ -3096,11 +3096,33 @@ def _g4_policy_has_contradiction(g4_policy: str) -> bool:
 
 def _g4_policy_promotes_derived_evidence(g4_policy: str) -> bool:
     return any(
-        G4_DERIVED_PASSIVE_PERSON_PROMOTION.search(policy_clause) is not None
+        _g4_clause_passively_promotes_derived_evidence(policy_clause)
         or _g4_clause_grants_roster_authority(policy_clause)
         or _g4_clause_creates_person_record(policy_clause)
         for policy_clause in _g4_policy_clauses(g4_policy)
     )
+
+
+def _g4_clause_passively_promotes_derived_evidence(policy_clause: str) -> bool:
+    passive_promotion = G4_DERIVED_PASSIVE_PERSON_PROMOTION.search(policy_clause)
+    return passive_promotion is not None and not _source_action_is_negated(
+        policy_clause[: passive_promotion.end()]
+    )
+
+
+def _g4_authority_subject(authority_prefix: str) -> str:
+    relative_marker = re.search(r"\b(?:that|which)\s*$", authority_prefix, re.IGNORECASE)
+    if relative_marker is not None:
+        relative_subject = G4_AUTHORITATIVE_ROSTER_SUBJECT.search(
+            authority_prefix[: relative_marker.start()]
+        )
+        if relative_subject is not None:
+            return relative_subject.group()
+    return re.split(
+        r",|\bwhile\b",
+        authority_prefix,
+        flags=re.IGNORECASE,
+    )[-1]
 
 
 def _g4_clause_grants_roster_authority(policy_clause: str) -> bool:
@@ -3125,11 +3147,7 @@ def _g4_clause_grants_roster_authority(policy_clause: str) -> bool:
         if not evidence_sources:
             continue
         authority_prefix = policy_clause[: authority_action.start()]
-        authority_subject = re.split(
-            r",|\bwhile\b",
-            authority_prefix,
-            flags=re.IGNORECASE,
-        )[-1]
+        authority_subject = _g4_authority_subject(authority_prefix)
         action_target_text = policy_clause[
             authority_action.end() : authority_target.start()
         ]
@@ -3487,10 +3505,17 @@ def test_g2_policy_contradiction_detection_allows_approved_wording(
         ("Town Council deletes source documents.", True),
         ("Source-document mentions may become person entities.", True),
         ("Source-document mentions may create profiles.", True),
+        ("Source-document mentions may create a profile.", True),
+        ("Source-document mentions may create a membership.", True),
         ("Source-document mentions may create links to profiles.", True),
         ("Title inference may produce memberships.", True),
         ("Person entities may be created from source-document mentions.", True),
         ("Profiles are created from source-document mentions.", True),
+        (
+            "Neither profiles nor memberships are created from "
+            "source-document mentions.",
+            False,
+        ),
         (
             "Profiles for non-roster names may be created from "
             "source-document mentions.",
@@ -3615,6 +3640,11 @@ def test_g2_policy_contradiction_detection_allows_approved_wording(
             False,
         ),
         ("Title inference is derived evidence rather than roster authority.", False),
+        (
+            "Title inference helps locate official rosters that provide roster "
+            "authority.",
+            False,
+        ),
         (
             "Title inference, instead of official rosters, provides roster authority.",
             True,

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2927,6 +2927,13 @@ G4_PREMATURE_CITY_EXPANSION_POLICY = re.compile(
     r"|(?:starts|begins|proceeds|resumes)|(?:is|remains)\s+(?:allowed|unblocked))\b)",
     re.IGNORECASE,
 )
+G4_PREMATURE_ENFORCEMENT_POLICY = re.compile(
+    r"(?:\btown council\b[^.!?;]{0,80}\b(?:currently|already|now)\s+"
+    r"enforces?\s+(?:this|the)\s+(?:g4\s+)?policy\b"
+    r"|\bruntime enforcement\b[^.!?;]{0,80}\b"
+    r"(?:is|has been)\s+(?:complete|implemented|verified)\b)",
+    re.IGNORECASE,
+)
 OPERATOR_AUTH_APPROVAL_POLICY = re.compile(
     r"\boperator(?:-only)?(?: proxy)? authentication\s+(?:is\s+)?(?:approved|pending)\b",
     re.IGNORECASE,
@@ -2968,6 +2975,7 @@ def _g4_policy_has_contradiction(g4_policy: str) -> bool:
         or G4_SOURCE_RECORD_MODIFICATION_POLICY.search(normalized_g4_policy)
         or G4_SOURCE_WHILE_CONTINUATION_POLICY.search(normalized_g4_policy)
         or G4_PREMATURE_CITY_EXPANSION_POLICY.search(normalized_g4_policy)
+        or G4_PREMATURE_ENFORCEMENT_POLICY.search(normalized_g4_policy)
     )
 
 
@@ -3040,6 +3048,8 @@ def test_g2_policy_contradiction_detection_allows_approved_wording(
         ("Takedowns remove source text.", True),
         ("Corrections apply to derived records while they remove source documents.", True),
         ("Before T-GOV-2A completes, City Coverage Expansion may proceed.", True),
+        ("Town Council currently enforces this policy.", True),
+        ("Runtime enforcement is complete.", True),
         ("G4 is approved; T-GOV-2A remains pending.", False),
         ("Runtime enforcement is pending T-GOV-2A.", False),
         ("The historical alternatives were superseded by approved G4.", False),
@@ -3086,6 +3096,9 @@ def test_g2_policy_contradiction_detection_allows_approved_wording(
             "official membership data provides roster authority.",
             False,
         ),
+        ("Town Council does not yet enforce this policy.", False),
+        ("Runtime enforcement remains pending under T-GOV-2A.", False),
+        ("T-GOV-2A must complete before City Coverage Expansion starts.", False),
     ),
 )
 def test_g4_contradiction_detection_covers_equivalent_wording(
@@ -3116,6 +3129,21 @@ def test_g4_policy_scan_covers_live_data_governance_sections(
     )
 
     assert _g4_policy_has_contradiction(contradictory_governance)
+
+
+def test_g4_policy_scan_excludes_later_historical_adr_entries() -> None:
+    architecture_decisions = (ROOT / "docs" / "ADR.md").read_text(encoding="utf-8")
+    architecture_decisions_with_history = (
+        f"{architecture_decisions}\n"
+        "## 2026-07-30: Historical G4 wording\n\n"
+        "The prior policy said G4 remains open.\n"
+    )
+    live_g4_decision = _required_markdown_entry(
+        architecture_decisions_with_history,
+        "## 2026-07-26: Roster-gated person linking",
+    )
+
+    assert not _g4_policy_has_contradiction(live_g4_decision)
 
 
 def test_g4_roster_gated_policy_is_aligned() -> None:
@@ -3201,10 +3229,12 @@ def test_g4_roster_gated_policy_is_aligned() -> None:
     active_g4_policy = " ".join(
         (
             agent_policy,
-            architecture_decisions,
+            g4_decision,
             data_governance,
-            remediation_ledger,
-            roadmap,
+            g4_entry,
+            t_gov_2_entry,
+            t_gov_2a_entry,
+            city_coverage_plan,
         )
     )
     assert not _g4_policy_has_contradiction(active_g4_policy)

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2903,7 +2903,9 @@ G4_NON_ROSTER_PERSON_CREATION_POLICY = re.compile(
     r"|(?<!not )(?<!never )(?<!cannot )"
     r"(?:become|create|produce|appear in|are retained as|receive|"
     r"(?:are\s+)?link(?:ed|ing|s)?\s+to))"
-    r"(?![^.!?;]{0,40}\bnot\b)[^.!?;]{0,40}"
+    r"(?![^.!?;]{0,40}\bnot\s+(?:person entities|people metadata|profiles|"
+    r"memberships|vote attribution|cross-document aggregation)\b)"
+    r"[^.!?;]{0,40}"
     r"\b(?:person entities|people metadata|profiles|memberships|"
     r"vote attribution|cross-document aggregation)\b",
     re.IGNORECASE,
@@ -2913,7 +2915,9 @@ G4_NON_ROSTER_WHILE_CONTINUATION_POLICY = re.compile(
     r"\bwhile\s+they\s+(?:(?:may|can)\s+)?"
     r"(?:become|create|produce|appear in|are retained as|receive|"
     r"(?:be\s+|are\s+)?link(?:ed|ing|s)?\s+to)\b"
-    r"(?![^.!?;]{0,40}\bnot\b)[^.!?;]{0,40}"
+    r"(?![^.!?;]{0,40}\bnot\s+(?:person entities|people metadata|profiles|"
+    r"memberships|vote attribution|cross-document aggregation)\b)"
+    r"[^.!?;]{0,40}"
     r"\b(?:person entities|people metadata|profiles|memberships|"
     r"vote attribution|cross-document aggregation)\b",
     re.IGNORECASE,
@@ -2937,7 +2941,7 @@ G4_SOURCE_RECORD_TARGET = re.compile(
     re.IGNORECASE,
 )
 G4_EXTERNAL_SOURCE_CUSTODIAN_ACTIVE_ACTOR = re.compile(
-    r"\b(?:the\s+)?"
+    r"(?:^|[,;]\s*|\bwhile\s+)(?:only\s+)?(?:the\s+)?"
     r"(?:originating municipality|source municipality|records? custodian)\b"
     r"(?:\s+(?:may|can|will|must|should|does|is|are))?\s*$",
     re.IGNORECASE,
@@ -2949,7 +2953,8 @@ G4_EXTERNAL_SOURCE_CUSTODIAN_ACTOR = re.compile(
 )
 G4_EXTERNAL_SOURCE_CUSTODIAN_PASSIVE_AGENT = re.compile(
     r"^\s+by\s+(?:the\s+)?"
-    r"(?:originating municipality|source municipality|records? custodian)\b",
+    r"(?:originating municipality|source municipality|records? custodian)\b"
+    r"(?!\s*,?\s*(?:and|or)\b)",
     re.IGNORECASE,
 )
 G4_SOURCE_ACTION_BARRIER = re.compile(
@@ -3021,7 +3026,10 @@ G4_PREMATURE_CITY_EXPANSION_POLICY = re.compile(
     r"(?:\bcity coverage expansion\b"
     r"(?=[^.!?;]{0,120}\b(?:(?:may|can)\s+(?:start|begin|proceed|resume)"
     r"|(?:starts|begins|proceeds|resumes)|(?:is|remains)\s+(?:allowed|unblocked))\b)"
-    r"[^.!?;]{0,160}\b(?:(?<!not )(?<!never )before|without)\b"
+    r"[^.!?;]{0,160}\b(?:(?<!not )(?<!never )before\b[^.!?;]{0,80}"
+    r"\b(?:t-gov-2a|roster enforcement|roster-gated person linking)\b"
+    r"|prior\s+to\s+(?:the\s+)?completion\s+of\s+t-gov-2a\b"
+    r"|without\b[^.!?;]{0,40}\b(?:completion\s+of|completing)\s+t-gov-2a\b)"
     r"|\bt-gov-2a\b[^.!?;]{0,80}\b(?:is|becomes|remains)\s+optional\b"
     r"[^.!?;]{0,80}\bbefore\b[^.!?;]{0,80}\bcity coverage expansion\b"
     r"|\bt-gov-2a\b[^.!?;]{0,40}\b"
@@ -3116,15 +3124,20 @@ def _g4_clause_grants_roster_authority(policy_clause: str) -> bool:
         )
         if not evidence_sources:
             continue
-        evidence_source = evidence_sources[-1]
-        source_action_text = policy_clause[
-            evidence_source.end() : authority_action.start()
-        ]
+        authority_prefix = policy_clause[: authority_action.start()]
+        authority_subject = re.split(
+            r",|\bwhile\b",
+            authority_prefix,
+            flags=re.IGNORECASE,
+        )[-1]
         action_target_text = policy_clause[
             authority_action.end() : authority_target.start()
         ]
         if (
-            G4_AUTHORITATIVE_ROSTER_SUBJECT.search(source_action_text) is None
+            (
+                G4_AUTHORITATIVE_ROSTER_SUBJECT.search(authority_subject) is None
+                or G4_DERIVED_EVIDENCE_SOURCE.search(authority_subject) is not None
+            )
             and not _source_action_is_negated(
                 policy_clause[: authority_action.start()].rsplit(",", maxsplit=1)[-1]
             )
@@ -3349,6 +3362,7 @@ def test_g2_policy_contradiction_detection_allows_approved_wording(
         ("Working default until the ADR lands.", True),
         ("Option B remains a live alternative.", True),
         ("Title inference may establish roster authority.", True),
+        ("Title inference and official rosters provide roster authority.", True),
         ("Title inference constitutes roster authority.", True),
         ("Title inference qualifies as roster authority.", True),
         ("Source-document mentions provide roster authority.", True),
@@ -3359,6 +3373,10 @@ def test_g2_policy_contradiction_detection_allows_approved_wording(
         ("Linker-created memberships are roster authority.", True),
         ("Memberships created by the entity linker are roster authority.", True),
         ("Non-roster names may become person entities.", True),
+        (
+            "Non-roster names may become person entities, but they are not public.",
+            True,
+        ),
         ("Non-roster names may be linked to person entities.", True),
         ("Non-roster names link to person entities.", True),
         ("Non-roster names are linked to person entities.", True),
@@ -3541,9 +3559,14 @@ def test_g2_policy_contradiction_detection_allows_approved_wording(
             "publication.",
             False,
         ),
+        ("Only the originating municipality may edit source records.", False),
         (
             "At the originating municipality's request, Town Council may edit "
             "source records.",
+            True,
+        ),
+        (
+            "Town Council and the originating municipality may edit source records.",
             True,
         ),
         (
@@ -3560,6 +3583,16 @@ def test_g2_policy_contradiction_detection_allows_approved_wording(
             "Source records may be edited by the originating municipality "
             "before publication.",
             False,
+        ),
+        (
+            "Source records may be edited by the originating municipality or "
+            "Town Council.",
+            True,
+        ),
+        (
+            "Source records may be edited by the originating municipality, or "
+            "Town Council.",
+            True,
         ),
         ("Corrections remove entity links to source documents.", False),
         (
@@ -3618,6 +3651,20 @@ def test_g2_policy_contradiction_detection_allows_approved_wording(
         (
             "City Coverage Expansion may proceed after T-GOV-2A completes, "
             "never before verification.",
+            False,
+        ),
+        (
+            "City Coverage Expansion can start prior to completion of T-GOV-2A.",
+            True,
+        ),
+        (
+            "City Coverage Expansion may proceed before roster-gated person "
+            "linking is complete and verified.",
+            True,
+        ),
+        (
+            "City Coverage Expansion may proceed without delay once T-GOV-2A "
+            "is complete and verified.",
             False,
         ),
         (

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2891,19 +2891,61 @@ G4_NON_ROSTER_WHILE_CONTINUATION_POLICY = re.compile(
     r"vote attribution|cross-document aggregation)\b",
     re.IGNORECASE,
 )
-G4_SOURCE_RECORD_MODIFICATION_POLICY = re.compile(
-    r"(?:\b(?:corrections?|takedowns?)\b"
-    r"(?![^.!?;]{0,80}\bwhile\b)"
-    r"[^.!?;]{0,80}\b"
-    r"(?:(?:may|can)\s+(?:edit|modify|rewrite|delete|alter|remove)"
-    r"|(?<!not )(?<!never )(?<!cannot )"
-    r"(?:edits?|modifies?|rewrites?|deletes?|alters?|removes?))"
-    r"\b[^.!?;]{0,40}\b(?:municipal\s+)?source "
-    r"(?:documents?|records?|text)\b"
-    r"|\b(?:municipal\s+)?source (?:documents?|records?|text)\b[^.!?;]{0,80}"
-    r"\b(?:(?:may|can|will)\s+be\s+"
-    r"(?:edited|modified|rewritten|deleted|altered)"
-    r"|(?:is|are)\s+(?:edited|modified|rewritten|deleted|altered))\b)",
+G4_POLICY_SENTENCE_BOUNDARY = re.compile(r"[.!?;]+")
+G4_POLICY_CONTRAST_BOUNDARY = re.compile(r"\b(?:but|while)\b", re.IGNORECASE)
+G4_SOURCE_ACTIVE_ACTION = re.compile(
+    r"\b(?:edit(?:ed|ing|s)?|modif(?:ied|ies|y|ying)|rewrite(?:s|ten)?|"
+    r"rewriting|delete(?:d|ing|s)?|alter(?:ed|ing|s)?|remove(?:d|s)?|removing)\b",
+    re.IGNORECASE,
+)
+G4_SOURCE_PASSIVE_ACTION = re.compile(
+    r"\b(?:edited|modified|rewritten|deleted|altered|removed)\b",
+    re.IGNORECASE,
+)
+G4_SOURCE_RECORD_SUBJECT = re.compile(
+    r"\b(?:corrections?|takedowns?|removal requests?)\b",
+    re.IGNORECASE,
+)
+G4_SOURCE_RECORD_TARGET = re.compile(
+    r"\b(?:municipal\s+)?source (?:documents?|records?|text)\b",
+    re.IGNORECASE,
+)
+G4_SOURCE_ACTION_BARRIER = re.compile(
+    r"\b(?:not|rather than|instead of|keep(?:s|ing)?|leav(?:e|es|ing)|"
+    r"preserv(?:e|es|ed|ing)|retain(?:s|ed|ing)?)\b",
+    re.IGNORECASE,
+)
+G4_SOURCE_TARGET_PRESERVATION = re.compile(
+    r"^\s*(?:(?:is|are|will be|must be|should be)\s+(?:kept\s+)?unchanged|"
+    r"remain(?:s|ed)?\s+unchanged|"
+    r"(?:is|are|will be|must be|should be)\s+(?:preserved|retained))\b",
+    re.IGNORECASE,
+)
+G4_SOURCE_NOMINAL_AUTHORIZATION = re.compile(
+    r"\b(?:deletion|modification|removal|alteration|rewriting|editing)\s+of\s+"
+    r"(?:municipal\s+)?source (?:documents?|records?|text)\b"
+    r"[^.!?;]{0,40}\b(?:is|are|may be|can be|will be|must be|should be)\s+"
+    r"(?P<negated>not\s+)?"
+    r"(?:allowed|authorized|permitted)\b",
+    re.IGNORECASE,
+)
+G4_SOURCE_NEGATION_CUE = re.compile(
+    r"\b(?:not(?:\s+(?:allowed|permitted|authorized)(?:\s+to)?)?|never|cannot|"
+    r"prohibit(?:s|ed)?|forbid(?:s|den)?)\b",
+    re.IGNORECASE,
+)
+G4_SOURCE_AFFIRMATIVE_CUE = re.compile(
+    r"\b(?:may|can|will|must|should)\b",
+    re.IGNORECASE,
+)
+G4_SOURCE_INHERITED_PASSIVE_SUBJECT = re.compile(
+    r"^\s*(?:(?:they|it)\s+)?(?:may|can|will|must|should|is|are)\b",
+    re.IGNORECASE,
+)
+G4_SOURCE_NEW_SUBJECT_CUE = re.compile(
+    r"\b(?:and|or)\s+(?:[a-z][a-z-]*\s+){1,4}"
+    r"(?:(?:is|are|will|may|can|must|should)\s+(?:be\s+)?|"
+    r"(?:has|have)\s+been\s+)$",
     re.IGNORECASE,
 )
 G4_SOURCE_WHILE_CONTINUATION_POLICY = re.compile(
@@ -2972,11 +3014,116 @@ def _g4_policy_has_contradiction(g4_policy: str) -> bool:
         or G4_DERIVED_WHILE_CONTINUATION_POLICY.search(normalized_g4_policy)
         or G4_NON_ROSTER_PERSON_CREATION_POLICY.search(normalized_g4_policy)
         or G4_NON_ROSTER_WHILE_CONTINUATION_POLICY.search(normalized_g4_policy)
-        or G4_SOURCE_RECORD_MODIFICATION_POLICY.search(normalized_g4_policy)
+        or _g4_policy_allows_source_record_modification(normalized_g4_policy)
         or G4_SOURCE_WHILE_CONTINUATION_POLICY.search(normalized_g4_policy)
         or G4_PREMATURE_CITY_EXPANSION_POLICY.search(normalized_g4_policy)
         or G4_PREMATURE_ENFORCEMENT_POLICY.search(normalized_g4_policy)
     )
+
+
+def _g4_policy_allows_source_record_modification(g4_policy: str) -> bool:
+    for policy_sentence in G4_POLICY_SENTENCE_BOUNDARY.split(g4_policy):
+        correction_context = G4_SOURCE_RECORD_SUBJECT.search(policy_sentence) is not None
+        if any(
+            nominal_action.group("negated") is None
+            for nominal_action in G4_SOURCE_NOMINAL_AUTHORIZATION.finditer(
+                policy_sentence
+            )
+        ):
+            return True
+        source_context = False
+        for policy_segment in G4_POLICY_CONTRAST_BOUNDARY.split(policy_sentence):
+            source_targets = tuple(G4_SOURCE_RECORD_TARGET.finditer(policy_segment))
+            if correction_context and _segment_allows_active_source_edit(
+                policy_segment,
+                source_targets,
+            ):
+                return True
+            if _segment_allows_passive_source_edit(
+                policy_segment,
+                source_targets,
+                source_context,
+            ):
+                return True
+            source_context = bool(source_targets) or (
+                source_context
+                and G4_SOURCE_INHERITED_PASSIVE_SUBJECT.match(policy_segment) is not None
+            )
+    return False
+
+
+def _segment_allows_active_source_edit(
+    policy_segment: str,
+    source_targets: tuple[re.Match[str], ...],
+) -> bool:
+    for source_target in source_targets:
+        source_actions = tuple(
+            G4_SOURCE_ACTIVE_ACTION.finditer(
+                policy_segment,
+                0,
+                source_target.start(),
+            )
+        )
+        if not source_actions:
+            continue
+        source_action = source_actions[-1]
+        action_target_text = policy_segment[
+            source_action.end() : source_target.start()
+        ]
+        if (
+            G4_SOURCE_ACTION_BARRIER.search(action_target_text) is None
+            and G4_SOURCE_TARGET_PRESERVATION.match(
+                policy_segment[source_target.end() :]
+            )
+            is None
+            and not _source_action_is_negated(
+                policy_segment[: source_action.start()]
+            )
+        ):
+            return True
+    return False
+
+
+def _segment_allows_passive_source_edit(
+    policy_segment: str,
+    source_targets: tuple[re.Match[str], ...],
+    source_context: bool,
+) -> bool:
+    for source_action in G4_SOURCE_PASSIVE_ACTION.finditer(policy_segment):
+        explicit_source = any(
+            source_target.end() <= source_action.start()
+            for source_target in source_targets
+        )
+        inherited_source = (
+            not source_targets
+            and source_context
+            and G4_SOURCE_INHERITED_PASSIVE_SUBJECT.match(policy_segment) is not None
+            and G4_SOURCE_NEW_SUBJECT_CUE.search(
+                policy_segment[: source_action.start()]
+            )
+            is None
+        )
+        if (
+            (explicit_source or inherited_source)
+            and not _source_action_is_negated(policy_segment[: source_action.start()])
+        ):
+            return True
+    return False
+
+
+def _source_action_is_negated(action_prefix: str) -> bool:
+    latest_negative = max(
+        (negative_cue.end() for negative_cue in G4_SOURCE_NEGATION_CUE.finditer(action_prefix)),
+        default=-1,
+    )
+    latest_affirmative = max(
+        (
+            affirmative_cue.end()
+            for affirmative_cue in G4_SOURCE_AFFIRMATIVE_CUE.finditer(action_prefix)
+        ),
+        default=-1,
+    )
+    return latest_negative > latest_affirmative
 
 
 @pytest.mark.parametrize(
@@ -3057,6 +3204,78 @@ def test_g2_policy_contradiction_detection_allows_approved_wording(
         ("Non-roster names do not become person entities.", False),
         ("Corrections apply to derived records; source documents are not modified.", False),
         ("Corrections do not edit municipal source records.", False),
+        ("Corrections are not allowed to edit municipal source records.", False),
+        (
+            "Corrections do not edit derived indexes but may remove municipal "
+            "source records.",
+            True,
+        ),
+        (
+            "Corrections may edit municipal source records but do not modify "
+            "derived indexes.",
+            True,
+        ),
+        (
+            "Corrections do not edit source records but may delete source documents.",
+            True,
+        ),
+        (
+            "Source documents are not modified but may be deleted during correction.",
+            True,
+        ),
+        ("Corrections do not edit or remove source records.", False),
+        (
+            "Corrections are not allowed to modify or delete source documents.",
+            False,
+        ),
+        ("Corrections do not edit, modify, or remove source records.", False),
+        (
+            "Source documents are not modified, but derived indexes are deleted.",
+            False,
+        ),
+        ("Corrections apply while staff may edit source documents.", True),
+        ("Corrections edit derived indexes and preserve source documents.", False),
+        (
+            "Source documents are not modified but may be retained and derived "
+            "indexes are deleted.",
+            False,
+        ),
+        ("Corrections permit editing source documents.", True),
+        ("Deletion of source records is authorized for takedowns.", True),
+        ("Deletion of source records is not authorized for takedowns.", False),
+        ("Corrections prohibit editing source documents.", False),
+        (
+            "Corrections remove derived records and source documents remain unchanged.",
+            False,
+        ),
+        (
+            "Source documents are not modified but may be retained, and derived "
+            "indexes will be deleted.",
+            False,
+        ),
+        ("Deletion of source records may be authorized for takedowns.", True),
+        (
+            "Deletion of source records is authorized for private-individual "
+            "removal requests.",
+            True,
+        ),
+        (
+            "Corrections remove derived records and do not edit source documents.",
+            False,
+        ),
+        ("Deletion of source records is authorized.", True),
+        ("Removal of municipal source documents is permitted.", True),
+        ("Corrections remove derived records, not source documents.", False),
+        (
+            "Corrections alter derived indexes rather than source records.",
+            False,
+        ),
+        (
+            "Corrections modify only derived records, leaving source documents "
+            "unchanged.",
+            False,
+        ),
+        ("Source documents are not modified but they may be deleted.", True),
         ("Title inference does not constitute roster authority.", False),
         ("City Coverage Expansion remains blocked until T-GOV-2A completes.", False),
         (

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2869,7 +2869,7 @@ G4_DERIVED_PASSIVE_PERSON_PROMOTION = re.compile(
 )
 G4_DERIVED_PERSON_RELATION_BARRIER = re.compile(
     r"\b(?:links?|linked|references?|referenced|associations?|associated|related)"
-    r"\s+(?:to|with|by)\b",
+    r"\s+(?:to|with|by)\s+roster-authorized\s*$",
     re.IGNORECASE,
 )
 G4_DERIVED_AUTHORITY_ACTION = re.compile(
@@ -2934,6 +2934,16 @@ G4_SOURCE_RECORD_TARGET = re.compile(
 )
 G4_EXTERNAL_SOURCE_CUSTODIAN = re.compile(
     r"\b(?:originating municipality|source municipality|records? custodian)\b",
+    re.IGNORECASE,
+)
+G4_EXTERNAL_SOURCE_CUSTODIAN_ACTOR = re.compile(
+    r"\bby\s+(?:the\s+)?"
+    r"(?:originating municipality|source municipality|records? custodian)\b",
+    re.IGNORECASE,
+)
+G4_EXTERNAL_SOURCE_CUSTODIAN_PASSIVE_AGENT = re.compile(
+    r"^\s+by\s+(?:the\s+)?"
+    r"(?:originating municipality|source municipality|records? custodian)\b",
     re.IGNORECASE,
 )
 G4_SOURCE_ACTION_BARRIER = re.compile(
@@ -3008,7 +3018,8 @@ G4_PREMATURE_CITY_EXPANSION_POLICY = re.compile(
     r"[^.!?;]{0,160}\b(?:(?<!not )(?<!never )before|without)\b"
     r"|\bt-gov-2a\b[^.!?;]{0,80}\b(?:is|becomes|remains)\s+optional\b"
     r"[^.!?;]{0,80}\bbefore\b[^.!?;]{0,80}\bcity coverage expansion\b"
-    r"|\bt-gov-2a\b[^.!?;]{0,40}\bneed(?:s)?\s+not\s+"
+    r"|\bt-gov-2a\b[^.!?;]{0,40}\b"
+    r"(?:need(?:s)?\s+not|do(?:es)?\s+not\s+need\s+to)\s+"
     r"(?:be\s+)?complete\b[^.!?;]{0,80}\bbefore\b[^.!?;]{0,80}"
     r"\bcity coverage expansion\b"
     r"|\bbefore\b[^.!?;]{0,80}\bt-gov-2a\b[^.!?;]{0,80}"
@@ -3171,7 +3182,10 @@ def _g4_policy_allows_source_record_modification(g4_policy: str) -> bool:
     for policy_sentence in _g4_policy_clauses(g4_policy):
         if any(
             nominal_action.group("negated") is None
-            and G4_EXTERNAL_SOURCE_CUSTODIAN.search(policy_sentence) is None
+            and G4_EXTERNAL_SOURCE_CUSTODIAN_ACTOR.search(
+                nominal_action.group()
+            )
+            is None
             for nominal_action in G4_SOURCE_NOMINAL_AUTHORIZATION.finditer(
                 policy_sentence
             )
@@ -3259,6 +3273,10 @@ def _segment_allows_passive_source_edit(
         )
         if (
             (explicit_source or inherited_source)
+            and G4_EXTERNAL_SOURCE_CUSTODIAN_PASSIVE_AGENT.match(
+                policy_segment[source_action.end() :]
+            )
+            is None
             and not _source_action_is_negated(policy_segment[: source_action.start()])
         ):
             return True
@@ -3442,6 +3460,7 @@ def test_g2_policy_contradiction_detection_allows_approved_wording(
         ("Town Council deletes source documents.", True),
         ("Source-document mentions may become person entities.", True),
         ("Source-document mentions may create profiles.", True),
+        ("Source-document mentions may create links to profiles.", True),
         ("Title inference may produce memberships.", True),
         ("Person entities may be created from source-document mentions.", True),
         ("Profiles are created from source-document mentions.", True),
@@ -3516,6 +3535,16 @@ def test_g2_policy_contradiction_detection_allows_approved_wording(
         (
             "Deletion of source records by the originating municipality is "
             "permitted under local retention law.",
+            False,
+        ),
+        (
+            "Deletion of source records by Town Council is permitted when the "
+            "originating municipality requests it.",
+            True,
+        ),
+        (
+            "Source records may be edited by the originating municipality "
+            "before publication.",
             False,
         ),
         ("Corrections remove entity links to source documents.", False),
@@ -3597,6 +3626,11 @@ def test_g2_policy_contradiction_detection_allows_approved_wording(
         ("T-GOV-2A must complete before City Coverage Expansion starts.", False),
         (
             "T-GOV-2A need not complete before City Coverage Expansion proceeds.",
+            True,
+        ),
+        (
+            "T-GOV-2A does not need to be complete before City Coverage "
+            "Expansion proceeds.",
             True,
         ),
     ),

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2862,7 +2862,8 @@ G4_DERIVED_PERSON_RELATION_BARRIER = re.compile(
 G4_DERIVED_AUTHORITY_ACTION = re.compile(
     r"\b(?:is|are|be|becom(?:e|es|ing)|constitut(?:e|es|ed|ing)|"
     r"establish(?:es|ed|ing)?|serv(?:e|es|ed|ing)\s+as|"
-    r"qualif(?:y|ies|ied|ying)\s+as|provid(?:e|es|ed|ing))\b",
+    r"qualif(?:y|ies|ied|ying)\s+as|count(?:s|ed|ing)?\s+as|"
+    r"provid(?:e|es|ed|ing))\b",
     re.IGNORECASE,
 )
 G4_DERIVED_AUTHORITY_TARGET = re.compile(r"\broster authority\b", re.IGNORECASE)
@@ -2917,6 +2918,7 @@ G4_SOURCE_RECORD_TARGET = re.compile(
 )
 G4_SOURCE_ACTION_BARRIER = re.compile(
     r"\b(?:not|rather than|instead of|links? to|linked to|associated with|related to|"
+    r"derived from|extracted from|built from|"
     r"keep(?:s|ing)?|leav(?:e|es|ing)|"
     r"preserv(?:e|es|ed|ing)|retain(?:s|ed|ing)?)\b",
     re.IGNORECASE,
@@ -2954,6 +2956,10 @@ G4_SHARED_NEGATION = re.compile(
     r"(?:\b(?:forbidden|prohibited|not (?:allowed|permitted|authorized))\s+to\b"
     r"|\b(?:do|does|must|may|can|will|should)\s+not\b|\bcannot\b)"
     r"[^.!?;]{0,80}\band\s*$",
+    re.IGNORECASE,
+)
+G4_PAIRED_NEGATION = re.compile(
+    r"\bneither\b[^.!?;]{0,120}\bnor\b",
     re.IGNORECASE,
 )
 G4_SOURCE_INHERITED_PASSIVE_SUBJECT = re.compile(
@@ -3228,7 +3234,9 @@ def _segment_allows_passive_source_edit(
 
 
 def _source_action_is_negated(action_prefix: str) -> bool:
-    if G4_SHARED_NEGATION.search(action_prefix):
+    if G4_SHARED_NEGATION.search(action_prefix) or G4_PAIRED_NEGATION.search(
+        action_prefix
+    ):
         return True
     action_scope = G4_NEGATION_SCOPE_BOUNDARY.split(action_prefix)[-1]
     latest_negative = max(
@@ -3476,6 +3484,15 @@ def test_g2_policy_contradiction_detection_allows_approved_wording(
             "Title inference, instead of official rosters, provides roster authority.",
             True,
         ),
+        ("Title inference may count as roster authority.", True),
+        (
+            "Neither title inference nor source-document mentions provide "
+            "roster authority.",
+            False,
+        ),
+        ("Corrections remove links derived from source documents.", False),
+        ("Corrections remove metadata extracted from source records.", False),
+        ("Corrections remove profiles built from source documents.", False),
         ("Title inference does not constitute roster authority.", False),
         ("City Coverage Expansion remains blocked until T-GOV-2A completes.", False),
         (

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2840,34 +2840,41 @@ G4_LIVE_OPTIONS_POLICY = re.compile(
     r"|\bworking\s+default\s+until\s+(?:the\s+)?adr\s+lands\b)",
     re.IGNORECASE,
 )
-G4_DERIVED_ROSTER_AUTHORITY_POLICY = re.compile(
+G4_DERIVED_EVIDENCE_SOURCE = re.compile(
     r"\b(?:title inference|source-document mentions?|linker-created memberships?"
-    r"|memberships created by the entity linker)\b"
-    r"(?![^.!?;]{0,80}\bwhile\b)"
-    r"[^.!?;]{0,80}\b(?:(?:may|can)\s+"
-    r"(?:be|become|constitute|establish|serve as|qualify as|provide)"
-    r"|(?:is|are)(?:\s+valid)?"
-    r"|(?<!not )(?<!never )(?<!cannot )"
-    r"(?:constitutes?|establishes?|serves? as|qualifies? as|provides?))"
-    r"\s+roster authority\b",
+    r"|memberships created by the entity linker)\b",
     re.IGNORECASE,
 )
-G4_DERIVED_PERSON_AUTHORIZATION_POLICY = re.compile(
-    r"\b(?:title inference|source-document mentions?|linker-created memberships?"
-    r"|memberships created by the entity linker)\b"
-    r"(?![^.!?;]{0,80}\bwhile\b)"
-    r"[^.!?;]{0,80}\b(?:(?:may|can)\s+authorize"
-    r"|(?<!not )(?<!never )(?<!cannot )authorizes?)\b"
-    r"[^.!?;]{0,40}\b(?:person creation|person entities|people-facing records)\b",
+G4_DERIVED_PERSON_ACTION = re.compile(
+    r"(?<!-)\b(?:authoriz(?:e|es|ed|ing)|becom(?:e|es|ing)|"
+    r"creat(?:e|es|ed|ing)|produc(?:e|es|ed|ing))\b",
     re.IGNORECASE,
 )
-G4_DERIVED_WHILE_CONTINUATION_POLICY = re.compile(
-    r"\b(?:title inference|source-document mentions?|linker-created memberships?"
-    r"|memberships created by the entity linker)\b[^.!?;]{0,80}"
-    r"\bwhile\s+(?:it|they)\s+"
-    r"(?:(?:may|can)\s+)?(?:provides?|constitutes?|authorizes?)\b"
-    r"[^.!?;]{0,40}\b(?:roster authority|person creation|person entities|"
-    r"people-facing records)\b",
+G4_DERIVED_PERSON_TARGET = re.compile(
+    r"\b(?:person creation|person entities|people-facing records)\b",
+    re.IGNORECASE,
+)
+G4_DERIVED_PERSON_RELATION_BARRIER = re.compile(
+    r"\b(?:links?|linked|references?|referenced|associations?|associated|related)"
+    r"\s+(?:to|with|by)\b",
+    re.IGNORECASE,
+)
+G4_DERIVED_AUTHORITY_ACTION = re.compile(
+    r"\b(?:is|are|be|becom(?:e|es|ing)|constitut(?:e|es|ed|ing)|"
+    r"establish(?:es|ed|ing)?|serv(?:e|es|ed|ing)\s+as|"
+    r"qualif(?:y|ies|ied|ying)\s+as|provid(?:e|es|ed|ing))\b",
+    re.IGNORECASE,
+)
+G4_DERIVED_AUTHORITY_TARGET = re.compile(r"\broster authority\b", re.IGNORECASE)
+G4_DERIVED_AUTHORITY_RELATION_BARRIER = re.compile(
+    r"\b(?:rather than|instead of)\b",
+    re.IGNORECASE,
+)
+G4_AUTHORITATIVE_ROSTER_SUBJECT = re.compile(
+    r"(?<!not )(?<!rather than )(?<!instead of )"
+    r"\b(?:independently authoritative(?: official)?"
+    r"(?: membership data| rosters?)|official membership data|official rosters?)"
+    r"\s*,?\s*$",
     re.IGNORECASE,
 )
 G4_NON_ROSTER_PERSON_CREATION_POLICY = re.compile(
@@ -2891,19 +2898,17 @@ G4_NON_ROSTER_WHILE_CONTINUATION_POLICY = re.compile(
     r"vote attribution|cross-document aggregation)\b",
     re.IGNORECASE,
 )
-G4_POLICY_SENTENCE_BOUNDARY = re.compile(r"[.!?;]+")
+G4_POLICY_SENTENCE_BOUNDARY = re.compile(r"[.!?]+")
+G4_POLICY_CLAUSE_BOUNDARY = re.compile(r";+")
+G4_POLICY_LIST_NEGATION = re.compile(r"\b(?:forbidden|prohibited)\s*:", re.IGNORECASE)
 G4_POLICY_CONTRAST_BOUNDARY = re.compile(r"\b(?:but|while)\b", re.IGNORECASE)
 G4_SOURCE_ACTIVE_ACTION = re.compile(
     r"\b(?:edit(?:ed|ing|s)?|modif(?:ied|ies|y|ying)|rewrite(?:s|ten)?|"
-    r"rewriting|delete(?:d|ing|s)?|alter(?:ed|ing|s)?|remove(?:d|s)?|removing)\b",
+    r"rewriting|delet(?:e|ed|es|ing)|alter(?:ed|ing|s)?|remove(?:d|s)?|removing)\b",
     re.IGNORECASE,
 )
 G4_SOURCE_PASSIVE_ACTION = re.compile(
     r"\b(?:edited|modified|rewritten|deleted|altered|removed)\b",
-    re.IGNORECASE,
-)
-G4_SOURCE_RECORD_SUBJECT = re.compile(
-    r"\b(?:corrections?|takedowns?|removal requests?)\b",
     re.IGNORECASE,
 )
 G4_SOURCE_RECORD_TARGET = re.compile(
@@ -2911,8 +2916,14 @@ G4_SOURCE_RECORD_TARGET = re.compile(
     re.IGNORECASE,
 )
 G4_SOURCE_ACTION_BARRIER = re.compile(
-    r"\b(?:not|rather than|instead of|keep(?:s|ing)?|leav(?:e|es|ing)|"
+    r"\b(?:not|rather than|instead of|links? to|linked to|associated with|related to|"
+    r"keep(?:s|ing)?|leav(?:e|es|ing)|"
     r"preserv(?:e|es|ed|ing)|retain(?:s|ed|ing)?)\b",
+    re.IGNORECASE,
+)
+G4_SOURCE_PASSIVE_SUBJECT_BARRIER = re.compile(
+    r"\b(?:derived (?:records?|indexes?|metadata|summaries|profiles?|memberships?)"
+    r"|entity links?|annotations?)\b",
     re.IGNORECASE,
 )
 G4_SOURCE_TARGET_PRESERVATION = re.compile(
@@ -2931,11 +2942,18 @@ G4_SOURCE_NOMINAL_AUTHORIZATION = re.compile(
 )
 G4_SOURCE_NEGATION_CUE = re.compile(
     r"\b(?:not(?:\s+(?:allowed|permitted|authorized)(?:\s+to)?)?|never|cannot|"
-    r"prohibit(?:s|ed)?|forbid(?:s|den)?)\b",
+    r"prohibit(?:s|ed)?|forbid(?:s|den)?|prohibited|forbidden)\b",
     re.IGNORECASE,
 )
 G4_SOURCE_AFFIRMATIVE_CUE = re.compile(
     r"\b(?:may|can|will|must|should)\b",
+    re.IGNORECASE,
+)
+G4_NEGATION_SCOPE_BOUNDARY = re.compile(r"\b(?:and|but|while)\b", re.IGNORECASE)
+G4_SHARED_NEGATION = re.compile(
+    r"(?:\b(?:forbidden|prohibited|not (?:allowed|permitted|authorized))\s+to\b"
+    r"|\b(?:do|does|must|may|can|will|should)\s+not\b|\bcannot\b)"
+    r"[^.!?;]{0,80}\band\s*$",
     re.IGNORECASE,
 )
 G4_SOURCE_INHERITED_PASSIVE_SUBJECT = re.compile(
@@ -3009,9 +3027,7 @@ def _g4_policy_has_contradiction(g4_policy: str) -> bool:
     return bool(
         G4_UNRESOLVED_POLICY.search(normalized_g4_policy)
         or G4_LIVE_OPTIONS_POLICY.search(normalized_g4_policy)
-        or G4_DERIVED_ROSTER_AUTHORITY_POLICY.search(normalized_g4_policy)
-        or G4_DERIVED_PERSON_AUTHORIZATION_POLICY.search(normalized_g4_policy)
-        or G4_DERIVED_WHILE_CONTINUATION_POLICY.search(normalized_g4_policy)
+        or _g4_policy_promotes_derived_evidence(normalized_g4_policy)
         or G4_NON_ROSTER_PERSON_CREATION_POLICY.search(normalized_g4_policy)
         or G4_NON_ROSTER_WHILE_CONTINUATION_POLICY.search(normalized_g4_policy)
         or _g4_policy_allows_source_record_modification(normalized_g4_policy)
@@ -3021,9 +3037,105 @@ def _g4_policy_has_contradiction(g4_policy: str) -> bool:
     )
 
 
-def _g4_policy_allows_source_record_modification(g4_policy: str) -> bool:
+def _g4_policy_promotes_derived_evidence(g4_policy: str) -> bool:
+    return any(
+        _g4_clause_grants_roster_authority(policy_clause)
+        or _g4_clause_creates_person_record(policy_clause)
+        for policy_clause in _g4_policy_clauses(g4_policy)
+    )
+
+
+def _g4_clause_grants_roster_authority(policy_clause: str) -> bool:
+    for authority_target in G4_DERIVED_AUTHORITY_TARGET.finditer(policy_clause):
+        authority_actions = tuple(
+            G4_DERIVED_AUTHORITY_ACTION.finditer(
+                policy_clause,
+                0,
+                authority_target.start(),
+            )
+        )
+        if not authority_actions:
+            continue
+        authority_action = authority_actions[-1]
+        evidence_sources = tuple(
+            G4_DERIVED_EVIDENCE_SOURCE.finditer(
+                policy_clause,
+                0,
+                authority_action.start(),
+            )
+        )
+        if not evidence_sources:
+            continue
+        evidence_source = evidence_sources[-1]
+        source_action_text = policy_clause[
+            evidence_source.end() : authority_action.start()
+        ]
+        action_target_text = policy_clause[
+            authority_action.end() : authority_target.start()
+        ]
+        if (
+            G4_AUTHORITATIVE_ROSTER_SUBJECT.search(source_action_text) is None
+            and not _source_action_is_negated(
+                policy_clause[: authority_action.start()].rsplit(",", maxsplit=1)[-1]
+            )
+            and G4_SOURCE_NEGATION_CUE.search(action_target_text) is None
+            and G4_DERIVED_AUTHORITY_RELATION_BARRIER.search(action_target_text)
+            is None
+        ):
+            return True
+    return False
+
+
+def _g4_clause_creates_person_record(policy_clause: str) -> bool:
+    for person_target in G4_DERIVED_PERSON_TARGET.finditer(policy_clause):
+        person_actions = tuple(
+            G4_DERIVED_PERSON_ACTION.finditer(
+                policy_clause,
+                0,
+                person_target.start(),
+            )
+        )
+        if not person_actions:
+            continue
+        person_action = person_actions[-1]
+        evidence_sources = tuple(
+            G4_DERIVED_EVIDENCE_SOURCE.finditer(
+                policy_clause,
+                0,
+                person_action.start(),
+            )
+        )
+        if not evidence_sources:
+            continue
+        source_action_text = policy_clause[
+            evidence_sources[-1].end() : person_action.start()
+        ]
+        action_target_text = policy_clause[person_action.end() : person_target.start()]
+        if (
+            G4_AUTHORITATIVE_ROSTER_SUBJECT.search(source_action_text) is None
+            and G4_DERIVED_PERSON_RELATION_BARRIER.search(action_target_text) is None
+            and G4_SOURCE_NEGATION_CUE.search(action_target_text) is None
+            and not _source_action_is_negated(policy_clause[: person_action.start()])
+        ):
+            return True
+    return False
+
+
+def _g4_policy_clauses(g4_policy: str) -> tuple[str, ...]:
+    policy_clauses: list[str] = []
     for policy_sentence in G4_POLICY_SENTENCE_BOUNDARY.split(g4_policy):
-        correction_context = G4_SOURCE_RECORD_SUBJECT.search(policy_sentence) is not None
+        sentence_clauses = G4_POLICY_CLAUSE_BOUNDARY.split(policy_sentence)
+        list_match = G4_POLICY_LIST_NEGATION.search(sentence_clauses[0])
+        list_negation = list_match.group() if list_match else ""
+        policy_clauses.extend(
+            f"{list_negation} {policy_clause}" if list_negation else policy_clause
+            for policy_clause in sentence_clauses
+        )
+    return tuple(policy_clauses)
+
+
+def _g4_policy_allows_source_record_modification(g4_policy: str) -> bool:
+    for policy_sentence in _g4_policy_clauses(g4_policy):
         if any(
             nominal_action.group("negated") is None
             for nominal_action in G4_SOURCE_NOMINAL_AUTHORIZATION.finditer(
@@ -3034,7 +3146,7 @@ def _g4_policy_allows_source_record_modification(g4_policy: str) -> bool:
         source_context = False
         for policy_segment in G4_POLICY_CONTRAST_BOUNDARY.split(policy_sentence):
             source_targets = tuple(G4_SOURCE_RECORD_TARGET.finditer(policy_segment))
-            if correction_context and _segment_allows_active_source_edit(
+            if _segment_allows_active_source_edit(
                 policy_segment,
                 source_targets,
             ):
@@ -3092,6 +3204,10 @@ def _segment_allows_passive_source_edit(
     for source_action in G4_SOURCE_PASSIVE_ACTION.finditer(policy_segment):
         explicit_source = any(
             source_target.end() <= source_action.start()
+            and G4_SOURCE_PASSIVE_SUBJECT_BARRIER.search(
+                policy_segment[source_target.end() : source_action.start()]
+            )
+            is None
             for source_target in source_targets
         )
         inherited_source = (
@@ -3112,14 +3228,17 @@ def _segment_allows_passive_source_edit(
 
 
 def _source_action_is_negated(action_prefix: str) -> bool:
+    if G4_SHARED_NEGATION.search(action_prefix):
+        return True
+    action_scope = G4_NEGATION_SCOPE_BOUNDARY.split(action_prefix)[-1]
     latest_negative = max(
-        (negative_cue.end() for negative_cue in G4_SOURCE_NEGATION_CUE.finditer(action_prefix)),
+        (negative_cue.end() for negative_cue in G4_SOURCE_NEGATION_CUE.finditer(action_scope)),
         default=-1,
     )
     latest_affirmative = max(
         (
             affirmative_cue.end()
-            for affirmative_cue in G4_SOURCE_AFFIRMATIVE_CUE.finditer(action_prefix)
+            for affirmative_cue in G4_SOURCE_AFFIRMATIVE_CUE.finditer(action_scope)
         ),
         default=-1,
     )
@@ -3276,6 +3395,87 @@ def test_g2_policy_contradiction_detection_allows_approved_wording(
             False,
         ),
         ("Source documents are not modified but they may be deleted.", True),
+        ("Staff may edit municipal source records.", True),
+        ("Town Council deletes source documents.", True),
+        ("Source-document mentions may become person entities.", True),
+        ("Title inference may produce people-facing records.", True),
+        ("Source-document mentions may not become person entities.", False),
+        (
+            "Source-document mentions are not allowed to become person entities.",
+            False,
+        ),
+        (
+            "Title inference is not allowed to create people-facing records.",
+            False,
+        ),
+        (
+            "Corrections remove derived indexes associated with source documents.",
+            False,
+        ),
+        (
+            "Source-document mentions may create links to roster-authorized "
+            "person entities.",
+            False,
+        ),
+        (
+            "Source-document mentions may become linked to roster-authorized "
+            "person entities.",
+            False,
+        ),
+        (
+            "Source-document mentions may become associated with roster-authorized "
+            "person entities.",
+            False,
+        ),
+        (
+            "Source-document mentions remain searchable while they may create "
+            "links to roster-authorized person entities.",
+            False,
+        ),
+        (
+            "Title inference is prohibited; independently authoritative rosters "
+            "may create person entities.",
+            False,
+        ),
+        (
+            "Corrections remove derived data; source documents are the public "
+            "record and are not edited.",
+            False,
+        ),
+        ("Title inference, not official rosters, provides roster authority.", True),
+        (
+            "Title inference rather than official membership data establishes "
+            "roster authority.",
+            True,
+        ),
+        ("Staff are forbidden to edit and delete source records.", False),
+        ("Staff cannot edit and delete source records.", False),
+        ("Staff are deleting source documents.", True),
+        ("Corrections remove entity links to source documents.", False),
+        (
+            "Corrections modify annotations linked to municipal source records.",
+            False,
+        ),
+        (
+            "Source documents link to derived records that are deleted during "
+            "correction.",
+            False,
+        ),
+        (
+            "Source documents link to derived metadata that is deleted during "
+            "correction.",
+            False,
+        ),
+        (
+            "Source-document mentions remain searchable while official rosters "
+            "create person entities.",
+            False,
+        ),
+        ("Title inference is derived evidence rather than roster authority.", False),
+        (
+            "Title inference, instead of official rosters, provides roster authority.",
+            True,
+        ),
         ("Title inference does not constitute roster authority.", False),
         ("City Coverage Expansion remains blocked until T-GOV-2A completes.", False),
         (

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2843,22 +2843,88 @@ G4_LIVE_OPTIONS_POLICY = re.compile(
 G4_DERIVED_ROSTER_AUTHORITY_POLICY = re.compile(
     r"\b(?:title inference|source-document mentions?|linker-created memberships?"
     r"|memberships created by the entity linker)\b"
-    r".{0,80}\b(?:(?:may|can)\s+(?:be|become|constitute|establish|serve as)"
-    r"|(?:is|are)(?:\s+valid)?)\s+roster authority\b",
+    r"(?![^.!?;]{0,80}\bwhile\b)"
+    r"[^.!?;]{0,80}\b(?:(?:may|can)\s+"
+    r"(?:be|become|constitute|establish|serve as|qualify as|provide)"
+    r"|(?:is|are)(?:\s+valid)?"
+    r"|(?<!not )(?<!never )(?<!cannot )"
+    r"(?:constitutes?|establishes?|serves? as|qualifies? as|provides?))"
+    r"\s+roster authority\b",
+    re.IGNORECASE,
+)
+G4_DERIVED_PERSON_AUTHORIZATION_POLICY = re.compile(
+    r"\b(?:title inference|source-document mentions?|linker-created memberships?"
+    r"|memberships created by the entity linker)\b"
+    r"(?![^.!?;]{0,80}\bwhile\b)"
+    r"[^.!?;]{0,80}\b(?:(?:may|can)\s+authorize"
+    r"|(?<!not )(?<!never )(?<!cannot )authorizes?)\b"
+    r"[^.!?;]{0,40}\b(?:person creation|person entities|people-facing records)\b",
+    re.IGNORECASE,
+)
+G4_DERIVED_WHILE_CONTINUATION_POLICY = re.compile(
+    r"\b(?:title inference|source-document mentions?|linker-created memberships?"
+    r"|memberships created by the entity linker)\b[^.!?;]{0,80}"
+    r"\bwhile\s+(?:it|they)\s+"
+    r"(?:(?:may|can)\s+)?(?:provides?|constitutes?|authorizes?)\b"
+    r"[^.!?;]{0,40}\b(?:roster authority|person creation|person entities|"
+    r"people-facing records)\b",
     re.IGNORECASE,
 )
 G4_NON_ROSTER_PERSON_CREATION_POLICY = re.compile(
-    r"\bnon-roster names?\b.{0,80}\b(?:may|can)\s+(?:become|create|produce)"
-    r".{0,40}\b(?:person entities|people metadata|profiles|memberships|"
+    r"\bnon-roster (?:names?|people)\b"
+    r"(?![^.!?;]{0,80}\bwhile\b)"
+    r"[^.!?;]{0,80}\b(?:(?:may|can)\s+"
+    r"(?:become|create|produce|appear in|be retained as|receive)"
+    r"|are\s+allowed\s+to\s+"
+    r"(?:become|create|produce|appear in|be retained as|receive)"
+    r"|(?<!not )(?<!never )(?<!cannot )"
+    r"(?:become|create|produce|appear in|are retained as|receive))"
+    r"[^.!?;]{0,40}\b(?:person entities|people metadata|profiles|memberships|"
+    r"vote attribution|cross-document aggregation)\b",
+    re.IGNORECASE,
+)
+G4_NON_ROSTER_WHILE_CONTINUATION_POLICY = re.compile(
+    r"\bnon-roster (?:names?|people)\b[^.!?;]{0,80}"
+    r"\bwhile\s+they\s+(?:(?:may|can)\s+)?"
+    r"(?:become|create|produce|appear in|are retained as|receive)\b"
+    r"[^.!?;]{0,40}\b(?:person entities|people metadata|profiles|memberships|"
     r"vote attribution|cross-document aggregation)\b",
     re.IGNORECASE,
 )
 G4_SOURCE_RECORD_MODIFICATION_POLICY = re.compile(
-    r"(?:\b(?:corrections?|takedowns?)\b.{0,80}\b(?:may|can)\s+"
-    r"(?:edit|modify|rewrite|delete)\b.{0,40}\b(?:municipal\s+)?source "
+    r"(?:\b(?:corrections?|takedowns?)\b"
+    r"(?![^.!?;]{0,80}\bwhile\b)"
+    r"[^.!?;]{0,80}\b"
+    r"(?:(?:may|can)\s+(?:edit|modify|rewrite|delete|alter|remove)"
+    r"|(?<!not )(?<!never )(?<!cannot )"
+    r"(?:edits?|modifies?|rewrites?|deletes?|alters?|removes?))"
+    r"\b[^.!?;]{0,40}\b(?:municipal\s+)?source "
     r"(?:documents?|records?|text)\b"
-    r"|\b(?:municipal\s+)?source (?:documents?|records?|text)\b.{0,80}"
-    r"\b(?:may|can)\s+be\s+(?:edited|modified|rewritten|deleted)\b)",
+    r"|\b(?:municipal\s+)?source (?:documents?|records?|text)\b[^.!?;]{0,80}"
+    r"\b(?:(?:may|can|will)\s+be\s+"
+    r"(?:edited|modified|rewritten|deleted|altered)"
+    r"|(?:is|are)\s+(?:edited|modified|rewritten|deleted|altered))\b)",
+    re.IGNORECASE,
+)
+G4_SOURCE_WHILE_CONTINUATION_POLICY = re.compile(
+    r"\b(?:corrections?|takedowns?)\b[^.!?;]{0,80}"
+    r"\bwhile\s+they\s+(?:(?:may|can)\s+)?"
+    r"(?:edit|modify|rewrite|delete|alter|remove)\b"
+    r"[^.!?;]{0,40}\b(?:municipal\s+)?source "
+    r"(?:documents?|records?|text)\b",
+    re.IGNORECASE,
+)
+G4_PREMATURE_CITY_EXPANSION_POLICY = re.compile(
+    r"(?:\bcity coverage expansion\b"
+    r"(?=[^.!?;]{0,120}\b(?:(?:may|can)\s+(?:start|begin|proceed|resume)"
+    r"|(?:starts|begins|proceeds|resumes)|(?:is|remains)\s+(?:allowed|unblocked))\b)"
+    r"[^.!?;]{0,160}\b(?:(?<!not )(?<!never )before|without)\b"
+    r"|\bt-gov-2a\b[^.!?;]{0,80}\b(?:is|becomes|remains)\s+optional\b"
+    r"[^.!?;]{0,80}\bbefore\b[^.!?;]{0,80}\bcity coverage expansion\b"
+    r"|\bbefore\b[^.!?;]{0,80}\bt-gov-2a\b[^.!?;]{0,80}"
+    r"\bcity coverage expansion\b[^.!?;]{0,80}"
+    r"(?:(?:may|can)\s+(?:start|begin|proceed|resume)"
+    r"|(?:starts|begins|proceeds|resumes)|(?:is|remains)\s+(?:allowed|unblocked))\b)",
     re.IGNORECASE,
 )
 OPERATOR_AUTH_APPROVAL_POLICY = re.compile(
@@ -2895,8 +2961,13 @@ def _g4_policy_has_contradiction(g4_policy: str) -> bool:
         G4_UNRESOLVED_POLICY.search(normalized_g4_policy)
         or G4_LIVE_OPTIONS_POLICY.search(normalized_g4_policy)
         or G4_DERIVED_ROSTER_AUTHORITY_POLICY.search(normalized_g4_policy)
+        or G4_DERIVED_PERSON_AUTHORIZATION_POLICY.search(normalized_g4_policy)
+        or G4_DERIVED_WHILE_CONTINUATION_POLICY.search(normalized_g4_policy)
         or G4_NON_ROSTER_PERSON_CREATION_POLICY.search(normalized_g4_policy)
+        or G4_NON_ROSTER_WHILE_CONTINUATION_POLICY.search(normalized_g4_policy)
         or G4_SOURCE_RECORD_MODIFICATION_POLICY.search(normalized_g4_policy)
+        or G4_SOURCE_WHILE_CONTINUATION_POLICY.search(normalized_g4_policy)
+        or G4_PREMATURE_CITY_EXPANSION_POLICY.search(normalized_g4_policy)
     )
 
 
@@ -2939,19 +3010,82 @@ def test_g2_policy_contradiction_detection_allows_approved_wording(
         ("Options under consideration; exactly one will be adopted by ADR.", True),
         ("Working default until the ADR lands.", True),
         ("Title inference may establish roster authority.", True),
+        ("Title inference constitutes roster authority.", True),
+        ("Title inference qualifies as roster authority.", True),
+        ("Source-document mentions provide roster authority.", True),
+        ("Title inference can authorize person creation.", True),
+        ("Title inference is not rejected and constitutes roster authority.", True),
+        ("Title inference is reviewed while it provides roster authority.", True),
         ("Title inference\nmay establish roster authority.", True),
         ("Linker-created memberships are roster authority.", True),
         ("Memberships created by the entity linker are roster authority.", True),
         ("Non-roster names may become person entities.", True),
+        ("Non-roster names become person entities.", True),
+        ("Non-roster names can appear in people metadata.", True),
+        ("Non-roster names may receive profiles.", True),
+        ("Non-roster people may become person entities.", True),
+        ("Non-roster names remain searchable while they become person entities.", True),
+        ("Non-roster names are allowed to become person entities.", True),
         ("Non-roster names\nmay become person entities.", True),
         ("Corrections may edit municipal source records.", True),
+        ("Corrections edit municipal source records.", True),
+        ("Corrections alter municipal source records.", True),
+        ("Source documents will be modified during correction.", True),
         ("Source documents may be modified during correction.", True),
+        ("City Coverage Expansion may proceed before T-GOV-2A completes.", True),
+        ("City Coverage Expansion starts before T-GOV-2A completes.", True),
+        ("City Coverage Expansion is unblocked before roster enforcement.", True),
+        ("City Coverage Expansion is allowed before T-GOV-2A completes.", True),
+        ("T-GOV-2A is optional before City Coverage Expansion.", True),
+        ("Takedowns remove source text.", True),
+        ("Corrections apply to derived records while they remove source documents.", True),
+        ("Before T-GOV-2A completes, City Coverage Expansion may proceed.", True),
         ("G4 is approved; T-GOV-2A remains pending.", False),
         ("Runtime enforcement is pending T-GOV-2A.", False),
         ("The historical alternatives were superseded by approved G4.", False),
         ("Title inference and linker-created memberships are not roster authority.", False),
         ("Non-roster names do not become person entities.", False),
         ("Corrections apply to derived records; source documents are not modified.", False),
+        ("Corrections do not edit municipal source records.", False),
+        ("Title inference does not constitute roster authority.", False),
+        ("City Coverage Expansion remains blocked until T-GOV-2A completes.", False),
+        (
+            "City Coverage Expansion may proceed after T-GOV-2A is complete "
+            "and verified.",
+            False,
+        ),
+        (
+            "City Coverage Expansion starts only after T-GOV-2A is complete "
+            "and verified.",
+            False,
+        ),
+        ("City Coverage Expansion resumes when T-GOV-2A passes verification.", False),
+        ("Non-roster names remain searchable; official rosters create person entities.", False),
+        (
+            "Corrections alter derived indexes; municipal source records remain "
+            "unchanged.",
+            False,
+        ),
+        (
+            "City Coverage Expansion may proceed after T-GOV-2A completes, "
+            "never before verification.",
+            False,
+        ),
+        (
+            "Non-roster names remain searchable, while official rosters create "
+            "person entities.",
+            False,
+        ),
+        (
+            "Corrections alter derived indexes, while municipal source records "
+            "remain unchanged.",
+            False,
+        ),
+        (
+            "Title inference is reviewed, while independently authoritative "
+            "official membership data provides roster authority.",
+            False,
+        ),
     ),
 )
 def test_g4_contradiction_detection_covers_equivalent_wording(
@@ -2959,6 +3093,29 @@ def test_g4_contradiction_detection_covers_equivalent_wording(
     has_contradiction: bool,
 ) -> None:
     assert _g4_policy_has_contradiction(g4_policy) is has_contradiction
+
+
+@pytest.mark.parametrize(
+    "section_heading",
+    (
+        "## 2. Principles",
+        "## 4. Correction and takedown",
+        "## 5. Retention",
+    ),
+)
+def test_g4_policy_scan_covers_live_data_governance_sections(
+    section_heading: str,
+) -> None:
+    data_governance = (ROOT / "docs" / "DATA_GOVERNANCE.md").read_text(
+        encoding="utf-8"
+    )
+    contradictory_governance = data_governance.replace(
+        section_heading,
+        f"{section_heading}\n\nCorrections edit municipal source records.",
+        1,
+    )
+
+    assert _g4_policy_has_contradiction(contradictory_governance)
 
 
 def test_g4_roster_gated_policy_is_aligned() -> None:
@@ -3042,7 +3199,13 @@ def test_g4_roster_gated_policy_is_aligned() -> None:
         in normalized_agent_policy
     )
     active_g4_policy = " ".join(
-        (agent_policy, g4_decision, person_policy, g4_entry, t_gov_2_entry)
+        (
+            agent_policy,
+            architecture_decisions,
+            data_governance,
+            remediation_ledger,
+            roadmap,
+        )
     )
     assert not _g4_policy_has_contradiction(active_g4_policy)
     assert "status: complete and verified" in t_gov_2_entry

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2995,6 +2995,7 @@ G4_SOURCE_AFFIRMATIVE_CUE = re.compile(
     re.IGNORECASE,
 )
 G4_NEGATION_SCOPE_BOUNDARY = re.compile(r"\b(?:and|but|while)\b", re.IGNORECASE)
+G4_NO_DETERMINER_NEGATION = re.compile(r"^\s*no\b", re.IGNORECASE)
 G4_SHARED_NEGATION = re.compile(
     r"(?:\b(?:forbidden|prohibited|not (?:allowed|permitted|authorized))\s+to\b"
     r"|\b(?:do|does|must|may|can|will|should)\s+not\b|\bcannot\b)"
@@ -3324,8 +3325,10 @@ def _segment_allows_passive_source_edit(
 
 
 def _source_action_is_negated(action_prefix: str) -> bool:
-    if G4_SHARED_NEGATION.search(action_prefix) or G4_PAIRED_NEGATION.search(
-        action_prefix
+    if (
+        G4_NO_DETERMINER_NEGATION.search(action_prefix)
+        or G4_SHARED_NEGATION.search(action_prefix)
+        or G4_PAIRED_NEGATION.search(action_prefix)
     ):
         return True
     action_scope = G4_NEGATION_SCOPE_BOUNDARY.split(action_prefix)[-1]
@@ -3414,6 +3417,7 @@ def test_g2_policy_contradiction_detection_allows_approved_wording(
         ("Corrections alter municipal source records.", True),
         ("Source documents will be modified during correction.", True),
         ("Source documents may be modified during correction.", True),
+        ("No source documents may be edited.", False),
         ("City Coverage Expansion may proceed before T-GOV-2A completes.", True),
         ("City Coverage Expansion starts before T-GOV-2A completes.", True),
         ("City Coverage Expansion is unblocked before roster enforcement.", True),
@@ -3517,6 +3521,7 @@ def test_g2_policy_contradiction_detection_allows_approved_wording(
         ("Person entities may be created from source-document mentions.", True),
         ("Profiles are created from source-document mentions.", True),
         ("Profiles are generated from source-document mentions.", True),
+        ("No profiles may be created from source-document mentions.", False),
         (
             "Neither profiles nor memberships are created from "
             "source-document mentions.",

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2853,6 +2853,14 @@ G4_NON_ROSTER_PERSON_CREATION_POLICY = re.compile(
     r"vote attribution|cross-document aggregation)\b",
     re.IGNORECASE,
 )
+G4_SOURCE_RECORD_MODIFICATION_POLICY = re.compile(
+    r"(?:\b(?:corrections?|takedowns?)\b.{0,80}\b(?:may|can)\s+"
+    r"(?:edit|modify|rewrite|delete)\b.{0,40}\b(?:municipal\s+)?source "
+    r"(?:documents?|records?|text)\b"
+    r"|\b(?:municipal\s+)?source (?:documents?|records?|text)\b.{0,80}"
+    r"\b(?:may|can)\s+be\s+(?:edited|modified|rewritten|deleted)\b)",
+    re.IGNORECASE,
+)
 OPERATOR_AUTH_APPROVAL_POLICY = re.compile(
     r"\boperator(?:-only)?(?: proxy)? authentication\s+(?:is\s+)?(?:approved|pending)\b",
     re.IGNORECASE,
@@ -2888,6 +2896,7 @@ def _g4_policy_has_contradiction(g4_policy: str) -> bool:
         or G4_LIVE_OPTIONS_POLICY.search(normalized_g4_policy)
         or G4_DERIVED_ROSTER_AUTHORITY_POLICY.search(normalized_g4_policy)
         or G4_NON_ROSTER_PERSON_CREATION_POLICY.search(normalized_g4_policy)
+        or G4_SOURCE_RECORD_MODIFICATION_POLICY.search(normalized_g4_policy)
     )
 
 
@@ -2935,11 +2944,14 @@ def test_g2_policy_contradiction_detection_allows_approved_wording(
         ("Memberships created by the entity linker are roster authority.", True),
         ("Non-roster names may become person entities.", True),
         ("Non-roster names\nmay become person entities.", True),
+        ("Corrections may edit municipal source records.", True),
+        ("Source documents may be modified during correction.", True),
         ("G4 is approved; T-GOV-2A remains pending.", False),
         ("Runtime enforcement is pending T-GOV-2A.", False),
         ("The historical alternatives were superseded by approved G4.", False),
         ("Title inference and linker-created memberships are not roster authority.", False),
         ("Non-roster names do not become person entities.", False),
+        ("Corrections apply to derived records; source documents are not modified.", False),
     ),
 )
 def test_g4_contradiction_detection_covers_equivalent_wording(

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2827,6 +2827,19 @@ G2_OPEN_POLICY = re.compile(
     r"|\b(?:open|pending|unresolved)\s+g2\b)",
     re.IGNORECASE,
 )
+G4_UNRESOLVED_POLICY = re.compile(
+    r"(?:\bg4\b\s+(?:is|remains)\s+(?:open|pending|unresolved)\b"
+    r"|\bg4\b\s*(?:status\s*)?:\s*(?:open|pending|unresolved)\b"
+    r"|\bdecision\s+g4\b.{0,20}\b(?:open|pending|unresolved)\b"
+    r"|\b(?:open|pending|unresolved)\s+g4\b)",
+    re.IGNORECASE,
+)
+G4_LIVE_OPTIONS_POLICY = re.compile(
+    r"(?:\boptions?\s+under\s+consideration\b"
+    r"|\bexactly\s+one\s+will\s+be\s+adopted\s+by\s+adr\b"
+    r"|\bworking\s+default\s+until\s+(?:the\s+)?adr\s+lands\b)",
+    re.IGNORECASE,
+)
 OPERATOR_AUTH_APPROVAL_POLICY = re.compile(
     r"\boperator(?:-only)?(?: proxy)? authentication\s+(?:is\s+)?(?:approved|pending)\b",
     re.IGNORECASE,
@@ -2852,6 +2865,13 @@ PHASE_2_G3_BLOCKER_POLICY = re.compile(
 def _g2_policy_has_contradiction(g2_policy: str) -> bool:
     return bool(
         G2_OPEN_POLICY.search(g2_policy) or OPERATOR_AUTH_APPROVAL_POLICY.search(g2_policy)
+    )
+
+
+def _g4_policy_has_contradiction(g4_policy: str) -> bool:
+    return bool(
+        G4_UNRESOLVED_POLICY.search(g4_policy)
+        or G4_LIVE_OPTIONS_POLICY.search(g4_policy)
     )
 
 
@@ -2883,6 +2903,87 @@ def test_g2_policy_contradiction_detection_allows_approved_wording(
     approved_policy: str,
 ) -> None:
     assert not _g2_policy_has_contradiction(approved_policy)
+
+
+@pytest.mark.parametrize(
+    ("g4_policy", "has_contradiction"),
+    (
+        ("G4 remains open.", True),
+        ("G4 status: pending.", True),
+        ("DECISION G4 - unresolved", True),
+        ("Options under consideration; exactly one will be adopted by ADR.", True),
+        ("Working default until the ADR lands.", True),
+        ("G4 is approved; T-GOV-2A remains pending.", False),
+        ("Runtime enforcement is pending T-GOV-2A.", False),
+        ("The historical alternatives were superseded by approved G4.", False),
+    ),
+)
+def test_g4_contradiction_detection_covers_equivalent_wording(
+    g4_policy: str,
+    has_contradiction: bool,
+) -> None:
+    assert _g4_policy_has_contradiction(g4_policy) is has_contradiction
+
+
+def test_g4_roster_gated_policy_is_aligned() -> None:
+    architecture_decisions = (ROOT / "docs" / "ADR.md").read_text(encoding="utf-8")
+    data_governance = (ROOT / "docs" / "DATA_GOVERNANCE.md").read_text(
+        encoding="utf-8"
+    )
+    remediation_ledger = (
+        ROOT / "docs" / "plans" / "TOWN_COUNCIL_REMEDIATION_PLAN.md"
+    ).read_text(encoding="utf-8")
+
+    g4_decision = _required_markdown_entry(
+        architecture_decisions,
+        "## 2026-07-26: Roster-gated person linking",
+    )
+    person_policy = _required_markdown_section(
+        data_governance,
+        "## 3. Roster-gated person entities",
+        "\n## 4. Correction and takedown",
+    )
+    g4_entry = _required_markdown_section(
+        remediation_ledger,
+        "- G4 pii_policy:",
+        "\n- G5 migration_tooling:",
+    )
+    t_gov_2_entry = _required_markdown_section(
+        remediation_ledger,
+        "### T-GOV-2: ADR — Person-entity minimization & takedown (gate G4)",
+        "\n### T-GOV-2A:",
+    )
+    t_gov_2a_entry = _required_markdown_section(
+        remediation_ledger,
+        "### T-GOV-2A: Enforce roster-gated person linking",
+        "\n### T-GOV-3:",
+    )
+
+    assert "- Status: Accepted" in g4_decision
+    assert "independently authoritative official membership data" in g4_decision
+    assert "municipality, governing body, and meeting date" in g4_decision
+    assert "Title inference" in g4_decision
+    assert "linker-created memberships" in g4_decision
+    assert "does not yet enforce" in g4_decision
+    assert "T-GOV-2A" in g4_decision
+
+    assert "Status: effective." in data_governance
+    assert "independently authoritative official membership data" in person_policy
+    assert "municipality, governing body, and meeting date" in person_policy
+    assert "Non-roster names remain searchable source text" in person_policy
+    assert "person entities" in person_policy
+    assert "people metadata" in person_policy
+    assert "profiles" in person_policy
+    assert "cross-document aggregation" in person_policy
+    assert "Source documents are not modified" in person_policy
+
+    active_g4_policy = f"{person_policy} {g4_entry} {t_gov_2_entry}"
+    assert not _g4_policy_has_contradiction(active_g4_policy)
+    assert "status: complete and verified" in t_gov_2_entry
+    assert "status: pending" in t_gov_2a_entry
+    assert "City Coverage Expansion remains blocked until T-GOV-2A completes" in g4_entry
+    assert _remediation_task_states(remediation_ledger, "T-GOV-2") == ["Complete"]
+    assert _remediation_task_states(remediation_ledger, "T-GOV-2A") == ["Pending"]
 
 
 def test_g2_visitor_access_policy_is_aligned_after_t_sec_4_delivery():

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2837,7 +2837,9 @@ G4_UNRESOLVED_POLICY = re.compile(
 G4_LIVE_OPTIONS_POLICY = re.compile(
     r"(?:\boptions?\s+under\s+consideration\b"
     r"|\bexactly\s+one\s+will\s+be\s+adopted\s+by\s+adr\b"
-    r"|\bworking\s+default\s+until\s+(?:the\s+)?adr\s+lands\b)",
+    r"|\bworking\s+default\s+until\s+(?:the\s+)?adr\s+lands\b"
+    r"|\b(?:option [abc]|status quo)\b[^.!?;]{0,40}\b(?:remains?|is)\s+"
+    r"(?:a\s+)?(?:live|viable|current)\s+(?:alternative|choice|option)\b)",
     re.IGNORECASE,
 )
 G4_DERIVED_EVIDENCE_SOURCE = re.compile(
@@ -2887,7 +2889,8 @@ G4_NON_ROSTER_PERSON_CREATION_POLICY = re.compile(
     r"(?:become|create|produce|appear in|be retained as|receive)"
     r"|(?<!not )(?<!never )(?<!cannot )"
     r"(?:become|create|produce|appear in|are retained as|receive))"
-    r"[^.!?;]{0,40}\b(?:person entities|people metadata|profiles|memberships|"
+    r"(?![^.!?;]{0,40}\bnot\b)[^.!?;]{0,40}"
+    r"\b(?:person entities|people metadata|profiles|memberships|"
     r"vote attribution|cross-document aggregation)\b",
     re.IGNORECASE,
 )
@@ -2895,7 +2898,8 @@ G4_NON_ROSTER_WHILE_CONTINUATION_POLICY = re.compile(
     r"\bnon-roster (?:names?|people)\b[^.!?;]{0,80}"
     r"\bwhile\s+they\s+(?:(?:may|can)\s+)?"
     r"(?:become|create|produce|appear in|are retained as|receive)\b"
-    r"[^.!?;]{0,40}\b(?:person entities|people metadata|profiles|memberships|"
+    r"(?![^.!?;]{0,40}\bnot\b)[^.!?;]{0,40}"
+    r"\b(?:person entities|people metadata|profiles|memberships|"
     r"vote attribution|cross-document aggregation)\b",
     re.IGNORECASE,
 )
@@ -2905,11 +2909,12 @@ G4_POLICY_LIST_NEGATION = re.compile(r"\b(?:forbidden|prohibited)\s*:", re.IGNOR
 G4_POLICY_CONTRAST_BOUNDARY = re.compile(r"\b(?:but|while)\b", re.IGNORECASE)
 G4_SOURCE_ACTIVE_ACTION = re.compile(
     r"\b(?:edit(?:ed|ing|s)?|modif(?:ied|ies|y|ying)|rewrite(?:s|ten)?|"
-    r"rewriting|delet(?:e|ed|es|ing)|alter(?:ed|ing|s)?|remove(?:d|s)?|removing)\b",
+    r"rewriting|delet(?:e|ed|es|ing)|alter(?:ed|ing|s)?|remove(?:d|s)?|removing|"
+    r"redact(?:ed|ing|s)?)\b",
     re.IGNORECASE,
 )
 G4_SOURCE_PASSIVE_ACTION = re.compile(
-    r"\b(?:edited|modified|rewritten|deleted|altered|removed)\b",
+    r"\b(?:edited|modified|rewritten|deleted|altered|removed|redacted)\b",
     re.IGNORECASE,
 )
 G4_SOURCE_RECORD_TARGET = re.compile(
@@ -2935,7 +2940,8 @@ G4_SOURCE_TARGET_PRESERVATION = re.compile(
     re.IGNORECASE,
 )
 G4_SOURCE_NOMINAL_AUTHORIZATION = re.compile(
-    r"\b(?:deletion|modification|removal|alteration|rewriting|editing)\s+of\s+"
+    r"\b(?:deletion|modification|removal|alteration|rewriting|editing|redaction)"
+    r"\s+of\s+"
     r"(?:municipal\s+)?source (?:documents?|records?|text)\b"
     r"[^.!?;]{0,40}\b(?:is|are|may be|can be|will be|must be|should be)\s+"
     r"(?P<negated>not\s+)?"
@@ -3293,6 +3299,7 @@ def test_g2_policy_contradiction_detection_allows_approved_wording(
         ("DECISION G4 - unresolved", True),
         ("Options under consideration; exactly one will be adopted by ADR.", True),
         ("Working default until the ADR lands.", True),
+        ("Option B remains a live alternative.", True),
         ("Title inference may establish roster authority.", True),
         ("Title inference constitutes roster authority.", True),
         ("Title inference qualifies as roster authority.", True),
@@ -3306,6 +3313,7 @@ def test_g2_policy_contradiction_detection_allows_approved_wording(
         ("Non-roster names may become person entities.", True),
         ("Non-roster names become person entities.", True),
         ("Non-roster names can appear in people metadata.", True),
+        ("Non-roster names may appear in source text, not profiles.", False),
         ("Non-roster names may receive profiles.", True),
         ("Non-roster people may become person entities.", True),
         ("Non-roster names remain searchable while they become person entities.", True),
@@ -3462,6 +3470,7 @@ def test_g2_policy_contradiction_detection_allows_approved_wording(
         ("Staff are forbidden to edit and delete source records.", False),
         ("Staff cannot edit and delete source records.", False),
         ("Staff are deleting source documents.", True),
+        ("Staff may redact municipal source documents.", True),
         ("Corrections remove entity links to source documents.", False),
         (
             "Corrections modify annotations linked to municipal source records.",

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2930,6 +2930,7 @@ def test_g4_roster_gated_policy_is_aligned() -> None:
     data_governance = (ROOT / "docs" / "DATA_GOVERNANCE.md").read_text(
         encoding="utf-8"
     )
+    roadmap = (ROOT / "ROADMAP.md").read_text(encoding="utf-8")
     remediation_ledger = (
         ROOT / "docs" / "plans" / "TOWN_COUNCIL_REMEDIATION_PLAN.md"
     ).read_text(encoding="utf-8")
@@ -2958,6 +2959,11 @@ def test_g4_roster_gated_policy_is_aligned() -> None:
         "### T-GOV-2A: Enforce roster-gated person linking",
         "\n### T-GOV-3:",
     )
+    city_coverage_plan = _required_markdown_section(
+        roadmap,
+        "### City Coverage Expansion I/II",
+        "\n### Signal Intelligence",
+    )
 
     assert "- Status: Accepted" in g4_decision
     assert "independently authoritative official membership data" in g4_decision
@@ -2970,11 +2976,13 @@ def test_g4_roster_gated_policy_is_aligned() -> None:
     assert "Status: effective." in data_governance
     assert "independently authoritative official membership data" in person_policy
     assert "municipality, governing body, and meeting date" in person_policy
-    assert "Non-roster names remain searchable source text" in person_policy
-    assert "person entities" in person_policy
-    assert "people metadata" in person_policy
-    assert "profiles" in person_policy
-    assert "cross-document aggregation" in person_policy
+    normalized_person_policy = " ".join(person_policy.split())
+    assert (
+        "Non-roster names remain searchable source text. They do not become "
+        "person entities, people metadata, profiles, memberships, vote attribution, "
+        "or cross-document aggregation."
+        in normalized_person_policy
+    )
     assert "Source documents are not modified" in person_policy
 
     active_g4_policy = f"{person_policy} {g4_entry} {t_gov_2_entry}"
@@ -2982,6 +2990,10 @@ def test_g4_roster_gated_policy_is_aligned() -> None:
     assert "status: complete and verified" in t_gov_2_entry
     assert "status: pending" in t_gov_2a_entry
     assert "City Coverage Expansion remains blocked until T-GOV-2A completes" in g4_entry
+    assert (
+        "T-GOV-2A roster-gated person linking is complete and verified"
+        in city_coverage_plan
+    )
     assert _remediation_task_states(remediation_ledger, "T-GOV-2") == ["Complete"]
     assert _remediation_task_states(remediation_ledger, "T-GOV-2A") == ["Pending"]
 

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -2856,6 +2856,14 @@ G4_DERIVED_PERSON_TARGET = re.compile(
     r"\b(?:person creation|person entities|people-facing records)\b",
     re.IGNORECASE,
 )
+G4_DERIVED_PASSIVE_PERSON_PROMOTION = re.compile(
+    r"\b(?:person entities|people-facing records)\b[^.!?;]{0,40}"
+    r"\b(?:may|can|will|must|should)\s+be\s+"
+    r"(?:authorized|created|produced)\s+from\s+"
+    r"(?:title inference|source-document mentions?|linker-created memberships?"
+    r"|memberships created by the entity linker)\b",
+    re.IGNORECASE,
+)
 G4_DERIVED_PERSON_RELATION_BARRIER = re.compile(
     r"\b(?:links?|linked|references?|referenced|associations?|associated|related)"
     r"\s+(?:to|with|by)\b",
@@ -3053,7 +3061,8 @@ def _g4_policy_has_contradiction(g4_policy: str) -> bool:
 
 def _g4_policy_promotes_derived_evidence(g4_policy: str) -> bool:
     return any(
-        _g4_clause_grants_roster_authority(policy_clause)
+        G4_DERIVED_PASSIVE_PERSON_PROMOTION.search(policy_clause) is not None
+        or _g4_clause_grants_roster_authority(policy_clause)
         or _g4_clause_creates_person_record(policy_clause)
         for policy_clause in _g4_policy_clauses(g4_policy)
     )
@@ -3417,6 +3426,7 @@ def test_g2_policy_contradiction_detection_allows_approved_wording(
         ("Staff may edit municipal source records.", True),
         ("Town Council deletes source documents.", True),
         ("Source-document mentions may become person entities.", True),
+        ("Person entities may be created from source-document mentions.", True),
         ("Title inference may produce people-facing records.", True),
         ("Source-document mentions may not become person entities.", False),
         (
@@ -3595,6 +3605,20 @@ def test_g4_policy_scan_excludes_later_historical_adr_entries() -> None:
     assert not _g4_policy_has_contradiction(live_g4_decision)
 
 
+def test_g4_policy_scan_covers_city_expansion_readiness() -> None:
+    roadmap = (ROOT / "ROADMAP.md").read_text(encoding="utf-8")
+    city_readiness = _required_markdown_section(
+        roadmap,
+        "### City Expansion Readiness",
+        "\n## Next",
+    )
+
+    assert _g4_policy_has_contradiction(
+        f"{city_readiness}\nCity Coverage Expansion may proceed before "
+        "T-GOV-2A completes."
+    )
+
+
 def test_g4_roster_gated_policy_is_aligned() -> None:
     agent_policy = (ROOT / "AGENTS.md").read_text(encoding="utf-8")
     architecture_decisions = (ROOT / "docs" / "ADR.md").read_text(encoding="utf-8")
@@ -3634,6 +3658,11 @@ def test_g4_roster_gated_policy_is_aligned() -> None:
         roadmap,
         "### City Coverage Expansion I/II",
         "\n### Signal Intelligence",
+    )
+    city_readiness = _required_markdown_section(
+        roadmap,
+        "### City Expansion Readiness",
+        "\n## Next",
     )
 
     assert "- Status: Accepted" in g4_decision
@@ -3683,6 +3712,7 @@ def test_g4_roster_gated_policy_is_aligned() -> None:
             g4_entry,
             t_gov_2_entry,
             t_gov_2a_entry,
+            city_readiness,
             city_coverage_plan,
         )
     )


### PR DESCRIPTION
## What changed
- record approved G4 Option A in the architecture decision record
- make roster-gated person treatment effective data-governance policy
- mark T-GOV-2 complete while leaving runtime enforcement and remediation to T-GOV-2A
- add contradiction and cross-document alignment guardrails

## Why
Public-record mentions alone must not create persistent people metadata. Only independently authoritative membership data for the municipality, governing body, and meeting date can authorize person linking.

## Risk and compatibility
Documentation and guardrail contracts only. Runtime behavior is unchanged and explicitly remains pending under T-GOV-2A. City Coverage Expansion remains blocked until that enforcement work completes.

## Verification
- PASS: `.venv/bin/ruff check .`
- PASS: `.venv/bin/mypy`
- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_repository_guardrails.py` (383 passed)
- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py` (2 passed)
- PASS: `PYTHONPATH=. .venv/bin/python -m pytest -q tests/` (1581 passed, 19 skipped)
- PASS: `git diff --check origin/master...HEAD`
- PASS: two independent reviews; trailing-whitespace P2 fixed; no remaining P1/P2

## Remaining work
T-GOV-2A must add authoritative roster input, runtime gating, existing derived-data remediation, reindexing, and prevention of re-derivation.