### PR TITLE
Synchronize architecture and pipeline documentation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -47,9 +47,11 @@ Operational tuning, rollout state, and troubleshooting are maintained in:
 #### Internal services
 - `crawler` (Scrapy ingestion)
 - `pipeline` (batch enrichment and indexing)
+- `tika` (document extraction and OCR service called by pipeline and workers)
 - `api` (FastAPI read/write endpoints)
+- `semantic` (FastAPI semantic retrieval service)
 - `frontend` server-side route handlers (same-origin proxy for protected write actions)
-- `worker` (Celery async task execution)
+- `worker`, `enrichment-worker`, and `semantic-worker` (queue-specific Celery execution)
 - `inference` (HTTP LLM service when `LOCAL_AI_BACKEND=http`)
 - `postgres` (system of record, including semantic and lineage data)
 - `redis` (Celery queue/result backend + provider metrics aggregation)
@@ -65,9 +67,20 @@ flowchart LR
         Legi["Legistar / Granicus"]
     end
 
+    subgraph Policy["Policy and Configuration"]
+        Registry["Approved city rollout registry"]
+    end
+
     subgraph Crawl["Ingestion (Scrapy)"]
         Spider["Crawler Service"]
-        Promote["promote_stage.py"]
+        Promote["pipeline/promote_stage.py"]
+    end
+
+    subgraph Processing["Pipeline Processing"]
+        Pipeline["Batch pipeline"]
+        Extractor["Extraction module"]
+        Tika["Apache Tika"]
+        Roster["Roster synchronization"]
     end
 
     subgraph DB["PostgreSQL"]
@@ -80,20 +93,26 @@ flowchart LR
 
     subgraph Async["Async (FastAPI + Celery + Redis)"]
         API["FastAPI"]
-        Queue[("Redis queue/result")]
-        Worker["Celery worker"]
+        Queue[("default queue")]
+        EnrichQueue[("enrichment queue")]
+        SemanticQueue[("semantic queue")]
+        Worker["default worker"]
+        EnrichWorker["enrichment worker"]
+        SemanticWorker["semantic worker"]
         LocalAI["LocalAI Orchestrator"]
     end
 
     subgraph Inference["Inference Runtime Modes"]
         InProc["InProcessLlamaProvider\n(LOCAL_AI_BACKEND=inprocess)"]
         HttpProv["HttpInferenceProvider\n(LOCAL_AI_BACKEND=http)"]
-        HttpSvc["inference service (Ollama/vLLM/llama.cpp server)"]
+        HttpSvc["HTTP inference service\n(Ollama or OpenAI-compatible, such as MLX-LM)"]
     end
 
     subgraph Search["Search + UI"]
         Meili["Meilisearch"]
-        Semantic["Semantic backend\n(FAISS bridge -> pgvector target)"]
+        SemanticSvc["Semantic HTTP service"]
+        SemanticBackend["FAISS/NumPy or pgvector backend"]
+        SemanticArtifacts[("FAISS/NumPy index artifacts")]
         UI["Next.js UI"]
     end
 
@@ -105,21 +124,31 @@ flowchart LR
     Web --> Spider
     Legi --> Spider
     Spider --> Stage --> Promote --> Core
+    Registry --> Roster
+    Legi --> Roster --> People
 
-    Core -->|"run_pipeline.py facade"| Meili
-    Core -->|"NLP/entity enrichment"| People
-    Core --> Sem
+    Core --> Pipeline --> Meili
+    Pipeline --> Extractor --> Tika
+    Extractor -->|"persist content and hash"| Core
     Agenda --> Meili
 
     UI -->|"search/read"| API
     API --> Meili
-    API --> Semantic
+    API -->|"HTTP"| SemanticSvc
+    SemanticSvc -->|"pgvector candidate recall"| Meili
+    SemanticSvc --> SemanticBackend
+    SemanticBackend -->|"FAISS/NumPy"| SemanticArtifacts
+    SemanticBackend -->|"pgvector"| Sem
     People -->|"people reads"| API
     UI -->|"proxied protected catalog reads/writes"| API
     API <--> Queue --> Worker --> LocalAI
+    API --> EnrichQueue --> EnrichWorker
+    Pipeline --> SemanticQueue
+    Worker --> SemanticQueue --> SemanticWorker --> Sem
     LocalAI --> InProc
     LocalAI --> HttpProv --> HttpSvc
     Worker --> Core
+    EnrichWorker --> Core
     UI -->|"GET /tasks/{id}"| API
 
     API -. metrics .-> Prom
@@ -138,7 +167,7 @@ flowchart LR
    - city-scoped recovery can opt into no-delta crawling when an operator needs a bounded historical backfill instead of the normal stored anchor.
 
 #### Batch enrichment
-1. Extraction writes canonical text to `catalog.content` and computes `content_hash`.
+1. The extraction service calls Apache Tika over HTTP, then writes canonical text to `catalog.content` and computes `content_hash`; Tika does not write application data.
 2. Agenda segmentation and summary hydration derive structured agenda state and summary state from the extracted corpus.
 3. Entity, topic, and organization stages enrich records after the core derived states exist. Person extraction and document-derived person linking are not enrichment stages.
 4. Search freshness is maintained through both broad batch hydration and task-driven targeted reindex of changed catalogs.
@@ -168,8 +197,8 @@ flowchart LR
 #### Async user-triggered generation
 1. UI calls protected write endpoints.
 2. Frontend server-side route handlers forward protected mutations with `API_AUTH_KEY`; the browser does not hold a public write key.
-3. API enqueues Celery tasks in Redis.
-4. Worker executes task and persists updates.
+3. API routes user-triggered generation through Redis to the default or enrichment queue.
+4. The matching worker executes the task and persists updates; post-write and maintenance flows dispatch embedding hydration to the semantic queue. Semantic retrieval remains a synchronous API-to-semantic-service HTTP path.
 5. UI polls `/tasks/{id}` with bounded retry logic.
 
 Trust note:
@@ -248,12 +277,17 @@ Primary owners:
 - Retrieval over-fetches candidates and de-duplicates by `catalog_id` before pagination.
 - If pgvector embeddings are missing or stale for the recalled meetings, semantic mode degrades to lexical results and reports why in `semantic_diagnostics`.
 - FAISS is a temporary bridge path while pgvector is hydrated and validated.
+- The API delegates semantic retrieval over HTTP to the dedicated `semantic`
+  service. FAISS/NumPy queries its filesystem index directly; pgvector recalls
+  meeting candidates from Meilisearch and reranks them against Postgres.
 
 Primary owners:
 - `api/main.py`
 - `api/search_routes.py`
 - `api/search_read_routes.py` facade plus focused `api/search_read_*` helpers
 - `api/search_semantic_routes.py`
+- `api/search/semantic_support.py`
+- `semantic_service/main.py` facade plus focused `semantic_service/*` helpers
 - `pipeline/semantic_backend_runtime.py`
 - `pipeline/semantic_backend_types.py`
 - `pipeline/semantic_faiss_backend.py`
@@ -279,15 +313,17 @@ Primary owners:
 
 #### Inference Provider Architecture (Stable baseline + Experimental future)
 
-- `LocalAI` handles orchestration (prompting, grounding, fallback policy).
+- `LocalAI` handles product orchestration, including prompting, grounding, and deterministic content fallback where the calling operation permits it.
 - Transport is abstracted behind `InferenceProvider`:
   - `InProcessLlamaProvider`
   - `HttpInferenceProvider`
+- HTTP mode supports Ollama and OpenAI-compatible protocols, including host
+  MLX-LM deployments; configuration selects one protocol and endpoint.
 - HTTP retry orchestration stays in `pipeline/http_inference_attempts.py`;
   in-process locking and reset behavior stays adapter-local.
-- Provider implementations import configuration and metrics from their owners,
-  never backward through the provider compatibility facade.
-- Providers emit typed errors (`ProviderTimeoutError`, `ProviderUnavailableError`, `ProviderResponseError`) so orchestration can distinguish retryable paths from deterministic fallback paths.
+- Provider implementations import contracts, configuration, and metrics directly
+  from their owners; no provider compatibility facade sits between them.
+- Providers emit typed errors (`ProviderTimeoutError`, `ProviderUnavailableError`, `ProviderResponseError`) so each calling operation can apply its documented retry, fail-fast, or deterministic-fallback policy.
 - Under prefork workers, provider telemetry is mirrored to Redis-backed aggregates so `tc_provider_*` series remain visible.
 
 Hardware topology:
@@ -322,8 +358,10 @@ Primary owners:
   - `api/main.py` (FastAPI app assembly and security middleware)
   - `api/task_routes.py` route assembly, `api/task_dispatch.py` broker boundary,
     and focused `api/task_route_*` helpers
-  - `pipeline/tasks.py` Celery entrypoints plus focused `pipeline/task_*`
-    operation owners
+  - `pipeline/tasks.py` default-queue entrypoints plus focused `pipeline/task_*`
+    operation owners, `pipeline/enrichment_tasks.py` for topic generation,
+    `pipeline/semantic_tasks.py` for embedding hydration, and
+    `pipeline/celery_app.py` for queue routing
   - `frontend/components/ResultCard.js` (polling/status UI)
 - Adjust lineage recompute behavior:
   - `pipeline/lineage_service.py` facade plus focused `pipeline/lineage_*` helpers
@@ -342,12 +380,14 @@ Primary owners:
 
 ### Code Map by Concern
 
-- Ingestion and promotion: `council_crawler/`, `crawler/promote_stage.py`
+- Ingestion and promotion: `council_crawler/`, `pipeline/promote_stage.py`
 - Canonical extraction/content hashing: `pipeline/extraction_service.py`, `pipeline/content_hash.py`
-- Async orchestration and writes: `pipeline/tasks.py` owns Celery identities,
-  retries, and sessions; focused `pipeline/task_*` modules own task-family
-  operations; vote extraction runs through `pipeline/vote_extractor.py` plus
-  focused `pipeline/vote_extraction_*` helpers
+- Async orchestration and writes: `pipeline/tasks.py` owns default-queue task
+  identities, retries, and sessions; `pipeline/enrichment_tasks.py` owns topic
+  generation; `pipeline/semantic_tasks.py` owns embedding hydration; focused
+  task modules own task-family operations; vote extraction runs through
+  `pipeline/vote_extractor.py` plus focused `pipeline/vote_extraction_*` helpers;
+  `pipeline/celery_app.py` owns queue declarations and task routing
 - Inference abstraction and provider telemetry: `pipeline/llm.py` product-policy facade plus focused `pipeline/local_ai_*` helpers, `pipeline/agenda_extraction.py`, `pipeline/inference_provider_contract.py`, `pipeline/http_inference_provider.py` adapter plus focused `pipeline/http_inference_*` helpers, `pipeline/inprocess_inference_provider.py`, `pipeline/provider_telemetry.py`, `pipeline/metrics.py`, `pipeline/metrics_provider_recorders.py`, `pipeline/metrics_redis_backend.py`
 - API surface and auth: `api/main.py`, `api/app_setup.py`, `api/search_routes.py` router aggregation, `api/search_read_routes.py` facade plus focused `api/search_read_*` helpers, `api/task_routes.py` route assembly, `api/task_dispatch.py`, focused `api/task_route_*` helpers, focused `api/search/*_support.py` helpers, `api/search/query_builder.py`, `api/metrics.py`
 - Semantic retrieval and embeddings: `semantic_service/main.py` route facade plus focused `semantic_service/*` helpers, `pipeline/semantic_backend_runtime.py`, `pipeline/semantic_backend_types.py`, `pipeline/semantic_faiss_backend.py`, `pipeline/semantic_pgvector_backend.py`, focused semantic backend helpers, `pipeline/models.py` facade plus focused `pipeline/model_*` modules
@@ -367,13 +407,13 @@ Primary owners:
 #### Request/read lifecycle
 1. UI calls read endpoints (`/search`, `/search/semantic`, lineage reads).
 2. API builds search/trend query contracts.
-3. API reads from Meilisearch and/or semantic backend.
+3. API reads lexical results from Meilisearch or calls the semantic HTTP service, which owns semantic backend access.
 4. API returns bounded, de-duplicated results.
 
 #### Write/task lifecycle
 1. UI sends protected POST (`/summarize`, `/segment`, `/topics`, `/extract`, `/votes`) with `X-API-Key`.
-2. API enqueues task in Redis-backed Celery queue.
-3. Worker executes pipeline logic and persists results.
+2. API enqueues user-triggered generation to the default or enrichment Redis-backed Celery queue.
+3. The corresponding worker executes pipeline logic and persists results; completed writes can dispatch embedding hydration to the semantic queue.
 4. UI polls `/tasks/{task_id}` until terminal state.
 
 #### Onboarding lifecycle
@@ -386,18 +426,21 @@ Primary owners:
 #### Inference lifecycle
 1. `LocalAI` selects transport (`InProcessLlamaProvider` or `HttpInferenceProvider`) based on configured backend.
 2. Provider executes request and emits `tc_provider_*` telemetry.
-3. Typed errors drive retry/fail-fast behavior.
+3. Typed errors let the calling operation distinguish transport retry, fail-fast, and permitted deterministic-fallback behavior.
 4. No silent remote-to-local fallback is permitted.
 
 ### Extension Points and Safe Customization Seams
 
-- Add new generation capability: add route in `api/task_routes.py` + task in `pipeline/tasks.py` + UI task-state wiring.
+- Add new generation capability: add the route through `api/task_routes.py`,
+  dispatch through `api/task_dispatch.py`, register the Celery identity in the
+  appropriate queue owner, add non-default routing in `pipeline/celery_app.py`,
+  keep operation logic in a focused task module, and add UI task-state wiring.
 - Add provider transport: implement the `InferenceProvider` contract from
   `pipeline/inference_provider_contract.py`, keep transport policy in the
-  adapter, and preserve typed errors plus metrics. Add facade imports only when
-  they are an explicit runtime compatibility contract.
+  adapter, preserve typed errors plus metrics, and wire backend selection in
+  `pipeline/local_ai_runtime.py`. Do not add a provider compatibility facade.
 - Extend query behavior: modify `api/search/query_builder.py` to avoid search/trend filter drift.
-- Add enrichment stage: append explicit stage in pipeline orchestration with deterministic write contract.
+- Add enrichment stage: append an explicit stage in pipeline orchestration with a deterministic write contract. Document-derived enrichment must not create or link person or membership records; `docs/DATA_GOVERNANCE.md` owns that authority policy.
 
 ## 4) Hard Contracts
 
@@ -438,7 +481,10 @@ Owners:
 - Hash-based staleness (`content_hash`, source-hash fields) governs regeneration correctness.
 
 Owners:
-- `pipeline/tasks.py`
+- `pipeline/vote_extractor.py` plus focused `pipeline/vote_extraction_*` helpers
+- `city_metadata/city_rollout_registry.csv`
+- `pipeline/legistar_roster.py`
+- `pipeline/roster_sync.py`
 - `pipeline/models.py` facade plus focused `pipeline/model_*` modules
 - `pipeline/content_hash.py`
 
@@ -512,7 +558,7 @@ Owners:
 ### Environment and Compatibility Contract
 
 - Baseline contributor runtime is local-first.
-- Required local services for full stack behavior: `postgres`, `redis`, `meilisearch`, API/worker services, and inference runtime in selected backend mode.
+- Required local services for full stack behavior: `postgres`, `redis`, `meilisearch`, Tika/extraction, API, semantic, queue-specific worker services, and the inference runtime selected by configuration.
 - `LOCAL_AI_BACKEND=inprocess` and `LOCAL_AI_BACKEND=http` are supported architecture modes.
 - Remote `HttpInferenceProvider` endpoint unavailability is a hard error path (fail-fast).
 - TTFT/TPS metrics are observational unless promoted by policy docs.
@@ -523,8 +569,14 @@ Owners:
 
 - Entrypoint and quickstart: [`README.md`](README.md)
 - Architecture and design intent: this file (`ARCHITECTURE.md`)
+- Agent workflow and repository policy: [`AGENTS.md`](AGENTS.md)
+- Pipeline behavior and rationale: [`docs/PIPELINE.md`](docs/PIPELINE.md)
 - Operator runbook and commands: [`docs/OPERATIONS.md`](docs/OPERATIONS.md)
 - Benchmark numbers and reproducibility: [`docs/PERFORMANCE.md`](docs/PERFORMANCE.md)
+- Security threat model and controls: [`SECURITY.md`](SECURITY.md)
+- Testing policy and approved fake boundaries: [`docs/TESTING.MD`](docs/TESTING.MD)
+- Static-analysis and guardrail policy: [`docs/ENGINEERING_GUARDRAILS.md`](docs/ENGINEERING_GUARDRAILS.md)
+- Person and civic-data authority policy: [`docs/DATA_GOVERNANCE.md`](docs/DATA_GOVERNANCE.md)
 - Milestone sequencing and status: [`ROADMAP.md`](ROADMAP.md)
 - City onboarding workflow and latest rollout evidence: [`docs/OPERATIONS.md`](docs/OPERATIONS.md), [`docs/city-onboarding-status.md`](docs/city-onboarding-status.md)
 - Adding new city crawlers: [`docs/CONTRIBUTING_CITIES.md`](docs/CONTRIBUTING_CITIES.md)

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -1,13 +1,14 @@
 # Town Council Pipeline Guide
 
-Last updated: 2026-07-31
+Last updated: 2026-08-02
 
 ## 1) Purpose and Boundaries
 
 ### What this document covers
 This document explains how Town Council's pipeline works end-to-end, including:
 - batch processing flow (`pipeline/run_pipeline.py`)
-- async write/generation flow (`api/main.py` + `pipeline/tasks.py`)
+- async write/generation flow (`api/task_routes.py`, `api/task_dispatch.py`, and
+  the queue-specific Celery task owners)
 - inference, data freshness, observability, and failure handling
 
 ### What this document does not replace
@@ -28,7 +29,8 @@ Town Council uses two complementary pipelines:
 
 2. Async pipeline (record-scoped, on demand):
 - executes user-triggered writes and generation through background tasks
-- primary entrypoints: protected API write endpoints in `api/main.py` and tasks in `pipeline/tasks.py`
+- primary entrypoints: protected routes in `api/task_routes.py`, dispatch in
+  `api/task_dispatch.py`, and queue-specific Celery task owners
 
 ### Why both pipelines exist
 - Batch pipeline provides broad consistency and index freshness.
@@ -62,6 +64,10 @@ Per-record behavior in `process_document_chunk()`:
 - persist extraction lifecycle state (`pending` / `complete` / `failed_terminal`)
 - commit per record
 
+Why this exists:
+- Chunked parallelism improves throughput.
+- Per-record commits preserve partial progress if a later record fails.
+
 ### Extraction lifecycle state
 - `catalog.extraction_status` is now the durable extraction backlog contract:
   - `pending`: extraction still eligible for batch work
@@ -78,10 +84,6 @@ Per-record behavior in `process_document_chunk()`:
 Why this exists:
 - Prevents permanent extraction failures from hiding the true backlog.
 - Keeps already-extracted rows eligible for downstream enrichment without forcing re-extraction.
-
-Why this exists:
-- Chunked parallelism improves throughput.
-- Per-record commits preserve partial progress if a later record fails.
 
 ### Stage C: Derived generation backfills
 - in-process maintenance agenda segmentation backfill
@@ -127,7 +129,7 @@ Person records are not derived from meeting documents. The explicit
 sources outside the profiled batch pipeline. Cities without current roster
 authorization expose source records but no people-facing data.
 
-## 4) Async Task Pipeline Walkthrough (`api/main.py` -> `pipeline/tasks.py`)
+## 4) Async Task Pipeline Walkthrough
 
 ### Request lifecycle
 1. UI/client calls protected write endpoint (for example `POST /summarize/{catalog_id}`).
@@ -142,10 +144,11 @@ authorization expose source records but no people-facing data.
 - `topics`: writes topic outputs and source-hash linkage.
 - `votes`: runs vote extraction/update logic over agenda items.
 
-`pipeline/tasks.py` owns registered Celery task identities, retry handling, and
-session lifecycle. The focused `pipeline/task_*` modules call their domain
-owners directly; no task facade bag or injected callable layer sits between
-the entrypoint and the task family.
+`pipeline/tasks.py` owns default-queue task identities, retries, and sessions;
+`pipeline/enrichment_tasks.py` owns topic generation on the enrichment queue;
+and `pipeline/semantic_tasks.py` owns embedding hydration on the semantic
+queue. Focused task modules call their domain owners directly; no task facade
+bag or injected callable layer sits between an entrypoint and its task family.
 
 Why this exists:
 - Heavy extraction/generation work is isolated from synchronous API reads.
@@ -202,12 +205,17 @@ Why this exists:
 | Path | Trigger | OCR behavior | Cache/force behavior |
 |---|---|---|---|
 | Batch pipeline (`pipeline/run_pipeline.py` -> extraction paths) | Batch processing records that need extraction | Uses config defaults through extractor (`TIKA_OCR_FALLBACK_ENABLED`) | No API force flag; behavior follows pipeline extraction conditions |
-| Async API (`POST /extract/{catalog_id}` in `api/main.py`) | User-triggered re-extraction, optional `ocr_fallback=true` | Passes `ocr_fallback` query flag into task | API short-circuits to `cached` when `force=false` and content length is already substantial |
+| Async API (`POST /extract/{catalog_id}` in `api/task_routes.py`) | User-triggered re-extraction, optional `ocr_fallback=true` | Passes `ocr_fallback` query flag into task | API short-circuits to `cached` when `force=false` and content length is already substantial |
 | Async task (`extract_text_task` in `pipeline/tasks.py`) | Celery worker execution for one catalog | Calls `reextract_catalog_content(..., ocr_fallback=...)`, which passes per-call OCR setting into extractor | Returns `cached` unless `force=true` when existing text meets minimum chars; updates content/hash only on successful extraction |
 
-### OCR/Tika config defaults (`pipeline/config.py` facade)
+### OCR/Tika configuration fallbacks
 
-| Variable | Default | Meaning |
+`pipeline/config_processing.py` owns the loader fallbacks below, while runtime
+profiles and `docker-compose.yml` can override them. The standard Compose
+services currently enable `TIKA_OCR_FALLBACK_ENABLED`; operators should check
+both the loader and active runtime configuration when diagnosing extraction.
+
+| Variable | Loader fallback | Meaning |
 |---|---|---|
 | `TIKA_OCR_FALLBACK_ENABLED` | `false` | Enables second-pass OCR when first-pass text is empty/too short |
 | `TIKA_MIN_EXTRACTED_CHARS_FOR_NO_OCR` | `800` | Minimum chars for first-pass text to be considered good enough |
@@ -232,8 +240,9 @@ Why this exists:
 - `pipeline/local_ai_agenda_compat.py`, `pipeline/local_ai_provider_calls.py`: focused LocalAI compatibility and provider-call helpers
 - `pipeline/agenda_extraction.py`: agenda-extraction facade for prompt/parser/fallback compatibility
 - `pipeline/agenda_extraction_parser.py`, `pipeline/agenda_extraction_fallback.py`, `pipeline/agenda_extraction_acceptance.py`, `pipeline/agenda_extraction_pages.py`, `pipeline/agenda_extraction_noise.py`, `pipeline/agenda_extraction_numbered.py`, `pipeline/agenda_extraction_paragraphs.py`, `pipeline/agenda_extraction_diagnostics.py`: focused agenda-extraction implementation modules
-- `pipeline/http_inference_provider.py`: HTTP/Ollama transport adapter backed by
-  focused `pipeline/http_inference_*` helpers
+- `pipeline/http_inference_provider.py`: HTTP transport adapter for Ollama and
+  OpenAI-compatible protocols, backed by focused `pipeline/http_inference_*`
+  helpers
 - `pipeline/inprocess_inference_provider.py`: in-process llama transport abstraction
 - `pipeline/inference_provider_contract.py`: provider protocol and typed error contract
 - `pipeline/provider_telemetry.py`: provider telemetry formatting and direct
@@ -241,7 +250,8 @@ Why this exists:
 
 HTTP retries remain transport-local in `pipeline/http_inference_attempts.py`.
 Tests patch HTTP, configuration, and telemetry names at their implementation
-modules and fake the provider protocol at `pipeline/inference_provider_contract.py`.
+modules. Provider substitutes implement the `InferenceProvider` protocol defined
+in `pipeline/inference_provider_contract.py`.
 
 ### Typed provider errors
 - `ProviderTimeoutError`
@@ -313,7 +323,7 @@ Telemetry can be missing/degraded even when some tasks complete; promotion decis
 
 | Signature | Likely Root Cause | First Places to Check | Why Check Order Works |
 |---|---|---|---|
-| `missing_task_id` | API enqueue/write endpoint response issue | `api/main.py`, endpoint response payload, task queue health | Fastest way to confirm enqueue contract break |
+| `missing_task_id` | API enqueue/write endpoint response issue | `api/task_routes.py`, `api/task_dispatch.py`, endpoint response payload, task queue health | Fastest way to confirm enqueue contract break |
 | `task_poll_timeout` | worker backlog/inference stall/timeout budget mismatch | `pipeline/tasks.py`, worker logs, runtime profile timeouts, queue metrics | Distinguishes queue pressure from task logic bugs |
 | low-signal summary block | source text quality below summary gate | `pipeline/summary_quality.py`, extracted text quality, segmentation state | Avoids chasing LLM prompts when source is insufficient |
 | segmentation noisy/empty/failed | extraction artifacts or segmentation heuristics mismatch | `pipeline/agenda_resolver.py` facade plus focused `pipeline/agenda_resolver_*` modules, `pipeline/llm.py` segmentation paths, extraction output | Segmentation quality is upstream of summary quality |
@@ -325,25 +335,33 @@ Why this exists:
 ## 10) How to Extend the Pipeline Safely
 
 ### Checklist for a new async generation stage
-1. Add protected API route in `api/main.py`.
-2. Add task implementation in `pipeline/tasks.py`.
-3. Define deterministic write contract (which fields are written and when).
-4. Ensure task lifecycle is observable via `GET /tasks/{task_id}`.
-5. Add metrics and error mapping semantics.
-6. Add tests for contract, retries/fallbacks, and stale/fresh behavior.
-7. Update docs (`README.md`, this file, `docs/OPERATIONS.md`, and `ARCHITECTURE.md` when architectural contract changes).
+1. Add the protected route through `api/task_routes.py` and the appropriate focused `api/task_route_*` owner.
+2. Add named dispatch and broker-error mapping in `api/task_dispatch.py`.
+3. Register the Celery identity in the existing queue owner (`pipeline/tasks.py`,
+   `pipeline/enrichment_tasks.py`, or `pipeline/semantic_tasks.py`) and keep
+   operation logic in a focused owner module.
+4. Add an exact route in `pipeline/celery_app.py` when the task belongs to a
+   non-default queue.
+5. Define deterministic write contract (which fields are written and when).
+6. Ensure task lifecycle is observable via `GET /tasks/{task_id}`.
+7. Add metrics and error mapping semantics.
+8. Add tests for contract, retries/fallbacks, and stale/fresh behavior.
+9. Update docs (`README.md`, this file, `docs/OPERATIONS.md`, and `ARCHITECTURE.md` when architectural contract changes).
 
 ### Why this exists
 Most regressions come from partial stage additions (route without durable write semantics, or task without observability/tests).
 
-## 11) Source-of-Truth File Map
+## 11) Primary Implementation Map
 
 Use these files as primary references:
 - Batch orchestration: `pipeline/run_pipeline.py` facade plus `pipeline/run_pipeline_steps.py`, `pipeline/run_pipeline_onboarding.py`, `pipeline/run_pipeline_selectors.py`, `pipeline/run_pipeline_extraction.py`, and `pipeline/run_pipeline_parallel.py`
-- Async orchestration: `pipeline/tasks.py` Celery entrypoints plus focused
-  `pipeline/task_*` operation owners
+- Async orchestration: `pipeline/tasks.py` default-queue entrypoints plus
+  focused `pipeline/task_*` operation owners, `pipeline/enrichment_tasks.py`
+  for topic generation, and `pipeline/semantic_tasks.py` for embedding hydration
+- Queue declarations and task routing: `pipeline/celery_app.py`
 - API task routes: `api/task_routes.py` assembly plus focused
   `api/task_route_*` helpers
+- API task lifecycle: `api/task_route_support.py` owns task-result translation
 - API task dispatch: `api/task_dispatch.py` owns named Celery sends and broker
   failure mapping
 - API app assembly: `api/main.py`
@@ -355,6 +373,9 @@ Use these files as primary references:
 - Provider transport: `pipeline/http_inference_provider.py` adapter plus
   focused `pipeline/http_inference_*` helpers and
   `pipeline/inprocess_inference_provider.py`
+- Semantic retrieval: `semantic_service/main.py` route facade plus focused
+  `semantic_service/*` helpers; `pipeline/semantic_backend_runtime.py` owns
+  backend selection through the contract in `pipeline/semantic_backend_types.py`
 - Extraction freshness/hash: `pipeline/extraction_service.py`, `pipeline/content_hash.py`
 - Metrics: `pipeline/metrics.py` (facade), `pipeline/metrics_definitions.py`, `pipeline/metrics_provider_keys.py`, `pipeline/metrics_redis_backend.py`, `pipeline/metrics_provider_recorders.py`, `pipeline/metrics_provider_collector.py`, `pipeline/metrics_task_recorders.py`, `pipeline/metrics_celery_signals.py`, `pipeline/metrics_profile_events.py`
 - Summary text runtime: `pipeline/text_generation.py` facade plus `pipeline/summary_text_formatting.py`, `pipeline/summary_text_prompting.py`, `pipeline/summary_source_quality.py`, `pipeline/summary_grounding.py`, and `pipeline/summary_backfill_*` helpers

--- a/docs/TESTING.MD
+++ b/docs/TESTING.MD
@@ -5,8 +5,8 @@ API" (`docs/ADR.md`, decision gate G3). `AGENTS.md` `<code_quality>` states
 the principle — tests assert observable behavior, not private implementation
 details — and this document says how to do that in this repository.
 
-Status: effective. During remediation Phase 2, tests are actively migrated to
-these rules; new tests must follow them immediately.
+Status: effective. The remediation migration is complete; new and modified
+tests must follow these rules.
 
 ## The core rule
 
@@ -27,7 +27,7 @@ invented for tests.
 | Celery dispatch       | Patch `api.task_dispatch.celery_app.send_task` or use Celery eager mode |
 | Celery result backend | Patch `api.task_route_support.AsyncResult`                  |
 | Inference / LLM       | Fake provider implementing `pipeline/inference_provider_contract.py` |
-| Semantic backend/runtime | After T-SEM-1 repoints consumers to resolve backend selection through the owner module, patch `pipeline.semantic_backend_runtime.get_semantic_backend` to return a fake implementing `pipeline.semantic_backend_types.SemanticBackend`; pgvector retrieval fakes also implement the public `rerank_candidates_with_diagnostics` or `rerank_candidates` capability exercised by the test; after T-SEM-1 moves optional FAISS and SentenceTransformer ownership there, substitute those adapters only in that module; never patch backend private methods |
+| Semantic backend/runtime | Patch `pipeline.semantic_backend_runtime.get_semantic_backend` to return a fake implementing `pipeline.semantic_backend_types.SemanticBackend`; pgvector retrieval fakes implement the public rerank capability exercised by the test; substitute optional FAISS and SentenceTransformer adapters only in their implementation owner modules; never patch backend private methods |
 | Meilisearch           | Patch the client object where it is constructed (`api/search/support_core.py`, `pipeline/indexer.py`) |
 | Outbound HTTP         | `httpx`/`requests` transport mocks at the call site      |
 | Clock                 | Pass/patch time at the function under test, not globally |

--- a/docs/city-onboarding-status.md
+++ b/docs/city-onboarding-status.md
@@ -1,9 +1,11 @@
 # City Onboarding Status
 
-Last updated: 2026-04-04
+Document reviewed: 2026-08-02
 
 This sheet tracks rollout readiness and quality gates per city.
-Machine-readable rollout truth lives in `city_metadata/city_rollout_registry.csv`; this page mirrors that registry for operator review.
+Machine-readable rollout status and roster authorization live in
+`city_metadata/city_rollout_registry.csv`. This operator view combines selected
+rollout fields with provider and spider evidence; it is not a complete registry mirror.
 
 | city_slug | provider | spider_exists | enabled | quality_gate | last_verified |
 |---|---|---:|---:|---|---|


### PR DESCRIPTION
## What changed
- align the architecture diagram with roster authority, Tika, semantic service boundaries, and queue-specific workers
- correct pipeline task ownership, routing guidance, inference protocols, and OCR configuration precedence
- update completed-remediation testing language and clarify city onboarding document metadata

## Why
The remediation deletion wave left several living documentation statements inconsistent with current code and service ownership.

## Risk and compatibility
Documentation only. No runtime defaults, APIs, schemas, policies, or operational state change.

## Verification
- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py` (2 passed)
- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_env_example_profile_alignment.py` (4 passed)
- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_repository_guardrails.py` (554 passed)
- PASS: `git diff --check`
- PASS: final independent review found no remaining P1/P2 findings

## Remaining deficit
A bounded guardrail for backticked implementation-map paths remains a separate follow-up; it is intentionally excluded from this documentation-only PR.