### PR TITLE
Add post-remediation follow-up plan documentation

### DIFF
--- a/docs/plans/POST_REMEDIATION_FOLLOWUP_PLAN.md
+++ b/docs/plans/POST_REMEDIATION_FOLLOWUP_PLAN.md
@@ -1,0 +1,385 @@
+# Focused Plan: Post-Remediation Follow-Up
+
+Scope: pipeline-doc integrity, baseline v2 evidence readiness, and
+architecture-watchlist retirement.
+
+plan_id: POST-REM-FOLLOWUP-2026-08
+status_tracking: PR checkboxes against the task table below. Do NOT add a
+changelog section to this file and do NOT extend the frozen remediation plan
+(docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md is historical evidence per the
+2026-08-02 postmortem prevention table).
+source: External review of docs/PIPELINE.md (verified against tree, all 72
+file refs currently valid) + verification of the baseline_representative_v2
+gap analysis. Both reviews dated 2026-08-02.
+amended: 2026-08-02 — Lane ARCH added from the 2026-07-19 architecture
+interrogation's deferred watchlist (docs/reviews/architecture-review-2026-07-19.html),
+re-verified against the 2026-08-02 tree: prerequisites have cleared on most
+items, converting them from "deferred" to "eligible".
+postmortem_compliance: This plan follows the program postmortem's prevention
+rules — it is small and focused; new checks are syntactic and bounded; task
+ownership below was traced from entrypoints/consumers/docs/tests/CI, not from
+expected diffs; policy meaning lands in canonical docs, task state lands in
+the tracker table only.
+
+---
+
+## Directives (apply to every task)
+
+- D1. AGENTS.md remains supreme; the planning templates
+  (docs selection rules) apply — T-BASE-2 is a mandatory Full-template task
+  because it touches soak-baseline comparability.
+- D2. Sourced vs derived: every step in an execution procedure (numbered
+  steps in a task, a Full plan, or a PR body) must be marked either
+  [sourced: <doc §>] or [derived: <policy it follows>]. Task charters in
+  this file are scoping documents, not procedures; their Full plans carry
+  the markings. Steps may not be presented as documented requirements
+  unless a citation exists.
+- D3. When restating the compatibility-seam prevention rule anywhere, quote
+  its standard exactly:
+  "proves duplication or reverse dependency and removes more seam machinery than it adds."
+  Looser paraphrases (e.g. "proves it obsolete") drop the
+  net-seam-reduction test and are incorrect.
+- D4. Minimal diffs; no drive-by edits to PIPELINE.md sections not named in
+  a task; the doc's honest documentation of retained facades is intentional
+  and stays.
+- D5. Deletion-test standard for every ARCH task: the change must remove
+  complexity rather than move it, and per the compatibility-seam rule (D3)
+  must remove more seam machinery than it adds. A task whose investigation
+  concludes "no change warranted" is a VALID completion — record the
+  evidence and close it.
+- D6. No campaign: at most TWO ARCH *implementation* PRs in flight at once
+  (P3 investigations and Full-plan authoring do not count toward the cap);
+  one domain per PR; investigation and implementation are separate PRs.
+  Template routing follows the planning templates' selection rules, which
+  this plan cannot override (D1): T-ARCH-4 (schema/migrations) and
+  T-ARCH-5, T-ARCH-1 (facade families) are Full-mandatory regardless of
+  tier; T-ARCH-2/3 Full per their gates; T-ARCH-9 may use Light;
+  T-ARCH-10 may use Light with the guardrail-change justification the
+  AGENTS.md maintenance triggers require.
+  Because every ARCH deletion PR also edits tests/test_repository_guardrails.py
+  (removing entries for deleted files), guardrail-file edits SERIALIZE:
+  T-ARCH-10 lands first, and no two ARCH PRs touching that file may be in
+  flight together.
+- D7. Priority tiers below are a proposal; gate GA-1 applies.
+
+## Gates
+
+- GA-1 (operator): ratify or reorder the ARCH priority ranking. Blocks all
+  ARCH implementation PRs; does not block investigations or Full-plan
+  drafting.
+- GA-2 (operator): one Postgres parity run for T-ARCH-4 (set
+  TEST_POSTGRES_DATABASE_URL, run the currently-skipped migrate_v10
+  tests); attach the run output to the T-ARCH-4 PR. Blocks T-ARCH-4 only.
+- GB-1 (procedure): if two consecutive T-BASE-2 captures report
+  `reduced-confidence`, HALT and escalate with both run reports attached.
+  Do not tune thresholds, retry indefinitely, or reinterpret the analyzer
+  state.
+
+## Task tracker
+
+| id        | state | evidence (PR #) |
+|-----------|-------|-----------------|
+| T-DOC-1   | open  |                 |
+| T-DOC-2   | open  |                 |
+| T-DOC-3   | open  |                 |
+| T-DOC-4   | open  |                 |
+| T-BASE-1  | open  |                 |
+| T-BASE-2  | open  |                 |
+| T-ARCH-1  | open  |                 |
+| T-ARCH-2  | open  |                 |
+| T-ARCH-3  | open  |                 |
+| T-ARCH-4  | open  |                 |
+| T-ARCH-5  | open  |                 |
+| T-ARCH-6  | open  |                 |
+| T-ARCH-7  | open  |                 |
+| T-ARCH-8  | open  |                 |
+| T-ARCH-9  | open  |                 |
+| T-ARCH-10 | open  |                 |
+
+---
+
+## Lane DOC — PIPELINE.md integrity (one PR, agent-executable)
+
+### T-DOC-1: Repair the Stage B duplicated rationale block
+- files_owned: docs/PIPELINE.md (§3 Stage B only)
+- do: Two consecutive "Why this exists:" blocks sit at the end of Stage B
+  (extraction-lifecycle rationale, then an orphaned chunking rationale).
+  Move the chunking rationale ("Chunked parallelism improves throughput…
+  per-record commits preserve partial progress…") directly under the
+  `run_parallel_processing()` / `process_document_chunk()` description, so
+  each block follows the mechanism it explains. No wording changes.
+- accept: Exactly one "Why this exists:" per mechanism in Stage B; content
+  byte-identical apart from relocation.
+- verify: `PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py`
+
+### T-DOC-2: Guard the §11 file map with a syntactic existence check
+- files_owned: tests/test_docs_links.py (or a sibling
+  tests/test_pipeline_doc_file_map.py if link-test scope is link-only by
+  design — decide in-PR and say why)
+- do: Add a bounded check: extract backtick-quoted `pipeline/|api/|scripts/|
+  docs/` paths ending in .py/.md from docs/PIPELINE.md; assert each literal
+  path exists and each glob family matches at least one file. No prose
+  interpretation, no content assertions — path existence only, per the
+  postmortem rule for custom checks ("exact-set… syntactic and bounded").
+- accept: Test passes on HEAD; deleting any referenced module makes it fail;
+  the check names its supported cases in a docstring (paths and globs) and
+  nothing else.
+- forbidden: Extending the check to other docs in this PR; asserting doc
+  content beyond path existence.
+- verify: targeted pytest for the new test + full suite.
+
+### T-DOC-3: Config-default provenance note on the OCR table
+- files_owned: docs/PIPELINE.md (§5 config table only)
+- do: Add one line under the `TIKA_*` table: defaults are defined in
+  `pipeline/config_processing.py`; that file wins on any conflict with this
+  table (or any other doc). Do not remove the table.
+- accept: Provenance line present; table values unchanged (spot-verified:
+  OCR fallback False, min chars 800 currently match code).
+- verify: docs-link test.
+
+### T-DOC-4: Retitle "Source-of-Truth File Map"
+- files_owned: docs/PIPELINE.md (§11 heading + any intra-doc references)
+- do: Rename §11 to "Primary File Map". Rationale: under AGENTS.md
+  hierarchy-of-truth, code is ground truth; a non-canonical explainer doc
+  should not claim source-of-truth status in a heading.
+- accept: No occurrence of "Source-of-Truth" remains in PIPELINE.md;
+  inbound anchors (README.md, ARCHITECTURE.md) checked and updated if they
+  deep-link the heading.
+- verify: docs-link test; grep.
+
+---
+
+## Lane BASE — baseline_representative_v2 evidence readiness
+
+### T-BASE-1: Promote the capture-hygiene rule into PERFORMANCE.md
+- files_owned: docs/PERFORMANCE.md (baseline interpretation-rules section,
+  ~L121 block), docs/OPERATIONS.md (cross-reference line near the baseline
+  capture commands, ~L1528, only if a pointer is missing)
+- do: The rule "a baseline capture run makes no optimization, threshold, or
+  runtime-policy changes; if capture exposes a defect, fix it in a separate
+  PR and recapture" is currently only derived (from AGENTS.md hard
+  invariants + the atomic-change policy) — it appears in no baseline doc.
+  Add it to PERFORMANCE.md's baseline rules so it becomes [sourced].
+  Runtime-policy immutability may cite AGENTS.md hard invariants inline.
+- accept: The rule is stated once in PERFORMANCE.md; OPERATIONS capture
+  section points to the rules rather than duplicating them; D2 marking in
+  the PR body.
+- verify: docs-link test; grep confirms single statement.
+
+### T-BASE-2: The evidence PR (Full template; human-gated execution)
+- files_owned: profiling/baselines/baseline_representative_v2.json (new),
+  PR body artifacts; ROADMAP.md City Expansion Readiness status line only
+  if the operator chooses to tick it in the same PR.
+- depends_on: T-BASE-1 (so every step below is [sourced])
+- human_gate: the capture itself runs on the operator's machine with the
+  local runtime profile — an agent prepares the plan and assembles the PR;
+  it does not execute the capture or fabricate its artifacts. Absence of
+  artifacts = the task is blocked, not improvisable.
+- procedure (all steps must carry D2 markings in the plan):
+  1. `--dry-run-prepare` inspection of controlled preconditioning
+     [sourced: PERFORMANCE interpretation rules; OPERATIONS ~L1528].
+  2. Stable local baseline run using the v2 manifest
+     [sourced: OPERATIONS baseline capture section].
+  3. `baseline_valid=true` and no `reduced-confidence` analyzer state
+     [sourced: v1 baseline schema + PERFORMANCE rules].
+  4. Required artifacts present: provider telemetry, phase timings, stable
+     workload counters [sourced: baseline schema fields
+     elapsed_seconds/top_phases/stable_counters/reference_run_id].
+  5. Derive the expected-baseline JSON from that run, same schema as v1
+     [sourced: profiling/baselines/baseline_representative_v1.json].
+  6. Re-run comparison via `--compare-to` against the proposed baseline;
+     include commands, runtime profile, run ID, and reports in the PR body
+     [sourced: PERFORMANCE rules].
+  7. No optimization/threshold/runtime-policy changes in the capture PR;
+     defects found → separate fix PR, then recapture
+     [sourced: PERFORMANCE after T-BASE-1].
+- context_for_reviewer (include verbatim in the PR body): v2 uses the
+  identical 30 catalog IDs as v1 with phase quotas redistributed — entity
+  4→8 absorbs the retired people phase's slots (people 4→0; extract 8,
+  segment 6, summary 6, org 2 unchanged). This preserves record-level
+  workload comparability while removing the non-comparable phase; v1 and
+  its checked-in expectation remain immutable historical evidence.
+- accept: profiling/baselines/baseline_representative_v2.json merged;
+  comparison run green under documented tolerances; PR body carries all
+  step evidence with D2 markings.
+- explicitly_not_claimed: merging this PR clears the baseline prerequisite
+  only; City Expansion Readiness additionally requires the rollout-registry
+  wave selection and crawl/derived-state/queue gates in ROADMAP.md — do not
+  mark expansion ready on this PR.
+
+---
+
+## Lane ARCH — watchlist retirement (gated by D5–D7)
+
+Source for every task: the 2026-07-19 architecture interrogation, re-verified
+against the 2026-08-02 tree. Priority tiers: P1 = cheap true deletions with
+evidence in hand; P2 = deep-module work needing a Full plan; P3 =
+investigations that may close with no code change.
+
+### T-ARCH-4: Retire shallow migration wrappers  [P1, Full-mandatory]
+- gate: GA-2 (operator parity run)
+- files_owned (contract-graph traced, per postmortem Lesson 2):
+  pipeline/migrate_v8.py, migrate_v9.py, migrate_v10.py,
+  pipeline/db_migrate.py, every caller of run_migrations/migrate chains
+  (startup and CLI entrypoints — enumerate in the Full plan),
+  docs/OPERATIONS.md (migration section), docs/PIPELINE.md (§11 entries
+  for deleted modules), alembic/ (only if delegation wiring changes),
+  their tests.
+- do: With Alembic as schema owner, delete the version-wrapper modules;
+  db_migrate.py remains the single deep entrypoint delegating to Alembic.
+  The Full plan MUST state the upgrade story for pre-Alembic databases
+  (contributor dev DBs that were never stamped): either an automatic
+  stamp-if-at-v10 path or a documented one-time operator command — silent
+  loss of the legacy upgrade path is a rejection criterion.
+- accept: No pipeline/migrate_v*.py remain; fresh-DB and upgraded-DB
+  schema diff empty; a v9/v10-era database's documented upgrade path
+  verified in the parity run; OPERATIONS and §11 updated; suite green;
+  GA-2 output attached.
+
+### T-ARCH-5: Retire LocalAI private re-exports  [P1, Full-mandatory]
+- files_owned: pipeline/llm.py, pipeline/local_ai_agenda_compat.py,
+  consumers identified by the census below, their tests,
+  docs/PIPELINE.md (§11 entries touched)
+- do: Step 1 (in the Full plan): consumer census — enumerate every import
+  of llm.py's aliased symbols and of local_ai_agenda_compat, from code and
+  from tests, distinguishing (a) external consumers of re-exports from
+  (b) llm.py's own internal delegation to implementation modules, which is
+  legitimate implementation and STAYS. Step 2: repoint (a) to the
+  implementation modules (agenda_extraction, agenda_summary,
+  agenda_text_heuristics), delete local_ai_agenda_compat.py, and remove
+  the now-unconsumed re-export surface. Keep LocalAI product policy and
+  public entrypoints intact.
+- accept (behavioral, not lexical): no module outside llm.py imports a
+  symbol from llm.py that llm.py merely re-exports from another module;
+  local_ai_agenda_compat.py deleted; census table in the PR body with each
+  consumer's disposition; D5 evidence (net symbols/seams removed); suite
+  green. Renaming aliases without removing the re-export relationship does
+  NOT satisfy this task.
+
+### T-ARCH-9: Fremont/Moraga recorded-parse parity  [P1, Light OK]
+- files_owned: tests/test_crawler_refactor_contract.py (or sibling),
+  checked-in HTML fixtures
+- do: Close the review's candidate-06 test deficit with CHECKED-IN
+  fixtures exercising the same event/document parse-depth Belmont's test
+  has. Fixtures are representative HTML consistent with the template
+  contract — synthesized or historically recorded — NOT live captures:
+  the spiders target portal eras that may no longer exist (Moraga's start
+  URL is 2017-era), so live capture would test a different site than the
+  code was written for. If a portal has genuinely changed, that is a
+  separate crawler-maintenance finding to file, not a reason to weaken the
+  fixture.
+- accept: All three spiders have equivalent parse-depth coverage from
+  checked-in fixtures; no test performs network I/O.
+
+### T-ARCH-10: Guardrail-file diet  [P1, Light OK, lands FIRST in lane]
+- files_owned: tests/test_repository_guardrails.py
+- do: Apply the postmortem's prevention rule to the 5,555-line file — but
+  classify before deleting. For every assertion targeting document
+  content, record one of: (a) pure prose-content assertion (headings,
+  phrasing, casing of narrative text) → DELETE; (b) invariant-bearing
+  assertion (e.g., frozen-document immutability, link integrity) →
+  REPLACE with a syntactic equivalent (content-hash pin for frozen files,
+  path-existence for links) that names its supported cases; (c) syntactic
+  code-policy check → KEEP. The classification table ships in the PR body.
+  Differential change, not a rewrite: this is the candidate-07 end-state
+  the program did not reach, taken in one bounded step.
+- accept: No test asserts prose content of docs/plans/* or
+  docs/postmortems/*; every invariant previously enforced by a deleted
+  assertion has a named syntactic replacement or a recorded decision to
+  drop it; file materially smaller; every retained custom check names its
+  supported cases in a docstring; suite green.
+- sequencing: lands before any other ARCH implementation PR (see D6
+  guardrail-file serialization).
+
+### T-ARCH-1: Search facade stack retirement  [P2, largest, Full-mandatory]
+- gate: GA-1 + its own Full-template plan (one stratum per PR)
+- files_owned: derived per contract-graph tracing in the Full plan —
+  candidate set: api/search_routes.py, api/search_read_*.py, api/search/,
+  api/main.py wiring, consuming tests, docs/PIPELINE.md §11 entries
+- do: MANDATORY investigation first: a route/consumer inventory
+  establishing which endpoints are wired, which modules are live routes vs
+  helpers vs genuinely superseded strata. The retirement direction is an
+  OUTPUT of that inventory, not an input — do not assume oldest-first or
+  that newer strata are complete replacements. Then retire one proven-
+  redundant stratum per PR under the D5 deletion test.
+- accept (per stratum PR): the inventory evidence names the stratum
+  redundant; it is deleted end-to-end including its tests' patch targets;
+  no re-export bridge left behind; §11 updated.
+
+### T-ARCH-2: ResultCard decomposition  [P2, Full-mandatory]
+- gate: GA-1 + Full plan (design pass, not mechanical)
+- files_owned: frontend/components/ResultCard.js, frontend/lib/,
+  frontend/components/__tests__/
+- do: Both review prerequisites are met (runner + 42-test harness) and the
+  polling seam is already extracted (taskPolling.js). Continue along the
+  review's seam list — mutation dispatch, formatting, rendering — one
+  extraction per PR, each behind the existing tests. The Full plan sets an
+  explicit numeric line budget and a one-responsibility statement for what
+  remains in ResultCard.js; "near composition-only" without numbers is not
+  an acceptance criterion.
+- accept (per extraction PR): behavior parity — the existing test files
+  pass with their ASSERTIONS unchanged (imports/patch targets may move per
+  TESTING.MD); the extracted module has its own test; ResultCard.js
+  shrinks toward the Full plan's stated budget.
+
+### T-ARCH-3: Deepen semantic retrieval interface  [P2, Full-mandatory]
+- gate: GA-1 + Full plan
+- files_owned: semantic_service/retrieval.py, its callers and tests
+- do: Replace the 13-parameter retrieve signatures with a typed request
+  contract (match the *_contracts.py convention); implementation callables
+  become private.
+- accept: Public retrieve interface takes the request contract (plus at
+  most session/config); every contract field is individually typed and
+  documented — no dict payload field, no **kwargs, no Any escape hatch
+  (a god-object with an opaque bag does not satisfy this task); suite
+  green.
+
+### T-ARCH-6: Frontend search coordinator  [P3, investigation first]
+- do: Investigate consolidating live/demo search adapters behind one
+  coordinator (frontend/state/search-state.js + lib/api.js). Output: a
+  one-page finding — proceed with a Full plan, or close per D5.
+
+### T-ARCH-7: Index projection consolidation  [P3, investigation first]
+- do: Post-G4/T-IDX-1, investigate whether projection policy (what enters
+  the search index per data class) has a single owner; propose one if not.
+  DATA_GOVERNANCE §3 is the policy source; code should mirror it in one
+  place.
+
+### T-ARCH-8: Crawler staging persistence  [P3, investigation first]
+- do: The review flagged duplicated session/transaction policy; current
+  tree shows it concentrated in council_crawler pipelines.py. Verify
+  against pipeline/ persistence policy and either file a narrow follow-up
+  or close with evidence. Expected outcome: closes cheaply.
+
+---
+
+## Execution order
+
+```
+PR 1: T-DOC-1 + T-DOC-3 + T-DOC-4 (single doc-integrity PR)
+PR 2: T-DOC-2 (its own PR: new guardrail, reviewed against postmortem rules)
+PR 3: T-BASE-1 (doc promotion; unblocks sourced markings)
+PR 4: T-BASE-2 (operator capture + agent-assembled evidence PR)
+ARCH: T-ARCH-10 lands FIRST (guardrail-file serialization, D6); then P1
+      tasks (T-ARCH-4/5/9) in any order, max two implementation PRs in
+      flight; P2 tasks after GA-1, each behind its own Full plan;
+      P3 investigations anytime, implementation only via new gated tasks.
+```
+
+DOC, BASE, and ARCH lanes are independent; T-BASE-2 alone is sequenced
+after T-BASE-1; T-ARCH-4 alone is gated on the operator parity run.
+
+## Out of scope
+
+- Any other PIPELINE.md edits, including facade-inventory pruning — the
+  retained-facade honesty is a feature (though ARCH deletions must update
+  the §11 map entries they invalidate; the T-DOC-2 check will catch misses).
+- Extending the file-map existence check to other documents (revisit only
+  if a second doc exhibits the same staleness risk — the second-finding
+  rule, not preemption).
+- Baseline threshold or tolerance changes; runtime-profile changes; any
+  soak-gate semantics (hard invariants, human decision required).
+- Reopening or amending the frozen remediation plan.
+- Any facade retirement outside the domains named in Lane ARCH — the
+  candidate-08 rule stands: no repository-wide purge; watchlist domains
+  only, one at a time, under D5/D6.

--- a/docs/plans/POST_REMEDIATION_FOLLOWUP_PLAN.md
+++ b/docs/plans/POST_REMEDIATION_FOLLOWUP_PLAN.md
@@ -125,10 +125,15 @@ the tracker table only.
   name any additional file before implementation; this charter does not
   authorize edits elsewhere.
 - do: Add a bounded check: extract every backtick-quoted syntactic path
-  candidate from docs/PIPELINE.md that is either a literal `.py`/`.md` path
-  or a terminal wildcard path. Terminal wildcards may be extensionless, such
-  as `pipeline/task_*`, `api/task_route_*`, or `semantic_service/*`. Extract
-  candidates without first consulting the filesystem. Derive the family
+  candidate only from the text between the `## 11)` heading and the next
+  level-two heading in docs/PIPELINE.md. A candidate must be an unambiguous
+  repository-relative reference containing `/` and must be either a literal
+  `.py`/`.md` path or a terminal wildcard path. Terminal wildcards may be
+  extensionless, such as `pipeline/task_*`, `api/task_route_*`, or
+  `semantic_service/*`. Bare names such as `db_migrate.py`, commands, and
+  generated artifact names outside §11 are not part of this contract; do not
+  infer a parent directory from prose. Extract candidates without first
+  consulting the filesystem. Derive the family
   set from those candidates' leading path segments, not from a hardcoded list
   or the set of directories that currently exists. Then assert that each
   candidate family exists, each literal path exists, and each glob family
@@ -139,7 +144,8 @@ the tracker table only.
 - accept: Test passes on HEAD; deleting a literal referenced path or top-level
   family makes it fail; removing the final match for a glob family makes it
   fail, including for an extensionless terminal wildcard. The check names
-  these supported cases in a docstring and does not
+  these supported cases in a docstring; a bare filename outside §11 does not
+  enter the candidate set. The check does not
   claim that it protects every individual member represented only by a glob.
 - forbidden: Extending the check to other docs in this PR; asserting doc
   content beyond path existence.

--- a/docs/plans/POST_REMEDIATION_FOLLOWUP_PLAN.md
+++ b/docs/plans/POST_REMEDIATION_FOLLOWUP_PLAN.md
@@ -11,10 +11,11 @@ changelog section to this file and do NOT extend the frozen remediation plan
 source: External review of docs/PIPELINE.md (verified against tree, all 72
 file refs currently valid) + verification of the baseline_representative_v2
 gap analysis. Both reviews dated 2026-08-02.
-amended: 2026-08-02 — Lane ARCH added from the 2026-07-19 architecture
-interrogation's deferred watchlist (docs/reviews/architecture-review-2026-07-19.html),
-re-verified against the 2026-08-02 tree: prerequisites have cleared on most
-items, converting them from "deferred" to "eligible".
+amended: 2026-08-03 — reconciled against live master (parent of PR #224
+commit 83b020a) after Codex review flagged snapshot staleness: T-DOC-1,
+T-DOC-3, T-DOC-4, and T-ARCH-9 were already completed on master and are
+closed as pre-existing below. Earlier verification dates in this file refer
+to the 2026-08-02 archive snapshot, which master has since advanced past.
 postmortem_compliance: This plan follows the program postmortem's prevention
 rules — it is small and focused; new checks are syntactic and bounded; task
 ownership below was traced from entrypoints/consumers/docs/tests/CI, not from
@@ -61,6 +62,11 @@ the tracker table only.
   T-ARCH-10 lands first, and no two ARCH PRs touching that file may be in
   flight together.
 - D7. Priority tiers below are a proposal; gate GA-1 applies.
+- D8. Snapshot staleness: this plan was authored against an archive
+  snapshot. Before opening any task's PR, re-verify the task's premise
+  against HEAD. A premise that no longer holds closes the task as
+  pre-completed (record the evidence in the tracker) — it does not license
+  no-op or contradictory work.
 
 ## Gates
 
@@ -70,19 +76,27 @@ the tracker table only.
 - GA-2 (operator): one Postgres parity run for T-ARCH-4 (set
   TEST_POSTGRES_DATABASE_URL, run the currently-skipped migrate_v10
   tests); attach the run output to the T-ARCH-4 PR. Blocks T-ARCH-4 only.
-- GB-1 (procedure): if two consecutive T-BASE-2 captures report
-  `reduced-confidence`, HALT and escalate with both run reports attached.
-  Do not tune thresholds, retry indefinitely, or reinterpret the analyzer
-  state.
+- GB-1 (procedure, restating canonical policy — no new gate semantics):
+  a `reduced-confidence` or non-baseline-valid capture is `non_comparable`;
+  per docs/PERFORMANCE.md compare policy, inspect result.json and the
+  listed confidence reason and fix that reason before using any run for
+  the expected baseline [sourced: PERFORMANCE.md interpretation rules +
+  compare policy]. Fixes land in separate PRs, then recapture
+  [sourced: PERFORMANCE.md after T-BASE-1]. If the listed reason
+  implicates runtime policy or profile configuration, escalate to the
+  operator — agents may not alter those (AGENTS.md hard invariants).
+  This gate introduces no retry counts or halt thresholds; any such
+  addition would be a soak-gate semantic requiring ratification in
+  canonical policy, not in this plan.
 
 ## Task tracker
 
 | id        | state | evidence (PR #) |
 |-----------|-------|-----------------|
-| T-DOC-1   | open  |                 |
+| T-DOC-1   | closed (pre-completed) | master@parent-of-83b020a |
 | T-DOC-2   | open  |                 |
-| T-DOC-3   | open  |                 |
-| T-DOC-4   | open  |                 |
+| T-DOC-3   | closed (pre-completed) | master@parent-of-83b020a |
+| T-DOC-4   | closed (pre-completed) | master@parent-of-83b020a |
 | T-BASE-1  | open  |                 |
 | T-BASE-2  | open  |                 |
 | T-ARCH-1  | open  |                 |
@@ -93,31 +107,28 @@ the tracker table only.
 | T-ARCH-6  | open  |                 |
 | T-ARCH-7  | open  |                 |
 | T-ARCH-8  | open  |                 |
-| T-ARCH-9  | open  |                 |
+| T-ARCH-9  | closed (pre-completed) | master@parent-of-83b020a |
 | T-ARCH-10 | open  |                 |
 
 ---
 
 ## Lane DOC — PIPELINE.md integrity (one PR, agent-executable)
 
-### T-DOC-1: Repair the Stage B duplicated rationale block
-- files_owned: docs/PIPELINE.md (§3 Stage B only)
-- do: Two consecutive "Why this exists:" blocks sit at the end of Stage B
-  (extraction-lifecycle rationale, then an orphaned chunking rationale).
-  Move the chunking rationale ("Chunked parallelism improves throughput…
-  per-record commits preserve partial progress…") directly under the
-  `run_parallel_processing()` / `process_document_chunk()` description, so
-  each block follows the mechanism it explains. No wording changes.
-- accept: Exactly one "Why this exists:" per mechanism in Stage B; content
-  byte-identical apart from relocation.
-- verify: `PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py`
+### T-DOC-1: Repair the Stage B duplicated rationale block  [CLOSED — pre-completed on master]
+- evidence: master PIPELINE.md places the chunking rationale directly under run_parallel_processing(); no orphaned duplicate block remains.
 
 ### T-DOC-2: Guard the §11 file map with a syntactic existence check
 - files_owned: tests/test_docs_links.py (or a sibling
   tests/test_pipeline_doc_file_map.py if link-test scope is link-only by
   design — decide in-PR and say why)
-- do: Add a bounded check: extract backtick-quoted `pipeline/|api/|scripts/|
-  docs/` paths ending in .py/.md from docs/PIPELINE.md; assert each literal
+- do: Add a bounded check: extract every backtick-quoted repository path
+  from docs/PIPELINE.md matching `<family>/<...>.py|.md` where the family
+  set is DERIVED from the document itself (any leading path segment that
+  is a top-level repo directory), not hardcoded — the map already
+  references semantic_service/ alongside pipeline/, api/, scripts/, and
+  docs/, and a hardcoded prefix list silently exempts whole families
+  (Codex P2, PR #224: deleting semantic_service/main.py would have passed
+  a pipeline|api|scripts|docs check). Assert each literal
   path exists and each glob family matches at least one file. No prose
   interpretation, no content assertions — path existence only, per the
   postmortem rule for custom checks ("exact-set… syntactic and bounded").
@@ -128,24 +139,11 @@ the tracker table only.
   content beyond path existence.
 - verify: targeted pytest for the new test + full suite.
 
-### T-DOC-3: Config-default provenance note on the OCR table
-- files_owned: docs/PIPELINE.md (§5 config table only)
-- do: Add one line under the `TIKA_*` table: defaults are defined in
-  `pipeline/config_processing.py`; that file wins on any conflict with this
-  table (or any other doc). Do not remove the table.
-- accept: Provenance line present; table values unchanged (spot-verified:
-  OCR fallback False, min chars 800 currently match code).
-- verify: docs-link test.
+### T-DOC-3: Config-default provenance note on the OCR table  [CLOSED — pre-completed on master]
+- evidence: master PIPELINE.md states pipeline/config_processing.py owns the loader fallbacks for the table.
 
-### T-DOC-4: Retitle "Source-of-Truth File Map"
-- files_owned: docs/PIPELINE.md (§11 heading + any intra-doc references)
-- do: Rename §11 to "Primary File Map". Rationale: under AGENTS.md
-  hierarchy-of-truth, code is ground truth; a non-canonical explainer doc
-  should not claim source-of-truth status in a heading.
-- accept: No occurrence of "Source-of-Truth" remains in PIPELINE.md;
-  inbound anchors (README.md, ARCHITECTURE.md) checked and updated if they
-  deep-link the heading.
-- verify: docs-link test; grep.
+### T-DOC-4: Retitle "Source-of-Truth File Map"  [CLOSED — pre-completed on master]
+- evidence: master §11 is titled "Primary Implementation Map"; no "Source-of-Truth" occurrence remains.
 
 ---
 
@@ -216,25 +214,36 @@ against the 2026-08-02 tree. Priority tiers: P1 = cheap true deletions with
 evidence in hand; P2 = deep-module work needing a Full plan; P3 =
 investigations that may close with no code change.
 
-### T-ARCH-4: Retire shallow migration wrappers  [P1, Full-mandatory]
+### T-ARCH-4: Rationalize the migrate chain vs Alembic ownership  [P1, Full-mandatory]
 - gate: GA-2 (operator parity run)
-- files_owned (contract-graph traced, per postmortem Lesson 2):
-  pipeline/migrate_v8.py, migrate_v9.py, migrate_v10.py,
-  pipeline/db_migrate.py, every caller of run_migrations/migrate chains
-  (startup and CLI entrypoints — enumerate in the Full plan),
-  docs/OPERATIONS.md (migration section), docs/PIPELINE.md (§11 entries
-  for deleted modules), alembic/ (only if delegation wiring changes),
-  their tests.
-- do: With Alembic as schema owner, delete the version-wrapper modules;
-  db_migrate.py remains the single deep entrypoint delegating to Alembic.
-  The Full plan MUST state the upgrade story for pre-Alembic databases
-  (contributor dev DBs that were never stamped): either an automatic
-  stamp-if-at-v10 path or a documented one-time operator command — silent
-  loss of the legacy upgrade path is a rejection criterion.
-- accept: No pipeline/migrate_v*.py remain; fresh-DB and upgraded-DB
-  schema diff empty; a v9/v10-era database's documented upgrade path
-  verified in the parity run; OPERATIONS and §11 updated; suite green;
-  GA-2 output attached.
+- correction (Codex P1, PR #224): migrate_v10.py is NOT a shallow wrapper —
+  it owns ~200 lines of timestamp-contract validation and UTC conversion,
+  and pipeline/db_migration_runner.py imports migrate_v8 and migrate_v10
+  for unversioned-database adoption. The July watchlist's "shallow
+  wrapper" characterization applied to the v8/v9 era and does not transfer
+  wholesale. Blanket deletion would drop or merely relocate that
+  conversion, failing D5 and the legacy-upgrade criterion.
+- files_owned (contract-graph traced): pipeline/migrate_v8.py,
+  migrate_v9.py, migrate_v10.py, pipeline/db_migrate.py,
+  pipeline/db_migration_runner.py and every caller of the migrate chain
+  (enumerate in the Full plan), docs/OPERATIONS.md (migration section),
+  docs/PIPELINE.md (§11 entries for any deleted module), alembic/ (only
+  if delegation wiring changes), their tests.
+- do: Census first (in the Full plan): map every migrate_v* module's role —
+  implementation owner vs pass-through — and its consumers, including
+  db_migration_runner's unversioned-adoption path. Retire ONLY modules
+  the census proves are pass-throughs whose behavior Alembic revisions or
+  a retained owner already provide. migrate_v10's conversion logic is
+  RETAINED as the unversioned-adoption owner unless the census proves the
+  Alembic baseline subsumes it for every supported starting state; the
+  Full plan MUST state the upgrade story for pre-Alembic databases —
+  silent loss of the legacy upgrade path is a rejection criterion.
+- accept: Census table in the PR body with each module's disposition and
+  evidence; only census-proven pass-throughs deleted; fresh-DB and
+  upgraded-DB schema diff empty; a v9/v10-era database's documented
+  upgrade path verified in the parity run; OPERATIONS and §11 updated;
+  suite green; GA-2 output attached. "No change warranted" is a valid
+  census outcome (D5).
 
 ### T-ARCH-5: Retire LocalAI private re-exports  [P1, Full-mandatory]
 - files_owned: pipeline/llm.py, pipeline/local_ai_agenda_compat.py,
@@ -256,20 +265,8 @@ investigations that may close with no code change.
   green. Renaming aliases without removing the re-export relationship does
   NOT satisfy this task.
 
-### T-ARCH-9: Fremont/Moraga recorded-parse parity  [P1, Light OK]
-- files_owned: tests/test_crawler_refactor_contract.py (or sibling),
-  checked-in HTML fixtures
-- do: Close the review's candidate-06 test deficit with CHECKED-IN
-  fixtures exercising the same event/document parse-depth Belmont's test
-  has. Fixtures are representative HTML consistent with the template
-  contract — synthesized or historically recorded — NOT live captures:
-  the spiders target portal eras that may no longer exist (Moraga's start
-  URL is 2017-era), so live capture would test a different site than the
-  code was written for. If a portal has genuinely changed, that is a
-  separate crawler-maintenance finding to file, not a reason to weaken the
-  fixture.
-- accept: All three spiders have equivalent parse-depth coverage from
-  checked-in fixtures; no test performs network I/O.
+### T-ARCH-9: Fremont/Moraga recorded-parse parity  [CLOSED — pre-completed on master]
+- evidence: master test_crawler_refactor_contract.py has equivalent Belmont/Fremont/Moraga archive event contracts with document-level assertions and no network I/O.
 
 ### T-ARCH-10: Guardrail-file diet  [P1, Light OK, lands FIRST in lane]
 - files_owned: tests/test_repository_guardrails.py
@@ -356,14 +353,16 @@ investigations that may close with no code change.
 ## Execution order
 
 ```
-PR 1: T-DOC-1 + T-DOC-3 + T-DOC-4 (single doc-integrity PR)
-PR 2: T-DOC-2 (its own PR: new guardrail, reviewed against postmortem rules)
-PR 3: T-BASE-1 (doc promotion; unblocks sourced markings)
-PR 4: T-BASE-2 (operator capture + agent-assembled evidence PR)
+PR 1: T-DOC-2 (only remaining DOC task; new guardrail, reviewed against
+      postmortem rules — T-DOC-1/3/4 closed as pre-completed on master)
+PR 2: T-BASE-1 (doc promotion; unblocks sourced markings)
+PR 3: T-BASE-2 (operator capture + agent-assembled evidence PR)
 ARCH: T-ARCH-10 lands FIRST (guardrail-file serialization, D6); then P1
-      tasks (T-ARCH-4/5/9) in any order, max two implementation PRs in
-      flight; P2 tasks after GA-1, each behind its own Full plan;
-      P3 investigations anytime, implementation only via new gated tasks.
+      tasks (T-ARCH-4/5) in any order, max two implementation PRs in
+      flight (T-ARCH-9 closed as pre-completed); P2 tasks after GA-1,
+      each behind its own Full plan; P3 investigations anytime,
+      implementation only via new gated tasks. Per D8, every task
+      re-verifies its premise against HEAD before its PR opens.
 ```
 
 DOC, BASE, and ARCH lanes are independent; T-BASE-2 alone is sequenced

--- a/docs/plans/POST_REMEDIATION_FOLLOWUP_PLAN.md
+++ b/docs/plans/POST_REMEDIATION_FOLLOWUP_PLAN.md
@@ -193,9 +193,11 @@ the tracker table only.
 - context_for_reviewer (include verbatim in the PR body): v2 uses the
   identical 30 catalog IDs as v1 with phase quotas redistributed — entity
   4→8 absorbs the retired people phase's slots (people 4→0; extract 8,
-  segment 6, summary 6, org 2 unchanged). This preserves record-level
-  workload comparability while removing the non-comparable phase; v1 and
-  its checked-in expectation remain immutable historical evidence.
+  segment 6, summary 6, org 2 unchanged). The shared IDs preserve record
+  identity only. The phase change makes v1 and v2 non-comparable: do not use
+  cross-version timings or stable counters for regression or promotion
+  decisions. v1 and its checked-in expectation remain immutable historical
+  evidence.
 - accept: profiling/baselines/baseline_representative_v2.json merged;
   comparison run green under documented tolerances; PR body carries all
   step evidence with D2 markings.
@@ -278,13 +280,17 @@ investigations that may close with no code change.
   REPLACE with a syntactic equivalent (content-hash pin for frozen files,
   path-existence for links) that names its supported cases; (c) syntactic
   code-policy check → KEEP. The classification table ships in the PR body.
+  An invariant-bearing assertion may be dropped only after a separate,
+  ratified change removes or replaces the invariant in its canonical policy;
+  recording a drop decision in the PR body is not sufficient.
   Differential change, not a rewrite: this is the candidate-07 end-state
   the program did not reach, taken in one bounded step.
 - accept: No test asserts prose content of docs/plans/* or
   docs/postmortems/*; every invariant previously enforced by a deleted
-  assertion has a named syntactic replacement or a recorded decision to
-  drop it; file materially smaller; every retained custom check names its
-  supported cases in a docstring; suite green.
+  assertion has a named syntactic replacement, or its canonical policy change
+  was separately ratified and merged before the assertion is removed; file
+  materially smaller; every retained custom check names its supported cases
+  in a docstring; suite green.
 - sequencing: lands before any other ARCH implementation PR. Later PRs follow
   D6's conditional shared-file rule.
 

--- a/docs/plans/POST_REMEDIATION_FOLLOWUP_PLAN.md
+++ b/docs/plans/POST_REMEDIATION_FOLLOWUP_PLAN.md
@@ -148,9 +148,11 @@ The document must contain:
 - immutable commit SHA for each run
 - host platform, Docker version, and explicit inference backend/model identity
 - manifest and sidecar identity, including SHA-256 and catalog IDs
-- recorded preconditioning result
+- recorded direct reset counts and the execution matrix derived from the
+  restored pre-run state
 - pre-run database snapshot, index, and semantic-state identifiers defined by
   the Full plan
+- recorded service and queue quiescence evidence before each measured run
 - controlled runtime-profile fields, request/sample count, and warm/cold
   condition
 - required artifact presence and SHA-256 values
@@ -170,14 +172,47 @@ reviewer from reproducing the package's hashes, validation, or derivation.
 - Generate the expected baseline deterministically from run A.
 - Require these v2 phase families from the manifest and command plan:
   `extract_parallel`, `segment_agenda`, `summarize`, `entity_backfill`, and
-  `org_backfill`, with expected coverage `8`, `6`, `6`, `8`, and `2`.
+  `org_backfill`.
+- Treat `phase_quotas`, `strata`, and `expected_phase_coverage` as direct
+  selection metadata, not observed execution coverage. For the approved
+  restored v2 state, validate direct quotas and runtime outcomes separately:
+  - extraction: `8` direct catalogs; `8` selected and processed. Preconditioning
+    does not reset extraction, so another count is non-comparable unless the
+    Full plan explicitly changes the restoration mechanism.
+  - segmentation: `6` direct catalogs; `6` selected.
+  - summary: `6` direct catalogs; `12` selected after the six segmentation
+    catalogs also lose summary state.
+  - entity enrichment: `8` direct catalogs; `8` selected.
+  - organization enrichment: `2` direct event resets; the runner selects every
+    unique event attached to the 30 scoped catalogs. The current evidence shows
+    `24` selected and `2` linked, but T-BASE-2A must derive and record the event
+    count from each restored snapshot instead of treating `24` as universal.
 - Require the existing stable-counter families `agenda_segmentation_backfill`,
-  `summary_hydration_backfill`, and `entity_backfill`. Add normalized
-  completion evidence for extract and organization work because those paths
+  `summary_hydration_backfill`, and `entity_backfill`. Add normalized extract
+  evidence with selected, processed, and failure totals. Add normalized
+  organization evidence with selected events, linked events, failures, and the
+  manifest-to-event mapping. Add normalized segmentation reindex-failure
+  evidence until that path exposes it in the stable counter. Those paths
   currently lack equivalent structured counters.
-- Fail generation and comparison unless all five workload families executed
-  successfully and their observed coverage matches the v2 sidecar. Empty or
-  partial phase/counter contracts are invalid.
+- Define successful execution through observable outcomes rather than attempt
+  counts:
+  - extraction selects and processes `8`; every direct extraction catalog ends
+    with complete extraction state, nonempty content, and a content hash, with
+    zero failed catalogs.
+  - segmentation reports `selected=6`, `complete=6`, and zero empty, failed, or
+    other outcomes, with zero reindex failures.
+  - summary reports `selected=12`, `complete=12`, `cached=0`, `stale=0`,
+    `blocked_low_signal=0`, `blocked_ungrounded=0`, `not_generated_yet=0`,
+    `error=0`, `other=0`, `reindex_failed=0`, and
+    `embed_dispatch_failed=0`.
+  - entity enrichment reports `selected=8`, `complete=8`, and freshness
+    advanced for all eight reset catalogs; an exception fails the run.
+  - organization enrichment reports the derived selected-event count,
+    `linked=2`, zero failed reindexes, and successful reindexing of every
+    changed catalog.
+- Fail generation and comparison unless direct selections match the v2
+  sidecar, all accepted outcomes above hold, and observed execution matches the
+  restored-state matrix. Empty or partial phase/counter contracts are invalid.
 - Treat partial, failed, reduced-confidence, provenance-mismatched, or reused
   run IDs as non-comparable.
 - Document that `--dry-run-prepare` currently runs migration and hash-backfill
@@ -220,6 +255,17 @@ output directories. Each must be complete, baseline-valid under the
 T-BASE-2A contract, and full-confidence. Any mismatch, partial run, or failed
 restoration is non-comparable and requires restoration followed by recapture.
 
+Each capture must also exclude unrelated asynchronous work. T-BASE-2A's Full
+plan must choose either a dedicated isolated Compose project or a documented
+stop-and-drain sequence followed by transient profiling command containers.
+Immediately before each measured run, record the chosen isolation mechanism
+and zero broker depth for every queue configured for the profile stack. If any
+worker daemons remain running, also record zero Celery active, reserved, and
+scheduled tasks. Keep unrelated task producers and asynchronous consumers
+stopped during measurement, and record any work emitted by the profile after
+the measured commands. An empty queue check while unrelated producers or
+consumers remain live is not sufficient.
+
 Run A deterministically produces the expected baseline. Run B is compared
 against it. `reference_run_id` names run A. The v1 and v2 workloads remain
 non-comparable because v2 removes the retired people phase and reallocates its
@@ -230,8 +276,11 @@ catalogs to entity enrichment.
 - T-BASE-2A's validator accepts the checked-in A/B evidence.
 - Run B compares successfully against the expectation generated from run A.
 - Required phase and stable-counter families are nonempty.
-- All five v2 workload families executed successfully with coverage matching
-  the manifest sidecar.
+- Direct selections match the manifest sidecar, every workload satisfies the
+  explicit accepted outcomes in T-BASE-2A, and observed execution matches its
+  complete restored-state matrix.
+- Both captures include passing quiescence evidence and show no unrelated task
+  execution during the measured commands.
 - Canonical documents agree that v2 evidence has landed while retaining all
   other City Coverage Expansion gates.
 - No optimization, threshold, runtime-profile, or gate-policy change appears
@@ -345,16 +394,37 @@ are cohesive.
 
 ### T-ARCH-10I: Bounded guardrail assertion census
 
-**Seeds:** matches from this reproducible command only:
+**Seeds:** complete matching test functions emitted by this reproducible,
+single-file command only:
 
 ```bash
-rg -n 'docs/(plans|postmortems)/' tests/test_repository_guardrails.py
+awk '
+function flush_test() {
+  if (in_test && relevant) printf "%s", test_block
+}
+/^(async )?def / {
+  flush_test()
+  in_test = ($0 ~ /^(async )?def test_/)
+  relevant = 0
+  test_block = ""
+}
+in_test {
+  test_block = test_block sprintf("%d:%s\n", NR, $0)
+  if ($0 ~ /docs\/(plans|postmortems)\// ||
+      $0 ~ /ROOT \/ "docs" \/ "(plans|postmortems)"/) relevant = 1
+}
+END { flush_test() }
+' tests/test_repository_guardrails.py
 ```
 
-Classify the resulting assertions by canonical invariant and enforcement type.
-Do not build an AST analyzer or classify unrelated portions of the 5,555-line
-file. A child task must cover one assertion family only and use the complete
-guardrail verification row.
+The two match branches cover slash-delimited literals and `pathlib`-constructed
+directory references. At the reconciled commit, the command emits nine tests
+containing 13 references: 12 constructed paths and one slash-delimited literal.
+Classify every assertion consuming plan or postmortem content in each emitted
+test by canonical invariant and enforcement type. Do not build an AST analyzer
+or classify unrelated test functions in the 5,555-line file. A child task must
+cover one assertion family only and use the complete guardrail verification
+row.
 
 ### Investigation verification
 

--- a/docs/plans/POST_REMEDIATION_FOLLOWUP_PLAN.md
+++ b/docs/plans/POST_REMEDIATION_FOLLOWUP_PLAN.md
@@ -126,7 +126,9 @@ the tracker table only.
   authorize edits elsewhere.
 - do: Add a bounded check: extract every backtick-quoted syntactic path
   candidate only from the text between the `## 11)` heading and the next
-  level-two heading in docs/PIPELINE.md. A candidate must be an unambiguous
+  level-two heading in docs/PIPELINE.md. Fail unless exactly one `## 11)`
+  section exists and that section yields at least one candidate. A candidate
+  must be an unambiguous
   repository-relative reference containing `/` and must be either a literal
   `.py`/`.md` path or a terminal wildcard path. Terminal wildcards may be
   extensionless, such as `pipeline/task_*`, `api/task_route_*`, or
@@ -145,7 +147,9 @@ the tracker table only.
   family makes it fail; removing the final match for a glob family makes it
   fail, including for an extensionless terminal wildcard. The check names
   these supported cases in a docstring; a bare filename outside §11 does not
-  enter the candidate set. The check does not
+  enter the candidate set. Removing or duplicating the §11 heading, or
+  producing an empty candidate set, makes the test fail. These are parser
+  preconditions, not assertions about narrative wording. The check does not
   claim that it protects every individual member represented only by a glob.
 - forbidden: Extending the check to other docs in this PR; asserting doc
   content beyond path existence.

--- a/docs/plans/POST_REMEDIATION_FOLLOWUP_PLAN.md
+++ b/docs/plans/POST_REMEDIATION_FOLLOWUP_PLAN.md
@@ -4,15 +4,19 @@ Scope: pipeline-doc integrity, baseline v2 evidence readiness, and
 architecture-watchlist retirement.
 
 plan_id: POST-REM-FOLLOWUP-2026-08
-status_tracking: PR checkboxes against the task table below. Do NOT add a
+status_tracking: task state and evidence cells in the table below. Every task
+PR may update only its own two cells in this file, even when the task's
+implementation ownership is otherwise narrower. Do NOT add a
 changelog section to this file and do NOT extend the frozen remediation plan
 (docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md is historical evidence per the
 2026-08-02 postmortem prevention table).
-source: External review of docs/PIPELINE.md (verified against tree, all 72
-file refs currently valid) + verification of the baseline_representative_v2
-gap analysis. Both reviews dated 2026-08-02.
-amended: 2026-08-03 — reconciled against live master (parent of PR #224
-commit 83b020a) after Codex review flagged snapshot staleness: T-DOC-1,
+source: External review of docs/PIPELINE.md + verification of the
+baseline_representative_v2 gap analysis. Both reviews dated 2026-08-02. The
+file-map existence claim remains review evidence until T-DOC-2 supplies the
+reproducible repository check.
+amended: 2026-08-03 — reconciled against immutable master commit
+a62ca0eff8eb7aae0e4d1b6776efefd7b401a1b1 after Codex review flagged
+snapshot staleness: T-DOC-1,
 T-DOC-3, T-DOC-4, and T-ARCH-9 were already completed on master and are
 closed as pre-existing below. Earlier verification dates in this file refer
 to the 2026-08-02 archive snapshot, which master has since advanced past.
@@ -27,8 +31,11 @@ the tracker table only.
 ## Directives (apply to every task)
 
 - D1. AGENTS.md remains supreme; the planning templates
-  (docs selection rules) apply — T-BASE-2 is a mandatory Full-template task
-  because it touches soak-baseline comparability.
+  (docs selection rules) apply. T-DOC-2 is Full-template work because it
+  adds persistent enforcement machinery; T-BASE-2 is Full-template work
+  because it touches soak-baseline comparability. T-ARCH-10 is an
+  investigation only; any implementation it recommends gets a separate
+  Full plan sized by assertion family.
 - D2. Sourced vs derived: every step in an execution procedure (numbered
   steps in a task, a Full plan, or a PR body) must be marked either
   [sourced: <doc §>] or [derived: <policy it follows>]. Task charters in
@@ -52,12 +59,10 @@ the tracker table only.
   (P3 investigations and Full-plan authoring do not count toward the cap);
   one domain per PR; investigation and implementation are separate PRs.
   Template routing follows the planning templates' selection rules, which
-  this plan cannot override (D1): T-ARCH-4 (schema/migrations) and
-  T-ARCH-5, T-ARCH-1 (facade families) are Full-mandatory regardless of
-  tier; T-ARCH-2/3 Full per their gates; T-ARCH-9 may use Light;
-  T-ARCH-10 may use Light with the guardrail-change justification the
-  AGENTS.md maintenance triggers require.
-  T-ARCH-10 lands first. After that, an ARCH task edits
+  this plan cannot override (D1): T-ARCH-5 and T-ARCH-1 (facade families)
+  are Full-mandatory regardless of
+  tier; T-ARCH-2/3 Full per their gates. T-ARCH-10 does not authorize an
+  implementation PR. An ARCH task edits
   tests/test_repository_guardrails.py only when its live HEAD census finds an
   entry affected by the task. PRs that actually edit that shared file
   SERIALIZE; independent ARCH PRs remain subject only to the two-PR cap.
@@ -73,9 +78,6 @@ the tracker table only.
 - GA-1 (operator): ratify or reorder the ARCH priority ranking. Blocks all
   ARCH implementation PRs; does not block investigations or Full-plan
   drafting.
-- GA-2 (operator): one Postgres parity run for T-ARCH-4 (set
-  TEST_POSTGRES_DATABASE_URL, run the currently-skipped migrate_v10
-  tests); attach the run output to the T-ARCH-4 PR. Blocks T-ARCH-4 only.
 - GB-1 (procedure, restating canonical policy — no new gate semantics):
   a `reduced-confidence` or non-baseline-valid capture is `non_comparable`;
   per docs/PERFORMANCE.md compare policy, inspect result.json and the
@@ -91,24 +93,25 @@ the tracker table only.
 
 ## Task tracker
 
-| id        | state | evidence (PR #) |
+| id        | state | immutable evidence and proving check |
 |-----------|-------|-----------------|
-| T-DOC-1   | closed (pre-completed) | master@parent-of-83b020a |
+| T-DOC-1   | closed (pre-completed) | `git show a62ca0e:docs/PIPELINE.md \| sed -n '52,68p'` |
 | T-DOC-2   | open  |                 |
-| T-DOC-3   | closed (pre-completed) | master@parent-of-83b020a |
-| T-DOC-4   | closed (pre-completed) | master@parent-of-83b020a |
+| T-DOC-3   | closed (pre-completed) | `git show a62ca0e:docs/PIPELINE.md \| sed -n '208,220p'` |
+| T-DOC-4   | closed (pre-completed) | `git show a62ca0e:docs/PIPELINE.md \| rg '^## 11\\) Primary Implementation Map$'` |
 | T-BASE-1  | open  |                 |
 | T-BASE-2  | open  |                 |
 | T-ARCH-1  | open  |                 |
 | T-ARCH-2  | open  |                 |
 | T-ARCH-3  | open  |                 |
-| T-ARCH-4  | open  |                 |
+| T-ARCH-4  | closed (pre-completed) | `a62ca0e`; [Python Guardrails run 30770109810](https://github.com/manumissio/town-council/actions/runs/30770109810) |
 | T-ARCH-5  | open  |                 |
 | T-ARCH-6  | open  |                 |
 | T-ARCH-7  | open  |                 |
 | T-ARCH-8  | open  |                 |
-| T-ARCH-9  | closed (pre-completed) | master@parent-of-83b020a |
+| T-ARCH-9  | closed (pre-completed) | [run 30770109810](https://github.com/manumissio/town-council/actions/runs/30770109810); `git show a62ca0e:tests/test_crawler_refactor_contract.py \| rg 'Fremont\|Moraga'` |
 | T-ARCH-10 | open  |                 |
+| T-ARCH-11 | blocked | ADR and supported-starting-state decision required |
 
 ---
 
@@ -117,13 +120,15 @@ the tracker table only.
 ### T-DOC-1: Repair the Stage B duplicated rationale block  [CLOSED — pre-completed on master]
 - evidence: master PIPELINE.md places the chunking rationale directly under run_parallel_processing(); no orphaned duplicate block remains.
 
-### T-DOC-2: Guard the §11 file map with a syntactic existence check
-- files_owned: tests/test_docs_links.py (or a sibling
-  tests/test_pipeline_doc_file_map.py if link-test scope is link-only by
-  design — decide in-PR and say why)
+### T-DOC-2: Guard the §11 file map with a syntactic existence check  [Full]
+- files_owned: tests/test_pipeline_doc_file_map.py (new). The Full plan must
+  name any additional file before implementation; this charter does not
+  authorize edits elsewhere.
 - do: Add a bounded check: extract every backtick-quoted syntactic path
-  candidate from docs/PIPELINE.md matching `<family>/<...>.py|.md`, including
-  glob families, without first consulting the filesystem. Derive the family
+  candidate from docs/PIPELINE.md that is either a literal `.py`/`.md` path
+  or a terminal wildcard path. Terminal wildcards may be extensionless, such
+  as `pipeline/task_*`, `api/task_route_*`, or `semantic_service/*`. Extract
+  candidates without first consulting the filesystem. Derive the family
   set from those candidates' leading path segments, not from a hardcoded list
   or the set of directories that currently exists. Then assert that each
   candidate family exists, each literal path exists, and each glob family
@@ -133,7 +138,8 @@ the tracker table only.
   postmortem rule for custom checks ("exact-set… syntactic and bounded").
 - accept: Test passes on HEAD; deleting a literal referenced path or top-level
   family makes it fail; removing the final match for a glob family makes it
-  fail. The check names these supported cases in a docstring and does not
+  fail, including for an extensionless terminal wildcard. The check names
+  these supported cases in a docstring and does not
   claim that it protects every individual member represented only by a glob.
 - forbidden: Extending the check to other docs in this PR; asserting doc
   content beyond path existence.
@@ -162,34 +168,51 @@ the tracker table only.
   Runtime-policy immutability may cite AGENTS.md hard invariants inline.
 - accept: The rule is stated once in PERFORMANCE.md; OPERATIONS capture
   section points to the rules rather than duplicating them; D2 marking in
-  the PR body.
-- verify: docs-link test; grep confirms single statement.
+  the PR body. If OPERATIONS changes, update its `Last updated` marker.
+- verify: docs-link test; env/profile alignment test; grep confirms single
+  statement; `git diff --check`.
 
 ### T-BASE-2: The evidence PR (Full template; human-gated execution)
 - files_owned: profiling/baselines/baseline_representative_v2.json (new),
-  PR body artifacts; ROADMAP.md City Expansion Readiness status line only
-  if the operator chooses to tick it in the same PR.
+  docs/PERFORMANCE.md, docs/OPERATIONS.md,
+  profiling/manifests/README.md, and docs/ADR.md. Preserve the accepted ADR
+  decision and add implementation status; do not rewrite its history.
 - depends_on: T-BASE-1 (so every step below is [sourced])
-- human_gate: the capture itself runs on the operator's machine with the
-  local runtime profile — an agent prepares the plan and assembles the PR;
-  it does not execute the capture or fabricate its artifacts. Absence of
-  artifacts = the task is blocked, not improvisable.
+- human_gate: two independent captures run on the operator's machine with
+  the same immutable commit, manifest and sidecar, preconditioned dataset,
+  index artifacts, semantic settings, runtime profile, and warm/cold
+  condition. The operator supplies complete artifacts for reference run A
+  and validation run B. An agent prepares the plan and assembles the PR; it
+  does not execute captures or fabricate artifacts. Absence of either
+  artifact set = blocked, not improvisable.
 - procedure (all steps must carry D2 markings in the plan):
   1. `--dry-run-prepare` inspection of controlled preconditioning
      [sourced: PERFORMANCE interpretation rules; OPERATIONS ~L1528].
-  2. Stable local baseline run using the v2 manifest
+  2. Stable local reference run A using the v2 manifest
      [sourced: OPERATIONS baseline capture section].
-  3. `baseline_valid=true` and no `reduced-confidence` analyzer state
+  3. Run A has `baseline_valid=true` and no `reduced-confidence` analyzer state
      [sourced: v1 baseline schema + PERFORMANCE rules].
-  4. Required artifacts present: provider telemetry, phase timings, stable
+  4. Run A artifacts present: provider telemetry, phase timings, stable
      workload counters [sourced: baseline schema fields
      elapsed_seconds/top_phases/stable_counters/reference_run_id].
-  5. Derive the expected-baseline JSON from that run, same schema as v1
+  5. Derive the expected-baseline JSON from run A, same schema as v1, and set
+     `reference_run_id` to run A
      [sourced: profiling/baselines/baseline_representative_v1.json].
-  6. Re-run comparison via `--compare-to` against the proposed baseline;
-     include commands, runtime profile, run ID, and reports in the PR body
-     [sourced: PERFORMANCE rules].
-  7. No optimization/threshold/runtime-policy changes in the capture PR;
+  6. Capture independent validation run B under the same immutable commit,
+     manifest and sidecar, preconditioned dataset, index artifacts, semantic
+     settings, runtime profile, and warm/cold condition. Record those fields
+     for both runs. Run B must also be baseline-valid and full-confidence,
+     and may not reuse run A's output directory or run ID. Any mismatch makes
+     the comparison `non_comparable` [sourced: PERFORMANCE interpretation
+     rules; derived: independent validation].
+  7. Compare run B via `--compare-to` against the expected baseline derived
+     from run A. Include both commands, the shared runtime profile, both run
+     IDs, and both artifact/report sets in the PR body
+     [sourced: PERFORMANCE rules; derived: independent validation].
+  8. Synchronize the four owned canonical documents from pending-candidate
+     wording to merged-baseline status without changing the accepted ADR
+     decision [derived: docs ownership and history preservation].
+  9. No optimization/threshold/runtime-policy changes in the capture PR;
      defects found → separate fix PR, then recapture
      [sourced: PERFORMANCE after T-BASE-1].
 - context_for_reviewer (include verbatim in the PR body): v2 uses the
@@ -201,8 +224,10 @@ the tracker table only.
   decisions. v1 and its checked-in expectation remain immutable historical
   evidence.
 - accept: profiling/baselines/baseline_representative_v2.json merged;
-  comparison run green under documented tolerances; PR body carries all
-  step evidence with D2 markings.
+  independent run B compares green against run A's expectation under
+  documented tolerances; `reference_run_id` names run A; both artifact sets
+  and all step evidence appear in the PR body with D2 markings; owned docs
+  agree on implementation status.
 - explicitly_not_claimed: merging this PR clears the baseline prerequisite
   only; City Expansion Readiness additionally requires the rollout-registry
   wave selection and crawl/derived-state/queue gates in ROADMAP.md — do not
@@ -217,42 +242,29 @@ against the 2026-08-02 tree. Priority tiers: P1 = cheap true deletions with
 evidence in hand; P2 = deep-module work needing a Full plan; P3 =
 investigations that may close with no code change.
 
-### T-ARCH-4: Verify the frozen migrate chain before future sunset  [P1, Full-mandatory, investigation]
-- gate: GA-2 (operator parity run)
-- correction (Codex P1, PR #224): the accepted Alembic ADR requires the
-  migrate_v8/v9/v10 chain to remain readable and frozen while
-  pipeline/db_migration_runner.py uses it for unversioned-database adoption.
-  migrate_v10.py is not a shallow wrapper; it owns timestamp-contract
-  validation and UTC conversion. This task preserves the current chain and
-  cannot authorize deletion while that ADR remains active.
-- files_owned: docs/plans/POST_REMEDIATION_FOLLOWUP_PLAN.md (tracker state and
-  evidence link only). The Full plan reads the migration modules, callers,
-  Alembic revisions, tests, and migration documentation as census evidence;
-  it does not authorize edits to them. A discovered defect or future sunset
-  gets a separate task with its own ownership.
-- do: Census first (in the Full plan): map every migrate_v* module's role and
-  consumer, including db_migration_runner's unversioned-adoption path. Run
-  the GA-2 parity evidence and verify the frozen chain still reaches the
-  Alembic baseline without schema drift. Do not delete, bypass, or rewire the
-  chain under the current ADR. A defect found by the census requires a
-  separate scoped repair, not an incidental sunset.
-- accept: Census table in the PR body with each module retained and its role
-  evidenced; fresh-DB and upgraded-DB schema diff empty; a v9/v10-era
-  database's documented upgrade path verified in the parity run; suite green;
-  GA-2 output attached. The expected outcome is "no change warranted" under
-  the current ADR.
-- future_sunset: The migration chain should be removed in a separate
-  Full-template PR after a separately ratified ADR change defines the new
-  support floor and proves that no supported unversioned or pre-Alembic
-  database still depends on the frozen runner. That PR must remove the chain
-  end to end, update migration and operator documentation, and verify every
-  supported starting state. This plan records the intended direction; it does
-  not authorize the sunset.
+### T-ARCH-4: Verify the frozen migrate chain  [CLOSED — pre-completed]
+- evidence: `.github/workflows/python-guardrails.yml` runs
+  `tests/test_alembic_migrations.py` against Postgres before the full suite,
+  which includes the frozen-runner and migrate_v8/v9/v10 contract tests;
+  `pipeline/db_migration_runner.py` still invokes that chain for the supported
+  unversioned-adoption path. Under the accepted ADR, the present result is
+  "retain the frozen chain." No duplicate parity gate is needed.
+
+### T-ARCH-11: Sunset the frozen migration chain  [future, Full, blocked]
+- gate: a separately ratified ADR must define the minimum supported database
+  state and retire support for unversioned/pre-Alembic starting states.
+- files_owned: must be derived by the Full plan after that decision; this
+  charter authorizes no migration-file edit or deletion.
+- do: prove that every supported database starts from an Alembic-owned state,
+  then remove the frozen runner and migrate_v8/v9/v10 end to end. Update
+  migration and operator documentation and verify each supported starting
+  state. This task records the operator's intended direction; it cannot begin
+  while the current ADR and support floor remain active.
 
 ### T-ARCH-5: Retire LocalAI private re-exports  [P1, Full-mandatory]
 - files_owned: pipeline/llm.py, pipeline/local_ai_agenda_compat.py,
   consumers identified by the census below, their tests,
-  docs/PIPELINE.md (§11 entries touched)
+  docs/PIPELINE.md (the LocalAI provider section and §11 entries touched)
 - do: Step 1 (in the Full plan): consumer census — enumerate every import
   of llm.py's aliased symbols and of local_ai_agenda_compat, from code and
   from tests, distinguishing (a) external consumers of re-exports from
@@ -260,7 +272,8 @@ investigations that may close with no code change.
   legitimate implementation and STAYS. The census covers every current
   implementation owner, including agenda_extraction, agenda_summary,
   agenda_text_heuristics, local_ai_runtime, and text_generation. Step 2:
-  repoint (a) to those implementation owners, delete
+  repoint (a) to those implementation owners, delete obsolete compatibility
+  tests whose only contract is the retired seam, delete
   local_ai_agenda_compat.py, and remove the now-unconsumed re-export surface.
   Keep LocalAI product policy and public entrypoints intact.
 - accept (behavioral, not lexical): no module outside llm.py imports a
@@ -273,35 +286,35 @@ investigations that may close with no code change.
 ### T-ARCH-9: Fremont/Moraga recorded-parse parity  [CLOSED — pre-completed on master]
 - evidence: master test_crawler_refactor_contract.py has equivalent Belmont/Fremont/Moraga archive event contracts with document-level assertions and no network I/O.
 
-### T-ARCH-10: Guardrail-file diet  [P1, Light OK, lands FIRST in lane]
-- files_owned: tests/test_repository_guardrails.py
-- do: Apply the postmortem's prevention rule to the 5,555-line file — but
-  classify before deleting. For every assertion targeting document
+### T-ARCH-10: Guardrail-file census  [P1, investigation only]
+- read_scope: tests/test_repository_guardrails.py, ruff.toml, mypy.ini,
+  .coveragerc, docs/ENGINEERING_GUARDRAILS.md, docs/TESTING.MD, and the
+  canonical document targeted by each document-content assertion.
+- files_owned: docs/plans/POST_REMEDIATION_FOLLOWUP_PLAN.md, tracker evidence
+  cell only. The investigation may not edit guardrails or tests.
+- do: Apply the postmortem's prevention rule to the 5,555-line file by
+  classifying every assertion targeting document
   content, record one of: (a) pure prose-content assertion (headings,
-  phrasing, casing of narrative text) → DELETE; (b) invariant-bearing
+  phrasing, casing of narrative text) → candidate for deletion; (b) invariant-bearing
   assertion (e.g., frozen-document immutability, link integrity) →
-  REPLACE with a syntactic equivalent (content-hash pin for frozen files,
+  candidate for syntactic replacement (content-hash pin for frozen files,
   path-existence for links) that names its supported cases; (c) syntactic
-  code-policy check → KEEP. The classification table ships in the PR body.
-  An invariant-bearing assertion may be dropped only after a separate,
-  ratified change removes or replaces the invariant in its canonical policy;
-  recording a drop decision in the PR body is not sufficient.
-  Differential change, not a rewrite: this is the candidate-07 end-state
-  the program did not reach, taken in one bounded step.
-- accept: No test asserts prose content of docs/plans/* or
-  docs/postmortems/*; every invariant previously enforced by a deleted
-  assertion has a named syntactic replacement, or its canonical policy change
-  was separately ratified and merged before the assertion is removed; file
-  materially smaller; every retained custom check names its supported cases
-  in a docstring; suite green.
-- sequencing: lands before any other ARCH implementation PR. Later PRs follow
-  D6's conditional shared-file rule.
+  code-policy check → retain. The PR body includes assertion family, current
+  invariant owner, disposition, estimated line delta, and proposed task ID.
+- accept: every document-content assertion belongs to exactly one family;
+  every proposed implementation is split by concrete assertion family,
+  declares exact ownership and size, uses a Full plan, and includes the full
+  guardrail verification row. The tracker records the investigation PR. No
+  implementation is authorized and unrelated ARCH work is not blocked.
+- verify: `PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py` and
+  `git diff --check` for the tracker-only investigation PR.
 
 ### T-ARCH-1: Search facade stack retirement  [P2, largest, Full-mandatory]
 - gate: GA-1 + its own Full-template plan (one stratum per PR)
 - files_owned: derived per contract-graph tracing in the Full plan —
   candidate set: api/search_routes.py, api/search_read_*.py, api/search/,
-  api/main.py wiring, consuming tests, docs/PIPELINE.md §11 entries
+  api/search_semantic_routes.py, api/trends_routes.py, api/main.py wiring,
+  consuming tests, docs/PIPELINE.md §11 entries
 - do: MANDATORY investigation first: a route/consumer inventory
   establishing which endpoints are wired, which modules are live routes vs
   helpers vs genuinely superseded strata. The retirement direction is an
@@ -314,8 +327,13 @@ investigations that may close with no code change.
 
 ### T-ARCH-2: ResultCard decomposition  [P2, Full-mandatory]
 - gate: GA-1 + Full plan (design pass, not mechanical)
-- files_owned: frontend/components/ResultCard.js, frontend/lib/,
-  frontend/components/__tests__/
+- investigation_scope: frontend/components/ResultCard.js,
+  frontend/lib/taskPolling.js,
+  frontend/components/__tests__/ResultCard.ai-disclaimer.test.js,
+  frontend/components/__tests__/ResultCard.people-projection.test.js, and
+  frontend/components/__tests__/ResultCard.polling-contract.test.js. The Full
+  plan must name each implementation file, new module, and test file exactly;
+  broad directory ownership is not permitted.
 - do: Both review prerequisites are met (runner + 42-test harness) and the
   polling seam is already extracted (taskPolling.js). Continue along the
   review's seam list — mutation dispatch, formatting, rendering — one
@@ -323,61 +341,96 @@ investigations that may close with no code change.
   explicit numeric line budget and a one-responsibility statement for what
   remains in ResultCard.js; "near composition-only" without numbers is not
   an acceptance criterion.
-- accept (per extraction PR): behavior parity — the existing test files
-  pass with their ASSERTIONS unchanged (imports/patch targets may move per
-  TESTING.MD); the extracted module has its own test; ResultCard.js
-  shrinks toward the Full plan's stated budget.
+- accept (per extraction PR): user-visible behavior parity. Source-text
+  assertions in ResultCard.ai-disclaimer.test.js may be replaced with
+  rendered-behavior assertions; do not preserve the old source arrangement
+  merely to keep a patch point. Other observable contracts remain covered,
+  the extracted module has its own behavior test, and ResultCard.js shrinks
+  toward the Full plan's stated budget.
 
 ### T-ARCH-3: Deepen semantic retrieval interface  [P2, Full-mandatory]
 - gate: GA-1 + Full plan
 - files_owned: semantic_service/retrieval.py, its callers and tests
 - do: Replace the 13-parameter retrieve signatures with a typed request
-  contract (match the *_contracts.py convention); implementation callables
-  become private.
-- accept: Public retrieve interface takes the request contract (plus at
-  most session/config); every contract field is individually typed and
+  contract containing only query, filters, pagination, and retrieval
+  settings (match the *_contracts.py convention). Backend, database session,
+  and Meilisearch client remain explicit boundary parameters. Injectable
+  implementation callables are removed in favor of private imports from
+  their implementation owners.
+- accept: Public retrieve interface takes the request contract plus explicit
+  backend, database-session, and Meilisearch-client boundaries; every
+  contract field is individually typed and
   documented — no dict payload field, no **kwargs, no Any escape hatch
   (a god-object with an opaque bag does not satisfy this task); suite
   green.
 
 ### T-ARCH-6: Frontend search coordinator  [P3, investigation first]
-- do: Investigate consolidating live/demo search adapters behind one
-  coordinator (frontend/state/search-state.js + lib/api.js). Output: a
-  one-page finding — proceed with a Full plan, or close per D5.
+- read_scope: frontend/state/search-state.js, frontend/lib/api.js, their
+  direct importers, and their tests.
+- files_owned: docs/plans/POST_REMEDIATION_FOLLOWUP_PLAN.md, tracker evidence
+  cell only.
+- do: Census live/demo adapter ownership and call direction. The PR body
+  table records adapter, caller, state owner, duplicated policy, and deletion
+  impact.
+- accept: close when one owner already exists or consolidation would only
+  move complexity; otherwise register a separately approved Full task with
+  exact files and deletion evidence. Verify docs links and `git diff --check`.
 
 ### T-ARCH-7: Index projection consolidation  [P3, investigation first]
-- do: Post-G4/T-IDX-1, investigate whether projection policy (what enters
-  the search index per data class) has a single owner; propose one if not.
-  DATA_GOVERNANCE §3 is the policy source; code should mirror it in one
-  place.
+- read_scope seeds: pipeline/indexer.py, pipeline/indexer_documents.py,
+  pipeline/indexer_meilisearch.py, pipeline/reindex_only.py,
+  pipeline/reindex_semantic.py, pipeline/task_side_effects.py,
+  api/search_read_meilisearch.py, semantic_service/main.py,
+  semantic_service/retrieval.py, tests/test_indexer_logic.py,
+  tests/test_indexer_official_roster.py, and DATA_GOVERNANCE §3. Expand the
+  census only through direct imports/callers found with
+  `rg -n 'index_documents|_build_.*search_doc|reindex|people_metadata'`.
+- files_owned: docs/plans/POST_REMEDIATION_FOLLOWUP_PLAN.md, tracker evidence
+  cell only.
+- do: Record data class, policy owner, implementation owner, consumers, and
+  conflicting/duplicated decisions in the PR body evidence table.
+- accept: close if every projection rule has one implementation owner;
+  otherwise register a separately approved Full task that names the exact
+  duplicated policy and files. Verify docs links and `git diff --check`.
 
 ### T-ARCH-8: Crawler staging persistence  [P3, investigation first]
-- do: The review flagged duplicated session/transaction policy; current
-  tree shows it concentrated in council_crawler pipelines.py. Verify
-  against pipeline/ persistence policy and either file a narrow follow-up
-  or close with evidence. Expected outcome: closes cheaply.
+- read_scope seeds: council_crawler/council_crawler/pipelines.py,
+  council_crawler/council_crawler/models.py,
+  council_crawler/council_crawler/settings.py, pipeline/promote_stage.py,
+  pipeline/db_session.py, tests/test_crawler_refactor_contract.py,
+  tests/test_database.py, and tests/test_pipeline_idempotency.py. Expand only
+  through direct imports/callers found with
+  `rg -n 'CreateEventPipeline|StageDocumentLinkPipeline|promote_stage|EventStage|UrlStage'`.
+- files_owned: docs/plans/POST_REMEDIATION_FOLLOWUP_PLAN.md, tracker evidence
+  cell only.
+- do: Record each local transaction block, owner, invariant, and any actual
+  duplicated policy in the PR body evidence table.
+- accept: default to closure when the two local transaction blocks are
+  cohesive and do not justify another seam. Only proven duplicated policy
+  may create a separately approved narrow task. Verify docs links and
+  `git diff --check`.
 
 ---
 
 ## Execution order
 
 ```
-PR 1: T-DOC-2 (only remaining DOC task; new guardrail, reviewed against
-      postmortem rules — T-DOC-1/3/4 closed as pre-completed on master)
-PR 2: T-BASE-1 (doc promotion; unblocks sourced markings)
-PR 3: T-BASE-2 (operator capture + agent-assembled evidence PR)
-ARCH: T-ARCH-10 lands FIRST; then the T-ARCH-4 verification investigation and
-      T-ARCH-5 implementation may proceed. At most two implementation PRs are
-      in flight (T-ARCH-9 closed as pre-completed).
-      Only tasks whose live census requires an edit to the shared guardrail
-      file serialize under D6. P2 tasks follow GA-1, each behind its own Full
-      plan; P3 investigations may run anytime, with implementation only via
-      new gated tasks. Per D8, every task re-verifies its premise against HEAD
-      before its PR opens.
+DOC lane: T-DOC-2 may proceed independently (T-DOC-1/3/4 are closed).
+BASE lane: T-BASE-1 -> independent operator runs A/B -> T-BASE-2.
+ARCH lane: T-ARCH-10 is an investigation and does not block T-ARCH-5 or other
+           unrelated work. T-ARCH-4 and T-ARCH-9 are closed; T-ARCH-11 is
+           blocked on a future ADR/support-floor decision. At most two
+           implementation PRs are in flight. Only tasks whose live census
+           requires an edit to the shared guardrail file serialize under D6.
+           P2 tasks follow GA-1 behind their own Full plans. P3 investigations
+           may run anytime; implementation requires a new gated task. Per D8,
+           every task re-verifies its premise against HEAD before its PR opens.
 ```
 
 DOC, BASE, and ARCH lanes are independent; T-BASE-2 alone is sequenced
-after T-BASE-1; T-ARCH-4 alone is gated on the operator parity run.
+after T-BASE-1. Investigation tasks may run in parallel when their read
+scopes do not overlap; each resulting implementation requires its own
+approved task and plan.
 
 ## Out of scope
 

--- a/docs/plans/POST_REMEDIATION_FOLLOWUP_PLAN.md
+++ b/docs/plans/POST_REMEDIATION_FOLLOWUP_PLAN.md
@@ -57,10 +57,10 @@ the tracker table only.
   tier; T-ARCH-2/3 Full per their gates; T-ARCH-9 may use Light;
   T-ARCH-10 may use Light with the guardrail-change justification the
   AGENTS.md maintenance triggers require.
-  Because every ARCH deletion PR also edits tests/test_repository_guardrails.py
-  (removing entries for deleted files), guardrail-file edits SERIALIZE:
-  T-ARCH-10 lands first, and no two ARCH PRs touching that file may be in
-  flight together.
+  T-ARCH-10 lands first. After that, an ARCH task edits
+  tests/test_repository_guardrails.py only when its live HEAD census finds an
+  entry affected by the task. PRs that actually edit that shared file
+  SERIALIZE; independent ARCH PRs remain subject only to the two-PR cap.
 - D7. Priority tiers below are a proposal; gate GA-1 applies.
 - D8. Snapshot staleness: this plan was authored against an archive
   snapshot. Before opening any task's PR, re-verify the task's premise
@@ -121,20 +121,19 @@ the tracker table only.
 - files_owned: tests/test_docs_links.py (or a sibling
   tests/test_pipeline_doc_file_map.py if link-test scope is link-only by
   design — decide in-PR and say why)
-- do: Add a bounded check: extract every backtick-quoted repository path
-  from docs/PIPELINE.md matching `<family>/<...>.py|.md` where the family
-  set is DERIVED from the document itself (any leading path segment that
-  is a top-level repo directory), not hardcoded — the map already
-  references semantic_service/ alongside pipeline/, api/, scripts/, and
-  docs/, and a hardcoded prefix list silently exempts whole families
-  (Codex P2, PR #224: deleting semantic_service/main.py would have passed
-  a pipeline|api|scripts|docs check). Assert each literal
-  path exists and each glob family matches at least one file. No prose
+- do: Add a bounded check: extract every backtick-quoted syntactic path
+  candidate from docs/PIPELINE.md matching `<family>/<...>.py|.md`, including
+  glob families, without first consulting the filesystem. Derive the family
+  set from those candidates' leading path segments, not from a hardcoded list
+  or the set of directories that currently exists. Then assert that each
+  candidate family exists, each literal path exists, and each glob family
+  matches at least one file. This keeps a misspelled or entirely deleted
+  family visible to the failure assertions. No prose
   interpretation, no content assertions — path existence only, per the
   postmortem rule for custom checks ("exact-set… syntactic and bounded").
-- accept: Test passes on HEAD; deleting any referenced module makes it fail;
-  the check names its supported cases in a docstring (paths and globs) and
-  nothing else.
+- accept: Test passes on HEAD; deleting any referenced module or top-level
+  family makes it fail; the check names its supported cases in a docstring
+  (paths and globs) and nothing else.
 - forbidden: Extending the check to other docs in this PR; asserting doc
   content beyond path existence.
 - verify: targeted pytest for the new test + full suite.
@@ -253,11 +252,12 @@ investigations that may close with no code change.
   of llm.py's aliased symbols and of local_ai_agenda_compat, from code and
   from tests, distinguishing (a) external consumers of re-exports from
   (b) llm.py's own internal delegation to implementation modules, which is
-  legitimate implementation and STAYS. Step 2: repoint (a) to the
-  implementation modules (agenda_extraction, agenda_summary,
-  agenda_text_heuristics), delete local_ai_agenda_compat.py, and remove
-  the now-unconsumed re-export surface. Keep LocalAI product policy and
-  public entrypoints intact.
+  legitimate implementation and STAYS. The census covers every current
+  implementation owner, including agenda_extraction, agenda_summary,
+  agenda_text_heuristics, local_ai_runtime, and text_generation. Step 2:
+  repoint (a) to those implementation owners, delete
+  local_ai_agenda_compat.py, and remove the now-unconsumed re-export surface.
+  Keep LocalAI product policy and public entrypoints intact.
 - accept (behavioral, not lexical): no module outside llm.py imports a
   symbol from llm.py that llm.py merely re-exports from another module;
   local_ai_agenda_compat.py deleted; census table in the PR body with each
@@ -285,8 +285,8 @@ investigations that may close with no code change.
   assertion has a named syntactic replacement or a recorded decision to
   drop it; file materially smaller; every retained custom check names its
   supported cases in a docstring; suite green.
-- sequencing: lands before any other ARCH implementation PR (see D6
-  guardrail-file serialization).
+- sequencing: lands before any other ARCH implementation PR. Later PRs follow
+  D6's conditional shared-file rule.
 
 ### T-ARCH-1: Search facade stack retirement  [P2, largest, Full-mandatory]
 - gate: GA-1 + its own Full-template plan (one stratum per PR)
@@ -357,12 +357,13 @@ PR 1: T-DOC-2 (only remaining DOC task; new guardrail, reviewed against
       postmortem rules — T-DOC-1/3/4 closed as pre-completed on master)
 PR 2: T-BASE-1 (doc promotion; unblocks sourced markings)
 PR 3: T-BASE-2 (operator capture + agent-assembled evidence PR)
-ARCH: T-ARCH-10 lands FIRST (guardrail-file serialization, D6); then P1
-      tasks (T-ARCH-4/5) in any order, max two implementation PRs in
-      flight (T-ARCH-9 closed as pre-completed); P2 tasks after GA-1,
-      each behind its own Full plan; P3 investigations anytime,
-      implementation only via new gated tasks. Per D8, every task
-      re-verifies its premise against HEAD before its PR opens.
+ARCH: T-ARCH-10 lands FIRST; then P1 tasks (T-ARCH-4/5) in any order, max
+      two implementation PRs in flight (T-ARCH-9 closed as pre-completed).
+      Only tasks whose live census requires an edit to the shared guardrail
+      file serialize under D6. P2 tasks follow GA-1, each behind its own Full
+      plan; P3 investigations may run anytime, with implementation only via
+      new gated tasks. Per D8, every task re-verifies its premise against HEAD
+      before its PR opens.
 ```
 
 DOC, BASE, and ARCH lanes are independent; T-BASE-2 alone is sequenced

--- a/docs/plans/POST_REMEDIATION_FOLLOWUP_PLAN.md
+++ b/docs/plans/POST_REMEDIATION_FOLLOWUP_PLAN.md
@@ -1,458 +1,424 @@
 # Focused Plan: Post-Remediation Follow-Up
 
-Scope: pipeline-doc integrity, baseline v2 evidence readiness, and
-architecture-watchlist retirement.
+Scope: baseline-v2 evidence readiness and bounded architecture investigations.
 
-plan_id: POST-REM-FOLLOWUP-2026-08
-status_tracking: task state and evidence cells in the table below. Every task
-PR may update only its own two cells in this file, even when the task's
-implementation ownership is otherwise narrower. Do NOT add a
-changelog section to this file and do NOT extend the frozen remediation plan
-(docs/plans/TOWN_COUNCIL_REMEDIATION_PLAN.md is historical evidence per the
-2026-08-02 postmortem prevention table).
-source: External review of docs/PIPELINE.md + verification of the
-baseline_representative_v2 gap analysis. Both reviews dated 2026-08-02. The
-file-map existence claim remains review evidence until T-DOC-2 supplies the
-reproducible repository check.
-amended: 2026-08-03 — reconciled against immutable master commit
-a62ca0eff8eb7aae0e4d1b6776efefd7b401a1b1 after Codex review flagged
-snapshot staleness: T-DOC-1,
-T-DOC-3, T-DOC-4, and T-ARCH-9 were already completed on master and are
-closed as pre-existing below. Earlier verification dates in this file refer
-to the 2026-08-02 archive snapshot, which master has since advanced past.
-postmortem_compliance: This plan follows the program postmortem's prevention
-rules — it is small and focused; new checks are syntactic and bounded; task
-ownership below was traced from entrypoints/consumers/docs/tests/CI, not from
-expected diffs; policy meaning lands in canonical docs, task state lands in
-the tracker table only.
+Plan ID: `POST-REM-FOLLOWUP-2026-08`
+
+Status owner: repository maintainer
+
+Source: operator-provided pipeline review, PR #224 review record, and the
+2026-08-02 remediation postmortem.
+
+Last reconciled: 2026-08-03 against commit
+`a62ca0eff8eb7aae0e4d1b6776efefd7b401a1b1` and current PR #224 HEAD.
+
+This file is the only task tracker for this follow-up. The frozen remediation
+plan remains historical evidence and must not be extended. Do not add a
+changelog here.
 
 ---
 
-## Directives (apply to every task)
+## 1. Operating Rules
 
-- D1. AGENTS.md remains supreme; the planning templates
-  (docs selection rules) apply. T-DOC-2 is Full-template work because it
-  adds persistent enforcement machinery; T-BASE-2 is Full-template work
-  because it touches soak-baseline comparability. T-ARCH-10 is an
-  investigation only; any implementation it recommends gets a separate
-  Full plan sized by assertion family.
-- D2. Sourced vs derived: every step in an execution procedure (numbered
-  steps in a task, a Full plan, or a PR body) must be marked either
-  [sourced: <doc §>] or [derived: <policy it follows>]. Task charters in
-  this file are scoping documents, not procedures; their Full plans carry
-  the markings. Steps may not be presented as documented requirements
-  unless a citation exists.
-- D3. When restating the compatibility-seam prevention rule anywhere, quote
-  its standard exactly:
-  "proves duplication or reverse dependency and removes more seam machinery than it adds."
-  Looser paraphrases (e.g. "proves it obsolete") drop the
-  net-seam-reduction test and are incorrect.
-- D4. Minimal diffs; no drive-by edits to PIPELINE.md sections not named in
-  a task; the doc's honest documentation of retained facades is intentional
-  and stays.
-- D5. Deletion-test standard for every ARCH task: the change must remove
-  complexity rather than move it, and per the compatibility-seam rule (D3)
-  must remove more seam machinery than it adds. A task whose investigation
-  concludes "no change warranted" is a VALID completion — record the
-  evidence and close it.
-- D6. No campaign: at most TWO ARCH *implementation* PRs in flight at once
-  (P3 investigations and Full-plan authoring do not count toward the cap);
-  one domain per PR; investigation and implementation are separate PRs.
-  Template routing follows the planning templates' selection rules, which
-  this plan cannot override (D1): T-ARCH-5 and T-ARCH-1 (facade families)
-  are Full-mandatory regardless of
-  tier; T-ARCH-2/3 Full per their gates. T-ARCH-10 does not authorize an
-  implementation PR. An ARCH task edits
-  tests/test_repository_guardrails.py only when its live HEAD census finds an
-  entry affected by the task. PRs that actually edit that shared file
-  SERIALIZE; independent ARCH PRs remain subject only to the two-PR cap.
-- D7. Priority tiers below are a proposal; gate GA-1 applies.
-- D8. Snapshot staleness: this plan was authored against an archive
-  snapshot. Before opening any task's PR, re-verify the task's premise
-  against HEAD. A premise that no longer holds closes the task as
-  pre-completed (record the evidence in the tracker) — it does not license
-  no-op or contradictory work.
+1. `AGENTS.md` and the canonical documents it names remain authoritative.
+2. Every task re-verifies its premise against HEAD before planning or edits.
+3. Investigation and implementation are separate PRs. An investigation may
+   close with "no change warranted."
+4. An investigation cannot authorize code changes. It may propose a child
+   implementation task with exact ownership, verification, and rollback;
+   adding that child to this tracker requires operator approval.
+5. Evidence used by later work must be checked in. PR prose may summarize it
+   but is not its only home.
+6. Each task PR updates only its own tracker row. Concurrent task branches
+   rebase before merge so tracker updates land sequentially.
+7. Compatibility work must prove duplication or reverse dependency and remove
+   more seam machinery than it adds.
+8. Citations are required for normative or non-obvious claims. No universal
+   sentence-tagging protocol is required.
+9. At most two future architecture implementation PRs may be active at once.
+   Investigation PRs do not count toward this limit.
 
-## Gates
+## 2. Task Tracker
 
-- GA-1 (operator): ratify or reorder the ARCH priority ranking. Blocks all
-  ARCH implementation PRs; does not block investigations or Full-plan
-  drafting.
-- GB-1 (procedure, restating canonical policy — no new gate semantics):
-  a `reduced-confidence` or non-baseline-valid capture is `non_comparable`;
-  per docs/PERFORMANCE.md compare policy, inspect result.json and the
-  listed confidence reason and fix that reason before using any run for
-  the expected baseline [sourced: PERFORMANCE.md interpretation rules +
-  compare policy]. Fixes land in separate PRs, then recapture
-  [sourced: PERFORMANCE.md after T-BASE-1]. If the listed reason
-  implicates runtime policy or profile configuration, escalate to the
-  operator — agents may not alter those (AGENTS.md hard invariants).
-  This gate introduces no retry counts or halt thresholds; any such
-  addition would be a soak-gate semantic requiring ratification in
-  canonical policy, not in this plan.
+| ID | State | Accountable role | Durable evidence |
+| --- | --- | --- | --- |
+| T-DOC-1 | Closed before this plan | Repository maintainer | PR #222 and current `docs/PIPELINE.md` Stage B |
+| T-DOC-2 | Closed, not pursued | Repository maintainer | PR #224 review record; permanent Markdown parser rejected |
+| T-DOC-3 | Closed before this plan | Repository maintainer | PR #222 and current OCR provenance note |
+| T-DOC-4 | Closed before this plan | Repository maintainer | PR #222 and current `Primary Implementation Map` heading |
+| T-BASE-1 | Open | Repository maintainer | Pending PR |
+| T-BASE-2A | Open | Repository maintainer | Pending Full plan and PR |
+| T-BASE-2B | Blocked on T-BASE-2A and operator captures | Repository operator | Pending evidence PR |
+| T-ARCH-1I | Open investigation | Repository maintainer | Pending checked-in census |
+| T-ARCH-2I | Open investigation | Frontend maintainer | Pending checked-in census |
+| T-ARCH-3I | Open investigation | Semantic-service maintainer | Pending checked-in census |
+| T-ARCH-4 | Closed before this plan | Repository maintainer | [Python Guardrails run 30770109810](https://github.com/manumissio/town-council/actions/runs/30770109810) |
+| T-ARCH-5I | Open investigation | Inference maintainer | Pending checked-in census |
+| T-ARCH-6I | Open investigation | Frontend maintainer | Pending checked-in census |
+| T-ARCH-7I | Open investigation | Search/index maintainer | Pending checked-in census |
+| T-ARCH-8I | Open investigation | Crawler maintainer | Pending checked-in census |
+| T-ARCH-9 | Closed before this plan | Crawler maintainer | Python Guardrails run 30770109810 and `tests/test_crawler_refactor_contract.py` |
+| T-ARCH-10I | Open investigation | Guardrail maintainer | Pending checked-in census |
 
-## Task tracker
-
-| id        | state | immutable evidence and proving check |
-|-----------|-------|-----------------|
-| T-DOC-1   | closed (pre-completed) | `git show a62ca0e:docs/PIPELINE.md \| sed -n '52,68p'` |
-| T-DOC-2   | open  |                 |
-| T-DOC-3   | closed (pre-completed) | `git show a62ca0e:docs/PIPELINE.md \| sed -n '208,220p'` |
-| T-DOC-4   | closed (pre-completed) | `git show a62ca0e:docs/PIPELINE.md \| rg '^## 11\\) Primary Implementation Map$'` |
-| T-BASE-1  | open  |                 |
-| T-BASE-2  | open  |                 |
-| T-ARCH-1  | open  |                 |
-| T-ARCH-2  | open  |                 |
-| T-ARCH-3  | open  |                 |
-| T-ARCH-4  | closed (pre-completed) | `a62ca0e`; [Python Guardrails run 30770109810](https://github.com/manumissio/town-council/actions/runs/30770109810) |
-| T-ARCH-5  | open  |                 |
-| T-ARCH-6  | open  |                 |
-| T-ARCH-7  | open  |                 |
-| T-ARCH-8  | open  |                 |
-| T-ARCH-9  | closed (pre-completed) | [run 30770109810](https://github.com/manumissio/town-council/actions/runs/30770109810); `git show a62ca0e:tests/test_crawler_refactor_contract.py \| rg 'Fremont\|Moraga'` |
-| T-ARCH-10 | open  |                 |
-| T-ARCH-11 | blocked | ADR and supported-starting-state decision required |
+Closed-state provenance remains tied to the cited commit/PR. Before relying on
+a closed state, rerun its current enforcing test or inspect the current
+canonical section; stale evidence reopens the task instead of licensing a
+contradictory change.
 
 ---
 
-## Lane DOC — PIPELINE.md integrity (one PR, agent-executable)
+## 3. Documentation Lane
 
-### T-DOC-1: Repair the Stage B duplicated rationale block  [CLOSED — pre-completed on master]
-- evidence: master PIPELINE.md places the chunking rationale directly under run_parallel_processing(); no orphaned duplicate block remains.
+### T-DOC-1, T-DOC-3, and T-DOC-4: Closed
 
-### T-DOC-2: Guard the §11 file map with a syntactic existence check  [Full]
-- files_owned: tests/test_pipeline_doc_file_map.py (new). The Full plan must
-  name any additional file before implementation; this charter does not
-  authorize edits elsewhere.
-- do: Add a bounded check: extract every backtick-quoted syntactic path
-  candidate only from the text between the `## 11)` heading and the next
-  level-two heading in docs/PIPELINE.md. Fail unless exactly one `## 11)`
-  section exists and that section yields at least one candidate. A candidate
-  must be an unambiguous
-  repository-relative reference containing `/` and must be either a literal
-  `.py`/`.md` path or a terminal wildcard path. Terminal wildcards may be
-  extensionless, such as `pipeline/task_*`, `api/task_route_*`, or
-  `semantic_service/*`. Bare names such as `db_migrate.py`, commands, and
-  generated artifact names outside §11 are not part of this contract; do not
-  infer a parent directory from prose. Extract candidates without first
-  consulting the filesystem. Derive the family
-  set from those candidates' leading path segments, not from a hardcoded list
-  or the set of directories that currently exists. Then assert that each
-  candidate family exists, each literal path exists, and each glob family
-  matches at least one file. This keeps a misspelled or entirely deleted
-  family visible to the failure assertions. No prose
-  interpretation, no content assertions — path existence only, per the
-  postmortem rule for custom checks ("exact-set… syntactic and bounded").
-- accept: Test passes on HEAD; deleting a literal referenced path or top-level
-  family makes it fail; removing the final match for a glob family makes it
-  fail, including for an extensionless terminal wildcard. The check names
-  these supported cases in a docstring; a bare filename outside §11 does not
-  enter the candidate set. Removing or duplicating the §11 heading, or
-  producing an empty candidate set, makes the test fail. These are parser
-  preconditions, not assertions about narrative wording. The check does not
-  claim that it protects every individual member represented only by a glob.
-- forbidden: Extending the check to other docs in this PR; asserting doc
-  content beyond path existence.
-- verify: `./.venv/bin/ruff check .` + targeted pytest for the new test + full
-  suite.
+PR #222 already repaired the Stage B rationale placement, added OCR-default
+provenance, and renamed the implementation map. Current verification:
 
-### T-DOC-3: Config-default provenance note on the OCR table  [CLOSED — pre-completed on master]
-- evidence: master PIPELINE.md states pipeline/config_processing.py owns the loader fallbacks for the table.
-
-### T-DOC-4: Retitle "Source-of-Truth File Map"  [CLOSED — pre-completed on master]
-- evidence: master §11 is titled "Primary Implementation Map"; no "Source-of-Truth" occurrence remains.
-
----
-
-## Lane BASE — baseline_representative_v2 evidence readiness
-
-### T-BASE-1: Promote the capture-hygiene rule into PERFORMANCE.md
-- files_owned: docs/PERFORMANCE.md (baseline interpretation-rules section,
-  ~L121 block), docs/OPERATIONS.md (cross-reference line near the baseline
-  capture commands, ~L1528, only if a pointer is missing)
-- do: The rule "a baseline capture run makes no optimization, threshold, or
-  runtime-policy changes; if capture exposes a defect, fix it in a separate
-  PR and recapture" is currently only derived (from AGENTS.md hard
-  invariants + the atomic-change policy) — it appears in no baseline doc.
-  Add it to PERFORMANCE.md's baseline rules so it becomes [sourced].
-  Runtime-policy immutability may cite AGENTS.md hard invariants inline.
-- accept: The rule is stated once in PERFORMANCE.md; OPERATIONS capture
-  section points to the rules rather than duplicating them; D2 marking in
-  the PR body. If OPERATIONS changes, update its `Last updated` marker.
-- verify: docs-link test; env/profile alignment test; grep confirms single
-  statement; `git diff --check`.
-
-### T-BASE-2: The evidence PR (Full template; human-gated execution)
-- files_owned: profiling/baselines/baseline_representative_v2.json (new),
-  docs/PERFORMANCE.md, docs/OPERATIONS.md,
-  profiling/manifests/README.md, and docs/ADR.md. Preserve the accepted ADR
-  decision and add implementation status; do not rewrite its history.
-- depends_on: T-BASE-1 (so every step below is [sourced])
-- human_gate: two independent captures run on the operator's machine with
-  the same immutable commit, manifest and sidecar, preconditioned dataset,
-  index artifacts, semantic settings, runtime profile, and warm/cold
-  condition. The operator supplies complete artifacts for reference run A
-  and validation run B. An agent prepares the plan and assembles the PR; it
-  does not execute captures or fabricate artifacts. Absence of either
-  artifact set = blocked, not improvisable.
-- procedure (all steps must carry D2 markings in the plan):
-  1. `--dry-run-prepare` inspection of controlled preconditioning
-     [sourced: PERFORMANCE interpretation rules; OPERATIONS ~L1528].
-  2. Stable local reference run A using the v2 manifest
-     [sourced: OPERATIONS baseline capture section].
-  3. Run A has `baseline_valid=true` and no `reduced-confidence` analyzer state
-     [sourced: v1 baseline schema + PERFORMANCE rules].
-  4. Run A artifacts present: provider telemetry, phase timings, stable
-     workload counters [sourced: baseline schema fields
-     elapsed_seconds/top_phases/stable_counters/reference_run_id].
-  5. Derive the expected-baseline JSON from run A, same schema as v1, and set
-     `reference_run_id` to run A
-     [sourced: profiling/baselines/baseline_representative_v1.json].
-  6. Capture independent validation run B under the same immutable commit,
-     manifest and sidecar, preconditioned dataset, index artifacts, semantic
-     settings, runtime profile, and warm/cold condition. Record those fields
-     for both runs. Run B must also be baseline-valid and full-confidence,
-     and may not reuse run A's output directory or run ID. Any mismatch makes
-     the comparison `non_comparable` [sourced: PERFORMANCE interpretation
-     rules; derived: independent validation].
-  7. Compare run B via `--compare-to` against the expected baseline derived
-     from run A. Include both commands, the shared runtime profile, both run
-     IDs, and both artifact/report sets in the PR body
-     [sourced: PERFORMANCE rules; derived: independent validation].
-  8. Synchronize the four owned canonical documents from pending-candidate
-     wording to merged-baseline status without changing the accepted ADR
-     decision [derived: docs ownership and history preservation].
-  9. No optimization/threshold/runtime-policy changes in the capture PR;
-     defects found → separate fix PR, then recapture
-     [sourced: PERFORMANCE after T-BASE-1].
-- context_for_reviewer (include verbatim in the PR body): v2 uses the
-  identical 30 catalog IDs as v1 with phase quotas redistributed — entity
-  4→8 absorbs the retired people phase's slots (people 4→0; extract 8,
-  segment 6, summary 6, org 2 unchanged). The shared IDs preserve record
-  identity only. The phase change makes v1 and v2 non-comparable: do not use
-  cross-version timings or stable counters for regression or promotion
-  decisions. v1 and its checked-in expectation remain immutable historical
-  evidence.
-- accept: profiling/baselines/baseline_representative_v2.json merged;
-  independent run B compares green against run A's expectation under
-  documented tolerances; `reference_run_id` names run A; both artifact sets
-  and all step evidence appear in the PR body with D2 markings; owned docs
-  agree on implementation status.
-- explicitly_not_claimed: merging this PR clears the baseline prerequisite
-  only; City Expansion Readiness additionally requires the rollout-registry
-  wave selection and crawl/derived-state/queue gates in ROADMAP.md — do not
-  mark expansion ready on this PR.
-
----
-
-## Lane ARCH — watchlist retirement (gated by D5–D7)
-
-Source for every task: the 2026-07-19 architecture interrogation, re-verified
-against the 2026-08-02 tree. Priority tiers: P1 = cheap true deletions with
-evidence in hand; P2 = deep-module work needing a Full plan; P3 =
-investigations that may close with no code change.
-
-### T-ARCH-4: Verify the frozen migrate chain  [CLOSED — pre-completed]
-- evidence: `.github/workflows/python-guardrails.yml` runs
-  `tests/test_alembic_migrations.py` against Postgres before the full suite,
-  which includes the frozen-runner and migrate_v8/v9/v10 contract tests;
-  `pipeline/db_migration_runner.py` still invokes that chain for the supported
-  unversioned-adoption path. Under the accepted ADR, the present result is
-  "retain the frozen chain." No duplicate parity gate is needed.
-
-### T-ARCH-11: Sunset the frozen migration chain  [future, Full, blocked]
-- gate: a separately ratified ADR must define the minimum supported database
-  state and retire support for unversioned/pre-Alembic starting states.
-- files_owned: must be derived by the Full plan after that decision; this
-  charter authorizes no migration-file edit or deletion.
-- do: prove that every supported database starts from an Alembic-owned state,
-  then remove the frozen runner and migrate_v8/v9/v10 end to end. Update
-  migration and operator documentation and verify each supported starting
-  state. This task records the operator's intended direction; it cannot begin
-  while the current ADR and support floor remain active.
-
-### T-ARCH-5: Retire LocalAI private re-exports  [P1, Full-mandatory]
-- files_owned: pipeline/llm.py, pipeline/local_ai_agenda_compat.py,
-  consumers identified by the census below, their tests,
-  docs/PIPELINE.md (the LocalAI provider section and §11 entries touched)
-- do: Step 1 (in the Full plan): consumer census — enumerate every import
-  of llm.py's aliased symbols and of local_ai_agenda_compat, from code and
-  from tests, distinguishing (a) external consumers of re-exports from
-  (b) llm.py's own internal delegation to implementation modules, which is
-  legitimate implementation and STAYS. The census covers every current
-  implementation owner, including agenda_extraction, agenda_summary,
-  agenda_text_heuristics, local_ai_runtime, and text_generation. Step 2:
-  repoint (a) to those implementation owners, delete obsolete compatibility
-  tests whose only contract is the retired seam, delete
-  local_ai_agenda_compat.py, and remove the now-unconsumed re-export surface.
-  Keep LocalAI product policy and public entrypoints intact.
-- accept (behavioral, not lexical): no module outside llm.py imports a
-  symbol from llm.py that llm.py merely re-exports from another module;
-  local_ai_agenda_compat.py deleted; census table in the PR body with each
-  consumer's disposition; D5 evidence (net symbols/seams removed); suite
-  green. Renaming aliases without removing the re-export relationship does
-  NOT satisfy this task.
-
-### T-ARCH-9: Fremont/Moraga recorded-parse parity  [CLOSED — pre-completed on master]
-- evidence: master test_crawler_refactor_contract.py has equivalent Belmont/Fremont/Moraga archive event contracts with document-level assertions and no network I/O.
-
-### T-ARCH-10: Guardrail-file census  [P1, investigation only]
-- read_scope: tests/test_repository_guardrails.py, ruff.toml, mypy.ini,
-  .coveragerc, docs/ENGINEERING_GUARDRAILS.md, docs/TESTING.MD, and the
-  canonical document targeted by each document-content assertion.
-- files_owned: docs/plans/POST_REMEDIATION_FOLLOWUP_PLAN.md, tracker evidence
-  cell only. The investigation may not edit guardrails or tests.
-- do: Apply the postmortem's prevention rule to the 5,555-line file by
-  classifying every assertion targeting document
-  content, record one of: (a) pure prose-content assertion (headings,
-  phrasing, casing of narrative text) → candidate for deletion; (b) invariant-bearing
-  assertion (e.g., frozen-document immutability, link integrity) →
-  candidate for syntactic replacement (content-hash pin for frozen files,
-  path-existence for links) that names its supported cases; (c) syntactic
-  code-policy check → retain. The PR body includes assertion family, current
-  invariant owner, disposition, estimated line delta, and proposed task ID.
-- accept: every document-content assertion belongs to exactly one family;
-  every proposed implementation is split by concrete assertion family,
-  declares exact ownership and size, uses a Full plan, and includes the full
-  guardrail verification row. The tracker records the investigation PR. No
-  implementation is authorized and unrelated ARCH work is not blocked.
-- verify: `PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py` and
-  `git diff --check` for the tracker-only investigation PR.
-
-### T-ARCH-1: Search facade stack retirement  [P2, largest, Full-mandatory]
-- gate: GA-1 + its own Full-template plan (one stratum per PR)
-- files_owned: derived per contract-graph tracing in the Full plan —
-  candidate set: api/search_routes.py, api/search_read_*.py, api/search/,
-  api/search_semantic_routes.py, api/trends_routes.py, api/main.py wiring,
-  consuming tests, docs/PIPELINE.md §11 entries
-- do: MANDATORY investigation first: a route/consumer inventory
-  establishing which endpoints are wired, which modules are live routes vs
-  helpers vs genuinely superseded strata. The retirement direction is an
-  OUTPUT of that inventory, not an input — do not assume oldest-first or
-  that newer strata are complete replacements. Then retire one proven-
-  redundant stratum per PR under the D5 deletion test.
-- accept (per stratum PR): the inventory evidence names the stratum
-  redundant; it is deleted end-to-end including its tests' patch targets;
-  no re-export bridge left behind; §11 updated.
-
-### T-ARCH-2: ResultCard decomposition  [P2, Full-mandatory]
-- gate: GA-1 + Full plan (design pass, not mechanical)
-- investigation_scope: frontend/components/ResultCard.js,
-  frontend/lib/taskPolling.js,
-  frontend/components/__tests__/ResultCard.ai-disclaimer.test.js,
-  frontend/components/__tests__/ResultCard.people-projection.test.js, and
-  frontend/components/__tests__/ResultCard.polling-contract.test.js. The Full
-  plan must name each implementation file, new module, and test file exactly;
-  broad directory ownership is not permitted.
-- do: Both review prerequisites are met (runner + 42-test harness) and the
-  polling seam is already extracted (taskPolling.js). Continue along the
-  review's seam list — mutation dispatch, formatting, rendering — one
-  extraction per PR, each behind the existing tests. The Full plan sets an
-  explicit numeric line budget and a one-responsibility statement for what
-  remains in ResultCard.js; "near composition-only" without numbers is not
-  an acceptance criterion.
-- accept (per extraction PR): user-visible behavior parity. Source-text
-  assertions in ResultCard.ai-disclaimer.test.js may be replaced with
-  rendered-behavior assertions; do not preserve the old source arrangement
-  merely to keep a patch point. Other observable contracts remain covered,
-  the extracted module has its own behavior test, and ResultCard.js shrinks
-  toward the Full plan's stated budget.
-
-### T-ARCH-3: Deepen semantic retrieval interface  [P2, Full-mandatory]
-- gate: GA-1 + Full plan
-- files_owned: semantic_service/retrieval.py, its callers and tests
-- do: Replace the 13-parameter retrieve signatures with a typed request
-  contract containing only query, filters, pagination, and retrieval
-  settings (match the *_contracts.py convention). Backend, database session,
-  and Meilisearch client remain explicit boundary parameters. Injectable
-  implementation callables are removed in favor of private imports from
-  their implementation owners.
-- accept: Public retrieve interface takes the request contract plus explicit
-  backend, database-session, and Meilisearch-client boundaries; every
-  contract field is individually typed and
-  documented — no dict payload field, no **kwargs, no Any escape hatch
-  (a god-object with an opaque bag does not satisfy this task); suite
-  green.
-
-### T-ARCH-6: Frontend search coordinator  [P3, investigation first]
-- read_scope: frontend/state/search-state.js, frontend/lib/api.js, their
-  direct importers, and their tests.
-- files_owned: docs/plans/POST_REMEDIATION_FOLLOWUP_PLAN.md, tracker evidence
-  cell only.
-- do: Census live/demo adapter ownership and call direction. The PR body
-  table records adapter, caller, state owner, duplicated policy, and deletion
-  impact.
-- accept: close when one owner already exists or consolidation would only
-  move complexity; otherwise register a separately approved Full task with
-  exact files and deletion evidence. Verify docs links and `git diff --check`.
-
-### T-ARCH-7: Index projection consolidation  [P3, investigation first]
-- read_scope seeds: pipeline/indexer.py, pipeline/indexer_documents.py,
-  pipeline/indexer_meilisearch.py, pipeline/reindex_only.py,
-  pipeline/reindex_semantic.py, pipeline/task_side_effects.py,
-  api/search_read_meilisearch.py, semantic_service/main.py,
-  semantic_service/retrieval.py, tests/test_indexer_logic.py,
-  tests/test_indexer_official_roster.py, and DATA_GOVERNANCE §3. Expand the
-  census only through direct imports/callers found with
-  `rg -n 'index_documents|_build_.*search_doc|reindex|people_metadata'`.
-- files_owned: docs/plans/POST_REMEDIATION_FOLLOWUP_PLAN.md, tracker evidence
-  cell only.
-- do: Record data class, policy owner, implementation owner, consumers, and
-  conflicting/duplicated decisions in the PR body evidence table.
-- accept: close if every projection rule has one implementation owner;
-  otherwise register a separately approved Full task that names the exact
-  duplicated policy and files. Verify docs links and `git diff --check`.
-
-### T-ARCH-8: Crawler staging persistence  [P3, investigation first]
-- read_scope seeds: council_crawler/council_crawler/pipelines.py,
-  council_crawler/council_crawler/models.py,
-  council_crawler/council_crawler/settings.py, pipeline/promote_stage.py,
-  pipeline/db_session.py, tests/test_crawler_refactor_contract.py,
-  tests/test_database.py, and tests/test_pipeline_idempotency.py. Expand only
-  through direct imports/callers found with
-  `rg -n 'CreateEventPipeline|StageDocumentLinkPipeline|promote_stage|EventStage|UrlStage'`.
-- files_owned: docs/plans/POST_REMEDIATION_FOLLOWUP_PLAN.md, tracker evidence
-  cell only.
-- do: Record each local transaction block, owner, invariant, and any actual
-  duplicated policy in the PR body evidence table.
-- accept: default to closure when the two local transaction blocks are
-  cohesive and do not justify another seam. Only proven duplicated policy
-  may create a separately approved narrow task. Verify docs links and
-  `git diff --check`.
-
----
-
-## Execution order
-
-```
-DOC lane: T-DOC-2 may proceed independently (T-DOC-1/3/4 are closed).
-BASE lane: T-BASE-1 -> independent operator runs A/B -> T-BASE-2.
-ARCH lane: T-ARCH-10 is an investigation and does not block T-ARCH-5 or other
-           unrelated work. T-ARCH-4 and T-ARCH-9 are closed; T-ARCH-11 is
-           blocked on a future ADR/support-floor decision. At most two
-           implementation PRs are in flight. Only tasks whose live census
-           requires an edit to the shared guardrail file serialize under D6.
-           P2 tasks follow GA-1 behind their own Full plans. P3 investigations
-           may run anytime; implementation requires a new gated task. Per D8,
-           every task re-verifies its premise against HEAD before its PR opens.
+```bash
+sed -n '52,68p' docs/PIPELINE.md
+sed -n '208,220p' docs/PIPELINE.md
+rg -n '^## 11\) Primary Implementation Map$' docs/PIPELINE.md
+PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py
 ```
 
-DOC, BASE, and ARCH lanes are independent; T-BASE-2 alone is sequenced
-after T-BASE-1. Investigation tasks may run in parallel when their read
-scopes do not overlap; each resulting implementation requires its own
-approved task and plan.
+### T-DOC-2: Do not build a PIPELINE.md path parser
 
-## Out of scope
+The proposed syntactic guard grew from a small existence test into a custom
+Markdown grammar with section-boundary, wildcard, tracked-file, and fixture
+requirements. Even then it could detect only stale literals and empty glob
+families, not a missing member from a still-populated wildcard family.
 
-- Any other PIPELINE.md edits, including facade-inventory pruning — the
-  retained-facade honesty is a feature (though ARCH deletions must update
-  the §11 map entries they invalidate; the T-DOC-2 check will catch misses).
-- Extending the file-map existence check to other documents (revisit only
-  if a second doc exhibits the same staleness risk — the second-finding
-  rule, not preemption).
-- Baseline threshold or tolerance changes; runtime-profile changes; any
-  soak-gate semantics (hard invariants, human decision required).
-- Reopening or amending the frozen remediation plan.
-- Any facade retirement outside the domains named in Lane ARCH — the
-  candidate-08 rule stands: no repository-wide purge; watchlist domains
-  only, one at a time, under D5/D6.
+Decision: do not add persistent enforcement machinery. Every architecture PR
+must update the exact `docs/PIPELINE.md` entries it invalidates and run the
+normal documentation checks. Architecture review remains responsible for
+semantic omissions.
+
+---
+
+## 4. Baseline Lane
+
+### T-BASE-1: Make capture hygiene canonical
+
+**Ownership**
+
+- `docs/PERFORMANCE.md`, baseline interpretation rules
+- `docs/OPERATIONS.md`, one pointer only if the capture section lacks it
+- this task's tracker row
+
+**Change**
+
+Add this rule once to `docs/PERFORMANCE.md`:
+
+> A baseline capture is measurement-only: do not change optimization,
+> thresholds, or runtime policy during capture. Fix defects in a separate PR,
+> then recapture.
+
+If `docs/OPERATIONS.md` changes, point to the performance rule rather than
+duplicating it. Update every materially changed document's `Last updated`
+marker.
+
+**Acceptance and verification**
+
+```bash
+test "$(rg -F -c 'A baseline capture is measurement-only:' docs/PERFORMANCE.md)" -eq 1
+PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_env_example_profile_alignment.py
+git diff --check
+```
+
+### T-BASE-2A: Add machine-verifiable baseline provenance
+
+This is a separate Full-template implementation task. It must land before any
+v2 capture is accepted.
+
+**Problem to solve**
+
+Current `baseline_valid` means only that baseline mode was selected. The
+comparator does not prove commit, manifest package, preconditioned workload,
+dataset/index state, semantic settings, or warm/cold condition. Run output
+directories are ignored, so PR prose alone is not durable evidence.
+
+**Required first production result**
+
+Given independent run directories A and B, one command produces a bounded,
+checked-in evidence document and exits nonzero unless the runs are comparable.
+The document must contain:
+
+- schema version and complete run IDs
+- immutable commit SHA for each run
+- host platform, Docker version, and explicit inference backend/model identity
+- manifest and sidecar identity, including SHA-256 and catalog IDs
+- recorded preconditioning result
+- pre-run database snapshot, index, and semantic-state identifiers defined by
+  the Full plan
+- controlled runtime-profile fields, request/sample count, and warm/cold
+  condition
+- required artifact presence and SHA-256 values
+- nonempty elapsed, phase, and stable-counter evidence
+- mismatch reasons and final `comparable` status
+
+The checked-in evidence package must contain every normalized input and value
+used for comparability and expected-baseline generation. External raw-artifact
+URLs may be included only as supplemental evidence; expiry cannot prevent a
+reviewer from reproducing the package's hashes, validation, or derivation.
+
+**Design constraints**
+
+- Extend existing profiler result/comparison modules; do not create a second
+  profiling framework.
+- Separate expected-baseline fields from analyzer-confidence evidence.
+- Generate the expected baseline deterministically from run A.
+- Require these v2 phase families from the manifest and command plan:
+  `extract_parallel`, `segment_agenda`, `summarize`, `entity_backfill`, and
+  `org_backfill`, with expected coverage `8`, `6`, `6`, `8`, and `2`.
+- Require the existing stable-counter families `agenda_segmentation_backfill`,
+  `summary_hydration_backfill`, and `entity_backfill`. Add normalized
+  completion evidence for extract and organization work because those paths
+  currently lack equivalent structured counters.
+- Fail generation and comparison unless all five workload families executed
+  successfully and their observed coverage matches the v2 sidecar. Empty or
+  partial phase/counter contracts are invalid.
+- Treat partial, failed, reduced-confidence, provenance-mismatched, or reused
+  run IDs as non-comparable.
+- Document that `--dry-run-prepare` currently runs migration and hash-backfill
+  setup before its dry-run preconditioning report. The Full plan must either
+  make inspection genuinely non-mutating or name those setup effects and the
+  restoration procedure.
+
+**Owned files and exact verification**
+
+The Full plan derives exact ownership from the existing profiler modules and
+tests before implementation. It must include targeted profiler tests, Ruff,
+Mypy when typed files change, the complete Python suite, and `git diff --check`.
+No runtime default, tolerance, or soak-gate semantic may change.
+
+### T-BASE-2B: Capture and promote baseline_representative_v2
+
+This Full-template evidence task begins only after T-BASE-2A merges and the
+operator supplies two independent captures.
+
+**Ownership**
+
+- `profiling/baselines/baseline_representative_v2.json` (new)
+- the checked-in evidence document produced by T-BASE-2A
+- `docs/PERFORMANCE.md`
+- `docs/OPERATIONS.md`
+- `profiling/manifests/README.md`
+- `docs/ADR.md`, implementation status only; preserve accepted history
+- `ROADMAP.md`, baseline-prerequisite status only; preserve every other gate
+- this task's tracker row
+
+**Capture contract**
+
+Run A and run B use the same immutable commit, host platform, Docker version,
+inference backend/model, manifest/sidecar, runtime profile, request/sample
+count, and warm/cold condition. Before run A and again before run B, restore
+the same captured database snapshot and recreate the same index and semantic
+state through the mechanism approved in T-BASE-2A's Full plan. Record the
+pre-run state identifiers for both captures. The runs use distinct run IDs and
+output directories. Each must be complete, baseline-valid under the
+T-BASE-2A contract, and full-confidence. Any mismatch, partial run, or failed
+restoration is non-comparable and requires restoration followed by recapture.
+
+Run A deterministically produces the expected baseline. Run B is compared
+against it. `reference_run_id` names run A. The v1 and v2 workloads remain
+non-comparable because v2 removes the retired people phase and reallocates its
+catalogs to entity enrichment.
+
+**Acceptance**
+
+- T-BASE-2A's validator accepts the checked-in A/B evidence.
+- Run B compares successfully against the expectation generated from run A.
+- Required phase and stable-counter families are nonempty.
+- All five v2 workload families executed successfully with coverage matching
+  the manifest sidecar.
+- Canonical documents agree that v2 evidence has landed while retaining all
+  other City Coverage Expansion gates.
+- No optimization, threshold, runtime-profile, or gate-policy change appears
+  in the evidence PR.
+
+**Verification**
+
+The Full plan must provide the exact T-BASE-2A validation/export command and
+expected output, plus:
+
+```bash
+PYTHONPATH=. .venv/bin/pytest -q tests/test_pipeline_profile_report.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_profile_pipeline_cli.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_operator_profile_helpers.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_env_example_profile_alignment.py
+PYTHONPATH=. .venv/bin/pytest -q
+git diff --check
+```
+
+---
+
+## 5. Architecture Investigation Lane
+
+Every open architecture item below is investigation-only. Its PR may add one
+evidence file under `docs/reviews/post-remediation/` and update its tracker
+row. Each evidence file must record the full HEAD SHA, exact census commands,
+the resulting population and count, zero unclassified entries, ownership and
+dependency direction, observable behavior at risk, deletion-test result, and
+either `close` or `propose child task`.
+
+A child task is not authorized until the operator approves its exact ID,
+ownership, Full plan, verification-matrix union, observable regression tests,
+and rollback. Parent investigations close when their evidence merges; they do
+not remain open across an undefined implementation campaign.
+
+### T-ARCH-1I: Search ownership census
+
+**Seeds:** `api/search_routes.py`, `api/search_read_*.py`, `api/search/`,
+`api/search_semantic_routes.py`, `api/trends_routes.py`, `api/main.py`, direct
+tests, and `docs/PIPELINE.md` §11.
+
+**Census:** trace router registration, imports, callers, and endpoint contracts.
+Classify every module as live route, implementation owner, compatibility seam,
+or unreferenced. Do not preselect a stratum for deletion.
+
+### T-ARCH-2I: ResultCard responsibility census
+
+**Seeds:** `frontend/components/ResultCard.js`, `frontend/lib/taskPolling.js`,
+and the three `ResultCard.*.test.js` files.
+
+**Census:** identify responsibilities, dependency direction, duplicated logic,
+and rendered behavior contracts. Do not use line count as a gate. Propose an
+extraction only when it improves cohesion or dependency direction and removes
+more complexity than it introduces. Source-text tests may be replaced only by
+rendered-behavior tests in an approved child task.
+
+### T-ARCH-3I: Semantic retrieval dependency census
+
+**Seeds:** `semantic_service/retrieval.py`, its direct callers, and retrieval
+tests.
+
+**Census:** evaluate the existing `SemanticRetrievalSettings` and
+`SemanticSearchFilters`, the duplicate raw filter representation, boundary
+parameters, and injected callables. Prefer composing or narrowing existing
+types. A new request contract is acceptable only if evidence proves net
+machinery reduction.
+
+### T-ARCH-5I: LocalAI compatibility census
+
+**Seeds:** `pipeline/llm.py`, `pipeline/local_ai_agenda_compat.py`,
+`pipeline/agenda_summary_batch.py`, agenda rendering/scaffold modules, all
+imports, and direct tests.
+
+**Census:** record every symbol, caller, signature, threshold, output contract,
+and production path. Prove behavioral equivalence per symbol before proposing
+migration or deletion. Current production use means deletion is not presumed.
+Any child task must own both affected LocalAI sections of `docs/PIPELINE.md`.
+
+### T-ARCH-6I: Frontend search coordination census
+
+**Seeds:** `frontend/state/search-state.js`, `frontend/lib/api.js`, their direct
+importers, and tests.
+
+**Census:** record adapter, caller, state owner, duplicated policy, and deletion
+impact. Close if one owner already exists or consolidation only moves
+complexity.
+
+### T-ARCH-7I: Search projection ownership census
+
+**Seeds:** `pipeline/indexer.py`, `pipeline/indexer_documents.py`,
+`pipeline/indexer_meilisearch.py`, `pipeline/reindex_only.py`,
+`pipeline/reindex_semantic.py`, `pipeline/task_side_effects.py`,
+`api/search_read_meilisearch.py`, `semantic_service/main.py`,
+`semantic_service/retrieval.py`, direct tests, and DATA_GOVERNANCE §3.
+
+**Census:** record each indexed data class, policy owner, implementation owner,
+consumer, and conflicting decision. Close if each projection rule already has
+one implementation owner.
+
+### T-ARCH-8I: Crawler staging transaction census
+
+**Seeds:** `council_crawler/council_crawler/pipelines.py`, crawler models and
+settings, `pipeline/promote_stage.py`, `pipeline/db_session.py`, and direct
+tests.
+
+**Census:** record each transaction block, owner, invariant, error behavior,
+and actual duplication. Do not introduce a shared seam unless repeated policy
+is proven. The expected cheap outcome is closure when the local transactions
+are cohesive.
+
+### T-ARCH-10I: Bounded guardrail assertion census
+
+**Seeds:** matches from this reproducible command only:
+
+```bash
+rg -n 'docs/(plans|postmortems)/' tests/test_repository_guardrails.py
+```
+
+Classify the resulting assertions by canonical invariant and enforcement type.
+Do not build an AST analyzer or classify unrelated portions of the 5,555-line
+file. A child task must cover one assertion family only and use the complete
+guardrail verification row.
+
+### Investigation verification
+
+Every investigation PR runs:
+
+```bash
+PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py
+git diff --check
+```
+
+Its evidence file also names the exact AGENTS verification-matrix union and
+observable regression scenarios required by any proposed child task.
+
+---
+
+## 6. Closed and Deferred Architecture Work
+
+### T-ARCH-4: Frozen migration chain retained
+
+Python Guardrails run 30770109810 separately ran PostgreSQL Alembic acceptance
+and then the complete suite containing the migrate_v8/v9/v10 contracts. The
+accepted ADR still supports unversioned-database adoption through
+`pipeline/db_migration_runner.py`; the chain remains active.
+
+### Deferred migration-chain sunset
+
+Operator direction is to sunset the frozen chain in a future PR. This is not
+an executable task yet. A new ADR must first define the minimum supported
+database state and retire unversioned/pre-Alembic adoption. Only then may a
+Full plan derive ownership and verification for deleting the chain.
+
+### T-ARCH-9: Crawler recorded-parse parity closed
+
+The complete suite in Python Guardrails run 30770109810 includes the
+Belmont/Fremont/Moraga recorded-parse contracts in
+`tests/test_crawler_refactor_contract.py`.
+
+---
+
+## 7. Execution
+
+The documentation, baseline, and architecture lanes may proceed independently.
+
+- Baseline order is strict: T-BASE-1, then T-BASE-2A, then operator captures
+  and T-BASE-2B.
+- Architecture investigations may run in parallel because they write separate
+  evidence files. Tracker updates merge sequentially after rebasing.
+- No architecture implementation begins until its investigation evidence and
+  separately numbered child task are approved.
+- The deferred migration sunset remains blocked on its ADR/support-floor
+  decision.
+
+## 8. Plan Verification
+
+```bash
+PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py
+PYTHONPATH=. .venv/bin/pytest -q tests/test_env_example_profile_alignment.py
+git diff --check
+```
+
+## 9. Out of Scope
+
+- Runtime defaults, model policy, thresholds, tolerances, and soak-gate changes
+- City Coverage Expansion before valid v2 evidence and all ROADMAP gates
+- Repository-wide facade removal or guardrail rewrites
+- A permanent Markdown or AST policy analyzer
+- Migration-chain deletion before the new ADR and support-floor decision

--- a/docs/plans/POST_REMEDIATION_FOLLOWUP_PLAN.md
+++ b/docs/plans/POST_REMEDIATION_FOLLOWUP_PLAN.md
@@ -131,12 +131,14 @@ the tracker table only.
   family visible to the failure assertions. No prose
   interpretation, no content assertions — path existence only, per the
   postmortem rule for custom checks ("exact-set… syntactic and bounded").
-- accept: Test passes on HEAD; deleting any referenced module or top-level
-  family makes it fail; the check names its supported cases in a docstring
-  (paths and globs) and nothing else.
+- accept: Test passes on HEAD; deleting a literal referenced path or top-level
+  family makes it fail; removing the final match for a glob family makes it
+  fail. The check names these supported cases in a docstring and does not
+  claim that it protects every individual member represented only by a glob.
 - forbidden: Extending the check to other docs in this PR; asserting doc
   content beyond path existence.
-- verify: targeted pytest for the new test + full suite.
+- verify: `./.venv/bin/ruff check .` + targeted pytest for the new test + full
+  suite.
 
 ### T-DOC-3: Config-default provenance note on the OCR table  [CLOSED — pre-completed on master]
 - evidence: master PIPELINE.md states pipeline/config_processing.py owns the loader fallbacks for the table.
@@ -215,36 +217,37 @@ against the 2026-08-02 tree. Priority tiers: P1 = cheap true deletions with
 evidence in hand; P2 = deep-module work needing a Full plan; P3 =
 investigations that may close with no code change.
 
-### T-ARCH-4: Rationalize the migrate chain vs Alembic ownership  [P1, Full-mandatory]
+### T-ARCH-4: Verify the frozen migrate chain before future sunset  [P1, Full-mandatory, investigation]
 - gate: GA-2 (operator parity run)
-- correction (Codex P1, PR #224): migrate_v10.py is NOT a shallow wrapper —
-  it owns ~200 lines of timestamp-contract validation and UTC conversion,
-  and pipeline/db_migration_runner.py imports migrate_v8 and migrate_v10
-  for unversioned-database adoption. The July watchlist's "shallow
-  wrapper" characterization applied to the v8/v9 era and does not transfer
-  wholesale. Blanket deletion would drop or merely relocate that
-  conversion, failing D5 and the legacy-upgrade criterion.
-- files_owned (contract-graph traced): pipeline/migrate_v8.py,
-  migrate_v9.py, migrate_v10.py, pipeline/db_migrate.py,
-  pipeline/db_migration_runner.py and every caller of the migrate chain
-  (enumerate in the Full plan), docs/OPERATIONS.md (migration section),
-  docs/PIPELINE.md (§11 entries for any deleted module), alembic/ (only
-  if delegation wiring changes), their tests.
-- do: Census first (in the Full plan): map every migrate_v* module's role —
-  implementation owner vs pass-through — and its consumers, including
-  db_migration_runner's unversioned-adoption path. Retire ONLY modules
-  the census proves are pass-throughs whose behavior Alembic revisions or
-  a retained owner already provide. migrate_v10's conversion logic is
-  RETAINED as the unversioned-adoption owner unless the census proves the
-  Alembic baseline subsumes it for every supported starting state; the
-  Full plan MUST state the upgrade story for pre-Alembic databases —
-  silent loss of the legacy upgrade path is a rejection criterion.
-- accept: Census table in the PR body with each module's disposition and
-  evidence; only census-proven pass-throughs deleted; fresh-DB and
-  upgraded-DB schema diff empty; a v9/v10-era database's documented
-  upgrade path verified in the parity run; OPERATIONS and §11 updated;
-  suite green; GA-2 output attached. "No change warranted" is a valid
-  census outcome (D5).
+- correction (Codex P1, PR #224): the accepted Alembic ADR requires the
+  migrate_v8/v9/v10 chain to remain readable and frozen while
+  pipeline/db_migration_runner.py uses it for unversioned-database adoption.
+  migrate_v10.py is not a shallow wrapper; it owns timestamp-contract
+  validation and UTC conversion. This task preserves the current chain and
+  cannot authorize deletion while that ADR remains active.
+- files_owned: docs/plans/POST_REMEDIATION_FOLLOWUP_PLAN.md (tracker state and
+  evidence link only). The Full plan reads the migration modules, callers,
+  Alembic revisions, tests, and migration documentation as census evidence;
+  it does not authorize edits to them. A discovered defect or future sunset
+  gets a separate task with its own ownership.
+- do: Census first (in the Full plan): map every migrate_v* module's role and
+  consumer, including db_migration_runner's unversioned-adoption path. Run
+  the GA-2 parity evidence and verify the frozen chain still reaches the
+  Alembic baseline without schema drift. Do not delete, bypass, or rewire the
+  chain under the current ADR. A defect found by the census requires a
+  separate scoped repair, not an incidental sunset.
+- accept: Census table in the PR body with each module retained and its role
+  evidenced; fresh-DB and upgraded-DB schema diff empty; a v9/v10-era
+  database's documented upgrade path verified in the parity run; suite green;
+  GA-2 output attached. The expected outcome is "no change warranted" under
+  the current ADR.
+- future_sunset: The migration chain should be removed in a separate
+  Full-template PR after a separately ratified ADR change defines the new
+  support floor and proves that no supported unversioned or pre-Alembic
+  database still depends on the frozen runner. That PR must remove the chain
+  end to end, update migration and operator documentation, and verify every
+  supported starting state. This plan records the intended direction; it does
+  not authorize the sunset.
 
 ### T-ARCH-5: Retire LocalAI private re-exports  [P1, Full-mandatory]
 - files_owned: pipeline/llm.py, pipeline/local_ai_agenda_compat.py,
@@ -363,8 +366,9 @@ PR 1: T-DOC-2 (only remaining DOC task; new guardrail, reviewed against
       postmortem rules — T-DOC-1/3/4 closed as pre-completed on master)
 PR 2: T-BASE-1 (doc promotion; unblocks sourced markings)
 PR 3: T-BASE-2 (operator capture + agent-assembled evidence PR)
-ARCH: T-ARCH-10 lands FIRST; then P1 tasks (T-ARCH-4/5) in any order, max
-      two implementation PRs in flight (T-ARCH-9 closed as pre-completed).
+ARCH: T-ARCH-10 lands FIRST; then the T-ARCH-4 verification investigation and
+      T-ARCH-5 implementation may proceed. At most two implementation PRs are
+      in flight (T-ARCH-9 closed as pre-completed).
       Only tasks whose live census requires an edit to the shared guardrail
       file serialize under D6. P2 tasks follow GA-1, each behind its own Full
       plan; P3 investigations may run anytime, with implementation only via


### PR DESCRIPTION
Introduced a focused plan for post-remediation follow-up, detailing directives, gates, and task tracker for improved documentation integrity and architecture watchlist retirement.

## Summary

- See above

## Validation

- [X] Tests added or updated for changed behavior
- [X] Local validation commands and results included

## Security Checklist

- [X] No secrets or partial secrets are logged
- [X] New endpoints/mutations enforce existing auth requirements
