### PR TITLE
T-DC-2A: Delete search lookup through api.main

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -20,14 +20,7 @@ from api.lineage_routes import build_lineage_router
 from api.people_routes import build_people_router
 from api.reporting_routes import build_reporting_router
 from api.search import support_core as search_support_core
-from api.search_routes import (
-    _build_meilisearch_filter_clauses as _build_meilisearch_filter_clauses,
-    _collect_meeting_docs as _collect_meeting_docs,
-    _semantic_service_get_json as _semantic_service_get_json,
-    client as client,
-    router as search_router,
-    search_documents_semantic as search_documents_semantic,
-)
+from api.search_routes import router as search_router
 from api.task_routes import (
     AsyncResult as AsyncResult,
     _enqueue_task as _enqueue_task,
@@ -38,11 +31,6 @@ from api.task_routes import (
     generate_topics_task as generate_topics_task,
     segment_agenda_task as segment_agenda_task,
 )
-from pipeline.config import (
-    SEMANTIC_ENABLED as SEMANTIC_ENABLED,
-    FEATURE_TRENDS_DASHBOARD as FEATURE_TRENDS_DASHBOARD,
-)
-
 # Metrics are internal-only and are scraped by Prometheus from the Docker network.
 from api.metrics import instrument_app
 

--- a/api/search/support_core.py
+++ b/api/search/support_core.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Any
 
 import meilisearch
 
@@ -67,24 +66,4 @@ SEMANTIC_ENABLED = pipeline_config.SEMANTIC_ENABLED
 
 logger = logging.getLogger("town-council-api")
 
-# Search helpers read this through api.main at runtime so existing tests can patch
-# the facade without knowing about the extracted modules.
 client = meilisearch.Client(MEILI_HOST, MEILI_MASTER_KEY, timeout=5)
-
-
-def _api_main() -> Any:
-    from api import main as api_main
-
-    return api_main
-
-
-def facade_value(name: str, fallback: Any) -> Any:
-    return getattr(_api_main(), name, fallback)
-
-
-def facade_callable(name: str, fallback: Any) -> Any:
-    return getattr(_api_main(), name, fallback)
-
-
-def search_client() -> Any:
-    return facade_value("client", client)

--- a/api/search/trends_support.py
+++ b/api/search/trends_support.py
@@ -3,24 +3,14 @@ from typing import Any, Optional
 
 from fastapi import HTTPException
 
+from api.search import support_core
 from api.search.filter_support import _build_meilisearch_filter_clauses
-from api.search.support_core import (
-    DOCUMENT_INDEX_NAME,
-    FEATURE_TRENDS_DASHBOARD,
-    MEETING_DOC_PAGE_SIZE,
-    MEETING_DOC_SCAN_LIMIT,
-    TOPICS_FACET_NAME,
-    TRENDS_DASHBOARD_DISABLED_DETAIL,
-    facade_callable,
-    facade_value,
-    search_client,
-)
 from pipeline.lexicon import is_trend_noise_topic
 
 
 def _require_trends_feature() -> None:
-    if not facade_value("FEATURE_TRENDS_DASHBOARD", FEATURE_TRENDS_DASHBOARD):
-        raise HTTPException(status_code=503, detail=TRENDS_DASHBOARD_DISABLED_DETAIL)
+    if not support_core.FEATURE_TRENDS_DASHBOARD:
+        raise HTTPException(status_code=503, detail=support_core.TRENDS_DASHBOARD_DISABLED_DETAIL)
 
 
 def _bucket_start(value: date, granularity: str) -> date:
@@ -54,9 +44,8 @@ def _iter_time_buckets(start: date, end: date, granularity: str) -> list[tuple[d
 
 
 def _facet_topics(city: Optional[str], date_from: Optional[str], date_to: Optional[str]) -> dict[str, int]:
-    index = search_client().index(DOCUMENT_INDEX_NAME)
-    filter_builder = facade_callable("_build_meilisearch_filter_clauses", _build_meilisearch_filter_clauses)
-    filters = filter_builder(
+    index = support_core.client.index(support_core.DOCUMENT_INDEX_NAME)
+    filters = _build_meilisearch_filter_clauses(
         city=city,
         meeting_type=None,
         org=None,
@@ -64,11 +53,11 @@ def _facet_topics(city: Optional[str], date_from: Optional[str], date_to: Option
         date_to=date_to,
         include_agenda_items=False,
     )
-    params: dict[str, Any] = {"limit": 0, "facets": [TOPICS_FACET_NAME]}
+    params: dict[str, Any] = {"limit": 0, "facets": [support_core.TOPICS_FACET_NAME]}
     if filters:
         params["filter"] = filters
     result = index.search("", params)
-    return result.get("facetDistribution", {}).get(TOPICS_FACET_NAME, {}) or {}
+    return result.get("facetDistribution", {}).get(support_core.TOPICS_FACET_NAME, {}) or {}
 
 
 def _parse_iso_date(value: Optional[str]) -> Optional[date]:
@@ -80,10 +69,12 @@ def _parse_iso_date(value: Optional[str]) -> Optional[date]:
         return None
 
 
-def _collect_meeting_docs(city: Optional[str], scan_limit: int = MEETING_DOC_SCAN_LIMIT) -> list[dict[str, Any]]:
-    index = search_client().index(DOCUMENT_INDEX_NAME)
-    filter_builder = facade_callable("_build_meilisearch_filter_clauses", _build_meilisearch_filter_clauses)
-    filters = filter_builder(
+def _collect_meeting_docs(
+    city: Optional[str],
+    scan_limit: int = support_core.MEETING_DOC_SCAN_LIMIT,
+) -> list[dict[str, Any]]:
+    index = support_core.client.index(support_core.DOCUMENT_INDEX_NAME)
+    filters = _build_meilisearch_filter_clauses(
         city=city,
         meeting_type=None,
         org=None,
@@ -95,9 +86,9 @@ def _collect_meeting_docs(city: Optional[str], scan_limit: int = MEETING_DOC_SCA
     offset = 0
     while offset < scan_limit:
         params: dict[str, Any] = {
-            "limit": min(MEETING_DOC_PAGE_SIZE, scan_limit - offset),
+            "limit": min(support_core.MEETING_DOC_PAGE_SIZE, scan_limit - offset),
             "offset": offset,
-            "attributesToRetrieve": [TOPICS_FACET_NAME, "date", "city"],
+            "attributesToRetrieve": [support_core.TOPICS_FACET_NAME, "date", "city"],
             "filter": filters,
         }
         if not filters:
@@ -105,7 +96,7 @@ def _collect_meeting_docs(city: Optional[str], scan_limit: int = MEETING_DOC_SCA
         page = index.search("", params)
         hits = page.get("hits", []) or []
         meeting_docs.extend(hits)
-        if len(hits) < MEETING_DOC_PAGE_SIZE:
+        if len(hits) < support_core.MEETING_DOC_PAGE_SIZE:
             break
         offset += len(hits)
     return meeting_docs
@@ -125,7 +116,7 @@ def _count_topics_from_docs(
             continue
         if end and (row_date is None or row_date > end):
             continue
-        topics = row.get(TOPICS_FACET_NAME) or []
+        topics = row.get(support_core.TOPICS_FACET_NAME) or []
         if isinstance(topics, list):
             for topic in topics:
                 topic_name = str(topic).strip()

--- a/api/search_read_meilisearch.py
+++ b/api/search_read_meilisearch.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from fastapi import HTTPException
 from meilisearch.errors import MeilisearchCommunicationError, MeilisearchError, MeilisearchTimeoutError
 
-from api import search_support
+from api.search import support_core
 
 SORTABLE_DATE_REINDEX_DETAIL = (
     "Meilisearch is not configured to sort by `date`. "
@@ -15,11 +15,11 @@ def run_lexical_search(index: object, query: str, search_params: dict[str, objec
     try:
         return index.search(query, search_params)
     except MeilisearchTimeoutError as exc:
-        search_support.logger.error("Search failed (Meilisearch timeout): %s", exc)
-        raise HTTPException(status_code=503, detail=search_support.SEARCH_ENGINE_TIMEOUT_DETAIL) from exc
+        support_core.logger.error("Search failed (Meilisearch timeout): %s", exc)
+        raise HTTPException(status_code=503, detail=support_core.SEARCH_ENGINE_TIMEOUT_DETAIL) from exc
     except MeilisearchCommunicationError as exc:
-        search_support.logger.error("Search failed (Meilisearch unavailable): %s", exc)
-        raise HTTPException(status_code=503, detail=search_support.SEARCH_ENGINE_UNAVAILABLE_DETAIL) from exc
+        support_core.logger.error("Search failed (Meilisearch unavailable): %s", exc)
+        raise HTTPException(status_code=503, detail=support_core.SEARCH_ENGINE_UNAVAILABLE_DETAIL) from exc
     except MeilisearchError as exc:
         raise map_meilisearch_error(exc) from exc
 
@@ -29,5 +29,5 @@ def map_meilisearch_error(exc: MeilisearchError) -> HTTPException:
     lowered = message.lower()
     if "sort" in lowered and ("sortable" in lowered or "attribute" in lowered):
         return HTTPException(status_code=400, detail=SORTABLE_DATE_REINDEX_DETAIL)
-    search_support.logger.error("Search failed (Meilisearch error): %s", exc)
-    return HTTPException(status_code=500, detail=search_support.INTERNAL_SEARCH_ENGINE_ERROR_DETAIL)
+    support_core.logger.error("Search failed (Meilisearch error): %s", exc)
+    return HTTPException(status_code=500, detail=support_core.INTERNAL_SEARCH_ENGINE_ERROR_DETAIL)

--- a/api/search_read_params.py
+++ b/api/search_read_params.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from fastapi import HTTPException
 
-from api import search_support
+from api.search import filter_support, support_core
 
 SEARCH_LIMIT_DEFAULT = 20
 SEARCH_LIMIT_MAX = 100
@@ -14,9 +14,9 @@ INVALID_SORT_MODE_DETAIL = "Invalid sort mode. Use newest|oldest|relevance."
 
 def validate_search_date_range(date_from: str | None, date_to: str | None) -> None:
     if date_from:
-        search_support.validate_date_format(date_from)
+        filter_support.validate_date_format(date_from)
     if date_to:
-        search_support.validate_date_format(date_to)
+        filter_support.validate_date_format(date_to)
 
 
 def build_lexical_search_params(
@@ -34,12 +34,12 @@ def build_lexical_search_params(
     search_params: dict[str, object] = {
         "limit": limit,
         "offset": offset,
-        "attributesToRetrieve": search_support.SEARCH_RESULT_ATTRIBUTES_TO_RETRIEVE,
-        "attributesToCrop": search_support.SEARCH_RESULT_ATTRIBUTES_TO_CROP,
-        "cropLength": search_support.SEARCH_RESULT_CROP_LENGTH,
-        "attributesToHighlight": search_support.SEARCH_RESULT_ATTRIBUTES_TO_HIGHLIGHT,
-        "highlightPreTag": search_support.SEARCH_HIGHLIGHT_PRE_TAG,
-        "highlightPostTag": search_support.SEARCH_HIGHLIGHT_POST_TAG,
+        "attributesToRetrieve": support_core.SEARCH_RESULT_ATTRIBUTES_TO_RETRIEVE,
+        "attributesToCrop": support_core.SEARCH_RESULT_ATTRIBUTES_TO_CROP,
+        "cropLength": support_core.SEARCH_RESULT_CROP_LENGTH,
+        "attributesToHighlight": support_core.SEARCH_RESULT_ATTRIBUTES_TO_HIGHLIGHT,
+        "highlightPreTag": support_core.SEARCH_HIGHLIGHT_PRE_TAG,
+        "highlightPostTag": support_core.SEARCH_HIGHLIGHT_POST_TAG,
     }
     apply_sort(search_params, sort)
     apply_filters(
@@ -79,11 +79,7 @@ def apply_filters(
     date_to: str | None,
     include_agenda_items: bool,
 ) -> None:
-    filter_builder = search_support.facade_callable(
-        "_build_meilisearch_filter_clauses",
-        search_support._build_meilisearch_filter_clauses,
-    )
-    filter_clauses = filter_builder(
+    filter_clauses = filter_support._build_meilisearch_filter_clauses(
         city=city,
         meeting_type=meeting_type,
         org=org,

--- a/api/search_read_routes.py
+++ b/api/search_read_routes.py
@@ -4,7 +4,7 @@ from typing import Any, Optional
 from fastapi import APIRouter, HTTPException, Query
 from meilisearch.errors import MeilisearchCommunicationError, MeilisearchError, MeilisearchTimeoutError
 
-from api import search_support
+from api.search import support_core
 from api.search_read_meilisearch import run_lexical_search
 from api.search_read_params import SEARCH_LIMIT_DEFAULT, SEARCH_LIMIT_MAX, build_lexical_search_params, validate_search_date_range
 from api.search_read_results import truncate_people_metadata
@@ -38,8 +38,7 @@ def search_documents(
     validate_search_date_range(date_from, date_to)
 
     if semantic:
-        semantic_search = search_support.facade_callable("search_documents_semantic", search_documents_semantic)
-        return semantic_search(
+        return search_documents_semantic(
             q=q,
             city=city,
             include_agenda_items=include_agenda_items,
@@ -52,7 +51,7 @@ def search_documents(
         )
 
     try:
-        index = search_support.search_client().index(search_support.DOCUMENT_INDEX_NAME)
+        index = support_core.client.index(support_core.DOCUMENT_INDEX_NAME)
         search_params = build_lexical_search_params(
             city=city,
             include_agenda_items=include_agenda_items,
@@ -67,13 +66,13 @@ def search_documents(
         results = run_lexical_search(index, q, search_params)
         truncate_people_metadata(results)
 
-        search_support.logger.info("Search query=%r city=%r returned %s hits", q, city, len(results["hits"]))
+        support_core.logger.info("Search query=%r city=%r returned %s hits", q, city, len(results["hits"]))
         return results
     except HTTPException:
         raise
     except (KeyError, RuntimeError, TypeError, ValueError) as exc:
-        search_support.logger.error("Search failed: %s", exc)
-        raise HTTPException(status_code=500, detail=search_support.INTERNAL_SEARCH_ENGINE_ERROR_DETAIL) from exc
+        support_core.logger.error("Search failed: %s", exc)
+        raise HTTPException(status_code=500, detail=support_core.INTERNAL_SEARCH_ENGINE_ERROR_DETAIL) from exc
 
 
 @router.get("/metadata")
@@ -91,8 +90,8 @@ def get_metadata() -> MetadataPayload:
 
 def _load_search_metadata() -> MetadataPayload:
     try:
-        index = search_support.search_client().index(search_support.DOCUMENT_INDEX_NAME)
-        metadata_response = index.search("", {"facets": search_support.METADATA_FACETS, "limit": 0})
+        index = support_core.client.index(support_core.DOCUMENT_INDEX_NAME)
+        metadata_response = index.search("", {"facets": support_core.METADATA_FACETS, "limit": 0})
 
         facets = metadata_response.get("facetDistribution", {})
         cities = sorted([city.replace("ca_", "").replace("_", " ").title() for city in facets.get("city", {}).keys()])
@@ -105,5 +104,5 @@ def _load_search_metadata() -> MetadataPayload:
             "meeting_types": meeting_types,
         }
     except (MeilisearchCommunicationError, MeilisearchTimeoutError, MeilisearchError, RuntimeError, ValueError) as exc:
-        search_support.logger.error("Metadata retrieval failed: %s", exc)
+        support_core.logger.error("Metadata retrieval failed: %s", exc)
         return EMPTY_SEARCH_METADATA

--- a/api/search_semantic_routes.py
+++ b/api/search_semantic_routes.py
@@ -2,7 +2,7 @@ from typing import Any, Optional
 
 from fastapi import APIRouter, HTTPException, Query
 
-from api import search_support
+from api.search import semantic_support, support_core
 
 SEMANTIC_SEARCH_LIMIT_DEFAULT = 20
 SEMANTIC_SEARCH_LIMIT_MAX = 100
@@ -22,13 +22,9 @@ def search_documents_semantic(
     limit: int = Query(SEMANTIC_SEARCH_LIMIT_DEFAULT, ge=1, le=SEMANTIC_SEARCH_LIMIT_MAX),
     offset: int = Query(0, ge=0),
 ) -> dict[str, Any]:
-    if not search_support.facade_value("SEMANTIC_ENABLED", search_support.SEMANTIC_ENABLED):
-        raise HTTPException(status_code=503, detail=search_support.SEMANTIC_DISABLED_DETAIL)
-    semantic_get_json = search_support.facade_callable(
-        "_semantic_service_get_json",
-        search_support._semantic_service_get_json,
-    )
-    return semantic_get_json(
+    if not support_core.SEMANTIC_ENABLED:
+        raise HTTPException(status_code=503, detail=support_core.SEMANTIC_DISABLED_DETAIL)
+    return semantic_support._semantic_service_get_json(
         "/search/semantic",
         {
             "q": q,

--- a/api/search_support.py
+++ b/api/search_support.py
@@ -37,10 +37,7 @@ from api.search.support_core import (
     TOPICS_FACET_NAME as TOPICS_FACET_NAME,
     TRENDS_DASHBOARD_DISABLED_DETAIL as TRENDS_DASHBOARD_DISABLED_DETAIL,
     client as client,
-    facade_callable as facade_callable,
-    facade_value as facade_value,
     logger as logger,
-    search_client as search_client,
 )
 from api.search.trends_support import (
     _collect_meeting_docs as _collect_meeting_docs,
@@ -78,11 +75,8 @@ __all__ = [
     "TOPICS_FACET_NAME",
     "TRENDS_DASHBOARD_DISABLED_DETAIL",
     "client",
-    "facade_callable",
-    "facade_value",
     "httpx",
     "logger",
-    "search_client",
     "validate_date_format",
     "_build_filter_values",
     "_build_meilisearch_filter_clauses",

--- a/api/trends_routes.py
+++ b/api/trends_routes.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import Response
 
 from api.app_setup import limiter
-from api import search_support
+from api.search import filter_support, support_core, trends_support
 from pipeline.lexicon import is_trend_noise_topic
 
 TRENDS_TOPICS_RATE_LIMIT = "60/minute"
@@ -43,20 +43,19 @@ def get_trends_topics(
     limit: int = Query(TRENDS_TOPICS_LIMIT_DEFAULT, ge=1, le=TRENDS_TOPICS_LIMIT_MAX),
 ) -> dict[str, Any]:
     _ = request
-    search_support._require_trends_feature()
+    trends_support._require_trends_feature()
     if date_from:
-        search_support.validate_date_format(date_from)
+        filter_support.validate_date_format(date_from)
     if date_to:
-        search_support.validate_date_format(date_to)
+        filter_support.validate_date_format(date_to)
     if date_from or date_to:
-        collect_meeting_docs = search_support.facade_callable("_collect_meeting_docs", search_support._collect_meeting_docs)
-        docs = collect_meeting_docs(city=city)
-        topic_counts = search_support._count_topics_from_docs(docs, date_from=date_from, date_to=date_to)
+        docs = trends_support._collect_meeting_docs(city=city)
+        topic_counts = trends_support._count_topics_from_docs(docs, date_from=date_from, date_to=date_to)
     else:
-        topic_counts = search_support._facet_topics(city=city, date_from=date_from, date_to=date_to)
+        topic_counts = trends_support._facet_topics(city=city, date_from=date_from, date_to=date_to)
     rows = _sorted_topic_rows(topic_counts, limit)
     return {
-        "city": search_support._normalize_city_or_400(city) if city else None,
+        "city": filter_support._normalize_city_or_400(city) if city else None,
         "date_from": date_from,
         "date_to": date_to,
         "items": [{"topic": topic, "count": int(count)} for topic, count in rows],
@@ -74,9 +73,9 @@ def get_trends_compare(
     limit: int = Query(TRENDS_COMPARE_LIMIT_DEFAULT, ge=1, le=TRENDS_COMPARE_LIMIT_MAX),
 ) -> dict[str, Any]:
     _ = request
-    search_support._require_trends_feature()
-    search_support.validate_date_format(date_from)
-    search_support.validate_date_format(date_to)
+    trends_support._require_trends_feature()
+    filter_support.validate_date_format(date_from)
+    filter_support.validate_date_format(date_to)
     start = datetime.strptime(date_from, "%Y-%m-%d").date()
     end = datetime.strptime(date_to, "%Y-%m-%d").date()
     if end < start:
@@ -84,14 +83,13 @@ def get_trends_compare(
     if len(cities) < 2:
         raise HTTPException(status_code=400, detail=TRENDS_MINIMUM_CITIES_DETAIL)
 
-    normalized_cities = [search_support._normalize_city_or_400(city) for city in cities]
-    buckets = search_support._iter_time_buckets(start=start, end=end, granularity=granularity)
-    collect_meeting_docs = search_support.facade_callable("_collect_meeting_docs", search_support._collect_meeting_docs)
-    docs_by_city = {city: collect_meeting_docs(city=city) for city in normalized_cities}
+    normalized_cities = [filter_support._normalize_city_or_400(city) for city in cities]
+    buckets = trends_support._iter_time_buckets(start=start, end=end, granularity=granularity)
+    docs_by_city = {city: trends_support._collect_meeting_docs(city=city) for city in normalized_cities}
 
     pooled: dict[str, int] = {}
     for meeting_docs in docs_by_city.values():
-        counts = search_support._count_topics_from_docs(meeting_docs, date_from=date_from, date_to=date_to)
+        counts = trends_support._count_topics_from_docs(meeting_docs, date_from=date_from, date_to=date_to)
         for topic, count in counts.items():
             pooled[topic] = pooled.get(topic, 0) + int(count)
     top_topics = [
@@ -103,7 +101,7 @@ def get_trends_compare(
     for city in normalized_cities:
         meeting_docs = docs_by_city.get(city, [])
         for bucket_start, bucket_end in buckets:
-            counts = search_support._count_topics_from_docs(
+            counts = trends_support._count_topics_from_docs(
                 meeting_docs,
                 date_from=bucket_start.isoformat(),
                 date_to=bucket_end.isoformat(),
@@ -135,30 +133,29 @@ def export_trends(
     limit: int = Query(TRENDS_EXPORT_LIMIT_DEFAULT, ge=1, le=TRENDS_EXPORT_LIMIT_MAX),
 ) -> Response | dict[str, Any]:
     _ = request
-    search_support._require_trends_feature()
+    trends_support._require_trends_feature()
     if date_from:
-        search_support.validate_date_format(date_from)
+        filter_support.validate_date_format(date_from)
     if date_to:
-        search_support.validate_date_format(date_to)
+        filter_support.validate_date_format(date_to)
     if date_from or date_to:
-        collect_meeting_docs = search_support.facade_callable("_collect_meeting_docs", search_support._collect_meeting_docs)
-        docs = collect_meeting_docs(city=city)
-        topic_counts = search_support._count_topics_from_docs(docs, date_from=date_from, date_to=date_to)
+        docs = trends_support._collect_meeting_docs(city=city)
+        topic_counts = trends_support._count_topics_from_docs(docs, date_from=date_from, date_to=date_to)
     else:
-        topic_counts = search_support._facet_topics(city=city, date_from=date_from, date_to=date_to)
+        topic_counts = trends_support._facet_topics(city=city, date_from=date_from, date_to=date_to)
     rows = _sorted_topic_rows(topic_counts, limit)
 
     if format == "csv":
         buffer = io.StringIO()
         writer = csv.writer(buffer)
-        writer.writerow(search_support.TOPICS_CSV_HEADER)
-        normalized_city = search_support._normalize_city_or_400(city) if city else ""
+        writer.writerow(support_core.TOPICS_CSV_HEADER)
+        normalized_city = filter_support._normalize_city_or_400(city) if city else ""
         for topic, count in rows:
             writer.writerow([topic, int(count), normalized_city, date_from or "", date_to or ""])
         return Response(content=buffer.getvalue(), media_type="text/csv")
 
     return {
-        "city": search_support._normalize_city_or_400(city) if city else None,
+        "city": filter_support._normalize_city_or_400(city) if city else None,
         "date_from": date_from,
         "date_to": date_to,
         "items": [{"topic": topic, "count": int(count)} for topic, count in rows],

--- a/docs/ADR.md
+++ b/docs/ADR.md
@@ -1451,3 +1451,37 @@ Use each entry to record:
   - [docs/PIPELINE.md](PIPELINE.md)
   - [docs/TESTING.MD](TESTING.MD)
   - [T-DE-2 implementation plan](plans/T_DE_2_PROVIDER_FACADE_DELETION_PLAN.md)
+
+## 2026-07-31: Delete search patch lookup through api.main
+
+- Status: Accepted
+- Decision:
+  - Search route implementations read configuration and the Meilisearch client
+    from `api/search/support_core.py`.
+  - Filter, semantic transport, and trends behavior call their focused
+    implementation owners directly.
+  - Delete `_api_main`, `facade_value`, `facade_callable`, and `search_client`;
+    remove the corresponding exports from `api/search_support.py`.
+  - Remove search-only patch aliases from `api/main.py`; tests use the
+    Meilisearch construction boundary, outbound HTTP boundary, or
+    implementation-owned feature flags.
+  - Keep `api/search_routes.py` and remaining router compatibility bags until
+    the separately planned T-DC-2B deletion.
+- Why:
+  - Dynamic lookup through `api.main` exists only to preserve historical test
+    patch paths and creates a reverse dependency from search implementations to
+    application assembly.
+  - G3 establishes that test patch targets are not public API and directs tests
+    to real implementation or approved service boundaries.
+  - Direct ownership removes lookup indirection without changing routes,
+    filters, responses, reader-key policy, or search backends.
+- Supersedes:
+  - The `api.main` search monkeypatch-preservation portions of "2026-04-22:
+    Split the search route family behind the search facade" and "2026-05-09:
+    Split Wave 2 task, search, onboarding, and repair cleanup seams." Their
+    route allocation remains active until T-DC-2B.
+- Canonical references:
+  - [ARCHITECTURE.md](../ARCHITECTURE.md)
+  - [docs/TESTING.MD](TESTING.MD)
+  - [SECURITY.md](../SECURITY.md)
+  - [T-DC-2A implementation plan](plans/T_DC_2A_SEARCH_MAIN_LOOKUP_DELETION_PLAN.md)

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,6 +1,6 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 3.88
+version: 3.90
 generated: 2026-07-26
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
@@ -10,6 +10,15 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v3.90:** Completes T-DC-2A after deleting dynamic search lookup through
+  `api.main`, removing seven search patch aliases, repointing routes and tests
+  to direct Meilisearch, semantic transport, filter, and trends owners, and
+  adding an AST deletion guard for imported, string, `patch.object`, and
+  `setattr` patch forms. T-DC-2B remains pending for broader router facade bags.
+- **v3.89:** Activates T-DC-2A with exact ownership to delete dynamic search
+  lookups through `api.main`, repoint routes and tests to direct search,
+  Meilisearch, and outbound-HTTP owners, and add a structural deletion guard.
+  Broader router facade bags remain reserved for T-DC-2B.
 - **v3.88:** Completes T-DE-2 after deleting the provider compatibility
   facade, repointing production and test imports to direct owners, removing
   provider-class re-exports from `pipeline.llm`, and passing the provider,
@@ -410,8 +419,8 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 | State | Tasks |
 |---|---|
-| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2, T-SEC-3, T-SEC-3C, T-SEC-4, T-SEC-4A, T-SEC-5, T-SEC-6, T-TIME-1, T-TIME-2, T-TIME-3, T-CRAWL-1, T-CRAWL-2, T-PLAT-1, T-PLAT-1A, T-PLAT-2, T-PLAT-2A, T-PLAT-2B, T-PLAT-2C, T-PLAT-3, T-PLAT-4, T-GOV-1, T-GOV-2, T-GOV-2A, T-GOV-3, T-GOV-3A, T-GOV-3B, T-GOV-4, T-GOV-5, T-GOV-6, T-DA-1, T-DB-1A, T-DB-1, T-DB-1B, T-DC-1, T-DD-1A, T-DD-1B, T-DE-1, T-DE-2 |
-| **Pending** | T-DC-2A, T-DC-2B, T-TASK-1, T-SEM-1, T-IDX-1, T-FE-1 |
+| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2, T-SEC-3, T-SEC-3C, T-SEC-4, T-SEC-4A, T-SEC-5, T-SEC-6, T-TIME-1, T-TIME-2, T-TIME-3, T-CRAWL-1, T-CRAWL-2, T-PLAT-1, T-PLAT-1A, T-PLAT-2, T-PLAT-2A, T-PLAT-2B, T-PLAT-2C, T-PLAT-3, T-PLAT-4, T-GOV-1, T-GOV-2, T-GOV-2A, T-GOV-3, T-GOV-3A, T-GOV-3B, T-GOV-4, T-GOV-5, T-GOV-6, T-DA-1, T-DB-1A, T-DB-1, T-DB-1B, T-DC-1, T-DC-2A, T-DD-1A, T-DD-1B, T-DE-1, T-DE-2 |
+| **Pending** | T-DC-2B, T-TASK-1, T-SEM-1, T-IDX-1, T-FE-1 |
 
 ---
 
@@ -1407,9 +1416,27 @@ files (GED-5 grant).
 
 ### T-DC-2A: Delete search-to-api.main patch lookup
 - priority: P2
-- status: pending Full plan and exact ownership
+- status: complete and verified 2026-07-31
 - depends_on: T-DC-1 (satisfied by PR #157)
-- files_owned: to be named in a separate Full plan before implementation
+- implementation_plan: `docs/plans/T_DC_2A_SEARCH_MAIN_LOOKUP_DELETION_PLAN.md`
+- files_owned: the implementation plan and ledger;
+  `api/main.py` (seven search patch aliases only);
+  `api/search/support_core.py`; `api/search/trends_support.py`;
+  `api/search_support.py`; `api/search_read_params.py`;
+  `api/search_read_meilisearch.py`; `api/search_read_routes.py`;
+  `api/search_semantic_routes.py`; `api/trends_routes.py`;
+  `tests/test_api.py`; `tests/test_catalog_lineage_endpoint.py`;
+  `tests/test_query_builder_parity_search_vs_trends.py`;
+  `tests/test_search_support_facade.py`; `tests/test_semantic_search_api.py`;
+  `tests/test_semantic_search_feature_flag.py`;
+  `tests/test_trends_compare_endpoint.py`; `tests/test_trends_export_csv.py`;
+  `tests/test_trends_topics_endpoint.py`; `tests/test_repository_guardrails.py`;
+  `docs/ADR.md`
+- delivered: Deleted four dynamic lookup functions, three facade exports, and
+  seven `api.main` search aliases; migrated route behavior and tests to direct
+  search-domain and approved service boundaries; and added repository guards
+  against reverse imports and stale patch forms. Search, security, static,
+  coverage, and complete Python gates pass.
 - do: Delete `_api_main`, `facade_value`, `facade_callable`, and
   `search_client` lookup behavior from the search support family. Repoint
   callers and tests to direct search implementation owners and the approved

--- a/docs/plans/T_DC_2A_SEARCH_MAIN_LOOKUP_DELETION_PLAN.md
+++ b/docs/plans/T_DC_2A_SEARCH_MAIN_LOOKUP_DELETION_PLAN.md
@@ -1,0 +1,325 @@
+# T-DC-2A: Delete Search-to-api.main Patch Lookup
+
+`artifact_contract: ce-unified-plan/v1`
+`artifact_readiness: implementation-ready`
+`execution: code`
+
+## 1. Context & Alignment
+
+**a) Driver.** Search route implementations still resolve feature flags,
+Meilisearch clients, filter builders, semantic transport, and trends helpers by
+looking back through `api.main`. That behavior exists only to preserve historical
+monkeypatch targets. It hides the real implementation owners, creates reverse
+imports, and allows tests to pass through a compatibility surface rather than
+the approved Meilisearch and outbound-HTTP boundaries. T-DC-2A deletes that
+lookup layer without changing search behavior or beginning T-DC-2B's broader
+router-facade deletion.
+
+**b) Canonical documents consulted.**
+
+- `AGENTS.md` hierarchy, known-antipattern, workflow, API/search verification,
+  and reporting sections require direct implementation ownership, observable
+  tests, complete verification, and no compatibility aliases.
+- `docs/TESTING.MD` requires Meilisearch tests to patch the client where it is
+  constructed in `api/search/support_core.py` and outbound semantic requests at
+  the `httpx` call site.
+- `docs/ENGINEERING_GUARDRAILS.md` requires helper modules to avoid reverse
+  imports through facades and rejects preserving historical patch targets.
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md` sequences T-DC-2A after T-DC-1
+  and before T-DC-2B while freezing search, authentication, key, and response
+  behavior.
+- `docs/reviews/architecture-review-2026-07-19.html` identifies the search
+  facade stack as a deferred compatibility stratum that should be removed one
+  domain at a time after G3.
+- `docs/ADR.md` records the historical `api.main` patch-surface decision. A new
+  dated entry records that G3 and T-DC-2A supersede only its search lookup
+  compatibility, leaving T-DC-2B to address router facade bags.
+
+**c) Remediation alignment.** This is T-DC-2A in the DEDUP-C lane. Its exact
+`files_owned` set is:
+
+- `docs/plans/T_DC_2A_SEARCH_MAIN_LOOKUP_DELETION_PLAN.md`
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`
+- `api/main.py`
+- `api/search/support_core.py`
+- `api/search/trends_support.py`
+- `api/search_support.py`
+- `api/search_read_params.py`
+- `api/search_read_meilisearch.py`
+- `api/search_read_routes.py`
+- `api/search_semantic_routes.py`
+- `api/trends_routes.py`
+- `tests/test_api.py`
+- `tests/test_catalog_lineage_endpoint.py`
+- `tests/test_query_builder_parity_search_vs_trends.py`
+- `tests/test_search_support_facade.py`
+- `tests/test_semantic_search_api.py`
+- `tests/test_semantic_search_feature_flag.py`
+- `tests/test_trends_compare_endpoint.py`
+- `tests/test_trends_export_csv.py`
+- `tests/test_trends_topics_endpoint.py`
+- `tests/test_repository_guardrails.py`
+- `docs/ADR.md`
+
+This plan grants DEDUP-C narrow coordination over the GOV-owned ADR and
+structural guardrail only for this lookup deletion. The `api/main.py` edit is
+limited to removing seven search patch aliases; its ASGI assembly and all other
+compatibility exports remain unchanged. `api/search_routes.py` remains outside
+this task; T-DC-2B owns its broader router dependency bag and the remaining
+`api.main` compatibility exports.
+
+**d) Decision gates.** G3 is satisfied by T-GOV-1 and explicitly removes the
+requirement to preserve monkeypatch facades. G1, G2, G4, and G5 are unaffected.
+No open decision gate blocks T-DC-2A.
+
+## 2. Design
+
+**e) Step-by-step approach.**
+
+1. Run the current route behavior suite to characterize lexical search,
+   metadata, semantic search, and trends outcomes before changing imports.
+2. Add failing structural tests that reject `_api_main`, `facade_value`,
+   `facade_callable`, and `search_client`, reject their re-export from
+   `api.search_support`, and reject imports of `api.main` from search helper
+   modules.
+3. Delete the four lookup functions and their `Any` import from
+   `api/search/support_core.py`. Keep the configured reader-key Meilisearch
+   client in that module as the approved construction boundary.
+4. Repoint route and helper modules directly:
+   - lexical and metadata routes use `api.search.support_core.client`;
+   - search parameter construction uses `api.search.filter_support` and
+     constants from `support_core`;
+   - semantic routes read `support_core.SEMANTIC_ENABLED` and call
+     `api.search.semantic_support._semantic_service_get_json`;
+   - trends routes use `api.search.trends_support` and
+     `api.search.filter_support` directly;
+   - trends support reads feature flags and the client from the
+     `support_core` module and calls the filter builder directly;
+   - Meilisearch error mapping reads logging and detail constants from
+     `support_core`.
+5. Remove the three exported lookup names from the `api.search_support`
+   compatibility surface. `_api_main` was private to `support_core`. Do not add
+   replacement wrappers or aliases.
+6. Remove the seven search patch aliases from `api.main`: `client`,
+   `_build_meilisearch_filter_clauses`, `_collect_meeting_docs`,
+   `_semantic_service_get_json`, `search_documents_semantic`,
+   `SEMANTIC_ENABLED`, and `FEATURE_TRENDS_DASHBOARD`. Keep only the search
+   router import needed for application assembly. Broader facade cleanup stays
+   with T-DC-2B.
+7. Repoint tests from `api.main` to the approved Meilisearch client or outbound
+   HTTP boundary and assert HTTP responses and persisted route effects. Keep
+   `api.main.app` imports because ASGI application assembly is not deleted here.
+   Delete the unrelated trends-flag patch from the lineage route test.
+8. Append a dated ADR entry that supersedes the old search patch-lookup
+   decision while preserving route contracts and the later T-DC-2B boundary.
+9. Mark T-DC-2A complete only after targeted, guardrail, coverage, and complete
+   suite verification succeeds.
+
+No production module or abstraction is added. Existing implementation modules
+remain the only owners.
+
+**f) Reuse audit.** Reuse `api/search/support_core.py` as configuration,
+constant, logging, and Meilisearch-client owner; `filter_support.py` as filter
+validation owner; `semantic_support.py` as outbound semantic transport owner;
+and `trends_support.py` as trends data owner. The deleted dynamic lookup layer
+is the older stratum; nothing replaces it.
+
+**g) Data contracts.** Route paths, query parameters, response dictionaries,
+HTTP status codes, Meilisearch request dictionaries, semantic diagnostics, and
+trends CSV columns remain unchanged. No new typed contract or raw external
+input boundary is introduced. Tests and untracked callers that patch search
+internals through `api.main` intentionally lose that compatibility path and
+must use the documented implementation boundary.
+
+**h) Schema and migrations.** None.
+
+## 3. Security & Data Governance
+
+**i) Security boundary.** `api/search/support_core.py` handles
+`MEILI_SEARCH_KEY` and is therefore security-sensitive under `AGENTS.md`.
+This task does not change key resolution, host selection, client construction,
+timeout behavior, or permissions. The `SECURITY.md` reader-key control remains:
+API and semantic readers receive only `search` and `stats.get` on `documents`,
+while writer/admin services retain the master key. An attacker gains no new
+capability because only Python lookup ownership changes.
+
+**j) Secrets.** No credential, key, environment variable, or default changes.
+The existing reader-only Meilisearch key remains owned by `support_core`.
+
+**k) Person data.** No person entity, roster, people metadata, or publication
+behavior changes. Roster-gated people results continue to follow G4.
+
+**l) Untrusted input.** FastAPI continues to validate route/query input.
+`filter_support` continues to normalize filters before Meilisearch receives
+them, and `semantic_support` continues to validate outbound response status and
+JSON. This task changes import ownership only.
+
+## 4. Code Health
+
+**m) GED conformance sweep.** The implementation deletes four functions and
+replaces dynamic lookup with qualified module calls. No new nesting, long
+parameter list, timestamp, environment read, broad handler, or runtime literal
+is introduced. Existing route and search-domain names remain unchanged.
+
+**n) Antipattern scan, plan pass.**
+
+- A1/H1: no external API or dependency call changes.
+- B1/B2/C1: no wrapper, registry, injection layer, alias, or dual path replaces
+  the deleted lookup behavior.
+- C2/D2: tests move to approved Meilisearch and outbound-HTTP boundaries rather
+  than preserving `api.main` patch targets or mocking the route under test.
+- D1/D3: response, error, query, and filter assertions remain; only obsolete
+  patch-path assertions are replaced by deletion and direct-owner contracts.
+- E1/E2: edits stay within the exact owned paths and do not reformat unrelated
+  code.
+- F1/F2: no logic is copied; callers invoke existing owners.
+- A2-A4, B3, E3, H2-H4: no planned violation.
+
+**o) Ratchet interaction.** `api/search/trends_support.py` and
+`api/trends_routes.py` retain their existing `DTZ007` debt because date parsing
+behavior is frozen here. No Ruff selector, BLE001 boundary, formatter scope,
+Mypy scope, or coverage threshold changes.
+
+**p) Dead code and duplication audit.** Delete four lookup functions, one
+unused type import, three compatibility exports, and test patch paths.
+Reuse all route/query implementations. Expected production delta is negative;
+test/docs growth records the deletion contract without runtime machinery.
+
+## 5. Testing
+
+**q) Edge and failure scenarios.**
+
+1. Lexical search still sends the same query, filters, sorting, limit, and
+   offset to Meilisearch.
+2. Metadata retains its one-hour process-local cache and empty failure payload.
+3. Meilisearch timeout, unavailable, invalid-sort, and generic errors retain
+   their HTTP mappings.
+4. Semantic-disabled requests return 503.
+5. Semantic requests preserve filters, diagnostics, upstream status, and
+   non-dictionary error details.
+6. Trends feature disablement returns 503.
+7. Trends topic, comparison, date filtering, and CSV output remain unchanged.
+8. Feature flags patched at their direct owner affect route behavior without
+   `api.main` lookup.
+9. Every search route/helper uses the configured reader client directly.
+10. No helper imports or inspects `api.main`, none of the four lookup names can
+    return through `api.search_support`, and none of the seven search patch
+    aliases survives in `api.main`.
+11. Authentication and Meilisearch key behavior remain unchanged.
+12. Date-filtered trends execute normal Meilisearch pagination and filtering
+    rather than a patched `_collect_meeting_docs` helper.
+
+**r) Test mapping.**
+
+| Tests | Scenarios |
+|---|---|
+| `tests/test_api.py` | 1-3, 5, 9, 11 |
+| `tests/test_catalog_lineage_endpoint.py` | 10 |
+| `tests/test_semantic_search_feature_flag.py` | 4, 8 |
+| `tests/test_semantic_search_api.py` | 5, 8 |
+| `tests/test_trends_compare_endpoint.py` | 7-9, 12 |
+| `tests/test_trends_export_csv.py` | 7-9 |
+| `tests/test_trends_topics_endpoint.py` | 6-9 |
+| `tests/test_query_builder_parity_search_vs_trends.py` | 1, 7 |
+| `tests/test_search_support_facade.py` | 10 |
+| `tests/test_repository_guardrails.py` | 10 |
+| Existing auth and API suites | 1-11 |
+
+Write and run the structural deletion tests red before implementation.
+
+**s) Fakes and mocks.** Meilisearch tests patch
+`api.search.support_core.client`, the approved construction boundary.
+Semantic tests patch `api.search.semantic_support.httpx.get`, the approved
+outbound-HTTP boundary. Feature tests patch implementation-owned configuration
+at `api.search.support_core.SEMANTIC_ENABLED` and
+`api.search.support_core.FEATURE_TRENDS_DASHBOARD`; these are configuration
+state changes, not substitute service boundaries. No accessor, copied
+`api.main` value, facade/re-export patch, or new fake seam is added.
+
+**t) Verification rows.** Apply the API/search behavior, guardrail/tooling,
+and docs-only rows. Run coverage because production API files change, then the
+complete Python suite because the search compatibility boundary is
+cross-cutting.
+
+## 6. Execution, Rollback, Docs
+
+**u) Exact commands.**
+
+```bash
+git fetch origin --prune
+git switch master
+git merge --ff-only origin/master
+git switch -c codex/t-dc-2a-search-main-lookup-deletion
+
+PYTHONPATH=. .venv/bin/pytest -q \
+  tests/test_api.py \
+  tests/test_catalog_lineage_endpoint.py \
+  tests/test_semantic_search_feature_flag.py \
+  tests/test_semantic_search_api.py \
+  tests/test_trends_compare_endpoint.py \
+  tests/test_trends_export_csv.py \
+  tests/test_trends_topics_endpoint.py \
+  tests/test_query_builder_parity_search_vs_trends.py \
+  tests/test_search_support_facade.py
+
+# Expected red after adding deletion contracts and before implementation.
+PYTHONPATH=. .venv/bin/pytest -q \
+  tests/test_search_support_facade.py \
+  tests/test_repository_guardrails.py::test_search_helpers_do_not_lookup_api_main
+
+./.venv/bin/ruff check .
+./.venv/bin/ruff format --check . --config ruff-format.toml
+./.venv/bin/mypy
+PYTHONPATH=. .venv/bin/pytest -q tests/test_repository_guardrails.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_api.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_query_builder_filters.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_query_builder_parity_search_vs_trends.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_meilisearch_key_security.py
+PYTHONPATH=. .venv/bin/pytest -q \
+  tests/test_semantic_search_feature_flag.py \
+  tests/test_semantic_search_api.py \
+  tests/test_trends_compare_endpoint.py \
+  tests/test_trends_export_csv.py \
+  tests/test_trends_topics_endpoint.py
+PYTHONPATH=. .venv/bin/python -m pytest -q --cov \
+  --cov-config=.coveragerc \
+  --cov-report=term-missing:skip-covered \
+  tests/
+PYTHONPATH=. .venv/bin/pytest -q
+git diff --check
+git status --short
+```
+
+Run an independent planning review before implementation and a fresh
+pre-commit code review after verification. Resolve every eligible P1/P2 and
+rerun affected commands.
+
+**v) Rollback.** Revert the T-DC-2A merge commit. This restores dynamic lookup
+and test patch paths atomically. Rerun the API/search, guardrail, docs-link,
+coverage, and complete-suite commands above. No migration, data repair, cache
+purge, or external-state restoration is required.
+
+**w) Docs synchronization.** Update `docs/ADR.md` with the direct search-owner
+decision and the boundary left for T-DC-2B. Update the remediation ledger and
+this implementation plan. `ARCHITECTURE.md` remains unchanged because its
+broader `api.main`, `api.search_routes`, and `api.search_support` facade map is
+not retired until T-DC-2B. README, operations, pipeline, security, testing, and
+data-governance docs require no change.
+
+## 7. Delivery Self-Audit
+
+**x) Antipattern scan, diff pass.** Re-run A-F and H. Reject any compatibility
+alias, new dependency injection, duplicated filter/client policy, route or
+query drift, widened ignore, test assertion weakening, unrelated formatting,
+type suppression, or import-time side effect.
+
+**y) Evidence.** Report the baseline characterization, tests-first red result,
+all commands from 6u, exact pass/skip/fail and coverage counts, planning-review
+and pre-commit-review findings, fixes applied, commit hashes, PR URL, review
+thread count, and final CI state. Mark anything unrun as `NOT VERIFIED`.
+
+**z) Deviations.** Expected result is none. Any path outside the exact ownership
+set, route-contract change, feature-flag default change, Meilisearch key or
+client-policy change, compatibility alias, skipped review, unresolved P1/P2,
+or unrun required check is a blocker and must be reported.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -168,7 +168,7 @@ def test_search_endpoint_params(mocker):
     """Test the /search endpoint handles query parameters correctly and builds filters."""
     mock_index = mocker.Mock()
     mock_index.search.return_value = {"hits": [], "estimatedTotalHits": 0}
-    mocker.patch("api.main.client.index", return_value=mock_index)
+    mocker.patch("api.search.support_core.client.index", return_value=mock_index)
     
     # Test with multiple filters (meeting-only by default)
     response = client.get("/search?q=zoning&city=berkeley&meeting_type=Regular&limit=10&offset=5", headers={"X-API-Key": VALID_KEY})
@@ -188,10 +188,17 @@ def test_search_endpoint_params(mocker):
     assert "sort" not in search_params
 
 
-def test_search_semantic_flag_delegates_through_main_facade(mocker):
-    semantic_search = mocker.patch(
-        "api.main.search_documents_semantic",
-        return_value={"hits": [], "estimatedTotalHits": 0, "semantic_diagnostics": {"engine": "faiss"}},
+def test_search_semantic_flag_delegates_to_semantic_service(mocker):
+    mocker.patch("api.search.support_core.SEMANTIC_ENABLED", True)
+    semantic_response = MagicMock(status_code=200)
+    semantic_response.json.return_value = {
+        "hits": [],
+        "estimatedTotalHits": 0,
+        "semantic_diagnostics": {"engine": "faiss"},
+    }
+    semantic_get = mocker.patch(
+        "api.search.semantic_support.httpx.get",
+        return_value=semantic_response,
     )
 
     response = client.get(
@@ -200,23 +207,24 @@ def test_search_semantic_flag_delegates_through_main_facade(mocker):
     )
     assert response.status_code == 200
     assert response.json()["semantic_diagnostics"]["engine"] == "faiss"
-    semantic_search.assert_called_once_with(
-        q="zoning",
-        city="berkeley",
-        include_agenda_items=False,
-        meeting_type="Regular",
-        org=None,
-        date_from=None,
-        date_to=None,
-        limit=10,
-        offset=5,
-    )
+    semantic_params = semantic_get.call_args.kwargs["params"]
+    assert semantic_params == {
+        "q": "zoning",
+        "city": "berkeley",
+        "include_agenda_items": False,
+        "meeting_type": "Regular",
+        "org": None,
+        "date_from": None,
+        "date_to": None,
+        "limit": 10,
+        "offset": 5,
+    }
 
 
 def test_search_endpoint_normalizes_meeting_type_and_org_whitespace(mocker):
     mock_index = mocker.Mock()
     mock_index.search.return_value = {"hits": [], "estimatedTotalHits": 0}
-    mocker.patch("api.main.client.index", return_value=mock_index)
+    mocker.patch("api.search.support_core.client.index", return_value=mock_index)
 
     response = client.get(
         "/search?q=zoning&meeting_type=%20%20Regular%20%20Meeting%20&org=%20City%20%20Council%20",
@@ -231,7 +239,7 @@ def test_search_endpoint_normalizes_meeting_type_and_org_whitespace(mocker):
 
 def test_search_rejects_invalid_city_filter(mocker):
     mock_index = mocker.Mock()
-    mocker.patch("api.main.client.index", return_value=mock_index)
+    mocker.patch("api.search.support_core.client.index", return_value=mock_index)
 
     response = client.get("/search?q=zoning&city=%21%21%21", headers={"X-API-Key": VALID_KEY})
     assert response.status_code == 400
@@ -241,7 +249,7 @@ def test_search_rejects_invalid_city_filter(mocker):
 def test_search_sort_newest_sets_meilisearch_sort(mocker):
     mock_index = mocker.Mock()
     mock_index.search.return_value = {"hits": [], "estimatedTotalHits": 0}
-    mocker.patch("api.main.client.index", return_value=mock_index)
+    mocker.patch("api.search.support_core.client.index", return_value=mock_index)
 
     response = client.get("/search?q=zoning&sort=newest", headers={"X-API-Key": VALID_KEY})
     assert response.status_code == 200
@@ -252,7 +260,7 @@ def test_search_sort_newest_sets_meilisearch_sort(mocker):
 def test_search_sort_oldest_sets_meilisearch_sort(mocker):
     mock_index = mocker.Mock()
     mock_index.search.return_value = {"hits": [], "estimatedTotalHits": 0}
-    mocker.patch("api.main.client.index", return_value=mock_index)
+    mocker.patch("api.search.support_core.client.index", return_value=mock_index)
 
     response = client.get("/search?q=zoning&sort=oldest", headers={"X-API-Key": VALID_KEY})
     assert response.status_code == 200
@@ -263,7 +271,7 @@ def test_search_sort_oldest_sets_meilisearch_sort(mocker):
 def test_search_sort_relevance_does_not_set_meilisearch_sort(mocker):
     mock_index = mocker.Mock()
     mock_index.search.return_value = {"hits": [], "estimatedTotalHits": 0}
-    mocker.patch("api.main.client.index", return_value=mock_index)
+    mocker.patch("api.search.support_core.client.index", return_value=mock_index)
 
     response = client.get("/search?q=zoning&sort=relevance", headers={"X-API-Key": VALID_KEY})
     assert response.status_code == 200
@@ -274,7 +282,7 @@ def test_search_sort_relevance_does_not_set_meilisearch_sort(mocker):
 def test_search_sort_invalid_returns_400(mocker):
     mock_index = mocker.Mock()
     mock_index.search.return_value = {"hits": [], "estimatedTotalHits": 0}
-    mocker.patch("api.main.client.index", return_value=mock_index)
+    mocker.patch("api.search.support_core.client.index", return_value=mock_index)
 
     response = client.get("/search?q=zoning&sort=wat", headers={"X-API-Key": VALID_KEY})
     assert response.status_code == 400
@@ -283,7 +291,7 @@ def test_search_sort_invalid_returns_400(mocker):
 def test_search_sort_rejected_by_meilisearch_returns_actionable_400(mocker):
     mock_index = mocker.Mock()
     mock_index.search.side_effect = MeilisearchError("Attribute `date` is not sortable. Invalid sort.")
-    mocker.patch("api.main.client.index", return_value=mock_index)
+    mocker.patch("api.search.support_core.client.index", return_value=mock_index)
 
     response = client.get("/search?q=zoning&sort=newest", headers={"X-API-Key": VALID_KEY})
     assert response.status_code == 400
@@ -302,7 +310,7 @@ def test_search_truncates_people_metadata_in_hits_and_formatted_hits(mocker):
         ],
         "estimatedTotalHits": 1,
     }
-    mocker.patch("api.main.client.index", return_value=mock_index)
+    mocker.patch("api.search.support_core.client.index", return_value=mock_index)
 
     response = client.get("/search?q=zoning", headers={"X-API-Key": VALID_KEY})
 
@@ -315,7 +323,7 @@ def test_search_truncates_people_metadata_in_hits_and_formatted_hits(mocker):
 def test_search_timeout_returns_503(mocker):
     mock_index = mocker.Mock()
     mock_index.search.side_effect = MeilisearchTimeoutError("timeout")
-    mocker.patch("api.main.client.index", return_value=mock_index)
+    mocker.patch("api.search.support_core.client.index", return_value=mock_index)
 
     response = client.get("/search?q=zoning", headers={"X-API-Key": VALID_KEY})
 
@@ -326,7 +334,7 @@ def test_search_timeout_returns_503(mocker):
 def test_search_unavailable_returns_503(mocker):
     mock_index = mocker.Mock()
     mock_index.search.side_effect = MeilisearchCommunicationError("unavailable")
-    mocker.patch("api.main.client.index", return_value=mock_index)
+    mocker.patch("api.search.support_core.client.index", return_value=mock_index)
 
     response = client.get("/search?q=zoning", headers={"X-API-Key": VALID_KEY})
 
@@ -337,7 +345,7 @@ def test_search_unavailable_returns_503(mocker):
 def test_search_generic_meilisearch_error_returns_500(mocker):
     mock_index = mocker.Mock()
     mock_index.search.side_effect = MeilisearchError("unexpected")
-    mocker.patch("api.main.client.index", return_value=mock_index)
+    mocker.patch("api.search.support_core.client.index", return_value=mock_index)
 
     response = client.get("/search?q=zoning", headers={"X-API-Key": VALID_KEY})
 
@@ -351,7 +359,7 @@ def test_search_injection_protection(mocker):
     """
     mock_index = mocker.Mock()
     mock_index.search.return_value = {"hits": []}
-    mocker.patch("api.main.client.index", return_value=mock_index)
+    mocker.patch("api.search.support_core.client.index", return_value=mock_index)
     
     # Attempt a "Quote Escape" attack in the city parameter
     malicious_city = 'berkeley" OR 1=1 OR city="'
@@ -453,7 +461,6 @@ def test_task_status_rejects_invalid_uuid():
 def test_lineage_endpoint_not_gated_by_trends_flag(mocker):
     from api.main import get_db
 
-    mocker.patch("api.main.FEATURE_TRENDS_DASHBOARD", False)
     rows = [
         (
             MagicMock(id=101, lineage_id="lin-101", lineage_confidence=0.8, lineage_updated_at=None, summary="Summary"),

--- a/tests/test_catalog_lineage_endpoint.py
+++ b/tests/test_catalog_lineage_endpoint.py
@@ -7,8 +7,6 @@ from api.main import app, get_db
 
 
 def test_catalog_lineage_endpoint_returns_thread(mocker):
-    mocker.patch("api.main.FEATURE_TRENDS_DASHBOARD", False)
-
     db = MagicMock()
     db.get.return_value = SimpleNamespace(id=101, lineage_id="lin-101", lineage_confidence=0.8)
     rows = [

--- a/tests/test_query_builder_parity_search_vs_trends.py
+++ b/tests/test_query_builder_parity_search_vs_trends.py
@@ -1,4 +1,4 @@
-from api.main import _build_meilisearch_filter_clauses
+from api.search.filter_support import _build_meilisearch_filter_clauses
 from api.search.query_builder import build_meili_filter_clauses, normalize_filters
 
 

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -585,6 +585,114 @@ def _forbidden_imports(module_path: Path, forbidden_modules: set[str]) -> list[s
     return found_imports
 
 
+def _dotted_reference(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if not isinstance(node, ast.Attribute):
+        return None
+    parent_reference = _dotted_reference(node.value)
+    if parent_reference is None:
+        return None
+    return f"{parent_reference}.{node.attr}"
+
+
+def _search_main_import_context(
+    test_tree: ast.AST,
+    forbidden_names: set[str],
+) -> tuple[set[str], set[str]]:
+    main_module_bindings: set[str] = set()
+    references: set[str] = set()
+    for node in ast.walk(test_tree):
+        if isinstance(node, ast.Import):
+            main_module_bindings.update(
+                alias.asname or "api.main"
+                for alias in node.names
+                if alias.name == "api.main"
+            )
+        elif isinstance(node, ast.ImportFrom) and node.module == "api":
+            main_module_bindings.update(
+                alias.asname or alias.name
+                for alias in node.names
+                if alias.name == "main"
+            )
+        elif isinstance(node, ast.ImportFrom) and node.module == "api.main":
+            references.update(
+                f"line {node.lineno}: import {alias.name}"
+                for alias in node.names
+                if alias.name in forbidden_names
+            )
+    return main_module_bindings, references
+
+
+def _search_main_object_patch_reference(
+    node: ast.AST,
+    main_module_bindings: set[str],
+    forbidden_names: set[str],
+) -> str | None:
+    if not isinstance(node, ast.Call):
+        return None
+    patch_function = _dotted_reference(node.func) or ""
+    is_object_patch = patch_function.endswith("patch.object")
+    is_setattr_patch = patch_function == "setattr" or patch_function.endswith(
+        ".setattr"
+    )
+    if not is_object_patch and not is_setattr_patch:
+        return None
+    if (
+        len(node.args) < 2
+        or _dotted_reference(node.args[0]) not in main_module_bindings
+    ):
+        return None
+    patch_name = node.args[1]
+    if not isinstance(patch_name, ast.Constant) or patch_name.value not in forbidden_names:
+        return None
+    patch_operation = "patch.object" if is_object_patch else "setattr"
+    return f"line {node.lineno}: {patch_operation} {patch_name.value}"
+
+
+def _search_main_alias_references(
+    test_path: Path,
+    forbidden_names: set[str],
+) -> list[str]:
+    test_tree = ast.parse(
+        test_path.read_text(encoding="utf-8"),
+        filename=str(test_path),
+    )
+    main_module_bindings, references = _search_main_import_context(
+        test_tree,
+        forbidden_names,
+    )
+
+    forbidden_references = {
+        f"{module_binding}.{forbidden_name}"
+        for module_binding in main_module_bindings
+        for forbidden_name in forbidden_names
+    }
+    forbidden_references.update(
+        f"api.main.{forbidden_name}" for forbidden_name in forbidden_names
+    )
+
+    for node in ast.walk(test_tree):
+        dotted_reference = _dotted_reference(node)
+        if dotted_reference in forbidden_references:
+            references.add(f"line {node.lineno}: {dotted_reference}")
+        if (
+            isinstance(node, ast.Constant)
+            and isinstance(node.value, str)
+            and node.value in forbidden_references
+        ):
+            references.add(f"line {node.lineno}: {node.value}")
+        patch_reference = _search_main_object_patch_reference(
+            node,
+            main_module_bindings,
+            forbidden_names,
+        )
+        if patch_reference is not None:
+            references.add(patch_reference)
+
+    return sorted(references)
+
+
 def _top_level_sync_function_lines(module_path: Path) -> list[int]:
     module_tree = ast.parse(
         module_path.read_text(encoding="utf-8"),
@@ -1726,6 +1834,124 @@ def test_provider_compatibility_facade_is_deleted() -> None:
 
     assert not deleted_facade.exists()
     assert remaining_imports == {}
+
+
+def test_search_helpers_do_not_lookup_api_main() -> None:
+    lookup_names = {"_api_main", "facade_value", "facade_callable", "search_client"}
+    main_search_aliases = {
+        "client",
+        "_build_meilisearch_filter_clauses",
+        "_collect_meeting_docs",
+        "_semantic_service_get_json",
+        "search_documents_semantic",
+        "SEMANTIC_ENABLED",
+        "FEATURE_TRENDS_DASHBOARD",
+    }
+    support_core_path = ROOT / "api/search/support_core.py"
+    support_core_tree = ast.parse(support_core_path.read_text(encoding="utf-8"))
+    support_core_functions = {
+        node.name
+        for node in support_core_tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+
+    search_support_path = ROOT / "api/search_support.py"
+    search_support_tree = ast.parse(search_support_path.read_text(encoding="utf-8"))
+    search_support_imports = {
+        alias.name
+        for node in search_support_tree.body
+        if isinstance(node, (ast.Import, ast.ImportFrom))
+        for alias in node.names
+    }
+
+    api_main_path = ROOT / "api/main.py"
+    api_main_tree = ast.parse(api_main_path.read_text(encoding="utf-8"))
+    api_main_imports = {
+        alias.name
+        for node in api_main_tree.body
+        if isinstance(node, (ast.Import, ast.ImportFrom))
+        for alias in node.names
+    }
+
+    search_helper_paths = sorted((ROOT / "api/search").rglob("*.py"))
+    search_helper_paths.extend(sorted((ROOT / "api").glob("search_*.py")))
+    search_helper_paths.append(ROOT / "api/trends_routes.py")
+    reverse_imports = {
+        str(search_helper_path.relative_to(ROOT)): forbidden_imports
+        for search_helper_path in search_helper_paths
+        if (
+            forbidden_imports := _forbidden_imports(
+                search_helper_path,
+                {"api.main"},
+            )
+        )
+    }
+
+    stale_test_patches = {
+        str(test_path.relative_to(ROOT)): alias_references
+        for test_path in _tracked_files()
+        if test_path.suffix == ".py"
+        and test_path.relative_to(ROOT).parts[0] == "tests"
+        and (
+            alias_references := _search_main_alias_references(
+                test_path,
+                main_search_aliases,
+            )
+        )
+    }
+
+    assert lookup_names.isdisjoint(support_core_functions)
+    assert lookup_names.isdisjoint(search_support_imports)
+    assert main_search_aliases.isdisjoint(api_main_imports)
+    assert reverse_imports == {}
+    assert _forbidden_imports(
+        ROOT / "api/search_read_meilisearch.py",
+        {"api.search_support"},
+    ) == []
+    assert stale_test_patches == {}
+
+
+def test_search_main_alias_guard_covers_import_and_object_patch_forms(
+    tmp_path: Path,
+) -> None:
+    test_path = tmp_path / "test_stale_search_patches.py"
+    test_path.write_text(
+        "\n".join(
+            (
+                "import api.main",
+                "import api.main as api_main",
+                "from api import main as assembled_api",
+                "from api.main import client as reader_client",
+                "api.main" + ".SEMANTIC_ENABLED",
+                "api_main._collect_meeting_docs",
+                'mocker.patch("api.main.search_documents_semantic")',
+                'mocker.patch.object(assembled_api, "FEATURE_TRENDS_DASHBOARD")',
+                'monkeypatch.setattr(api_main, "client", replacement)',
+                "from api.main import app",
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    alias_references = _search_main_alias_references(
+        test_path,
+        {
+            "client",
+            "_collect_meeting_docs",
+            "search_documents_semantic",
+            "SEMANTIC_ENABLED",
+            "FEATURE_TRENDS_DASHBOARD",
+        },
+    )
+
+    assert alias_references == [
+        "line 4: import client",
+        "line 5: api.main.SEMANTIC_ENABLED",
+        "line 6: api_main._collect_meeting_docs",
+        "line 7: api.main.search_documents_semantic",
+        "line 8: patch.object FEATURE_TRENDS_DASHBOARD",
+        "line 9: setattr client",
+    ]
 
 
 def test_sync_global_guardrail_detects_top_level_functions(

--- a/tests/test_search_support_facade.py
+++ b/tests/test_search_support_facade.py
@@ -1,27 +1,12 @@
 import api.search_support as search_support
 
 
-def test_search_support_facade_preserves_route_patch_points():
-    expected_names = {
-        "client",
-        "httpx",
+def test_search_support_does_not_export_main_patch_lookups() -> None:
+    removed_lookup_names = {
         "search_client",
         "facade_callable",
         "facade_value",
-        "validate_date_format",
-        "_build_filter_values",
-        "_build_meilisearch_filter_clauses",
-        "_collect_meeting_docs",
-        "_count_topics_from_docs",
-        "_facet_topics",
-        "_iter_time_buckets",
-        "_normalize_city_or_400",
-        "_normalize_filters_or_400",
-        "_parse_iso_date",
-        "_require_trends_feature",
-        "_semantic_service_get_json",
-        "_semantic_service_healthcheck",
+        "_api_main",
     }
 
-    for name in expected_names:
-        assert hasattr(search_support, name), name
+    assert all(not hasattr(search_support, name) for name in removed_lookup_names)

--- a/tests/test_semantic_search_api.py
+++ b/tests/test_semantic_search_api.py
@@ -3,24 +3,23 @@ from unittest.mock import MagicMock
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
-import api.search_routes as search_routes
+from api.search import semantic_support
 from api.main import app, get_db
 
 VALID_KEY = "dev_secret_key_change_me"
 
 
 def test_semantic_search_success_with_filters(mocker):
-    mocker.patch("api.main.SEMANTIC_ENABLED", True)
-    mocker.patch(
-        "api.main._semantic_service_get_json",
-        return_value={
-            "hits": [{"id": "doc_10", "db_id": 10, "result_type": "meeting", "event_name": "Cupertino Meeting", "semantic_score": 0.9}],
-            "estimatedTotalHits": 1,
-            "limit": 20,
-            "offset": 0,
-            "semantic_diagnostics": {"engine": "faiss"},
-        },
-    )
+    mocker.patch("api.search.support_core.SEMANTIC_ENABLED", True)
+    response = MagicMock(status_code=200)
+    response.json.return_value = {
+        "hits": [{"id": "doc_10", "db_id": 10, "result_type": "meeting", "event_name": "Cupertino Meeting", "semantic_score": 0.9}],
+        "estimatedTotalHits": 1,
+        "limit": 20,
+        "offset": 0,
+        "semantic_diagnostics": {"engine": "faiss"},
+    }
+    mocker.patch("api.search.semantic_support.httpx.get", return_value=response)
     client = TestClient(app)
     resp = client.get("/search/semantic?q=zoning&city=cupertino", headers={"X-API-Key": VALID_KEY})
     assert resp.status_code == 200
@@ -31,14 +30,12 @@ def test_semantic_search_success_with_filters(mocker):
 
 
 def test_semantic_search_missing_artifacts_returns_503(mocker):
-    mocker.patch("api.main.SEMANTIC_ENABLED", True)
-    mocker.patch(
-        "api.main._semantic_service_get_json",
-        side_effect=HTTPException(
-            status_code=503,
-            detail="Semantic index artifacts are missing. Run `docker compose run --rm semantic python ../pipeline/reindex_semantic.py` and retry.",
-        ),
-    )
+    mocker.patch("api.search.support_core.SEMANTIC_ENABLED", True)
+    response = MagicMock(status_code=503)
+    response.json.return_value = {
+        "detail": "Semantic index artifacts are missing. Run `docker compose run --rm semantic python ../pipeline/reindex_semantic.py` and retry."
+    }
+    mocker.patch("api.search.semantic_support.httpx.get", return_value=response)
     client = TestClient(app)
     resp = client.get("/search/semantic?q=zoning", headers={"X-API-Key": VALID_KEY})
     assert resp.status_code == 503
@@ -49,10 +46,10 @@ def test_semantic_service_error_forwards_non_dict_json_detail(mocker):
     response = MagicMock()
     response.status_code = 502
     response.json.return_value = ["semantic", "error"]
-    mocker.patch("api.search_routes.httpx.get", return_value=response)
+    mocker.patch("api.search.semantic_support.httpx.get", return_value=response)
 
     try:
-        search_routes._semantic_service_get_json("/search/semantic", {"q": "zoning"})
+        semantic_support._semantic_service_get_json("/search/semantic", {"q": "zoning"})
     except HTTPException as exc:
         assert exc.status_code == 502
         assert exc.detail == ["semantic", "error"]

--- a/tests/test_semantic_search_feature_flag.py
+++ b/tests/test_semantic_search_feature_flag.py
@@ -10,7 +10,7 @@ VALID_KEY = "dev_secret_key_change_me"
 def test_semantic_search_disabled_returns_503(mocker):
     db = MagicMock()
     app.dependency_overrides[get_db] = lambda: db
-    mocker.patch("api.main.SEMANTIC_ENABLED", False)
+    mocker.patch("api.search.support_core.SEMANTIC_ENABLED", False)
     client = TestClient(app)
     try:
         resp = client.get("/search/semantic?q=zoning", headers={"X-API-Key": VALID_KEY})

--- a/tests/test_trends_compare_endpoint.py
+++ b/tests/test_trends_compare_endpoint.py
@@ -4,20 +4,30 @@ from api.main import app
 
 
 def test_trends_compare_returns_bucketed_series(mocker):
-    mocker.patch("api.main.FEATURE_TRENDS_DASHBOARD", True)
-    mocker.patch(
-        "api.main._collect_meeting_docs",
-        side_effect=[
-            [
-                {"date": "2025-01-12", "topics": ["housing", "zoning"], "city": "ca_berkeley"},
-                {"date": "2025-02-12", "topics": ["housing"], "city": "ca_berkeley"},
-            ],
-            [
+    mocker.patch("api.search.support_core.FEATURE_TRENDS_DASHBOARD", True)
+    mock_index = mocker.Mock()
+
+    def search_meetings(_query, search_params):
+        if 'city = "ca_berkeley"' in search_params["filter"]:
+            return {
+                "hits": [
+                    {"date": "2024-12-31", "topics": ["parks"], "city": "ca_berkeley"},
+                    {"date": "2025-01-12", "topics": ["housing", "zoning"], "city": "ca_berkeley"},
+                    {"date": "2025-02-12", "topics": ["housing"], "city": "ca_berkeley"},
+                    {"date": "2025-03-01", "topics": ["water"], "city": "ca_berkeley"},
+                ]
+            }
+        return {
+            "hits": [
+                {"date": "2024-12-20", "topics": ["parks"], "city": "ca_cupertino"},
                 {"date": "2025-01-20", "topics": ["housing"], "city": "ca_cupertino"},
                 {"date": "2025-02-03", "topics": ["zoning"], "city": "ca_cupertino"},
-            ],
-        ],
-    )
+                {"date": "2025-03-05", "topics": ["water"], "city": "ca_cupertino"},
+            ]
+        }
+
+    mock_index.search.side_effect = search_meetings
+    mocker.patch("api.search.support_core.client.index", return_value=mock_index)
     client = TestClient(app)
 
     resp = client.get(
@@ -27,5 +37,16 @@ def test_trends_compare_returns_bucketed_series(mocker):
     data = resp.json()
     assert data["granularity"] == "month"
     assert data["topics"] == ["housing", "zoning"]
-    assert len(data["series"]) >= 2
-    assert all("city" in row and "topics" in row for row in data["series"])
+    assert data["series"] == [
+        {"city": "ca_berkeley", "bucket": "2025-01-01", "topics": {"housing": 1, "zoning": 1}},
+        {"city": "ca_berkeley", "bucket": "2025-02-01", "topics": {"housing": 1, "zoning": 0}},
+        {"city": "ca_cupertino", "bucket": "2025-01-01", "topics": {"housing": 1, "zoning": 0}},
+        {"city": "ca_cupertino", "bucket": "2025-02-01", "topics": {"housing": 0, "zoning": 1}},
+    ]
+    search_params = [search_call.args[1] for search_call in mock_index.search.call_args_list]
+    assert {tuple(params["filter"]) for params in search_params} == {
+        ('result_type = "meeting"', 'city = "ca_berkeley"'),
+        ('result_type = "meeting"', 'city = "ca_cupertino"'),
+    }
+    assert all(params["limit"] == 200 and params["offset"] == 0 for params in search_params)
+    assert all(params["attributesToRetrieve"] == ["topics", "date", "city"] for params in search_params)

--- a/tests/test_trends_export_csv.py
+++ b/tests/test_trends_export_csv.py
@@ -4,12 +4,12 @@ from api.main import app
 
 
 def test_trends_export_csv(mocker):
-    mocker.patch("api.main.FEATURE_TRENDS_DASHBOARD", True)
+    mocker.patch("api.search.support_core.FEATURE_TRENDS_DASHBOARD", True)
     mock_index = mocker.Mock()
     mock_index.search.return_value = {
         "facetDistribution": {"topics": {"housing": 4, "budget": 2}}
     }
-    mocker.patch("api.main.client.index", return_value=mock_index)
+    mocker.patch("api.search.support_core.client.index", return_value=mock_index)
     client = TestClient(app)
 
     resp = client.get("/trends/export?format=csv&city=berkeley")

--- a/tests/test_trends_topics_endpoint.py
+++ b/tests/test_trends_topics_endpoint.py
@@ -4,7 +4,7 @@ from api.main import app
 
 
 def test_trends_topics_returns_facet_distribution(mocker):
-    mocker.patch("api.main.FEATURE_TRENDS_DASHBOARD", True)
+    mocker.patch("api.search.support_core.FEATURE_TRENDS_DASHBOARD", True)
     mock_index = mocker.Mock()
     mock_index.search.return_value = {
         "facetDistribution": {
@@ -14,7 +14,7 @@ def test_trends_topics_returns_facet_distribution(mocker):
             }
         }
     }
-    mocker.patch("api.main.client.index", return_value=mock_index)
+    mocker.patch("api.search.support_core.client.index", return_value=mock_index)
     client = TestClient(app)
     resp = client.get("/trends/topics?city=berkeley&limit=1")
     assert resp.status_code == 200
@@ -24,7 +24,7 @@ def test_trends_topics_returns_facet_distribution(mocker):
 
 
 def test_trends_topics_feature_flag_disabled(mocker):
-    mocker.patch("api.main.FEATURE_TRENDS_DASHBOARD", False)
+    mocker.patch("api.search.support_core.FEATURE_TRENDS_DASHBOARD", False)
     client = TestClient(app)
     resp = client.get("/trends/topics")
     assert resp.status_code == 503


### PR DESCRIPTION
## What changed
- deleted `_api_main`, `facade_value`, `facade_callable`, and `search_client`
- removed seven search-only patch aliases from `api.main`
- moved lexical, semantic, and trends callers to direct implementation owners
- repointed tests to Meilisearch, outbound HTTP, and implementation-owned feature flags
- added AST guardrails for stale imports, string patches, `patch.object`, and `setattr`
- recorded the accepted ADR and T-DC-2A completion

## Why
The lookup layer existed only to preserve historical monkeypatch targets. It created a reverse dependency from search helpers to application assembly and hid the actual runtime owners.

## Risk and compatibility
Route paths, query parameters, responses, feature behavior, pagination, filters, authentication, and Meilisearch key policy are unchanged. The only intentional compatibility break is removal of internal `api.main` test patch targets.

Trust boundary: `api/search/support_core.py` still resolves the reader-only Meilisearch key and constructs the same client with the same host and timeout. No credential, permission, or exposure change occurs.

## Verification
- PASS: `./.venv/bin/ruff check .`
- PASS: `./.venv/bin/ruff format --check . --config ruff-format.toml`
- PASS: `./.venv/bin/mypy`
- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_repository_guardrails.py tests/test_docs_links.py` (548 passed)
- PASS: focused API/search/security suite (92 passed)
- PASS: `PYTHONPATH=. .venv/bin/pytest -q` (1,774 passed, 20 skipped)
- PASS: coverage suite (83.03%, required 71%)

## Remaining work
T-DC-2B remains pending for the broader router facade bags.