### PR TITLE
Configure repository agent skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,20 @@ Town Council is a local-first civic data platform for crawling, extracting, inde
 Keep this file focused on repo-applicable operating policy: project constraints, commands, verification, quality rules, and reporting expectations. Do not use it for agent persona, chat-style output templates, session notes, or implementation logs.
 </project_identity>
 
+## Agent skills
+
+### Issue tracker
+
+Issues are tracked in GitHub Issues; pull requests are not a triage request surface. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Use the five canonical triage labels without aliases. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+This is a single-context repository. Read the root `CONTEXT.md` when present and the existing `docs/ADR.md`. See `docs/agents/domain.md`.
+
 <hierarchy_of_truth>
 1. Code for Behavior: For implementation details, function signatures, schemas, and active defaults, the codebase and tests are the descriptive ground truth. If documentation contradicts the code regarding how a feature works, assume the code is correct and update the documentation. Code is ground truth for *behavior only*; it is not a style guide for new structure. Structural idioms listed in `<known_antipatterns>` must not be replicated in new or modified code, even where they dominate the existing codebase.
 2. AGENTS.md for Agent Policy: For agent workflow, repository constraints, action permissions, verification routing, and reporting requirements, this document is the prescriptive entrypoint.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,20 @@
+# Domain Documentation
+
+Town Council uses a single domain context.
+
+## Before Exploring
+
+Read:
+
+- `CONTEXT.md` at the repository root when it exists.
+- `docs/ADR.md` for accepted architectural decisions relevant to the work.
+
+If `CONTEXT.md` does not exist, proceed silently. Domain-modeling work creates it only when the repository has resolved terminology worth recording.
+
+## Vocabulary
+
+Use terms defined in `CONTEXT.md`. If a required concept is missing, first determine whether existing project vocabulary already covers it. Record a genuine gap for later domain-modeling work rather than inventing a synonym.
+
+## Decision Conflicts
+
+Surface conflicts with `docs/ADR.md` explicitly. Do not silently override an accepted decision.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,26 @@
+# Issue Tracker: GitHub
+
+Issues and specifications live in this repository's GitHub Issues. Use the `gh` CLI from the repository checkout.
+
+## Operations
+
+- Create: `gh issue create --title "..." --body "..."`
+- Read: `gh issue view <number> --comments`
+- List: `gh issue list --state open`
+- Comment: `gh issue comment <number> --body "..."`
+- Label: `gh issue edit <number> --add-label "..."`
+- Close: `gh issue close <number> --comment "..."`
+
+Infer the repository from `git remote -v`.
+
+## Pull Requests as a Triage Surface
+
+PRs as a request surface: no.
+
+A bare `#<number>` may identify an issue or pull request because GitHub shares their number space. Check with `gh pr view <number>` and fall back to `gh issue view <number>`.
+
+## Skill Conventions
+
+When a skill says "publish to the issue tracker," create a GitHub issue.
+
+When a skill says "fetch the relevant ticket," read the GitHub issue and its comments.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,11 @@
+# Triage Labels
+
+| Canonical role | GitHub label | Meaning |
+| --- | --- | --- |
+| `needs-triage` | `needs-triage` | Maintainer evaluation required |
+| `needs-info` | `needs-info` | Waiting for reporter information |
+| `ready-for-agent` | `ready-for-agent` | Fully specified and ready for an agent |
+| `ready-for-human` | `ready-for-human` | Requires human implementation |
+| `wontfix` | `wontfix` | Will not be actioned |
+
+Skills must use the mapped GitHub label when referring to a canonical role.


### PR DESCRIPTION
## Summary

- Configure GitHub Issues as the repository issue tracker for agent skills.
- Record the five default triage-label mappings.
- Define the repository as a single domain context using the existing `docs/ADR.md`.
- Add the approved `Agent skills` navigation block to `AGENTS.md`.
- Provision the four missing GitHub state labels so every configured triage transition works.

## Why

The Matt Pocock engineering skills need repository-specific tracker, triage, and domain-document conventions before first use.

## Risk / compatibility

- Documentation-only repository diff; no application, CI, runtime, or data behavior changes.
- Pull requests remain excluded from the triage request surface.
- No competing ADR directory or root context file is introduced.
- All five configured triage labels now exist in GitHub Issues.

## Validation

- [x] Tests added or updated for changed behavior (not applicable; documentation configuration only)
- [x] Local validation commands and results included

`PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py` - PASS (2 passed)  
`git diff --check` - PASS  
`gh label list --limit 100 --json name,color,description` - PASS (all five mapped labels present)  
Manual Markdown and repository-reference audit - PASS

## Security Checklist

- [x] No secrets or partial secrets are logged
- [x] New endpoints/mutations enforce existing auth requirements (not applicable; no endpoint or mutation changes)
