### PR TITLE
T-PLAT-2E: Migrate the Meilisearch Python SDK

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -2,7 +2,7 @@ beautifulsoup4==4.15.0
 celery==5.6.3
 fastapi==0.115.8
 httpx==0.28.1
-meilisearch==0.31.0
+meilisearch==0.43.0
 pip-audit==2.10.1
 prometheus-client==0.26.0
 psycopg2-binary==2.9.10

--- a/docs/ADR.md
+++ b/docs/ADR.md
@@ -8,6 +8,36 @@ Use each entry to record:
 - the affected boundary or contract
 - links to the canonical docs that carry the ongoing operational or architecture detail
 
+## 2026-08-02: Retire Meilisearch SDK compatibility helpers
+
+- Status: Accepted
+- Decision:
+  - Town Council uses the typed task models and filtered-delete API provided by
+    Meilisearch Python SDK 0.43.0.
+  - Settings updates and targeted deletion pass their typed task IDs through
+    the existing successful-task waiter. Transport failures and completed
+    failed tasks stop the indexing operation.
+  - The dictionary task-ID adapter and legacy filtered-delete method fallback
+    are deleted rather than retained as compatibility seams.
+- Why:
+  - The shared client pin now provides one supported task and filtered-delete
+    contract across every Python image.
+  - Treating an accepted asynchronous request as success could publish data
+    before required settings or deletion completed.
+- Supersedes:
+  - The task-ID and filtered-delete compatibility-helper clauses in the
+    2026-05-08 indexing decision below.
+  - `pipeline/indexer.py` remains the full and targeted indexing facade.
+    `pipeline/indexer_meilisearch.py` continues to own settings, batch flush,
+    and successful-task verification.
+- Affected boundaries:
+  - Meilisearch remains v1.6 with the same index, settings, document payloads,
+    reader/writer key separation, API behavior, and replacement-reindex
+    recovery contract.
+- Canonical references:
+  - [T-PLAT-2E implementation plan](plans/T_PLAT_2E_MEILISEARCH_SDK_MIGRATION_PLAN.md)
+  - [Town Council remediation plan](plans/TOWN_COUNCIL_REMEDIATION_PLAN.md)
+
 ## 2026-07-26: Roster-gated person linking
 
 - Status: Accepted

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,7 +1,7 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 3.99
-generated: 2026-08-01
+version: 4.00
+generated: 2026-08-02
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
 orchestrator_contract: Codex instantiates one agent per lane. Agents run in
@@ -10,6 +10,12 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v4.00:** Marks T-PLAT-2D complete after PR #218 upgraded the semantic
+  Torch runtime to 2.13.0 and Dependabot alert #121 reported fixed. Activates
+  T-PLAT-2E with exact 14-file ownership to migrate the Meilisearch Python SDK
+  from 0.31.0 to 0.43.0, delete obsolete task-ID and filtered-delete
+  compatibility helpers, preserve failed-task propagation, and validate the
+  existing Meilisearch v1.6 reader/writer boundary.
 - **v3.99:** Marks T-IDX-1 complete after PR #217 and activates urgent
   T-PLAT-2D to patch Dependabot alert #121 by moving the semantic Torch base
   and CPU pins from 2.11.0 to 2.13.0. The separately prepared Meilisearch SDK
@@ -454,8 +460,8 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 | State | Tasks |
 |---|---|
-| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2, T-SEC-3, T-SEC-3C, T-SEC-4, T-SEC-4A, T-SEC-5, T-SEC-6, T-TIME-1, T-TIME-2, T-TIME-3, T-CRAWL-1, T-CRAWL-2, T-PLAT-1, T-PLAT-1A, T-PLAT-2, T-PLAT-2A, T-PLAT-2B, T-PLAT-2C, T-PLAT-3, T-PLAT-4, T-GOV-1, T-GOV-2, T-GOV-2A, T-GOV-3, T-GOV-3A, T-GOV-3B, T-GOV-4, T-GOV-5, T-GOV-6, T-DA-1, T-DB-1A, T-DB-1, T-DB-1B, T-DC-1, T-DC-2A, T-DC-2B, T-DD-1A, T-DD-1B, T-DE-1, T-DE-2, T-TASK-1, T-SEM-1, T-IDX-1 |
-| **In progress** | T-PLAT-2D |
+| **Complete** | T-CI-0, T-CI-1, T-CI-1A, T-CI-2, T-CI-2A, T-CI-3, T-CI-4, T-CI-5, T-SEC-1, T-SEC-2, T-SEC-3, T-SEC-3C, T-SEC-4, T-SEC-4A, T-SEC-5, T-SEC-6, T-TIME-1, T-TIME-2, T-TIME-3, T-CRAWL-1, T-CRAWL-2, T-PLAT-1, T-PLAT-1A, T-PLAT-2, T-PLAT-2A, T-PLAT-2B, T-PLAT-2C, T-PLAT-2D, T-PLAT-3, T-PLAT-4, T-GOV-1, T-GOV-2, T-GOV-2A, T-GOV-3, T-GOV-3A, T-GOV-3B, T-GOV-4, T-GOV-5, T-GOV-6, T-DA-1, T-DB-1A, T-DB-1, T-DB-1B, T-DC-1, T-DC-2A, T-DC-2B, T-DD-1A, T-DD-1B, T-DE-1, T-DE-2, T-TASK-1, T-SEM-1, T-IDX-1 |
+| **In progress** | T-PLAT-2E |
 | **Pending** | T-FE-1 |
 
 ---
@@ -1898,7 +1904,7 @@ files (GED-5 grant).
 
 ### T-PLAT-2D: Patch the Torch semantic runtime
 - priority: P1 (urgent dependency security patch)
-- status: in progress
+- status: complete and verified 2026-08-02 (PR #218; alert #121 fixed)
 - depends_on: T-IDX-1 merge; serialized ahead of prepared Meilisearch work
 - implementation_plan:
   `docs/plans/T_PLAT_2D_TORCH_SECURITY_PATCH_PLAN.md`
@@ -1927,6 +1933,41 @@ files (GED-5 grant).
 - verify: Follow the Full T-PLAT-2D plan, including tests-first red evidence,
   Ruff, Mypy, Docker and semantic tests, docs links, coverage-gated suite, real
   semantic image build and runtime smoke, independent review, and PR CI.
+
+### T-PLAT-2E: Migrate the Meilisearch Python SDK
+- priority: P1
+- status: in progress
+- depends_on: T-PLAT-2D merge; T-IDX-1 merge
+- implementation_plan:
+  `docs/plans/T_PLAT_2E_MEILISEARCH_SDK_MIGRATION_PLAN.md`
+- scope_authorization: Operator approved replacing closed Dependabot PR #197
+  with an owned Meilisearch migration on 2026-07-27.
+- files_owned: `docs/plans/T_PLAT_2E_MEILISEARCH_SDK_MIGRATION_PLAN.md`,
+  `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`, `docs/ADR.md`,
+  `constraints.txt`, `pipeline/indexer.py`,
+  `pipeline/indexer_meilisearch.py`, `ruff.toml`, `tests/test_api.py`,
+  `tests/test_async_flow.py`, `tests/test_docker_build_contracts.py`,
+  `tests/test_extract_task.py`, `tests/test_indexer_logic.py`,
+  `tests/test_repository_guardrails.py`,
+  `tests/test_tasks_vote_extraction_flow.py`
+- do: Upgrade only the shared Meilisearch Python SDK constraint from 0.31.0
+  to 0.43.0; consume typed task IDs directly; delete the obsolete task-ID and
+  filtered-delete compatibility helpers; and use the existing successful-task
+  waiter for settings and targeted deletion.
+- preserve: Meilisearch server v1.6, index UID and settings, reader/writer key
+  separation, task ordering, replacement-index recovery, document payloads,
+  API/search behavior, people-field absence, runtime defaults, and soak
+  comparability.
+- forbidden: Server-image, key, port, API, schema, environment, index-contract,
+  workflow, inference, or soak-policy changes; compatibility shims; failed-task
+  swallowing; unrelated dependency updates; edits outside `files_owned`.
+- accept: Exact pin and typed-task contracts pass; all Python gates pass; four
+  affected images resolve SDK 0.43.0 with clean dependency checks; an isolated
+  v1.6 server accepts settings, add/search/stats/task-list/filter-delete flows;
+  and a scoped reader can search/read stats but cannot add or change settings.
+- verify: Follow the Full T-PLAT-2E plan, including tests-first red evidence,
+  Ruff, formatter, Mypy, targeted and coverage-gated suites, four image builds,
+  isolated reader/writer runtime smoke, independent review, and PR CI.
 
 ### T-PLAT-3: Backup/restore runbook
 - priority: P1
@@ -2283,10 +2324,10 @@ Gate:    G3 satisfied (T-GOV-1 Accepted ADR + active docs/TESTING.MD)
 Phase 2: completed foundations [T-DA-1, T-DB-1A, T-DB-1, T-DB-1B,
          T-DC-1, T-DD-1A, T-DD-1B, T-DE-1]
 Next:    Serialize each task's Full-plan registration through this ledger.
-         T-IDX-1 is complete; T-PLAT-2D is the active security patch.
+         T-PLAT-2D is complete; T-PLAT-2E is the active SDK migration.
 Phase 3: agent-plat [T-PLAT-1 after T-TIME-1 and T-TIME-2, T-PLAT-1A
          closure, T-PLAT-2B security patch, then T-PLAT-2..4; complete;
-         T-PLAT-2D alert #121 patch active before prepared Meilisearch work]
+         T-PLAT-2D alert #121 patch complete; T-PLAT-2E Meilisearch active]
          || agent-gov [T-GOV-2 policy and T-GOV-2A runtime enforcement
          complete; T-GOV-3A/B and T-GOV-5 complete]
 After:   T-FE-1 follows behavior-test design. City Coverage Expansion awaits

--- a/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
+++ b/docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md
@@ -1,6 +1,6 @@
 # Town Council Remediation Plan (Codex Multi-Agent)
 
-version: 4.00
+version: 4.01
 generated: 2026-08-02
 source: Four-pass external code review (security, architecture, smells, process)
 source_artifact: [Town Council architecture review](../reviews/architecture-review-2026-07-19.html)
@@ -10,6 +10,11 @@ remains in force; where this plan is stricter, this plan wins for these tasks.
 
 ## Changelog
 
+- **v4.01:** Expands T-PLAT-2E from 14 to 17 owned files after the complete
+  suite exposed three agenda-maintenance test boundaries that still returned
+  untyped Meilisearch deletion tasks. The operator approved aligning those
+  fakes with SDK 0.43.0 while preserving their observable persistence and
+  reindex contracts.
 - **v4.00:** Marks T-PLAT-2D complete after PR #218 upgraded the semantic
   Torch runtime to 2.13.0 and Dependabot alert #121 reported fixed. Activates
   T-PLAT-2E with exact 14-file ownership to migrate the Meilisearch Python SDK
@@ -1946,9 +1951,12 @@ files (GED-5 grant).
   `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`, `docs/ADR.md`,
   `constraints.txt`, `pipeline/indexer.py`,
   `pipeline/indexer_meilisearch.py`, `ruff.toml`, `tests/test_api.py`,
-  `tests/test_async_flow.py`, `tests/test_docker_build_contracts.py`,
-  `tests/test_extract_task.py`, `tests/test_indexer_logic.py`,
+  `tests/test_async_flow.py`,
+  `tests/test_backlog_maintenance_laserfiche_guard.py`,
+  `tests/test_docker_build_contracts.py`, `tests/test_extract_task.py`,
+  `tests/test_indexer_logic.py`, `tests/test_pipeline_batching.py`,
   `tests/test_repository_guardrails.py`,
+  `tests/test_tasks_agenda_summary_format.py`,
   `tests/test_tasks_vote_extraction_flow.py`
 - do: Upgrade only the shared Meilisearch Python SDK constraint from 0.31.0
   to 0.43.0; consume typed task IDs directly; delete the obsolete task-ID and

--- a/docs/plans/T_PLAT_2E_MEILISEARCH_SDK_MIGRATION_PLAN.md
+++ b/docs/plans/T_PLAT_2E_MEILISEARCH_SDK_MIGRATION_PLAN.md
@@ -30,7 +30,7 @@ dependency migrations proceed.
 - `docs/reviews/architecture-review-2026-07-19.html`: compatibility layers are
   retired only through narrow, evidence-backed tasks.
 
-**c) Remediation alignment.** T-PLAT-2E owns exactly these 14 paths:
+**c) Remediation alignment.** T-PLAT-2E owns exactly these 17 paths:
 
 - `docs/plans/T_PLAT_2E_MEILISEARCH_SDK_MIGRATION_PLAN.md`
 - `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`
@@ -41,10 +41,13 @@ dependency migrations proceed.
 - `ruff.toml`
 - `tests/test_api.py`
 - `tests/test_async_flow.py`
+- `tests/test_backlog_maintenance_laserfiche_guard.py`
 - `tests/test_docker_build_contracts.py`
 - `tests/test_extract_task.py`
 - `tests/test_indexer_logic.py`
+- `tests/test_pipeline_batching.py`
 - `tests/test_repository_guardrails.py`
+- `tests/test_tasks_agenda_summary_format.py`
 - `tests/test_tasks_vote_extraction_flow.py`
 
 No other tracked path may change. T-IDX-1 merged as PR #217 and T-PLAT-2D
@@ -164,7 +167,7 @@ effect is added. Existing task-ordering constants and domain names are reused.
 - D1-D3: tests strengthen typed-response and propagation contracts without
   skips, widened tolerances, private production patch targets, or call-order
   assertions unrelated to recovery correctness.
-- E1-E3: edits stay within the 14 owned paths and avoid mechanical churn.
+- E1-E3: edits stay within the 17 owned paths and avoid mechanical churn.
 - F1-F2: no duplicate SDK adapter or shared location is created.
 - H2-H4: no `Any`, ignore, cast, hand-rolled response model, or import-time
   work is introduced.
@@ -207,6 +210,7 @@ typed-response-compatible objects. Expected production delta is negative.
 | `test_indexer_logic.py` typed task/settings/delete/recovery tests | 1-6, 10 |
 | `test_api.py` current `IndexStats` fixture and search contracts | 7, 10 |
 | Async/extract/vote task tests with typed fake tasks | 1, 2, 10 |
+| Agenda maintenance, batching, and summary tests with typed delete-task fakes | 1, 2, 10 |
 | Repository guardrail BLE001 inventory | 3, 8 |
 | Four Docker image dependency inspections | 8, 10 |
 | Isolated Meilisearch v1.6 runtime smoke | 1-6, 8-10 |
@@ -217,7 +221,10 @@ is asserted.
 **s) Fakes and mocks.** Tests patch the approved Meilisearch client boundary
 only where constructed in `pipeline.indexer` or `api.search.support_core`.
 Task-result fakes expose the public `task_uid` attribute consumed from the SDK.
-No facade, re-export, unit-under-test, or new production seam is patched.
+The agenda maintenance, batching, and summary tests also return a successful
+typed wait result because their observable persistence paths reindex changed
+catalogs. No facade, re-export, unit-under-test, or new production seam is
+patched.
 
 **t) Verification rows.** Apply API/search behavior, guardrail/tooling,
 coverage-gate dependency contracts, and docs-only rows. Run the complete
@@ -254,6 +261,9 @@ Final local verification:
 PYTHONPATH=. .venv/bin/pytest -q tests/test_indexer_logic.py tests/test_api.py
 PYTHONPATH=. .venv/bin/pytest -q \
   tests/test_async_flow.py tests/test_extract_task.py \
+  tests/test_backlog_maintenance_laserfiche_guard.py \
+  tests/test_pipeline_batching.py \
+  tests/test_tasks_agenda_summary_format.py \
   tests/test_tasks_vote_extraction_flow.py
 PYTHONPATH=. .venv/bin/pytest -q \
   tests/test_docker_build_contracts.py tests/test_repository_guardrails.py \

--- a/docs/plans/T_PLAT_2E_MEILISEARCH_SDK_MIGRATION_PLAN.md
+++ b/docs/plans/T_PLAT_2E_MEILISEARCH_SDK_MIGRATION_PLAN.md
@@ -387,11 +387,32 @@ Delivery uses two commits:
 Push the branch, open one PR titled `T-PLAT-2E: Migrate the Meilisearch Python
 SDK`, request Codex review, and watch required checks to a decided state.
 
-**v) Rollback.** Revert the T-PLAT-2E merge commit, rebuild/recreate all four
-affected Python images, and rerun the same v1.6 smoke using SDK 0.31.0. No
-database migration, server downgrade, index migration, or data repair is
-required. If deployed together with T-IDX-1, do not restore the retired people
-projection when rebuilding the index.
+**v) Rollback.** Revert the T-PLAT-2E merge commit and validate the restored
+0.31.0 application contract rather than rerunning the 0.43-only typed-model
+smoke:
+
+```bash
+git revert <t-plat-2e-merge-commit>
+docker compose build api worker pipeline-batch semantic
+docker compose up -d postgres redis meilisearch
+docker compose run --rm --no-deps pipeline python reindex_only.py --replace-all
+for image in \
+  town-council-python-api \
+  town-council-python-worker-live \
+  town-council-python-worker-batch \
+  town-council-python-semantic
+do
+  docker run --rm "$image" python -c \
+    'import importlib.metadata as m; assert m.version("meilisearch") == "0.31.0"'
+done
+PYTHONPATH=. .venv/bin/pytest -q tests/test_indexer_logic.py tests/test_api.py
+```
+
+The reverted indexer contains the legacy task/detection adapter needed by SDK
+0.31.0, so its own replacement-reindex path is the rollback acceptance test.
+No database migration, server downgrade, or source-data repair is required. If
+deployed together with T-IDX-1, do not restore the retired people projection
+when rebuilding the index.
 
 **w) Docs synchronization.** Update this Full plan, the remediation ledger, and
 `docs/ADR.md`. The new ADR entry supersedes only the task-ID and filtered-delete

--- a/docs/plans/T_PLAT_2E_MEILISEARCH_SDK_MIGRATION_PLAN.md
+++ b/docs/plans/T_PLAT_2E_MEILISEARCH_SDK_MIGRATION_PLAN.md
@@ -1,0 +1,417 @@
+# T-PLAT-2E: Migrate the Meilisearch Python SDK
+
+`artifact_contract: ce-unified-plan/v1`  
+`artifact_readiness: implementation-ready`  
+`execution: code`
+
+## 1. Context & Alignment
+
+**a) Driver.** The repository pins Meilisearch's Python SDK at 0.31.0 while
+0.43.0 is the current published release. The old integration retains a
+dictionary task-ID adapter and a two-method filtered-delete fallback even
+though the supported SDK returns typed models and exposes one filtered-delete
+API. This task upgrades the shared client, deletes those compatibility strata,
+and proves it against the retained Meilisearch v1.6 server before the remaining
+dependency migrations proceed.
+
+**b) Canonical documents consulted.**
+
+- `AGENTS.md`: dependency calls must be verified; the Meilisearch trust
+  boundary, exact ownership, tests-first work, complete verification, and
+  security impact reporting apply.
+- `docs/TESTING.MD`: fake the Meilisearch client only where constructed and do
+  not preserve production patch targets for tests.
+- `docs/ENGINEERING_GUARDRAILS.md`: Ruff configuration owns BLE001 boundaries;
+  remove stale entries rather than widening them.
+- `SECURITY.md`: API and semantic readers retain scoped search keys while
+  writers retain the master key; backing stores remain Compose-network only.
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`: T-PLAT-2E follows T-IDX-1 and
+  owns one deliberate SDK migration rather than the closed raw Dependabot PR.
+- `docs/reviews/architecture-review-2026-07-19.html`: compatibility layers are
+  retired only through narrow, evidence-backed tasks.
+
+**c) Remediation alignment.** T-PLAT-2E owns exactly these 14 paths:
+
+- `docs/plans/T_PLAT_2E_MEILISEARCH_SDK_MIGRATION_PLAN.md`
+- `docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md`
+- `docs/ADR.md`
+- `constraints.txt`
+- `pipeline/indexer.py`
+- `pipeline/indexer_meilisearch.py`
+- `ruff.toml`
+- `tests/test_api.py`
+- `tests/test_async_flow.py`
+- `tests/test_docker_build_contracts.py`
+- `tests/test_extract_task.py`
+- `tests/test_indexer_logic.py`
+- `tests/test_repository_guardrails.py`
+- `tests/test_tasks_vote_extraction_flow.py`
+
+No other tracked path may change. T-IDX-1 merged as PR #217 and T-PLAT-2D
+merged as PR #218. T-FE-1 remains separate.
+
+**d) Decision-gate check.** No G1-G5 decision is required or foreclosed. The
+operator already approved replacing closed Dependabot PR #197 with an owned
+Meilisearch migration. Runtime defaults, server version, gate semantics, and
+soak comparability remain unchanged.
+
+## 2. Design
+
+**e) Step-by-step approach.**
+
+1. Register T-PLAT-2E and its ownership in the remediation ledger.
+2. Add failing tests before implementation for the exact dependency pin, typed
+   task results, filtered deletion, error propagation, and BLE001 ratchet.
+3. Change only the shared constraint from `meilisearch==0.31.0` to
+   `meilisearch==0.43.0`.
+4. Delete `_task_uid`; read `TaskInfo.task_uid` directly from every SDK
+   mutation response.
+5. Delete `_delete_documents_by_filter`; call
+   `Index.delete_documents(filter=...)` directly.
+6. Make the four index-setting updates and targeted filtered deletion use the
+   existing `_wait_for_task_success` contract with their typed task IDs.
+7. Propagate transport errors and completed failed-task states. Settings and
+   targeted deletion must not be treated as successful merely because the
+   server accepted them asynchronously.
+8. Remove `pipeline/indexer_meilisearch.py` from Ruff's BLE001 allowance and
+   from the exact broad-handler boundary inventory.
+9. Add an ADR entry that supersedes only the task-ID and filtered-delete
+   compatibility clauses of the 2026-05-08 indexing decision.
+10. Update Meilisearch fakes to return typed-model-compatible objects and update
+   the API statistics fixture for the current Pydantic model constructor.
+11. Run static, targeted, complete, image-build, and isolated v1.6 runtime
+    verification; simplify the diff; obtain independent pre-commit review;
+    apply eligible P1/P2 findings; commit, push, open one PR, and watch review
+    and CI to a decided state.
+
+No new production function, wrapper, module, registry, or compatibility path is
+introduced.
+
+**f) Reuse audit.** Extend the current Meilisearch clients, indexer recovery
+helpers, task-ordering tests, Docker dependency contracts, and guardrail
+inventory. Reader calls in `api/search/**` and `semantic_service/**` continue to
+use `Index.search()` dictionaries and `IndexStats.number_of_documents`. The two
+deleted helpers have no valid post-migration role.
+
+**g) Data contracts.** SDK task responses are existing `TaskInfo`, `Task`, and
+`TaskResults` models. Production code consumes `task_uid`, `status`, `error`,
+and `results` attributes directly. `IndexStats` remains the SDK's typed model;
+search responses remain dictionaries at the existing boundary. No project
+contract model is added around dependency-owned models.
+
+Verified against the published 0.43.0 source:
+
+- `Client.create_index(uid, options) -> TaskInfo`
+- `Client.wait_for_task(uid, timeout_in_ms, interval_in_ms) -> Task`
+- `Client.get_tasks(parameters) -> TaskResults`
+- `Index.add_documents(documents) -> TaskInfo`
+- `Index.delete_documents(ids=None, *, filter=None) -> TaskInfo`
+- `Index.delete_all_documents() -> TaskInfo`
+- index-setting update methods return `TaskInfo`
+- `TaskInfo.task_uid: int`
+- `Index.get_stats() -> IndexStats`
+- `IndexStats.number_of_documents: int`
+
+Context7's Meilisearch documentation was checked for server task, document,
+settings, search, and statistics behavior. The official 0.43.0 SDK source is
+authoritative for Python signatures because Context7's Python result describes
+a different third-party package.
+
+**h) Schema/migration impact.** None. Meilisearch remains derived state and the
+server image remains v1.6. The SDK migration itself requires no database or
+index migration. T-IDX-1's deployment replacement reindex remains required and
+may run once with the upgraded client.
+
+## 3. Security & Data Governance
+
+**i) Security-sensitive paths.** No owned path is listed as security-sensitive
+in `AGENTS.md`, but this task changes the API/pipeline/semantic-to-Meilisearch
+dependency boundary. An attacker gains no endpoint, credential, permission, or
+network path. `SECURITY.md` control 3 remains intact: readers use
+`MEILI_SEARCH_KEY`, writers use `MEILI_MASTER_KEY`, and the service stays on the
+Compose network. Runtime smoke output must not print either key.
+
+**j) Secrets.** No credential, key, default, environment variable, port,
+workflow permission, or image exposure changes.
+
+**k) Person data.** No person data is created, linked, aggregated, or exposed.
+T-IDX-1 has already removed meeting people projections; this migration must not
+restore them.
+
+**l) Untrusted input.** Meilisearch HTTP responses remain untrusted at the SDK
+boundary. Version 0.43.0 validates task and statistics responses through its
+Pydantic models. Search response dictionaries retain existing API validation
+and frontend sanitization boundaries.
+
+## 4. Code Health
+
+**m) GED conformance sweep.** Production changes reduce helpers and narrow one
+handler. No new nesting, callable parameter, timestamp, environment read,
+magic policy literal, broad exception, type suppression, or import-time side
+effect is added. Existing task-ordering constants and domain names are reused.
+
+**n) Antipattern scan, plan pass.**
+
+- A1/H1: PyPI and upstream releases confirm 0.43.0 is current; exact calls and
+  return types were verified from the tagged official source. There is no
+  published 0.43.1.
+- A2-A4: no new setting, silent default, placeholder, or unverified completion
+  claim.
+- B1-B3: no wrapper, registry, dual client, retry, or impossible-condition
+  validation is added.
+- C1-C2: both superseded helpers and the legacy-method test are deleted; tests
+  move to the supported client boundary.
+- D1-D3: tests strengthen typed-response and propagation contracts without
+  skips, widened tolerances, private production patch targets, or call-order
+  assertions unrelated to recovery correctness.
+- E1-E3: edits stay within the 14 owned paths and avoid mechanical churn.
+- F1-F2: no duplicate SDK adapter or shared location is created.
+- H2-H4: no `Any`, ignore, cast, hand-rolled response model, or import-time
+  work is introduced.
+
+**o) Ratchet interaction.** Remove one existing `BLE001` selector for
+`pipeline/indexer_meilisearch.py`; add or widen none. `pipeline/indexer.py`
+retains its approved batch-boundary handler. Ruff rule families, exclusions,
+formatter scope, Mypy scope, coverage floor, and CI gates remain unchanged.
+
+**p) Dead code and duplication audit.** Delete `_task_uid`,
+`_delete_documents_by_filter`, their facade imports, the fallback branch, the
+legacy-method test, and stale SDK-version prose. Replace fake dictionaries with
+typed-response-compatible objects. Expected production delta is negative.
+
+## 5. Testing
+
+**q) Edge cases and failure scenarios.**
+
+1. Every settings mutation returns `TaskInfo`; all four task IDs must be waited.
+2. Targeted reindex deletion must finish before replacement documents submit.
+3. A settings wait transport error or completed failed task aborts indexing.
+4. A targeted filtered-deletion wait error or completed failed task prevents
+   replacement documents from being submitted.
+5. A failed completed task still aborts recovery unless its explicitly accepted
+   index-already-exists code matches.
+6. Empty pending-task results end the idle wait; persistent work times out.
+7. `IndexStats` construction and `number_of_documents` access match SDK 0.43.0.
+8. All requirement consumers resolve exactly SDK 0.43.0.
+9. Meilisearch v1.6 accepts settings updates, document add/search/stats/task
+   listing, filtered deletion, and task waits from SDK 0.43.0.
+10. A scoped reader key can search and read stats but cannot add documents or
+    update settings. Writer credentials, server image, index settings, and
+    people-field absence remain unchanged.
+
+**r) Tests added or updated.**
+
+| Test | Scenarios |
+|---|---|
+| Docker dependency contract | 8, 10 |
+| `test_indexer_logic.py` typed task/settings/delete/recovery tests | 1-6, 10 |
+| `test_api.py` current `IndexStats` fixture and search contracts | 7, 10 |
+| Async/extract/vote task tests with typed fake tasks | 1, 2, 10 |
+| Repository guardrail BLE001 inventory | 3, 8 |
+| Four Docker image dependency inspections | 8, 10 |
+| Isolated Meilisearch v1.6 runtime smoke | 1-6, 8-10 |
+
+Tests are written and run red before implementation. No fixed total-test count
+is asserted.
+
+**s) Fakes and mocks.** Tests patch the approved Meilisearch client boundary
+only where constructed in `pipeline.indexer` or `api.search.support_core`.
+Task-result fakes expose the public `task_uid` attribute consumed from the SDK.
+No facade, re-export, unit-under-test, or new production seam is patched.
+
+**t) Verification rows.** Apply API/search behavior, guardrail/tooling,
+coverage-gate dependency contracts, and docs-only rows. Run the complete
+coverage suite because one shared dependency crosses API, pipeline, and
+semantic service images.
+
+## 6. Execution, Rollback, Docs
+
+**u) Exact commands.**
+
+```bash
+git fetch origin --prune
+git switch master
+git merge --ff-only origin/master
+git switch -c codex/t-plat-2e-meilisearch-sdk-migration
+```
+
+Tests-first red evidence:
+
+```bash
+PYTHONPATH=. .venv/bin/pytest -q \
+  tests/test_docker_build_contracts.py \
+  tests/test_indexer_logic.py \
+  tests/test_api.py \
+  tests/test_repository_guardrails.py
+```
+
+Final local verification:
+
+```bash
+./.venv/bin/ruff check .
+./.venv/bin/ruff format --check . --config ruff-format.toml
+./.venv/bin/mypy
+PYTHONPATH=. .venv/bin/pytest -q tests/test_indexer_logic.py tests/test_api.py
+PYTHONPATH=. .venv/bin/pytest -q \
+  tests/test_async_flow.py tests/test_extract_task.py \
+  tests/test_tasks_vote_extraction_flow.py
+PYTHONPATH=. .venv/bin/pytest -q \
+  tests/test_docker_build_contracts.py tests/test_repository_guardrails.py \
+  tests/test_docs_links.py
+PYTHONPATH=. .venv/bin/python -m pytest -q --cov --cov-config=.coveragerc \
+  --cov-report=term-missing:skip-covered tests/
+git diff --check
+git status --short
+```
+
+Image and runtime acceptance:
+
+```bash
+docker build --target python-api -t tc-meili-api:0.43.0 .
+docker build --target python-worker-live -t tc-meili-worker-live:0.43.0 .
+docker build --target python-worker-batch -t tc-meili-worker-batch:0.43.0 .
+docker build --target python-semantic -t tc-meili-semantic:0.43.0 .
+
+for image in \
+  tc-meili-api:0.43.0 \
+  tc-meili-worker-live:0.43.0 \
+  tc-meili-worker-batch:0.43.0 \
+  tc-meili-semantic:0.43.0
+do
+  docker run --rm "$image" python -c \
+    'import importlib.metadata as m; assert m.version("meilisearch") == "0.43.0"'
+  docker run --rm "$image" python -m pip check
+done
+```
+
+Run the cleanup-safe isolated server and client smoke below. It verifies the
+v1.6 server, typed task/status/stat contracts, filtered deletion, and a scoped
+reader's read-only permissions without printing either credential:
+
+```bash
+set -euo pipefail
+MEILI_SMOKE_NETWORK="tc-meili-sdk-${RANDOM}"
+MEILI_SMOKE_CONTAINER="tc-meili-v16-${RANDOM}"
+MEILI_SMOKE_MASTER_KEY="$(openssl rand -hex 32)"
+cleanup_meili_smoke() {
+  docker rm -f "$MEILI_SMOKE_CONTAINER" >/dev/null 2>&1 || true
+  docker network rm "$MEILI_SMOKE_NETWORK" >/dev/null 2>&1 || true
+}
+trap cleanup_meili_smoke EXIT
+
+docker network create "$MEILI_SMOKE_NETWORK" >/dev/null
+docker run -d --name "$MEILI_SMOKE_CONTAINER" \
+  --network "$MEILI_SMOKE_NETWORK" \
+  -e MEILI_ENV=production \
+  -e MEILI_MASTER_KEY="$MEILI_SMOKE_MASTER_KEY" \
+  getmeili/meilisearch:v1.6 >/dev/null
+
+docker run --rm -i \
+  --network "$MEILI_SMOKE_NETWORK" \
+  -e MEILI_SMOKE_URL="http://${MEILI_SMOKE_CONTAINER}:7700" \
+  -e MEILI_SMOKE_MASTER_KEY="$MEILI_SMOKE_MASTER_KEY" \
+  tc-meili-worker-live:0.43.0 python - <<'PY'
+import os
+import time
+
+from meilisearch import Client
+from meilisearch.errors import MeilisearchApiError, MeilisearchCommunicationError
+
+server_url = os.environ["MEILI_SMOKE_URL"]
+admin = Client(server_url, os.environ["MEILI_SMOKE_MASTER_KEY"])
+deadline = time.monotonic() + 60
+while True:
+    try:
+        health = admin.health()
+        break
+    except MeilisearchCommunicationError:
+        if time.monotonic() >= deadline:
+            raise
+        time.sleep(0.5)
+assert health["status"] == "available"
+assert admin.get_version()["pkgVersion"].startswith("1.6.")
+
+index_uid = "tc_sdk_smoke"
+creation = admin.create_index(index_uid, {"primaryKey": "id"})
+assert admin.wait_for_task(creation.task_uid).status == "succeeded"
+search_index = admin.index(index_uid)
+settings_tasks = (
+    search_index.update_filterable_attributes(["category"]),
+    search_index.update_sortable_attributes(["date"]),
+    search_index.update_searchable_attributes(["title"]),
+    search_index.update_ranking_rules(["sort", "words", "typo", "proximity", "attribute", "exactness"]),
+)
+for settings_task in settings_tasks:
+    assert admin.wait_for_task(settings_task.task_uid).status == "succeeded"
+
+addition = search_index.add_documents([
+    {"id": 1, "title": "Budget", "category": "minutes", "date": "2026-08-02"},
+    {"id": 2, "title": "Transit", "category": "agenda", "date": "2026-08-03"},
+])
+assert admin.wait_for_task(addition.task_uid).status == "succeeded"
+assert search_index.search("Budget")["estimatedTotalHits"] == 1
+assert search_index.get_stats().number_of_documents == 2
+assert admin.get_tasks({"indexUids": [index_uid]}).results
+
+deletion = search_index.delete_documents(filter='category = "minutes"')
+assert admin.wait_for_task(deletion.task_uid).status == "succeeded"
+assert search_index.get_stats().number_of_documents == 1
+
+reader_key = admin.create_key({
+    "description": "ephemeral SDK smoke reader",
+    "actions": ["search", "stats.get"],
+    "indexes": [index_uid],
+    "expiresAt": None,
+})
+reader_index = Client(server_url, reader_key.key).index(index_uid)
+assert reader_index.search("Transit")["estimatedTotalHits"] == 1
+assert reader_index.get_stats().number_of_documents == 1
+for forbidden_call in (
+    lambda: reader_index.add_documents([{"id": 3, "title": "Denied"}]),
+    lambda: reader_index.update_sortable_attributes(["title"]),
+):
+    try:
+        forbidden_call()
+    except MeilisearchApiError:
+        continue
+    raise AssertionError("scoped reader unexpectedly changed the index")
+print("Meilisearch v1.6 SDK and scoped-reader smoke passed")
+PY
+```
+
+Delivery uses two commits:
+
+1. `docs(remediation): authorize T-PLAT-2E SDK migration`
+2. `build(search): migrate the Meilisearch Python SDK`
+
+Push the branch, open one PR titled `T-PLAT-2E: Migrate the Meilisearch Python
+SDK`, request Codex review, and watch required checks to a decided state.
+
+**v) Rollback.** Revert the T-PLAT-2E merge commit, rebuild/recreate all four
+affected Python images, and rerun the same v1.6 smoke using SDK 0.31.0. No
+database migration, server downgrade, index migration, or data repair is
+required. If deployed together with T-IDX-1, do not restore the retired people
+projection when rebuilding the index.
+
+**w) Docs synchronization.** Update this Full plan, the remediation ledger, and
+`docs/ADR.md`. The new ADR entry supersedes only the task-ID and filtered-delete
+compatibility clauses of the 2026-05-08 indexing decision. Existing operations
+commands, API contract, architecture map, README, security, testing,
+performance, and data-governance text remain accurate.
+
+## 7. Delivery Self-Audit
+
+**x) Antipattern scan, diff pass.** Re-run A-F/H against the actual diff.
+Reject surviving compatibility helpers, dictionary task parsing, a new wrapper,
+server-image or credential changes, unrelated dependency updates, type
+suppression, allowlist widening, or any path outside ownership.
+
+**y) Evidence.** Report tests-first failures, every command from 6u with
+PASS/FAIL, exact pass/skip/fail and coverage totals, all image dependency
+checks, isolated v1.6 smoke results, planning-review and pre-commit-review
+findings, commit hashes, PR URL, unresolved-thread count, and final CI state.
+
+**z) Deviations.** Expected deviation report: none. Any additional path,
+server-image change, key or port change, compatibility path, unverified SDK
+call, package-resolution failure, skipped runtime gate, unresolved P1/P2, or
+unrun required check is a blocker.

--- a/pipeline/indexer.py
+++ b/pipeline/indexer.py
@@ -19,10 +19,8 @@ from pipeline.indexer_documents import (
 from pipeline.indexer_meilisearch import (
     _apply_index_settings,
     _clear_documents_index,
-    _delete_documents_by_filter,
     _flush_batch,
     INDEX_ALREADY_EXISTS_ERROR_CODE,
-    _task_uid,
     _verify_documents_index_settings,
     _wait_for_documents_index_idle,
     _wait_for_task_success,
@@ -293,12 +291,14 @@ def reindex_catalog(catalog_id: int) -> dict:
         for item, event, place, organization in item_docs:
             payload.append(_build_agenda_item_search_doc(item, event, place, organization))
 
-        delete_task = _delete_documents_by_filter(
-            index, f'catalog_id = {int(catalog_id)} AND result_type = "agenda_item"'
+        delete_task = index.delete_documents(
+            filter=f'catalog_id = {int(catalog_id)} AND result_type = "agenda_item"'
         )
-        delete_uid = _task_uid(delete_task)
-        if isinstance(delete_uid, int):
-            client.wait_for_task(delete_uid)
+        _wait_for_task_success(
+            client,
+            delete_task.task_uid,
+            "targeted agenda-item deletion",
+        )
         if payload:
             index.add_documents(payload)
 

--- a/pipeline/indexer_meilisearch.py
+++ b/pipeline/indexer_meilisearch.py
@@ -1,11 +1,8 @@
-import logging
 import time
 
 from meilisearch import Client
 from meilisearch.errors import MeilisearchError
 from meilisearch.index import Index
-
-logger = logging.getLogger("indexer")
 
 DOCUMENTS_INDEX_UID = "documents"
 INDEX_IDLE_TIMEOUT_SECONDS = 300.0
@@ -135,59 +132,36 @@ def _flush_batch(index, documents_batch, count, label):
         return count
 
 
-def _task_uid(task_result) -> int | None:
-    if isinstance(task_result, dict):
-        return task_result.get("taskUid") or task_result.get("uid")
-    return None
-
-
-def _delete_documents_by_filter(index, filter_expr: str):
-    """
-    Meilisearch SDK compatibility wrapper for filtered deletes.
-
-    Why this exists:
-    The repo pins meilisearch==0.31.0, whose Python client supports
-    `delete_documents(filter=...)` but does not expose
-    `delete_documents_by_filter(...)`. Centralizing the compatibility branch keeps
-    targeted reindexing durable across minor SDK surface differences.
-    """
-    if hasattr(index, "delete_documents"):
-        return index.delete_documents(filter=filter_expr)
-    if hasattr(index, "delete_documents_by_filter"):
-        return index.delete_documents_by_filter([filter_expr])
-    raise RuntimeError("Meilisearch client does not support filtered document deletion")
-
-
 def _apply_index_settings(client: Client, index: Index) -> None:
-    """
-    Apply Meilisearch index settings and wait for completion.
-
-    Why:
-    Settings updates are asynchronous in Meilisearch. If we don't wait, users can
-    observe confusing behavior (for example, sort being rejected immediately after reindex).
-    """
-    task_ids = []
-
-    task_ids.append(
-        _task_uid(
-            index.update_filterable_attributes(list(FILTERABLE_ATTRIBUTES))
-        )
+    """Publish each search setting only after Meilisearch confirms success."""
+    filterable_task = index.update_filterable_attributes(
+        list(FILTERABLE_ATTRIBUTES)
     )
-    task_ids.append(
-        _task_uid(index.update_sortable_attributes(list(SORTABLE_ATTRIBUTES)))
-    )
-    task_ids.append(
-        _task_uid(
-            index.update_searchable_attributes(list(SEARCHABLE_ATTRIBUTES))
-        )
-    )
-    task_ids.append(
-        _task_uid(index.update_ranking_rules(list(RANKING_RULES)))
+    _wait_for_task_success(
+        client,
+        filterable_task.task_uid,
+        "filterable attribute settings",
     )
 
-    for uid in [task_id for task_id in task_ids if isinstance(task_id, int)]:
-        try:
-            client.wait_for_task(uid)
-        except Exception as settings_wait_error:
-            # Settings still apply asynchronously; this wait improves deterministic maintenance paths.
-            logger.warning("search_index.settings_wait_failed task_id=%s error=%s", uid, settings_wait_error)
+    sortable_task = index.update_sortable_attributes(list(SORTABLE_ATTRIBUTES))
+    _wait_for_task_success(
+        client,
+        sortable_task.task_uid,
+        "sortable attribute settings",
+    )
+
+    searchable_task = index.update_searchable_attributes(
+        list(SEARCHABLE_ATTRIBUTES)
+    )
+    _wait_for_task_success(
+        client,
+        searchable_task.task_uid,
+        "searchable attribute settings",
+    )
+
+    ranking_task = index.update_ranking_rules(list(RANKING_RULES))
+    _wait_for_task_success(
+        client,
+        ranking_task.task_uid,
+        "ranking rule settings",
+    )

--- a/ruff.toml
+++ b/ruff.toml
@@ -72,7 +72,6 @@ extend-immutable-calls = ["fastapi.Depends", "fastapi.Query", "fastapi.Path", "f
 "pipeline/enrichment_tasks.py" = ["B904"]
 "pipeline/extractor.py" = ["C901"]
 "pipeline/indexer.py" = ["BLE001"]
-"pipeline/indexer_meilisearch.py" = ["BLE001"]
 "pipeline/llm.py" = ["BLE001"]
 "pipeline/local_ai_provider_calls.py" = ["BLE001"]
 "pipeline/model_base.py" = ["BLE001"]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -98,11 +98,9 @@ def test_cors_preflight_rejects_disallowed_origin():
 def test_stats_response_is_minimized(mocker):
     search_index = mocker.Mock()
     search_index.get_stats.return_value = IndexStats(
-        {
-            "numberOfDocuments": 42,
-            "isIndexing": True,
-            "fieldDistribution": {"content": 42},
-        }
+        number_of_documents=42,
+        is_indexing=True,
+        field_distribution={"content": 42},
     )
     mocker.patch("api.search.support_core.client.index", return_value=search_index)
 

--- a/tests/test_async_flow.py
+++ b/tests/test_async_flow.py
@@ -83,7 +83,13 @@ def _patch_agenda_provider(
 
 def _patch_meilisearch_client(mocker) -> MagicMock:
     search_client = MagicMock()
-    search_client.index.return_value.delete_documents.return_value = {"taskUid": 41}
+    search_client.index.return_value.delete_documents.return_value = SimpleNamespace(
+        task_uid=41
+    )
+    search_client.wait_for_task.return_value = SimpleNamespace(
+        status="succeeded",
+        error=None,
+    )
     mocker.patch.object(indexer.meilisearch, "Client", return_value=search_client)
     return search_client
 

--- a/tests/test_backlog_maintenance_laserfiche_guard.py
+++ b/tests/test_backlog_maintenance_laserfiche_guard.py
@@ -1,4 +1,5 @@
 import sys
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 sys.modules["llama_cpp"] = MagicMock()
@@ -75,8 +76,13 @@ def _install_successful_side_effect_boundaries(mocker):
     meili_client = MagicMock()
     documents_index = MagicMock()
     indexed_document_batches: list[list[dict[str, object]]] = []
+    documents_index.delete_documents.return_value = SimpleNamespace(task_uid=51)
     documents_index.add_documents.side_effect = indexed_document_batches.append
     meili_client.index.return_value = documents_index
+    meili_client.wait_for_task.return_value = SimpleNamespace(
+        status="succeeded",
+        error=None,
+    )
     mocker.patch.object(indexer.meilisearch, "Client", return_value=meili_client)
     enqueued_catalog_ids: list[int] = []
     mocker.patch.object(

--- a/tests/test_docker_build_contracts.py
+++ b/tests/test_docker_build_contracts.py
@@ -23,7 +23,7 @@ SHARED_EXACT_CONSTRAINTS = {
     "celery": "5.6.3",
     "fastapi": "0.115.8",
     "httpx": "0.28.1",
-    "meilisearch": "0.31.0",
+    "meilisearch": "0.43.0",
     "prometheus-client": "0.26.0",
     "psycopg2-binary": "2.9.10",
     "rapidfuzz": "3.14.3",

--- a/tests/test_extract_task.py
+++ b/tests/test_extract_task.py
@@ -1,4 +1,5 @@
 from datetime import date
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -53,7 +54,13 @@ def _patch_successful_tika(mocker) -> None:
 
 def _patch_meilisearch_client(mocker) -> MagicMock:
     search_client = MagicMock()
-    search_client.index.return_value.delete_documents.return_value = {"taskUid": 17}
+    search_client.index.return_value.delete_documents.return_value = SimpleNamespace(
+        task_uid=17
+    )
+    search_client.wait_for_task.return_value = SimpleNamespace(
+        status="succeeded",
+        error=None,
+    )
     mocker.patch.object(indexer.meilisearch, "Client", return_value=search_client)
     return search_client
 

--- a/tests/test_indexer_logic.py
+++ b/tests/test_indexer_logic.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock
 
 # Ensure the pipeline directory is in the path for indexer imports
 sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'pipeline'))
-from pipeline import indexer
+from pipeline import indexer, indexer_meilisearch
 
 
 class EmptyIndexQuery:
@@ -45,16 +45,16 @@ class ReplacementIndex:
         return SimpleNamespace(task_uid=91)
 
     def update_filterable_attributes(self, attributes):
-        return {"taskUid": 1}
+        return SimpleNamespace(task_uid=1)
 
     def update_sortable_attributes(self, attributes):
-        return {"taskUid": 2}
+        return SimpleNamespace(task_uid=2)
 
     def update_searchable_attributes(self, attributes):
-        return {"taskUid": 3}
+        return SimpleNamespace(task_uid=3)
 
     def update_ranking_rules(self, rules):
-        return {"taskUid": 4}
+        return SimpleNamespace(task_uid=4)
 
     def get_stats(self):
         self.index_events.append("stats_checked")
@@ -428,15 +428,19 @@ def test_indexer_reports_agenda_source_count_after_batch_attempt(
         yield session
 
     fake_index = MagicMock()
-    fake_index.update_filterable_attributes.return_value = {"taskUid": 1}
-    fake_index.update_sortable_attributes.return_value = {"taskUid": 2}
-    fake_index.update_searchable_attributes.return_value = {"taskUid": 3}
-    fake_index.update_ranking_rules.return_value = {"taskUid": 4}
+    fake_index.update_filterable_attributes.return_value = SimpleNamespace(task_uid=1)
+    fake_index.update_sortable_attributes.return_value = SimpleNamespace(task_uid=2)
+    fake_index.update_searchable_attributes.return_value = SimpleNamespace(task_uid=3)
+    fake_index.update_ranking_rules.return_value = SimpleNamespace(task_uid=4)
     if batch_submission_fails:
         fake_index.add_documents.side_effect = indexer.MeilisearchError("boom")
     fake_client = MagicMock()
     fake_client.create_index.return_value = SimpleNamespace(task_uid=77)
     fake_client.index.return_value = fake_index
+    fake_client.wait_for_task.return_value = SimpleNamespace(
+        status="succeeded",
+        error=None,
+    )
     mocker.patch.object(indexer, "db_session", fake_db_session)
     mocker.patch.object(indexer.meilisearch, "Client", return_value=fake_client)
     mocker.patch.object(indexer, "MEILISEARCH_BATCH_SIZE", 2)
@@ -445,7 +449,9 @@ def test_indexer_reports_agenda_source_count_after_batch_attempt(
 
     assert source_document_count == 2
     fake_index.update_sortable_attributes.assert_called_with(["date"])
-    assert fake_client.wait_for_task.call_count == 4
+    assert [
+        wait_call.args[0] for wait_call in fake_client.wait_for_task.call_args_list
+    ] == [1, 2, 3, 4]
     assert fake_index.add_documents.call_count == 1
     if not batch_submission_fails:
         sent_batch = fake_index.add_documents.call_args[0][0]
@@ -472,43 +478,62 @@ def test_flush_batch_keeps_count_on_error(mocker):
     assert count == 7
 
 
-def test_delete_documents_by_filter_prefers_supported_delete_documents_api():
+def test_apply_index_settings_rejects_failed_completed_task():
     fake_index = MagicMock()
-    fake_index.delete_documents.return_value = {"taskUid": 88}
-
-    result = indexer._delete_documents_by_filter(
-        fake_index,
-        'catalog_id = 9 AND result_type = "agenda_item"',
+    fake_index.update_filterable_attributes.return_value = SimpleNamespace(task_uid=1)
+    fake_index.update_sortable_attributes.return_value = SimpleNamespace(task_uid=2)
+    fake_index.update_searchable_attributes.return_value = SimpleNamespace(task_uid=3)
+    fake_index.update_ranking_rules.return_value = SimpleNamespace(task_uid=4)
+    fake_client = MagicMock()
+    fake_client.wait_for_task.side_effect = (
+        SimpleNamespace(status="succeeded", error=None),
+        SimpleNamespace(status="failed", error={"code": "invalid_settings"}),
     )
 
-    assert result == {"taskUid": 88}
-    fake_index.delete_documents.assert_called_once_with(
-        filter='catalog_id = 9 AND result_type = "agenda_item"'
+    with pytest.raises(RuntimeError, match="sortable attribute settings failed"):
+        indexer._apply_index_settings(fake_client, fake_index)
+
+    assert [
+        wait_call.args[0] for wait_call in fake_client.wait_for_task.call_args_list
+    ] == [1, 2]
+    fake_index.update_searchable_attributes.assert_not_called()
+    fake_index.update_ranking_rules.assert_not_called()
+
+
+def test_apply_index_settings_propagates_wait_error():
+    fake_index = MagicMock()
+    fake_index.update_filterable_attributes.return_value = SimpleNamespace(task_uid=1)
+    fake_index.update_sortable_attributes.return_value = SimpleNamespace(task_uid=2)
+    fake_index.update_searchable_attributes.return_value = SimpleNamespace(task_uid=3)
+    fake_index.update_ranking_rules.return_value = SimpleNamespace(task_uid=4)
+    fake_client = MagicMock()
+    fake_client.wait_for_task.side_effect = indexer.MeilisearchError(
+        "settings wait unavailable"
     )
 
-
-def test_delete_documents_by_filter_falls_back_when_only_legacy_method_exists():
-    class LegacyIndex:
-        def __init__(self):
-            self.calls = []
-
-        def delete_documents_by_filter(self, filters):
-            self.calls.append(filters)
-            return {"taskUid": 11}
-
-    fake_index = LegacyIndex()
-
-    result = indexer._delete_documents_by_filter(
-        fake_index,
-        'catalog_id = 9 AND result_type = "agenda_item"',
-    )
-
-    assert result == {"taskUid": 11}
-    assert fake_index.calls == [['catalog_id = 9 AND result_type = "agenda_item"']]
+    with pytest.raises(indexer.MeilisearchError, match="settings wait unavailable"):
+        indexer._apply_index_settings(fake_client, fake_index)
 
 
-def test_reindex_catalog_skips_schema_updates_and_reindexes_agenda_items(mocker):
-    meeting_doc = SimpleNamespace(
+class TargetedReindexQuery:
+    def __init__(self, catalog_rows):
+        self.catalog_rows = catalog_rows
+
+    def join(self, *args, **kwargs):
+        return self
+
+    def outerjoin(self, *args, **kwargs):
+        return self
+
+    def filter(self, *args, **kwargs):
+        return self
+
+    def all(self):
+        return self.catalog_rows
+
+
+def _targeted_reindex_session():
+    meeting_document = SimpleNamespace(
         id=1,
         catalog_id=9,
         event_id=4,
@@ -531,7 +556,6 @@ def test_reindex_catalog_skips_schema_updates_and_reindexes_agenda_items(mocker)
     )
     event = SimpleNamespace(name="Meeting", meeting_type="Regular", record_date=None, ocd_id="ocd-event")
     place = SimpleNamespace(display_name="ca_test", name="Test City", state="CA")
-    organization = None
     agenda_item = SimpleNamespace(
         id=11,
         ocd_id="ocd-item-11",
@@ -543,39 +567,41 @@ def test_reindex_catalog_skips_schema_updates_and_reindexes_agenda_items(mocker)
         catalog_id=9,
         catalog=SimpleNamespace(url="https://example.com/meeting.pdf"),
     )
-
-    class FakeQuery:
-        def __init__(self, rows):
-            self._rows = rows
-        def join(self, *args, **kwargs):
-            return self
-        def outerjoin(self, *args, **kwargs):
-            return self
-        def filter(self, *args, **kwargs):
-            return self
-        def options(self, *args, **kwargs):
-            return self
-        def all(self):
-            return self._rows
-
     session = MagicMock()
     session.query.side_effect = [
-        FakeQuery([(meeting_doc, catalog, event, place, organization)]),
-        FakeQuery([(agenda_item, event, place, organization)]),
+        TargetedReindexQuery([(meeting_document, catalog, event, place, None)]),
+        TargetedReindexQuery([(agenda_item, event, place, None)]),
     ]
+    return session
+
+
+def _patch_targeted_reindex_runtime(mocker, deletion_outcome):
+    targeted_reindex_session = _targeted_reindex_session()
 
     @contextmanager
     def fake_db_session():
-        yield session
+        yield targeted_reindex_session
 
     fake_index = MagicMock()
-    fake_index.delete_documents.return_value = {"taskUid": 88}
+    fake_index.delete_documents.return_value = SimpleNamespace(task_uid=88)
     fake_client = MagicMock()
     fake_client.create_index.return_value = SimpleNamespace(task_uid=77)
     fake_client.index.return_value = fake_index
+    if isinstance(deletion_outcome, Exception):
+        fake_client.wait_for_task.side_effect = deletion_outcome
+    else:
+        fake_client.wait_for_task.return_value = deletion_outcome
     mocker.patch.object(indexer, "db_session", fake_db_session)
     mocker.patch.object(indexer.meilisearch, "Client", return_value=fake_client)
     apply_settings = mocker.patch.object(indexer, "_apply_index_settings")
+    return fake_client, fake_index, apply_settings
+
+
+def test_reindex_catalog_skips_schema_updates_and_reindexes_agenda_items(mocker):
+    fake_client, fake_index, apply_settings = _patch_targeted_reindex_runtime(
+        mocker,
+        SimpleNamespace(status="succeeded", error=None),
+    )
 
     result = indexer.reindex_catalog(9)
 
@@ -584,10 +610,37 @@ def test_reindex_catalog_skips_schema_updates_and_reindexes_agenda_items(mocker)
         filter='catalog_id = 9 AND result_type = "agenda_item"'
     )
     fake_index.add_documents.assert_called_once()
-    fake_client.wait_for_task.assert_called_once_with(88)
+    fake_client.wait_for_task.assert_called_once_with(
+        88,
+        timeout_in_ms=indexer_meilisearch.INDEX_TASK_TIMEOUT_MS,
+        interval_in_ms=indexer_meilisearch.INDEX_TASK_POLL_INTERVAL_MS,
+    )
     sent = fake_index.add_documents.call_args.args[0]
     assert {doc["result_type"] for doc in sent} == {"meeting", "agenda_item"}
     assert result["agenda_item_documents"] == 1
+
+
+@pytest.mark.parametrize(
+    "deletion_outcome, expected_exception",
+    (
+        (
+            SimpleNamespace(status="failed", error={"code": "invalid_filter"}),
+            RuntimeError,
+        ),
+        (indexer.MeilisearchError("delete wait unavailable"), indexer.MeilisearchError),
+    ),
+)
+def test_reindex_catalog_does_not_publish_after_delete_failure(
+    mocker,
+    deletion_outcome,
+    expected_exception,
+):
+    _, fake_index, _ = _patch_targeted_reindex_runtime(mocker, deletion_outcome)
+
+    with pytest.raises(expected_exception):
+        indexer.reindex_catalog(9)
+
+    fake_index.add_documents.assert_not_called()
 
 
 def test_reindex_catalogs_dedupes_and_records_failures(mocker):

--- a/tests/test_pipeline_batching.py
+++ b/tests/test_pipeline_batching.py
@@ -1,6 +1,8 @@
-import pytest
-from unittest.mock import MagicMock
 import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
 
 # Mock heavy libraries
 sys.modules["llama_cpp"] = MagicMock()
@@ -37,6 +39,18 @@ from pipeline.models import Base, Catalog, Document, AgendaItem, Event, Place
 from pipeline.city_scope import ordered_hydration_cities, source_aliases_for_city
 from pipeline.content_hash import compute_content_hash
 from pipeline.summary_freshness import compute_agenda_items_hash
+
+
+def _successful_meilisearch_client() -> MagicMock:
+    search_client = MagicMock()
+    search_client.index.return_value.delete_documents.return_value = SimpleNamespace(
+        task_uid=61
+    )
+    search_client.wait_for_task.return_value = SimpleNamespace(
+        status="succeeded",
+        error=None,
+    )
+    return search_client
 
 
 def test_document_chunk_worker(mocker):
@@ -511,7 +525,7 @@ def test_deterministic_agenda_summary_payloads_persist_empty_agenda_fallback(
     )
     db.commit()
 
-    search_client = MagicMock()
+    search_client = _successful_meilisearch_client()
     mocker.patch.object(indexer.meilisearch, "Client", return_value=search_client)
     enqueued_catalog_ids: list[int] = []
     mocker.patch.object(
@@ -558,7 +572,7 @@ def test_empty_agenda_content_hash_backfill_marks_catalog_changed(
     mocker.patch.object(
         indexer.meilisearch,
         "Client",
-        return_value=MagicMock(),
+        return_value=_successful_meilisearch_client(),
     )
     enqueued_catalog_ids: list[int] = []
     mocker.patch.object(
@@ -891,7 +905,7 @@ def test_non_agenda_fallback_persists_content_hash_and_side_effects(
     mocker.patch.object(
         indexer.meilisearch,
         "Client",
-        return_value=MagicMock(),
+        return_value=_successful_meilisearch_client(),
     )
     enqueued_catalog_ids: list[int] = []
     mocker.patch.object(
@@ -984,7 +998,7 @@ def test_non_agenda_fallback_records_timeout_reason(
     mocker.patch.object(
         indexer.meilisearch,
         "Client",
-        return_value=MagicMock(),
+        return_value=_successful_meilisearch_client(),
     )
     mocker.patch.object(
         semantic_tasks.embed_catalog_task,

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -107,7 +107,6 @@ APPROVED_BROAD_EXCEPTION_PATHS = {
     "pipeline/diagnose_search_sort.py",
     "pipeline/diagnose_semantic_search.py",
     "pipeline/indexer.py",
-    "pipeline/indexer_meilisearch.py",
     "pipeline/llm.py",
     "pipeline/local_ai_provider_calls.py",
     "pipeline/model_base.py",

--- a/tests/test_tasks_agenda_summary_format.py
+++ b/tests/test_tasks_agenda_summary_format.py
@@ -1,6 +1,7 @@
 import logging
 import sys
 from datetime import date
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -104,8 +105,13 @@ def _install_summary_boundaries(mocker, db_session, summary_provider):
     meili_client = MagicMock()
     documents_index = MagicMock()
     indexed_document_batches: list[list[dict[str, object]]] = []
+    documents_index.delete_documents.return_value = SimpleNamespace(task_uid=71)
     documents_index.add_documents.side_effect = indexed_document_batches.append
     meili_client.index.return_value = documents_index
+    meili_client.wait_for_task.return_value = SimpleNamespace(
+        status="succeeded",
+        error=None,
+    )
     mocker.patch.object(indexer.meilisearch, "Client", return_value=meili_client)
     enqueued_catalog_ids: list[int] = []
     mocker.patch.object(

--- a/tests/test_tasks_vote_extraction_flow.py
+++ b/tests/test_tasks_vote_extraction_flow.py
@@ -1,5 +1,6 @@
 from datetime import date
 import json
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from sqlalchemy.orm import sessionmaker
@@ -89,7 +90,13 @@ def _patch_meilisearch_client(mocker, *, failure: Exception | None = None) -> Ma
         mocker.patch.object(indexer.meilisearch, "Client", side_effect=failure)
         return None
     search_client = MagicMock()
-    search_client.index.return_value.delete_documents.return_value = {"taskUid": 29}
+    search_client.index.return_value.delete_documents.return_value = SimpleNamespace(
+        task_uid=29
+    )
+    search_client.wait_for_task.return_value = SimpleNamespace(
+        status="succeeded",
+        error=None,
+    )
     mocker.patch.object(indexer.meilisearch, "Client", return_value=search_client)
     return search_client
 


### PR DESCRIPTION
## What changed

- Upgraded the shared Meilisearch Python SDK constraint from 0.31.0 to 0.43.0.
- Deleted the dictionary task-ID adapter and legacy filtered-delete fallback.
- Made index settings and targeted agenda-item deletion wait for successful typed tasks before continuing.
- Removed the obsolete `pipeline/indexer_meilisearch.py` BLE001 boundary and updated all affected test fakes.
- Recorded the superseding ADR decision and the operator-approved 17-file task ownership.

## Why

The old compatibility paths obscured the supported SDK contract and allowed asynchronous settings or deletion failures to be treated as success. The migration establishes one typed SDK contract across all Python images while retaining Meilisearch v1.6.

## Risk and compatibility

- Meilisearch server version, index contract, document payloads, runtime defaults, and soak policy are unchanged.
- Reader/writer key separation is unchanged. No endpoint, credential, port, or network exposure changes.
- Indexing now fails fast when a settings or targeted-deletion task fails, preventing replacement documents from being submitted after an incomplete deletion.
- Rollback rebuilds the reverted 0.31.0 images and runs the reverted application replacement-reindex path; no database migration or data repair is required.

## Verification

- PASS: `./.venv/bin/ruff check .`
- PASS: `./.venv/bin/ruff format --check . --config ruff-format.toml`
- PASS: `./.venv/bin/mypy`
- PASS: targeted migration suite, 686 tests before ownership expansion
- PASS: repaired agenda maintenance/batching/summary boundary suite, 49 tests
- PASS: repository guardrails, Docker contracts, and docs links, 586 tests
- PASS: coverage gate, 1,794 passed, 21 skipped, 83.26% coverage
- PASS: four Docker targets built with `meilisearch==0.43.0`; all passed `pip check`
- PASS: isolated Meilisearch v1.6 settings/add/search/stats/task-list/filter-delete smoke
- PASS: scoped reader could search/read stats and was denied document/settings writes
- PASS: independent pre-commit review; its one P2 test-gap finding was fixed and the affected 21 tests reran
- PASS: `git diff --check`

## Remaining deficits

None for T-PLAT-2E. CI and Codex review remain required before merge.
