### PR TITLE
T-PLAT-2D: Patch the Torch semantic runtime

### DIFF
--- a/docker/semantic-cpu-constraints.txt
+++ b/docker/semantic-cpu-constraints.txt
@@ -1,1 +1,1 @@
-torch==2.11.0+cpu
+torch==2.13.0+cpu

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,7 +1,7 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 3.98
-generated: 2026-07-26
+version: 3.99
+generated: 2026-08-01
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
 orchestrator_contract: Codex instantiates one agent per lane. Agents run in
@@ -10,6 +10,10 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v3.99:** Marks T-IDX-1 complete after PR #217 and activates urgent
+  T-PLAT-2D to patch Dependabot alert #121 by moving the semantic Torch base
+  and CPU pins from 2.11.0 to 2.13.0. The separately prepared Meilisearch SDK
+  migration remains unregistered until this security patch is complete.
 - **v3.98:** Marks T-SEM-1 complete after PR #216 and activates P1 T-IDX-1
   with exact 22-file ownership to delete obsolete meeting people projections
   from indexing, lexical search, and the frontend. Roster-backed people
@@ -450,8 +454,8 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 | State | Tasks |
 |---|---|
-| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2, T-SEC-3, T-SEC-3C, T-SEC-4, T-SEC-4A, T-SEC-5, T-SEC-6, T-TIME-1, T-TIME-2, T-TIME-3, T-CRAWL-1, T-CRAWL-2, T-PLAT-1, T-PLAT-1A, T-PLAT-2, T-PLAT-2A, T-PLAT-2B, T-PLAT-2C, T-PLAT-3, T-PLAT-4, T-GOV-1, T-GOV-2, T-GOV-2A, T-GOV-3, T-GOV-3A, T-GOV-3B, T-GOV-4, T-GOV-5, T-GOV-6, T-DA-1, T-DB-1A, T-DB-1, T-DB-1B, T-DC-1, T-DC-2A, T-DC-2B, T-DD-1A, T-DD-1B, T-DE-1, T-DE-2, T-TASK-1, T-SEM-1 |
-| **In progress** | T-IDX-1 |
+| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2, T-SEC-3, T-SEC-3C, T-SEC-4, T-SEC-4A, T-SEC-5, T-SEC-6, T-TIME-1, T-TIME-2, T-TIME-3, T-CRAWL-1, T-CRAWL-2, T-PLAT-1, T-PLAT-1A, T-PLAT-2, T-PLAT-2A, T-PLAT-2B, T-PLAT-2C, T-PLAT-3, T-PLAT-4, T-GOV-1, T-GOV-2, T-GOV-2A, T-GOV-3, T-GOV-3A, T-GOV-3B, T-GOV-4, T-GOV-5, T-GOV-6, T-DA-1, T-DB-1A, T-DB-1, T-DB-1B, T-DC-1, T-DC-2A, T-DC-2B, T-DD-1A, T-DD-1B, T-DE-1, T-DE-2, T-TASK-1, T-SEM-1, T-IDX-1 |
+| **In progress** | T-PLAT-2D |
 | **Pending** | T-FE-1 |
 
 ---
@@ -1892,6 +1896,38 @@ files (GED-5 grant).
   Ruff, Mypy, task and Docker contracts, docs links, coverage-gated suite,
   four image builds, isolated runtime smoke, independent review, and PR CI.
 
+### T-PLAT-2D: Patch the Torch semantic runtime
+- priority: P1 (urgent dependency security patch)
+- status: in progress
+- depends_on: T-IDX-1 merge; serialized ahead of prepared Meilisearch work
+- implementation_plan:
+  `docs/plans/T_PLAT_2D_TORCH_SECURITY_PATCH_PLAN.md`
+- scope_authorization: Operator requested remediation of Dependabot alert #121
+  on 2026-08-01.
+- files_owned: `docs/plans/T_PLAT_2D_TORCH_SECURITY_PATCH_PLAN.md`,
+  `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`,
+  `semantic_service/requirements.txt`,
+  `docker/semantic-cpu-constraints.txt`,
+  `tests/test_docker_build_contracts.py`
+- do: Replace the vulnerable audit-visible `torch==2.11.0` pin and matching
+  Docker `torch==2.11.0+cpu` constraint with patched 2.13.0 declarations.
+  Prove both pins stay aligned and validate the real CPU semantic image through
+  dependency, model-encoding, and FAISS search smokes.
+- preserve: Semantic APIs, model selection, embedding dimensions, index data,
+  worker behavior, Dockerfile, ports, credentials, runtime defaults, gate
+  semantics, and soak comparability.
+- forbidden: One-sided pin changes; application or Dockerfile edits; alert
+  suppression; unrelated dependency upgrades; compatibility code; API,
+  schema, workflow, environment, model-policy, or soak-policy changes; edits
+  outside `files_owned`.
+- accept: Exact pin contracts and all required Python gates pass;
+  `python-semantic` resolves `torch==2.13.0+cpu`; `pip check`, CPU-only runtime,
+  384-dimensional finite model embeddings, and FAISS nearest-neighbor search
+  pass; PR CI is green; alert #121 reports fixed after merge.
+- verify: Follow the Full T-PLAT-2D plan, including tests-first red evidence,
+  Ruff, Mypy, Docker and semantic tests, docs links, coverage-gated suite, real
+  semantic image build and runtime smoke, independent review, and PR CI.
+
 ### T-PLAT-3: Backup/restore runbook
 - priority: P1
 - status: complete and verified 2026-07-26 (PR #155)
@@ -2247,9 +2283,10 @@ Gate:    G3 satisfied (T-GOV-1 Accepted ADR + active docs/TESTING.MD)
 Phase 2: completed foundations [T-DA-1, T-DB-1A, T-DB-1, T-DB-1B,
          T-DC-1, T-DD-1A, T-DD-1B, T-DE-1]
 Next:    Serialize each task's Full-plan registration through this ledger.
-         T-SEM-1 is complete; T-IDX-1 is active under exact ownership.
+         T-IDX-1 is complete; T-PLAT-2D is the active security patch.
 Phase 3: agent-plat [T-PLAT-1 after T-TIME-1 and T-TIME-2, T-PLAT-1A
-         closure, T-PLAT-2B security patch, then T-PLAT-2..4; complete]
+         closure, T-PLAT-2B security patch, then T-PLAT-2..4; complete;
+         T-PLAT-2D alert #121 patch active before prepared Meilisearch work]
          || agent-gov [T-GOV-2 policy and T-GOV-2A runtime enforcement
          complete; T-GOV-3A/B and T-GOV-5 complete]
 After:   T-FE-1 follows behavior-test design. City Coverage Expansion awaits

--- a/docs/plans/T_PLAT_2D_TORCH_SECURITY_PATCH_PLAN.md
+++ b/docs/plans/T_PLAT_2D_TORCH_SECURITY_PATCH_PLAN.md
@@ -1,0 +1,291 @@
+# T-PLAT-2D: Patch the Torch Semantic Runtime
+
+`artifact_contract: ce-unified-plan/v1`
+`artifact_readiness: implementation-ready`
+`execution: code`
+
+## 1. Context & Alignment
+
+**a) Driver.** Dependabot alert #121 identifies the direct semantic-runtime
+dependency `torch==2.11.0` as vulnerable to memory corruption through
+`torch.jit.script`. GitHub's reviewed advisory marks Torch `<=2.12.1`
+vulnerable and `2.13.0` patched. Town Council does not call `torch.jit`, so
+current exploit reachability is not established, but keeping the vulnerable
+runtime is unnecessary risk.
+
+**b) Canonical documents consulted.**
+
+- `AGENTS.md` requires verified dependency changes, tests first, exact
+  ownership, Docker trust-boundary reporting, and no runtime-policy drift.
+- `SECURITY.md` "Dependency and supply chain" requires direct dependency
+  findings to remain visible and audit execution failures to block CI.
+- `docs/TESTING.MD` permits filesystem, subprocess, and container boundaries
+  without production test seams.
+- `docs/ENGINEERING_GUARDRAILS.md` keeps audit tooling outside production
+  manifests.
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md` serializes one owned platform
+  dependency task at a time.
+
+**c) Remediation alignment.** This is T-PLAT-2D in the platform lane. The
+separately prepared Meilisearch SDK migration remains unregistered until this
+urgent patch is complete and will receive the next available task ID. Exact
+`files_owned`:
+
+- `docs/plans/T_PLAT_2D_TORCH_SECURITY_PATCH_PLAN.md`
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`
+- `semantic_service/requirements.txt`
+- `docker/semantic-cpu-constraints.txt`
+- `tests/test_docker_build_contracts.py`
+
+**d) Decision-gate check.** No G1-G5 gate applies. This patch does not change
+model selection, semantic behavior, API contracts, gate semantics, or soak
+comparability.
+
+## 2. Design
+
+**e) Step-by-step approach.**
+
+1. Register T-PLAT-2D and mark merged T-IDX-1 complete.
+2. Change the existing exact-pin contract first and record its failure against
+   the vulnerable pins.
+3. Update the audit-visible semantic pin from `torch==2.11.0` to
+   `torch==2.13.0`.
+4. Update the Docker CPU constraint from `torch==2.11.0+cpu` to
+   `torch==2.13.0+cpu` in the same logical change.
+5. Strengthen the existing test so it also proves both declarations use the
+   same upstream version.
+6. Build only the `python-semantic` target, which owns Torch at runtime.
+7. Verify dependency consistency, CPU-only Torch, SentenceTransformers model
+   encoding, finite 384-dimensional embeddings, and FAISS nearest-neighbor
+   search inside the built image.
+8. Run repository gates, independent pre-commit review, atomic delivery, and
+   PR CI. Confirm alert #121 is fixed after merge.
+
+No new function or module is planned. The official CPU package index and
+published CPython 3.12 wheels were verified for Torch 2.13.0. The existing
+`sentence-transformers==3.3.0` requirement accepts Torch `>=1.11.0` without an
+upper bound; empirical image verification remains required.
+
+**f) Reuse audit.** Reuse the semantic manifest, CPU constraint, split Docker
+image, existing dependency contract test, model name, and FAISS runtime. No
+wrapper, compatibility path, dependency registry, or duplicate install path is
+added. The root constraints file remains unchanged because Torch's `+cpu`
+selection is semantic-image-specific.
+
+**g) Data contracts.** The semantic manifest remains the audit-visible upstream
+version contract. The Docker CPU constraint remains the deployment artifact
+contract. Both must declare the same upstream version after removing the local
+`+cpu` suffix.
+
+**h) Schema/migration impact.** None. No database, Alembic, timestamp, stored
+embedding, API, Celery, environment, or runtime-default change.
+
+## 3. Security & Data Governance
+
+**i) Security-sensitive path.** No `AGENTS.md` security-sensitive file is
+edited, but the dependency executes inside the semantic runtime and processes
+attacker-influenceable civic text. The patch removes a vulnerable package;
+ports, credentials, container users, permissions, and model policy are
+unchanged. `SECURITY.md` "Dependency and supply chain" applies.
+
+**j) Secrets.** None.
+
+**k) Person data.** None is created, linked, aggregated, or exposed. G4 is
+unaffected.
+
+**l) Untrusted input.** No new parser or rendering boundary is introduced.
+Existing extracted civic text continues through the established semantic
+service boundary.
+
+## 4. Code Health
+
+**m) GED conformance sweep.** No production Python logic, environment read,
+timestamp, handler, nesting, or parameter list changes. The two exact pins are
+required package coordinates, not duplicated business constants.
+
+**n) Antipattern scan, plan pass.** A1/H1 were corrected by checking the
+reviewed advisory, the upstream fix, published Torch 2.13.0 wheels, the official
+CPU index, and installed dependency contracts. B1/F1 are avoided by extending
+existing manifests and one test. D1 is avoided by raising the required version
+rather than suppressing the alert. D3 is accepted narrowly because exact pins
+are the observable deployment contract. A2-A4, B2-B3, C1-C2, D2, E1-E3, F2,
+and H2-H4 have no planned violation.
+
+**o) Ratchet interaction.** Ruff selectors, BLE001 boundaries, Mypy scope,
+coverage floor, required checks, and dependency-audit policy remain unchanged.
+
+**p) Dead code and duplication audit.** Replace both vulnerable declarations;
+no old pin survives. Expected non-document delta is one test strengthening and
+two version replacements.
+
+## 5. Testing
+
+**q) Edge cases and failures.**
+
+1. Updating only the semantic pin makes the CPU constraint inconsistent.
+2. Updating only the CPU constraint leaves the audit-visible vulnerable pin.
+3. A published wheel may import but fail during model loading or encoding.
+4. The image may resolve a CUDA or non-CPU artifact unexpectedly.
+5. Torch, Transformers, SentenceTransformers, NumPy, or FAISS may conflict.
+6. Embeddings may have wrong dimensions, non-finite values, or fail FAISS
+   normalization/search.
+7. Image size or latency may move; observations must not alter gates or soak
+   policy in this patch.
+8. An audit or CI discrepancy may leave alert #121 open after merge.
+
+**r) Tests and mapping.**
+
+| Verification | Scenarios |
+|---|---|
+| Exact semantic/CPU pin contract | 1, 2 |
+| `pip check` and import smoke in `python-semantic` | 4, 5 |
+| Model encode and FAISS search smoke | 3, 6 |
+| Existing Docker contract suite | 1, 2, 5 |
+| Complete coverage-gated Python suite | Regression coverage |
+| Post-merge Dependabot readback | 8 |
+
+Scenario 7 is recorded observationally from the Docker build and smoke; no
+threshold test is added.
+
+**s) Fakes and mocks.** None. Tests use the approved filesystem, subprocess,
+and container boundaries. No application symbol or facade is patched.
+
+**t) Verification rows.** Apply Docker dependency contracts, docs-only, and
+broad cross-cutting verification. Run Ruff, Mypy, Docker contracts, semantic
+tests, health-probe tests, docs links, the coverage-gated suite, and the real
+semantic image smoke.
+
+## 6. Execution, Rollback, Docs
+
+**u) Exact commands.**
+
+```bash
+PYTHONPATH=. .venv/bin/pytest -q \
+  tests/test_docker_build_contracts.py::test_semantic_cpu_constraint_preserves_auditable_upstream_version
+
+./.venv/bin/ruff check .
+./.venv/bin/mypy
+PYTHONPATH=. .venv/bin/pytest -q tests/test_docker_build_contracts.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_semantic_*.py
+PYTHONPATH=. .venv/bin/pytest -q \
+  tests/test_role_worker_healthchecks.py tests/test_worker_health_probes.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py
+PYTHONPATH=. .venv/bin/python -m pytest -q --cov \
+  --cov-config=.coveragerc --cov-report=term-missing:skip-covered tests/
+git diff --check
+
+docker build --target python-semantic -t town-council-torch-2.13.0 .
+docker run --rm --entrypoint python town-council-torch-2.13.0 -c \
+  "import torch; assert torch.__version__ == '2.13.0+cpu'; assert torch.version.cuda is None"
+docker run --rm --entrypoint pip town-council-torch-2.13.0 check
+```
+
+The runtime smoke downloads the public `all-MiniLM-L6-v2` model into the
+ephemeral container, encodes two strings, verifies finite 384-dimensional
+vectors, normalizes them with FAISS, and completes one nearest-neighbor search.
+Model download or inference errors fail the command immediately:
+
+```bash
+docker run --rm -i --entrypoint python town-council-torch-2.13.0 - <<'PY'
+import faiss
+import numpy as np
+from sentence_transformers import SentenceTransformer
+
+model = SentenceTransformer("all-MiniLM-L6-v2")
+embeddings = np.asarray(
+    model.encode(["city council agenda", "approved meeting minutes"]),
+    dtype="float32",
+)
+assert embeddings.shape == (2, 384)
+assert np.isfinite(embeddings).all()
+faiss.normalize_L2(embeddings)
+index = faiss.IndexFlatIP(embeddings.shape[1])
+index.add(embeddings)
+distances, neighbors = index.search(embeddings[:1], 1)
+assert distances.shape == (1, 1)
+assert neighbors.tolist() == [[0]]
+PY
+```
+
+The API and worker entrypoints run against isolated PostgreSQL and Redis. The
+trap removes all smoke containers and the network on success or failure:
+
+```bash
+set -euo pipefail
+SMOKE_NETWORK=tc-torch-smoke
+SMOKE_POSTGRES=tc-torch-postgres
+SMOKE_REDIS=tc-torch-redis
+SMOKE_SEMANTIC=tc-torch-semantic
+cleanup() {
+  docker rm -f "$SMOKE_SEMANTIC" "$SMOKE_POSTGRES" "$SMOKE_REDIS" \
+    >/dev/null 2>&1 || true
+  docker network rm "$SMOKE_NETWORK" >/dev/null 2>&1 || true
+}
+wait_for_container() {
+  local container_name=$1
+  shift
+  for _attempt in $(seq 1 60); do
+    if docker exec "$container_name" "$@" >/dev/null 2>&1; then
+      return 0
+    fi
+    if ! docker inspect -f '{{.State.Running}}' "$container_name" \
+      2>/dev/null | grep -qx true; then
+      docker logs "$container_name"
+      return 1
+    fi
+    sleep 1
+  done
+  docker logs "$container_name"
+  return 1
+}
+trap cleanup EXIT
+cleanup
+docker network create "$SMOKE_NETWORK"
+docker run -d --name "$SMOKE_POSTGRES" --network "$SMOKE_NETWORK" \
+  -e POSTGRES_USER=town_council -e POSTGRES_PASSWORD=smoke_password \
+  -e POSTGRES_DB=town_council_db postgres:15-alpine
+docker run -d --name "$SMOKE_REDIS" --network "$SMOKE_NETWORK" \
+  redis:7-alpine redis-server --requirepass smoke_password
+wait_for_container "$SMOKE_POSTGRES" pg_isready -U town_council
+wait_for_container "$SMOKE_REDIS" sh -c \
+  'redis-cli -a smoke_password ping | grep -qx PONG'
+docker run -d --name "$SMOKE_SEMANTIC" --network "$SMOKE_NETWORK" \
+  -e DATABASE_URL=postgresql://town_council:smoke_password@tc-torch-postgres:5432/town_council_db \
+  -e MEILI_HOST=http://127.0.0.1:7700 \
+  --entrypoint python town-council-torch-2.13.0 \
+  -m uvicorn semantic_service.main:app --host 0.0.0.0 --port 8010
+wait_for_container "$SMOKE_SEMANTIC" python -c \
+  "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8010/health', timeout=5)"
+docker run --rm --network "$SMOKE_NETWORK" \
+  -e DATABASE_URL=postgresql://town_council:smoke_password@tc-torch-postgres:5432/town_council_db \
+  -e CELERY_BROKER_URL=redis://:smoke_password@tc-torch-redis:6379/0 \
+  -e CELERY_RESULT_BACKEND=redis://:smoke_password@tc-torch-redis:6379/0 \
+  -e SEMANTIC_INDEX_DIR=/tmp/semantic \
+  --entrypoint python town-council-torch-2.13.0 \
+  scripts/semantic_worker_healthcheck.py
+```
+
+**v) Rollback.** Revert both pin changes together, rebuild `python-semantic`,
+and rerun the same dependency, image, and repository checks. No migration,
+reindex, data repair, or external-state cleanup is required. Rollback knowingly
+restores Dependabot alert #121.
+
+**w) Docs synchronization.** Update only this implementation plan and the
+remediation ledger. `SECURITY.md`, README, ADR, operations, performance,
+testing, architecture, API contracts, and data-governance docs remain accurate.
+
+## 7. Delivery Self-Audit
+
+**x) Diff scan.** Re-run A-F/H. Reject one-sided pin changes, a new constraint
+registry, Dockerfile churn, alert suppression, runtime-policy drift, unrelated
+dependency upgrades, compatibility code, test weakening, or edits outside the
+five owned files.
+
+**y) Evidence.** Report the tests-first failure; exact local gate outcomes;
+Docker build, package, model, and FAISS smoke outcomes; pre-commit review;
+commit hashes; PR URL; unresolved P1/P2 count; CI state; and post-merge alert
+state. Anything unrun is `NOT VERIFIED`.
+
+**z) Deviations.** Expected result is none. Any additional file, dependency,
+model, Dockerfile, workflow, API, schema, runtime-default, or soak-policy change
+is a blocker.

--- a/docs/plans/T_PLAT_2D_TORCH_SECURITY_PATCH_PLAN.md
+++ b/docs/plans/T_PLAT_2D_TORCH_SECURITY_PATCH_PLAN.md
@@ -161,7 +161,7 @@ semantic image smoke.
 
 ```bash
 PYTHONPATH=. .venv/bin/pytest -q \
-  tests/test_docker_build_contracts.py::test_semantic_cpu_constraint_preserves_auditable_upstream_version
+  tests/test_docker_build_contracts.py::test_semantic_cpu_constraint_uses_patched_matching_upstream_version
 
 ./.venv/bin/ruff check .
 ./.venv/bin/mypy

--- a/semantic_service/requirements.txt
+++ b/semantic_service/requirements.txt
@@ -11,4 +11,4 @@ numpy==2.4.4
 sentence-transformers==3.3.0
 faiss-cpu==1.10.0
 # Docker constrains this to the matching +cpu build; the base pin remains auditable.
-torch==2.11.0
+torch==2.13.0

--- a/tests/test_docker_build_contracts.py
+++ b/tests/test_docker_build_contracts.py
@@ -416,7 +416,7 @@ def test_dependency_audit_and_pgvector_constraints_remain_explicit() -> None:
         assert "pgvector>=0.5.0" in _requirement_directives(requirements_path)
 
 
-def test_semantic_cpu_constraint_preserves_auditable_upstream_version() -> None:
+def test_semantic_cpu_constraint_uses_patched_matching_upstream_version() -> None:
     semantic_directives = _requirement_directives(
         Path("semantic_service/requirements.txt")
     )
@@ -424,8 +424,12 @@ def test_semantic_cpu_constraint_preserves_auditable_upstream_version() -> None:
         Path("docker/semantic-cpu-constraints.txt")
     )
 
-    assert "torch==2.11.0" in semantic_directives
-    assert "torch==2.11.0+cpu" in cpu_constraint_directives
+    semantic_torch_pin = "torch==2.13.0"
+    cpu_torch_pin = "torch==2.13.0+cpu"
+
+    assert semantic_torch_pin in semantic_directives
+    assert cpu_torch_pin in cpu_constraint_directives
+    assert cpu_torch_pin.removesuffix("+cpu") == semantic_torch_pin
 
 
 def test_docker_preserves_requirement_paths_and_applies_constraints() -> None:


### PR DESCRIPTION
## What changed
- upgrade semantic Torch from `2.11.0` to patched `2.13.0`
- keep Docker's CPU constraint aligned at `2.13.0+cpu`
- strengthen the exact-pin contract against one-sided drift
- register T-PLAT-2D and mark merged T-IDX-1 complete

## Why
Dependabot alert #121 reports GHSA-rrmf-rvhw-rf47 / CVE-2025-3000 against the direct Torch runtime. Town Council does not invoke `torch.jit`, but the vulnerable package remains unnecessary latent exposure.

## Risk and compatibility
The change is limited to the semantic dependency and CPU artifact. APIs, model selection, embedding dimensions, index data, workers, runtime defaults, and soak policy are unchanged. The real ARM64 CPU image and semantic entrypoints were exercised.

## Verification
- PASS: `./.venv/bin/ruff check .`
- PASS: `./.venv/bin/mypy`
- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_docker_build_contracts.py` (30 passed)
- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_semantic_*.py` (52 passed)
- PASS: worker health-probe tests (9 passed)
- PASS: docs links (2 passed)
- PASS: coverage suite (1,792 passed, 21 skipped; 83.26% coverage, 71% required)
- PASS: `python-semantic` build resolved `torch==2.13.0+cpu`
- PASS: `pip check`, CPU-only runtime, model encoding, finite 384-dimensional embeddings, FAISS search, semantic API health, and semantic worker health

## Remaining
Dependabot alert state can only change after this reaches the default branch. Post-merge readback is required.
