### PR TITLE
Fix crawler startup under Scrapy 2.16

### DIFF
--- a/council_crawler/council_crawler/middlewares.py
+++ b/council_crawler/council_crawler/middlewares.py
@@ -47,14 +47,5 @@ class CouncilCrawlerSpiderMiddleware(object):
         # perform custom error handling at this middleware level.
         pass
 
-    def process_start_requests(start_requests, spider):
-        # Called with the start requests of the spider, and works
-        # similarly to the process_spider_output() method, except
-        # that it doesn’t have a response associated.
-
-        # Must return only requests (not items).
-        for r in start_requests:
-            yield r
-
     def spider_opened(self, spider):
         spider.logger.info('Spider opened: %s' % spider.name)

--- a/council_crawler/council_crawler/spiders/ca_berkeley.py
+++ b/council_crawler/council_crawler/spiders/ca_berkeley.py
@@ -11,7 +11,7 @@ class BerkeleyCustom(BaseCitySpider):
     name = 'berkeley'
     ocd_division_id = 'ocd-division/country:us/state:ca/place:berkeley'
 
-    def start_requests(self):
+    async def start(self):
         url = 'https://berkeleyca.gov/your-government/city-council/city-council-agendas'
         yield scrapy.Request(url=url, callback=self.parse)
 

--- a/council_crawler/council_crawler/spiders/ca_dublin.py
+++ b/council_crawler/council_crawler/spiders/ca_dublin.py
@@ -12,7 +12,7 @@ class Dublin(BaseCitySpider):
     name = 'dublin'
     ocd_division_id = 'ocd-division/country:us/state:ca/place:dublin'
 
-    def start_requests(self):
+    async def start(self):
         # The main meeting portal for Dublin, CA
         url = 'https://www.dublinca.gov/1604/Meetings-Agendas-Minutes-Video-on-Demand'
         yield scrapy.Request(url=url, callback=self.parse)

--- a/council_crawler/council_crawler/spiders/ca_san_mateo.py
+++ b/council_crawler/council_crawler/spiders/ca_san_mateo.py
@@ -33,7 +33,7 @@ class San_Mateo(BaseCitySpider):
                 self.last_meeting_date,
             )
 
-    def start_requests(self):
+    async def start(self):
         # PrimeGov is host-wide robots-blocked for San Mateo, and Laserfiche's
         # query-builder endpoint has proven less reliable than the listing
         # endpoint itself, so we construct the known-good listing query directly.

--- a/council_crawler/templates/legistar_api.py
+++ b/council_crawler/templates/legistar_api.py
@@ -45,9 +45,6 @@ class LegistarApi(BaseCitySpider):
     async def start(self):
         yield self._initial_events_request()
 
-    def start_requests(self):
-        yield self._initial_events_request()
-
     def _build_events_url(self, *, skip):
         query = urlencode(
             {

--- a/council_crawler/templates/legistar_cms.py
+++ b/council_crawler/templates/legistar_cms.py
@@ -47,7 +47,7 @@ class LegistarCms(BaseCitySpider):
         event['name'] = f"{self.city_display_name.title()}, CA {meeting_name.strip()}"
         return event
 
-    def start_requests(self):
+    async def start(self):
         for url in self.start_urls:
             yield scrapy.Request(url=url, callback=self.parse_calendar_window)
 

--- a/tests/test_dublin_spider.py
+++ b/tests/test_dublin_spider.py
@@ -1,4 +1,6 @@
+import asyncio
 import pytest
+import scrapy
 import sys
 import os
 from scrapy.http import HtmlResponse, Request
@@ -8,6 +10,17 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'council_crawler'))
 
 from council_crawler.spiders.ca_dublin import Dublin
+
+
+def test_dublin_uses_scrapy_start_contract(mocker):
+    mocker.patch.object(Dublin, "_get_last_meeting_date", return_value=None)
+    spider = Dublin()
+
+    assert Dublin.start is not scrapy.Spider.start
+    request = asyncio.run(anext(spider.start()))
+
+    assert request.url == "https://www.dublinca.gov/1604/Meetings-Agendas-Minutes-Video-on-Demand"
+    assert request.callback == spider.parse
 
 def test_dublin_spider_parsing():
     """

--- a/tests/test_legistar_api_spider_contract.py
+++ b/tests/test_legistar_api_spider_contract.py
@@ -1,3 +1,4 @@
+import asyncio
 import datetime
 import json
 import os
@@ -61,7 +62,7 @@ def test_sunnyvale_spider_uses_legistar_api_client(mocker):
     mocker.patch.object(Sunnyvale, "_get_last_meeting_date", return_value=None)
     spider = Sunnyvale()
 
-    [request] = list(spider.start_requests())
+    request = asyncio.run(anext(spider.start()))
 
     assert spider.name == "sunnyvale"
     assert spider.client_name == "sunnyvaleca"

--- a/tests/test_san_mateo_spider.py
+++ b/tests/test_san_mateo_spider.py
@@ -1,8 +1,10 @@
+import asyncio
 import datetime
 import json
 import os
 import sys
 
+import scrapy
 from scrapy.http import Request, TextResponse
 
 
@@ -32,14 +34,12 @@ def _text_response(url, body, *, meta=None):
     )
 
 
-def test_san_mateo_start_requests_build_direct_bootstrap_listing_query(mocker):
+def test_san_mateo_start_builds_direct_bootstrap_listing_query(mocker):
     mocker.patch.object(San_Mateo, "_get_last_meeting_date", return_value=None)
     spider = San_Mateo()
 
-    requests = list(spider.start_requests())
-
-    assert len(requests) == 1
-    request = requests[0]
+    assert San_Mateo.start is not scrapy.Spider.start
+    request = asyncio.run(anext(spider.start()))
     payload = json.loads(request.body.decode("utf-8"))
     assert request.url.endswith("/SearchService.aspx/GetSearchListing")
     assert request.method == "POST"
@@ -53,14 +53,12 @@ def test_san_mateo_start_requests_build_direct_bootstrap_listing_query(mocker):
     assert '[Date]<="' in payload["searchSyn"]
 
 
-def test_san_mateo_start_requests_omits_bootstrap_date_clause_when_delta_anchor_exists(mocker):
+def test_san_mateo_start_omits_bootstrap_date_clause_when_delta_anchor_exists(mocker):
     mocker.patch.object(San_Mateo, "_get_last_meeting_date", return_value=datetime.date(2026, 3, 1))
     spider = San_Mateo()
 
-    requests = list(spider.start_requests())
-
-    assert len(requests) == 1
-    payload = json.loads(requests[0].body.decode("utf-8"))
+    request = asyncio.run(anext(spider.start()))
+    payload = json.loads(request.body.decode("utf-8"))
     assert payload["searchSyn"] == '({[]:[Agency]="City Council"} & {[Agenda Reports]})'
 
 
@@ -68,10 +66,8 @@ def test_san_mateo_future_delta_anchor_falls_back_to_bootstrap_query(mocker):
     mocker.patch.object(San_Mateo, "_get_last_meeting_date", return_value=datetime.date(3023, 4, 3))
     spider = San_Mateo()
 
-    requests = list(spider.start_requests())
-
-    assert len(requests) == 1
-    payload = json.loads(requests[0].body.decode("utf-8"))
+    request = asyncio.run(anext(spider.start()))
+    payload = json.loads(request.body.decode("utf-8"))
     assert '{[]:[Agency]="City Council"}' in payload["searchSyn"]
     assert '[Date]>="' in payload["searchSyn"]
     assert '[Date]<="' in payload["searchSyn"]

--- a/tests/test_spiders.py
+++ b/tests/test_spiders.py
@@ -1,3 +1,4 @@
+import asyncio
 import sys
 import os
 import pytest
@@ -15,6 +16,32 @@ sys.path.append(os.path.join(root_dir, 'council_crawler'))
 from council_crawler.spiders.ca_belmont import Belmont
 from council_crawler.spiders.ca_berkeley import BerkeleyCustom
 from templates.legistar_cms import LegistarCms
+
+
+def test_berkeley_uses_scrapy_start_contract(mocker):
+    mocker.patch.object(BerkeleyCustom, "_get_last_meeting_date", return_value=None)
+    spider = BerkeleyCustom()
+
+    assert BerkeleyCustom.start is not scrapy.Spider.start
+    request = asyncio.run(anext(spider.start()))
+
+    assert request.url == "https://berkeleyca.gov/your-government/city-council/city-council-agendas"
+    assert request.callback == spider.parse
+
+
+def test_legistar_cms_uses_scrapy_start_contract(mocker):
+    mocker.patch.object(LegistarCms, "_get_last_meeting_date", return_value=None)
+    spider = LegistarCms(
+        legistar_url="https://test.legistar.com/Calendar.aspx",
+        city="testcity",
+        state="ca",
+    )
+
+    assert LegistarCms.start is not scrapy.Spider.start
+    request = asyncio.run(anext(spider.start()))
+
+    assert request.url == "https://test.legistar.com/Calendar.aspx"
+    assert request.callback == spider.parse_calendar_window
 
 def test_berkeley_custom_parsing(mocker):
     """


### PR DESCRIPTION
## What changed
- Migrated Berkeley, Dublin, San Mateo, and the Legistar CMS template from `start_requests()` to Scrapy 2.16 async `start()`.
- Removed the redundant legacy API-template hook and dead spider-middleware hook.
- Added startup-contract regression coverage for each affected crawler family.

## Why
The pinned crawler image runs Scrapy 2.16. Berkeley exited successfully while scheduling zero requests because its legacy startup method was ignored. The same defect affected San Mateo and other reusable crawler paths.

## Risk and compatibility
Low. Request URLs, callbacks, parsing, crawl politeness, and delta behavior are unchanged. The change removes legacy hooks rather than maintaining dual paths.

## Verification
- PASS: `./.venv/bin/ruff check .`
- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_spiders.py tests/test_san_mateo_spider.py tests/test_legistar_api_spider_contract.py tests/test_dublin_spider.py tests/test_crawler_refactor_contract.py` (55 passed)
- PASS: `PYTHONPATH=. .venv/bin/pytest -q` (1821 passed, 20 skipped)
- PASS: Docker Scrapy 2.16 Berkeley crawl (415 events and 1105 staged document links)
- PASS: independent pre-commit review after one finding was corrected

## Remaining deficits
- The remaining fresh-city crawls and baseline v2 regeneration stay paused until this PR merges, so all evidence references committed code.