### PR TITLE
T-SEM-1A: Approve semantic test boundary

### DIFF
--- a/docs/TESTING.MD
+++ b/docs/TESTING.MD
@@ -27,7 +27,7 @@ invented for tests.
 | Celery dispatch       | Patch `api.task_dispatch.celery_app.send_task` or use Celery eager mode |
 | Celery result backend | Patch `api.task_route_support.AsyncResult`                  |
 | Inference / LLM       | Fake provider implementing `pipeline/inference_provider_contract.py` |
-| Semantic backend/runtime | Patch `pipeline.semantic_backend_runtime.get_semantic_backend` to return a fake implementing `pipeline.semantic_backend_types.SemanticBackend`; after T-SEM-1 moves optional FAISS and SentenceTransformer ownership there, substitute those adapters only in that module; never patch backend private methods |
+| Semantic backend/runtime | Patch `pipeline.semantic_backend_runtime.get_semantic_backend` to return a fake implementing `pipeline.semantic_backend_types.SemanticBackend`; pgvector retrieval fakes also implement the public `rerank_candidates_with_diagnostics` or `rerank_candidates` capability exercised by the test; after T-SEM-1 moves optional FAISS and SentenceTransformer ownership there, substitute those adapters only in that module; never patch backend private methods |
 | Meilisearch           | Patch the client object where it is constructed (`api/search/support_core.py`, `pipeline/indexer.py`) |
 | Outbound HTTP         | `httpx`/`requests` transport mocks at the call site      |
 | Clock                 | Pass/patch time at the function under test, not globally |

--- a/docs/TESTING.MD
+++ b/docs/TESTING.MD
@@ -27,7 +27,7 @@ invented for tests.
 | Celery dispatch       | Patch `api.task_dispatch.celery_app.send_task` or use Celery eager mode |
 | Celery result backend | Patch `api.task_route_support.AsyncResult`                  |
 | Inference / LLM       | Fake provider implementing `pipeline/inference_provider_contract.py` |
-| Semantic backend/runtime | Patch `pipeline.semantic_backend_runtime.get_semantic_backend` to return a fake implementing `pipeline.semantic_backend_types.SemanticBackend`; pgvector retrieval fakes also implement the public `rerank_candidates_with_diagnostics` or `rerank_candidates` capability exercised by the test; after T-SEM-1 moves optional FAISS and SentenceTransformer ownership there, substitute those adapters only in that module; never patch backend private methods |
+| Semantic backend/runtime | After T-SEM-1 repoints consumers to resolve backend selection through the owner module, patch `pipeline.semantic_backend_runtime.get_semantic_backend` to return a fake implementing `pipeline.semantic_backend_types.SemanticBackend`; pgvector retrieval fakes also implement the public `rerank_candidates_with_diagnostics` or `rerank_candidates` capability exercised by the test; after T-SEM-1 moves optional FAISS and SentenceTransformer ownership there, substitute those adapters only in that module; never patch backend private methods |
 | Meilisearch           | Patch the client object where it is constructed (`api/search/support_core.py`, `pipeline/indexer.py`) |
 | Outbound HTTP         | `httpx`/`requests` transport mocks at the call site      |
 | Clock                 | Pass/patch time at the function under test, not globally |

--- a/docs/TESTING.MD
+++ b/docs/TESTING.MD
@@ -27,6 +27,7 @@ invented for tests.
 | Celery dispatch       | Patch `api.task_dispatch.celery_app.send_task` or use Celery eager mode |
 | Celery result backend | Patch `api.task_route_support.AsyncResult`                  |
 | Inference / LLM       | Fake provider implementing `pipeline/inference_provider_contract.py` |
+| Semantic backend/runtime | Patch `pipeline.semantic_backend_runtime.get_semantic_backend` to return a fake implementing `pipeline.semantic_backend_types.SemanticBackend`; after T-SEM-1 moves optional FAISS and SentenceTransformer ownership there, substitute those adapters only in that module; never patch backend private methods |
 | Meilisearch           | Patch the client object where it is constructed (`api/search/support_core.py`, `pipeline/indexer.py`) |
 | Outbound HTTP         | `httpx`/`requests` transport mocks at the call site      |
 | Clock                 | Pass/patch time at the function under test, not globally |

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,6 +1,6 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 3.95
+version: 3.96
 generated: 2026-07-26
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
@@ -10,6 +10,8 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v3.96:** Extends T-SEM-1A's approved fake contract to include the public
+  pgvector reranking capability consumed by semantic retrieval tests.
 - **v3.95:** Adds T-SEM-1A as a separate policy prerequisite that approves the
   typed semantic backend/runtime fake boundary required before T-SEM-1 can
   delete facade patch points. T-SEM-1 remains pending its corrected Full plan.
@@ -1538,7 +1540,9 @@ files (GED-5 grant).
 - files_owned: `docs/plans/T_SEM_1A_SEMANTIC_TEST_BOUNDARY_PLAN.md`;
   `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`; `docs/TESTING.MD`
 - do: Approve patching `semantic_backend_runtime.get_semantic_backend` to
-  return a `SemanticBackend` fake, then permit optional FAISS and
+  return a `SemanticBackend` fake; pgvector retrieval fakes also implement the
+  public `rerank_candidates_with_diagnostics` or `rerank_candidates`
+  capability exercised by the test. Permit optional FAISS and
   SentenceTransformer substitution there only after T-SEM-1 establishes that
   ownership.
 - preserve: Every existing approved fake boundary and the prohibition on

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,6 +1,6 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 3.94
+version: 3.95
 generated: 2026-07-26
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
@@ -10,6 +10,9 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v3.95:** Adds T-SEM-1A as a separate policy prerequisite that approves the
+  typed semantic backend/runtime fake boundary required before T-SEM-1 can
+  delete facade patch points. T-SEM-1 remains pending its corrected Full plan.
 - **v3.94:** Completes T-TASK-1 after deleting the task facade helper layer,
   global dependency bags, callable injection, the agenda segmentation service
   bag, and obsolete task-level provider catches. Celery identities, retry
@@ -438,7 +441,7 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 | State | Tasks |
 |---|---|
 | **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2, T-SEC-3, T-SEC-3C, T-SEC-4, T-SEC-4A, T-SEC-5, T-SEC-6, T-TIME-1, T-TIME-2, T-TIME-3, T-CRAWL-1, T-CRAWL-2, T-PLAT-1, T-PLAT-1A, T-PLAT-2, T-PLAT-2A, T-PLAT-2B, T-PLAT-2C, T-PLAT-3, T-PLAT-4, T-GOV-1, T-GOV-2, T-GOV-2A, T-GOV-3, T-GOV-3A, T-GOV-3B, T-GOV-4, T-GOV-5, T-GOV-6, T-DA-1, T-DB-1A, T-DB-1, T-DB-1B, T-DC-1, T-DC-2A, T-DC-2B, T-DD-1A, T-DD-1B, T-DE-1, T-DE-2, T-TASK-1 |
-| **In progress** | None |
+| **In progress** | T-SEM-1A |
 | **Pending** | T-SEM-1, T-IDX-1, T-FE-1 |
 
 ---
@@ -1527,10 +1530,27 @@ files (GED-5 grant).
 - forbidden: Task identity drift, new wrappers or compatibility exports,
   orchestration redesign, or implementation without exact ownership.
 
+### T-SEM-1A: Approve the semantic test boundary
+- priority: P1 prerequisite
+- status: in progress under
+  [T-SEM-1A implementation plan](T_SEM_1A_SEMANTIC_TEST_BOUNDARY_PLAN.md)
+- depends_on: G3 (satisfied by T-GOV-1)
+- files_owned: `docs/plans/T_SEM_1A_SEMANTIC_TEST_BOUNDARY_PLAN.md`;
+  `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`; `docs/TESTING.MD`
+- do: Approve patching `semantic_backend_runtime.get_semantic_backend` to
+  return a `SemanticBackend` fake, then permit optional FAISS and
+  SentenceTransformer substitution there only after T-SEM-1 establishes that
+  ownership.
+- preserve: Every existing approved fake boundary and the prohibition on
+  facade/private-method patch targets.
+- accept: T-SEM-1 can migrate semantic tests without preserving facade seams.
+- forbidden: Production changes, a fixture framework, private-method fakes, or
+  implementation mixed into this policy PR.
+
 ### T-SEM-1: Delete reverse semantic-index facade lookups
 - priority: P2
-- status: pending Full plan and exact ownership
-- depends_on: G3 (satisfied by T-GOV-1)
+- status: pending corrected Full plan and exact ownership after T-SEM-1A
+- depends_on: G3 (satisfied by T-GOV-1), T-SEM-1A
 - files_owned: to be named in a separate Full plan before implementation
 - do: Delete `_semantic_index_facade` lookups and implementation-callable
   exposure across semantic backends, row builders, artifact handling,
@@ -2175,7 +2195,7 @@ Gate:    G3 satisfied (T-GOV-1 Accepted ADR + active docs/TESTING.MD)
 Phase 2: completed foundations [T-DA-1, T-DB-1A, T-DB-1, T-DB-1B,
          T-DC-1, T-DD-1A, T-DD-1B, T-DE-1]
 Next:    Serialize each task's Full-plan registration through this ledger.
-         T-SEM-1 is next and requires its separate ownership review.
+         T-SEM-1A is active; T-SEM-1 follows after its policy prerequisite.
 Phase 3: agent-plat [T-PLAT-1 after T-TIME-1 and T-TIME-2, T-PLAT-1A
          closure, T-PLAT-2B security patch, then T-PLAT-2..4; complete]
          || agent-gov [T-GOV-2 policy and T-GOV-2A runtime enforcement

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -10,8 +10,9 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
-- **v3.96:** Extends T-SEM-1A's approved fake contract to include the public
-  pgvector reranking capability consumed by semantic retrieval tests.
+- **v3.96:** Extends T-SEM-1A's future-effective fake contract to include the
+  public pgvector reranking capability consumed by semantic retrieval tests
+  and records that T-SEM-1 must make consumers resolve the runtime owner.
 - **v3.95:** Adds T-SEM-1A as a separate policy prerequisite that approves the
   typed semantic backend/runtime fake boundary required before T-SEM-1 can
   delete facade patch points. T-SEM-1 remains pending its corrected Full plan.
@@ -1539,12 +1540,13 @@ files (GED-5 grant).
 - depends_on: G3 (satisfied by T-GOV-1)
 - files_owned: `docs/plans/T_SEM_1A_SEMANTIC_TEST_BOUNDARY_PLAN.md`;
   `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`; `docs/TESTING.MD`
-- do: Approve patching `semantic_backend_runtime.get_semantic_backend` to
-  return a `SemanticBackend` fake; pgvector retrieval fakes also implement the
-  public `rerank_candidates_with_diagnostics` or `rerank_candidates`
-  capability exercised by the test. Permit optional FAISS and
-  SentenceTransformer substitution there only after T-SEM-1 establishes that
-  ownership.
+- do: After T-SEM-1 repoints consumers to resolve backend selection through
+  the owner module, approve patching
+  `semantic_backend_runtime.get_semantic_backend` to return a
+  `SemanticBackend` fake. Pgvector retrieval fakes also implement the public
+  `rerank_candidates_with_diagnostics` or `rerank_candidates` capability
+  exercised by the test. Permit optional FAISS and SentenceTransformer
+  substitution there only after T-SEM-1 establishes that ownership.
 - preserve: Every existing approved fake boundary and the prohibition on
   facade/private-method patch targets.
 - accept: T-SEM-1 can migrate semantic tests without preserving facade seams.

--- a/docs/plans/T_SEM_1A_SEMANTIC_TEST_BOUNDARY_PLAN.md
+++ b/docs/plans/T_SEM_1A_SEMANTIC_TEST_BOUNDARY_PLAN.md
@@ -1,0 +1,152 @@
+# T-SEM-1A: Approve the Semantic Test Boundary
+
+## 1. Context & Alignment
+
+**a) Driver.** T-SEM-1 must delete the semantic facade and repoint service
+tests without preserving facade patch points. Those tests need to substitute a
+semantic backend or optional model runtime, but `docs/TESTING.MD` does not yet
+list that architectural boundary. Its policy requires boundary additions to
+land in a separate PR, so T-SEM-1A records the narrow boundary first.
+
+**b) Canonical documents consulted.**
+
+- `AGENTS.md` requires implementation-module patching, separate policy and
+  implementation changes, docs verification, and exact evidence.
+- `docs/TESTING.MD` requires an independent policy update before adding a fake
+  boundary.
+- `docs/ENGINEERING_GUARDRAILS.md` keeps test policy and static enforcement
+  separate.
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md` makes G3 effective and defines
+  T-SEM-1 as the next facade deletion.
+- `SECURITY.md` and `docs/DATA_GOVERNANCE.md` impose no additional constraint
+  because this is test policy only.
+
+**c) Remediation alignment.** T-SEM-1A owns exactly:
+
+- `docs/plans/T_SEM_1A_SEMANTIC_TEST_BOUNDARY_PLAN.md`
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`
+- `docs/TESTING.MD`
+
+T-SEM-1 remains pending and owns no implementation file until its corrected
+Full plan lands after this prerequisite.
+
+**d) Decision-gate check.** G3 is satisfied by T-GOV-1. This policy update is
+the separate approval mechanism required by `docs/TESTING.MD`; it does not
+depend on or foreclose G1, G2, G4, or G5.
+
+## 2. Design
+
+**e) Step-by-step approach.**
+
+1. Register T-SEM-1A before T-SEM-1 in the remediation ledger.
+2. Add one approved fake-boundary row for semantic backend/runtime behavior.
+3. Permit patching `pipeline.semantic_backend_runtime.get_semantic_backend` to
+   return a fake implementing the existing `SemanticBackend` contract.
+4. Permit optional FAISS and SentenceTransformer substitution only after
+   T-SEM-1 moves their ownership to `pipeline.semantic_backend_runtime`.
+5. Explicitly prohibit patching backend private methods.
+6. Keep database, filesystem, Meilisearch, HTTP, clock, and inference rows
+   unchanged.
+7. Verify docs links, review independently, commit, push, merge, then return to
+   a corrected T-SEM-1 Full plan.
+
+No runtime code, test seam, helper, environment variable, or dependency is
+added.
+
+**f) Reuse audit.** Reuse the existing `SemanticBackend` typed contract and
+the current approved-boundary table. No second testing policy, adapter class,
+fixture framework, or compatibility layer is introduced.
+
+**g) Data contracts.** The existing `SemanticBackend` contract remains
+unchanged. The policy authorizes substitution; it does not alter the contract.
+
+**h) Schema/migration impact.** None.
+
+## 3. Security & Data Governance
+
+**i) Security-sensitive paths.** None. Production credentials, endpoints,
+dependencies, and execution permissions are unchanged.
+
+**j) Secrets.** None.
+
+**k) Person data.** None.
+
+**l) Untrusted input.** None is newly parsed or rendered.
+
+## 4. Code Health
+
+**m) GED conformance sweep.** This is a three-file policy-only change. It adds
+no code, errors, timestamps, literals, environment reads, or runtime imports.
+
+**n) Antipattern scan, plan pass.**
+
+- A1/H1: `SemanticBackend` and `semantic_backend_runtime` exist in the checked
+  in code; no external API assumption is introduced.
+- B1-B3/F1-F2: no wrapper, registry, fixture framework, or duplicate policy.
+- C1-C2: the boundary exists to let T-SEM-1 delete, not preserve, facade patch
+  points.
+- D1-D3: no test is skipped, weakened, or rewritten in this PR.
+- E1-E3: only the three owned docs change.
+- A2-A4 and H2-H4: no violation.
+
+**o) Ratchet interaction.** No Ruff, Mypy, coverage, formatter, BLE001, or
+workflow setting changes.
+
+**p) Dead code and duplication audit.** None in this policy prerequisite.
+T-SEM-1 remains responsible for deleting the facade and old patch targets.
+
+## 5. Testing
+
+**q) Edge cases and failure scenarios.**
+
+1. The boundary must name the typed backend contract and runtime selection
+   function, not a facade.
+2. Optional runtime substitutions must remain future-effective until T-SEM-1
+   establishes the named direct owner.
+3. The row must not authorize patching backend private methods.
+4. Existing approved boundaries must remain unchanged.
+5. Links between the ledger, plan, and testing policy must resolve.
+
+**r) Tests added or updated.** No test code changes. `tests/test_docs_links.py`
+verifies scenario 5. Independent review verifies scenarios 1-4 against the
+policy text and checked-in owners.
+
+**s) Fakes and mocks.** None are used in this docs-only PR. The policy row
+authorizes only the future semantic boundary described above.
+
+**t) Verification rows.** The docs-only row applies. The optional environment
+alignment test is unnecessary because no runtime profile or environment
+contract changes.
+
+## 6. Execution, Rollback, Docs
+
+**u) Exact commands.**
+
+```bash
+PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py
+git diff --check
+git status --short
+```
+
+After review, commit, push, open the T-SEM-1A PR, watch CI, merge, synchronize
+`master`, and resume T-SEM-1.
+
+**v) Rollback.** Revert the T-SEM-1A merge commit and rerun docs links. No
+migration, data repair, configuration restore, or external-state cleanup is
+required. T-SEM-1 would become blocked again on an unapproved fake boundary.
+
+**w) Docs synchronization.** Update only `docs/TESTING.MD`, this plan, and the
+remediation ledger. Architecture, ADR, operations, README, security, data
+governance, performance, roadmap, and API contracts remain unchanged.
+
+## 7. Delivery Self-Audit
+
+**x) Diff scan.** Re-run A-F/H. Reject code changes, a facade patch target, a
+private-method fake, a second policy list, or a path outside the three-file set.
+
+**y) Evidence.** Report docs-link and diff-check outcomes, independent review,
+commit, PR, unresolved threads, and CI state. Mark anything unrun `NOT
+VERIFIED`.
+
+**z) Deviations.** Expected result is none. Any implementation edit, expanded
+boundary, skipped review, unresolved P1/P2, or unrun docs gate is a blocker.

--- a/docs/plans/T_SEM_1A_SEMANTIC_TEST_BOUNDARY_PLAN.md
+++ b/docs/plans/T_SEM_1A_SEMANTIC_TEST_BOUNDARY_PLAN.md
@@ -40,8 +40,10 @@ depend on or foreclose G1, G2, G4, or G5.
 
 1. Register T-SEM-1A before T-SEM-1 in the remediation ledger.
 2. Add one approved fake-boundary row for semantic backend/runtime behavior.
-3. Permit patching `pipeline.semantic_backend_runtime.get_semantic_backend` to
-   return a fake implementing the existing `SemanticBackend` contract.
+3. After T-SEM-1 repoints consumers to resolve backend selection through the
+   owner module, permit patching
+   `pipeline.semantic_backend_runtime.get_semantic_backend` to return a fake
+   implementing the existing `SemanticBackend` contract.
 4. Require pgvector retrieval fakes to implement the public
    `rerank_candidates_with_diagnostics` or `rerank_candidates` capability
    exercised by the test.
@@ -106,7 +108,8 @@ T-SEM-1 remains responsible for deleting the facade and old patch targets.
 **q) Edge cases and failure scenarios.**
 
 1. The boundary must name the typed backend contract and runtime selection
-   function, not a facade.
+   function, not a facade, and remain future-effective until consumers resolve
+   that owner directly in T-SEM-1.
 2. Pgvector retrieval tests must fake the public rerank capability they
    exercise rather than a backend private method.
 3. Optional runtime substitutions must remain future-effective until T-SEM-1

--- a/docs/plans/T_SEM_1A_SEMANTIC_TEST_BOUNDARY_PLAN.md
+++ b/docs/plans/T_SEM_1A_SEMANTIC_TEST_BOUNDARY_PLAN.md
@@ -42,12 +42,15 @@ depend on or foreclose G1, G2, G4, or G5.
 2. Add one approved fake-boundary row for semantic backend/runtime behavior.
 3. Permit patching `pipeline.semantic_backend_runtime.get_semantic_backend` to
    return a fake implementing the existing `SemanticBackend` contract.
-4. Permit optional FAISS and SentenceTransformer substitution only after
+4. Require pgvector retrieval fakes to implement the public
+   `rerank_candidates_with_diagnostics` or `rerank_candidates` capability
+   exercised by the test.
+5. Permit optional FAISS and SentenceTransformer substitution only after
    T-SEM-1 moves their ownership to `pipeline.semantic_backend_runtime`.
-5. Explicitly prohibit patching backend private methods.
-6. Keep database, filesystem, Meilisearch, HTTP, clock, and inference rows
+6. Explicitly prohibit patching backend private methods.
+7. Keep database, filesystem, Meilisearch, HTTP, clock, and inference rows
    unchanged.
-7. Verify docs links, review independently, commit, push, merge, then return to
+8. Verify docs links, review independently, commit, push, merge, then return to
    a corrected T-SEM-1 Full plan.
 
 No runtime code, test seam, helper, environment variable, or dependency is
@@ -58,7 +61,10 @@ the current approved-boundary table. No second testing policy, adapter class,
 fixture framework, or compatibility layer is introduced.
 
 **g) Data contracts.** The existing `SemanticBackend` contract remains
-unchanged. The policy authorizes substitution; it does not alter the contract.
+unchanged. Pgvector retrieval also consumes the public
+`rerank_candidates_with_diagnostics` or `rerank_candidates` capability. The
+policy authorizes fakes that match the production path exercised by a test; it
+does not alter either runtime contract.
 
 **h) Schema/migration impact.** None.
 
@@ -101,14 +107,16 @@ T-SEM-1 remains responsible for deleting the facade and old patch targets.
 
 1. The boundary must name the typed backend contract and runtime selection
    function, not a facade.
-2. Optional runtime substitutions must remain future-effective until T-SEM-1
+2. Pgvector retrieval tests must fake the public rerank capability they
+   exercise rather than a backend private method.
+3. Optional runtime substitutions must remain future-effective until T-SEM-1
    establishes the named direct owner.
-3. The row must not authorize patching backend private methods.
-4. Existing approved boundaries must remain unchanged.
-5. Links between the ledger, plan, and testing policy must resolve.
+4. The row must not authorize patching backend private methods.
+5. Existing approved boundaries must remain unchanged.
+6. Links between the ledger, plan, and testing policy must resolve.
 
 **r) Tests added or updated.** No test code changes. `tests/test_docs_links.py`
-verifies scenario 5. Independent review verifies scenarios 1-4 against the
+verifies scenario 6. Independent review verifies scenarios 1-5 against the
 policy text and checked-in owners.
 
 **s) Fakes and mocks.** None are used in this docs-only PR. The policy row


### PR DESCRIPTION
## What changed
- approved a typed semantic backend fake through `semantic_backend_runtime.get_semantic_backend`
- explicitly prohibited backend-private method patches
- deferred optional FAISS and SentenceTransformer substitution until T-SEM-1 moves ownership
- registered the separate policy prerequisite in the remediation plan

## Why
`docs/TESTING.MD` requires new fake boundaries to land independently. T-SEM-1 cannot delete the semantic facade safely while service tests lack an approved direct boundary.

## Risk and compatibility
Docs and test policy only. No runtime, API, model, backend, dependency, schema, or default change.

## Verification
- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py` (2 passed)
- PASS: `git diff --check`
- PASS: independent pre-commit review, no P1/P2

## Remaining work
T-SEM-1 remains pending its corrected Full plan and implementation.
