### PR TITLE
Skip heavy required checks for documentation-only PRs

### DIFF
--- a/.github/workflows/classify-documentation-only.yml
+++ b/.github/workflows/classify-documentation-only.yml
@@ -31,7 +31,7 @@ jobs:
 
           docs_only=false
           if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
-            changed_files="$(git diff --name-only --no-renames "$BASE_SHA" "$HEAD_SHA")"
+            changed_files="$(git diff --name-only --no-renames "$BASE_SHA...$HEAD_SHA")"
             if [ -n "$changed_files" ]; then
               docs_only=true
               while IFS= read -r changed_path; do

--- a/.github/workflows/classify-documentation-only.yml
+++ b/.github/workflows/classify-documentation-only.yml
@@ -1,0 +1,46 @@
+name: Classify Documentation-Only Changes
+
+on:
+  workflow_call:
+    outputs:
+      docs_only:
+        description: Whether every pull-request change is documentation
+        value: ${{ jobs.classify.outputs.docs_only }}
+
+permissions:
+  contents: read
+
+jobs:
+  classify:
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.classify.outputs.docs_only }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Classify change scope
+        id: classify
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          docs_only=false
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            changed_files="$(git diff --name-only --no-renames "$BASE_SHA" "$HEAD_SHA")"
+            if [ -n "$changed_files" ]; then
+              docs_only=true
+              while IFS= read -r changed_path; do
+                case "$changed_path" in
+                  docs/*|*.md) ;;
+                  *) docs_only=false; break ;;
+                esac
+              done <<< "$changed_files"
+            fi
+          fi
+
+          printf 'docs_only=%s\n' "$docs_only" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -9,7 +9,14 @@ permissions:
   contents: read
 
 jobs:
+  change-scope:
+    uses: ./.github/workflows/classify-documentation-only.yml
+
   frontend-tests:
+    needs: change-scope
+    if: >-
+      always() && (needs.change-scope.result != 'success' ||
+      needs.change-scope.outputs.docs_only != 'true')
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/python-guardrails.yml
+++ b/.github/workflows/python-guardrails.yml
@@ -9,7 +9,14 @@ permissions:
   contents: read
 
 jobs:
+  change-scope:
+    uses: ./.github/workflows/classify-documentation-only.yml
+
   python-guardrails:
+    needs: change-scope
+    if: >-
+      always() && (needs.change-scope.result != 'success' ||
+      needs.change-scope.outputs.docs_only != 'true')
     runs-on: ubuntu-latest
     env:
       TEST_POSTGRES_DATABASE_URL: postgresql://town_council:town_council_test@localhost:5432/town_council_test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,13 +206,15 @@ If the impact is unclear, invoke the objection protocol rather than guessing.
 </status_reporting_contract>
 
 <verification_matrix>
-Scope: the matrix is a fast local pre-check for iterating on a change. The
-authoritative CI verification is the full test suite run by both jobs on every
-pull request (`python-guardrails` for Python, `frontend-tests` for the
-frontend). The Python suite runs under the production scope and coverage floor
-configured in `.coveragerc`. A passing matrix row is necessary for proceeding,
-not sufficient for merge. Both jobs are mandatory under the active
-default-branch ruleset.
+Scope: the matrix is a fast local pre-check for iterating on a change. For
+pull requests containing code, configuration, or mixed changes, authoritative
+CI verification is the full test suite run by both required jobs
+(`python-guardrails` for Python, `frontend-tests` for the frontend). The Python
+suite runs under the production scope and coverage floor configured in
+`.coveragerc`. Documentation-only pull requests skip both expensive jobs after
+the shared workflow classifier succeeds; pushes to `master` always run them.
+A passing matrix row is necessary for proceeding, not sufficient for merge.
+Both job names remain mandatory under the active default-branch ruleset.
 
 All commands in applicable row(s) are mandatory, not advisory.
 If no row applies, run `PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py` at minimum.
@@ -225,6 +227,8 @@ Docs-only changes (`README.md`, `docs/**`, `AGENTS.md`, `ARCHITECTURE.md`):
 
 Guardrail/tooling changes (`ruff.toml`, `ruff-format.toml`, `mypy.ini`,
 `.pre-commit-config.yaml`, `.github/workflows/python-guardrails.yml`,
+`.github/workflows/frontend-tests.yml`,
+`.github/workflows/classify-documentation-only.yml`,
 `tests/test_repository_guardrails.py`):
 - `./.venv/bin/ruff check .`
 - `./.venv/bin/mypy`

--- a/docs/ENGINEERING_GUARDRAILS.md
+++ b/docs/ENGINEERING_GUARDRAILS.md
@@ -20,7 +20,7 @@ list (see `AGENTS.md` `<docs_sync_rules>`).
 | Typed subtree        | `mypy.ini` `files`/per-module sections           |
 | Coverage             | `.coveragerc`                                     |
 | Smell tests          | constants at the top of `tests/test_repository_guardrails.py` |
-| CI orchestration     | `.github/workflows/python-guardrails.yml`, `.github/workflows/frontend-tests.yml` |
+| CI orchestration     | `.github/workflows/classify-documentation-only.yml`, `.github/workflows/python-guardrails.yml`, `.github/workflows/frontend-tests.yml` |
 
 Cleanup-wave history (the former Batch A–G family lists) is decision record
 material, not living policy: see `docs/ADR.md`.
@@ -37,10 +37,13 @@ cd <REPO_ROOT>
 PYTHONPATH=. .venv/bin/pytest -q tests/test_repository_guardrails.py
 ```
 
-CI runs the static checks, fast-fail test subset, and complete Python suite
-under the `.coveragerc` production scope and coverage floor on every pull
-request and master push. The fast-fail subset provides earlier diagnostics;
-the coverage-enabled complete suite remains the Python merge gate (see
+For pull requests containing code, configuration, or mixed changes, CI runs
+the static checks, fast-fail test subset, and complete Python suite under the
+`.coveragerc` production scope and coverage floor. Documentation-only pull
+requests skip the expensive Python and frontend jobs after the shared workflow
+classifier succeeds. Pushes to `master` always run both complete gates. The
+fast-fail subset provides earlier diagnostics; the coverage-enabled complete
+suite remains the Python merge gate when that gate applies (see
 `docs/TESTING.MD`).
 
 Run that gate locally when changing coverage policy:

--- a/docs/TESTING.MD
+++ b/docs/TESTING.MD
@@ -75,12 +75,17 @@ task-family operation rather than patching names copied into `pipeline.tasks`.
    row(s). Fast, targeted, mandatory.
 2. Local, before handoff on cross-cutting work: full suite,
    `PYTHONPATH=. .venv/bin/pytest -q`.
-3. CI, authoritative merge gate: full Python suite + guardrail fast-fail
-   steps + frontend suite + coverage threshold (`.coveragerc`
-   `fail_under`).
+3. CI, authoritative merge gate for code, configuration, and mixed changes:
+   full Python suite + guardrail fast-fail steps + frontend suite + coverage
+   threshold (`.coveragerc` `fail_under`). Documentation-only pull requests
+   skip both expensive required jobs after the shared workflow classifier
+   succeeds; pushes to `master` always run the complete gates.
 
-A change is "verified" only at layer 3. Layers 1–2 are diagnostic (matching
-the existing `AGENTS.md` workflow contract).
+A code, configuration, or mixed change is "verified" only at layer 3. For a
+documentation-only change, the applicable local matrix row and human review
+provide the relevant evidence; a skipped required job makes no claim about the
+document's correctness. Layers 1–2 remain diagnostic for changes that require
+the complete CI gates (matching the existing `AGENTS.md` workflow contract).
 
 ## Flakes
 

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -1376,6 +1376,7 @@ def test_documentation_change_classifier_observes_complete_pull_request_scope(
         executable_directory / "git",
         "#!/usr/bin/env bash\n"
         "test \"$1\" = diff\n"
+        "test \"$4\" = \"$BASE_SHA...$HEAD_SHA\"\n"
         "printf '%s' \"$FAKE_CHANGED_FILES\"\n",
     )
     github_output = tmp_path / "github-output.txt"
@@ -1397,7 +1398,10 @@ def test_documentation_change_classifier_observes_complete_pull_request_scope(
     assert github_output.read_text(encoding="utf-8") == (
         f"docs_only={docs_only}\n"
     )
-    assert "git diff --name-only --no-renames" in classifier_script
+    assert (
+        'git diff --name-only --no-renames "$BASE_SHA...$HEAD_SHA"'
+        in classifier_script
+    )
 
 
 def test_documentation_change_classifier_failure_runs_required_checks(

--- a/tests/test_repository_guardrails.py
+++ b/tests/test_repository_guardrails.py
@@ -27,6 +27,13 @@ CPU_DEPENDENCY_AUDIT_ENV = (
     "PIP_CONSTRAINT=docker/semantic-cpu-constraints.txt "
     "PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cpu "
 )
+DOCUMENTATION_CHANGE_CLASSIFIER = (
+    ".github/workflows/classify-documentation-only.yml"
+)
+REQUIRED_CHECK_CHANGE_CONDITION = (
+    "always() && (needs.change-scope.result != 'success' || "
+    "needs.change-scope.outputs.docs_only != 'true')"
+)
 GENERATED_TIMESTAMP_COLUMNS = (
     ("person", "created_at"),
     ("data_issue", "created_at"),
@@ -1320,6 +1327,112 @@ def test_frontend_workflow_runs_for_every_pull_request_and_master_push():
     assert "paths-ignore:" not in event_configuration
 
 
+def test_required_ci_jobs_use_one_fail_closed_documentation_classifier():
+    classifier_reference = f"./{DOCUMENTATION_CHANGE_CLASSIFIER}"
+    workflow_jobs = (
+        (".github/workflows/python-guardrails.yml", "python-guardrails"),
+        (".github/workflows/frontend-tests.yml", "frontend-tests"),
+    )
+
+    for workflow_name, required_job_name in workflow_jobs:
+        workflow_contract = yaml.load(
+            (ROOT / workflow_name).read_text(encoding="utf-8"),
+            Loader=yaml.BaseLoader,
+        )
+        change_scope_job = workflow_contract["jobs"]["change-scope"]
+        required_job = workflow_contract["jobs"][required_job_name]
+
+        assert change_scope_job == {"uses": classifier_reference}
+        assert required_job["needs"] == "change-scope"
+        assert required_job["if"] == REQUIRED_CHECK_CHANGE_CONDITION
+
+
+@pytest.mark.parametrize(
+    ("event_name", "changed_files", "docs_only"),
+    (
+        ("pull_request", "docs/OPERATIONS.md\nARCHITECTURE.md\n", "true"),
+        ("pull_request", "docs/diagram.svg\nfrontend/README.md\n", "true"),
+        ("pull_request", "docs/OPERATIONS.md\npipeline/tasks.py\n", "false"),
+        ("pull_request", "pipeline/retired.py\ndocs/retired.md\n", "false"),
+        ("pull_request", "", "false"),
+        ("push", "docs/OPERATIONS.md\n", "false"),
+    ),
+)
+def test_documentation_change_classifier_observes_complete_pull_request_scope(
+    tmp_path: Path,
+    event_name: str,
+    changed_files: str,
+    docs_only: str,
+) -> None:
+    classifier_path = ROOT / DOCUMENTATION_CHANGE_CLASSIFIER
+    classifier_script = _workflow_run_step(
+        classifier_path,
+        "classify",
+        "Classify change scope",
+    )
+    executable_directory = tmp_path / "bin"
+    executable_directory.mkdir()
+    _write_test_executable(
+        executable_directory / "git",
+        "#!/usr/bin/env bash\n"
+        "test \"$1\" = diff\n"
+        "printf '%s' \"$FAKE_CHANGED_FILES\"\n",
+    )
+    github_output = tmp_path / "github-output.txt"
+
+    classifier_result = _run_workflow_script(
+        classifier_script,
+        tmp_path,
+        {
+            "BASE_SHA": "base-sha",
+            "FAKE_CHANGED_FILES": changed_files,
+            "GITHUB_EVENT_NAME": event_name,
+            "GITHUB_OUTPUT": str(github_output),
+            "HEAD_SHA": "head-sha",
+            "PATH": f"{executable_directory}:{os.environ['PATH']}",
+        },
+    )
+
+    assert classifier_result.returncode == 0, classifier_result.stderr
+    assert github_output.read_text(encoding="utf-8") == (
+        f"docs_only={docs_only}\n"
+    )
+    assert "git diff --name-only --no-renames" in classifier_script
+
+
+def test_documentation_change_classifier_failure_runs_required_checks(
+    tmp_path: Path,
+) -> None:
+    classifier_script = _workflow_run_step(
+        ROOT / DOCUMENTATION_CHANGE_CLASSIFIER,
+        "classify",
+        "Classify change scope",
+    )
+    executable_directory = tmp_path / "bin"
+    executable_directory.mkdir()
+    _write_test_executable(
+        executable_directory / "git",
+        "#!/usr/bin/env bash\nexit 2\n",
+    )
+
+    classifier_result = _run_workflow_script(
+        classifier_script,
+        tmp_path,
+        {
+            "BASE_SHA": "base-sha",
+            "GITHUB_EVENT_NAME": "pull_request",
+            "GITHUB_OUTPUT": str(tmp_path / "github-output.txt"),
+            "HEAD_SHA": "head-sha",
+            "PATH": f"{executable_directory}:{os.environ['PATH']}",
+        },
+    )
+
+    assert classifier_result.returncode != 0
+    assert "needs.change-scope.result != 'success'" in (
+        REQUIRED_CHECK_CHANGE_CONDITION
+    )
+
+
 def _workflow_job_check_producers(
     workflow_text: str,
     required_check_name: str,
@@ -1512,6 +1625,8 @@ jobs:
 
 def test_frontend_workflow_installs_locked_dependencies_before_tests():
     workflow_text = (ROOT / ".github" / "workflows" / "frontend-tests.yml").read_text(encoding="utf-8")
+    workflow_contract = yaml.load(workflow_text, Loader=yaml.BaseLoader)
+    frontend_steps = workflow_contract["jobs"]["frontend-tests"]["steps"]
     install_step = "      - name: Install dependencies\n        run: npm ci"
     test_step = "      - name: Run frontend tests\n        run: npm test"
 
@@ -1523,7 +1638,7 @@ def test_frontend_workflow_installs_locked_dependencies_before_tests():
     assert "working-directory: frontend" in workflow_text
     assert workflow_text.index(install_step) < workflow_text.index(test_step)
     assert "continue-on-error:" not in workflow_text
-    assert "if:" not in workflow_text
+    assert all("if" not in workflow_step for workflow_step in frontend_steps)
     assert "strategy:" not in workflow_text
 
 
@@ -5062,8 +5177,12 @@ def test_t_gov_4_agents_policy_is_complete():
 
     assert "<known_antipatterns>" in agent_policy
     assert "<security_sensitive_paths>" in agent_policy
-    assert "authoritative CI verification is the full test suite" in agent_policy
-    assert "Both jobs are mandatory under the active" in agent_policy
+    assert "authoritative\nCI verification is the full test suite" in agent_policy
+    assert (
+        "Documentation-only pull requests skip both expensive jobs"
+        in agent_policy
+    )
+    assert "Both job names remain mandatory under the active" in agent_policy
     assert "File-set enumerations" in agent_policy
     assert "the CI full-suite and frontend jobs are delivered by remediation" not in agent_policy
     assert "effective when the frontend test runner lands" not in agent_policy


### PR DESCRIPTION
## Summary

- Add one shared, fail-closed classifier for pull requests containing only Markdown files or files under `docs/`.
- Skip the required `python-guardrails` and `frontend-tests` jobs only when that classifier succeeds and reports a documentation-only PR.
- Keep both full suites running for mixed, code, configuration, empty-diff, classifier-failure, and `master` push cases.
- Update guardrail contracts and contributor policy to describe the new behavior.

## Why

The old policy ran both expensive required suites for every pull request, including documentation-only changes. The new policy preserves the required job names and branch ruleset while allowing GitHub to mark intentionally skipped jobs successful.

## Risk / compatibility

- Old gate: both required jobs ran on every pull request.
- New gate: both jobs skip only after a successful documentation-only classification; uncertainty fails closed by running both suites.
- Required check names, workflow permissions, CodeQL behavior, runtime defaults, and application behavior are unchanged.
- Remaining deficit: this mixed workflow/config PR exercises the full required checks. A later documentation-only PR must provide the first remote observation of both jobs being skipped successfully.

## Validation

- [x] Tests added or updated for changed behavior
- [x] Local validation commands and results included

`./.venv/bin/ruff check .` - PASS  
`./.venv/bin/mypy` - PASS (70 files)  
`PYTHONPATH=. .venv/bin/pytest -q tests/test_repository_guardrails.py` - PASS (562 passed)  
`PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py` - PASS (2 passed)  
`PYTHONPATH=. .venv/bin/pytest -q tests/test_env_example_profile_alignment.py` - PASS (4 passed)  
`PYTHONPATH=. .venv/bin/pytest -q` - PASS (1801 passed, 20 skipped)  
`git diff --check` - PASS

## Security Checklist

- [x] No secrets or partial secrets are logged
- [x] New endpoints/mutations enforce existing auth requirements (not applicable; no endpoint or mutation changes)
