### PR TITLE
Quarantine promotion-grade baseline captures

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,17 +115,19 @@ Notes:
 - `triage` and manifest-driven `baseline` runs are workload-only by default: they measure the selected catalog set and intentionally skip unrelated global prelude steps like staged download/promotion.
 - if the report marks a run as `reduced-confidence`, inspect `summary.json` and `result.json` before comparing it to other runs.
 
-Repeatable baseline run:
+Pinned-manifest diagnostic run:
 ```bash
-python scripts/profile_pipeline.py --mode baseline --manifest profiling/manifests/<name>.txt
+python scripts/profile_pipeline.py --mode baseline --manifest profiling/manifests/<name>.txt --diagnostic
 ```
+
+Promotion-grade baseline capture is temporarily quarantined while evidence-integrity checks are completed.
 
 Baseline manifest package workflow:
 ```bash
 python scripts/build_profile_manifest.py --name <name>
 python scripts/build_profile_manifest.py --name <name> --write
 python scripts/profile_pipeline.py --mode baseline --manifest profiling/manifests/<name>.txt --dry-run-prepare
-python scripts/profile_pipeline.py --mode baseline --manifest profiling/manifests/<name>.txt
+python scripts/profile_pipeline.py --mode baseline --manifest profiling/manifests/<name>.txt --diagnostic
 ```
 
 Analyze an existing profiling run:
@@ -141,7 +143,7 @@ Artifacts land under `experiments/results/profiling/<run_id>/` and include:
 
 Interpretation:
 - `triage` runs are diagnostic and optimized for speed.
-- `baseline` runs use a pinned manifest and are the only profiling runs that should be compared directly over time.
+- Baseline-valid runs use a pinned manifest and are the only profiling runs that should be compared directly over time; diagnostic baseline runs remain non-comparable.
 - baseline manifests can include a checked-in `.json` sidecar that recreates a representative pending-work workload for just the selected catalog IDs before the run starts.
 - `--dry-run-prepare` shows the exact preconditioning plan without mutating the workload.
 - queue wait is tracked separately from task execution so the report can distinguish worker backlog from slow execution.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,6 +1,6 @@
 # Operations Runbook
 
-Last updated: 2026-08-08
+Last updated: 2026-08-09
 
 ## Core workflow
 
@@ -896,15 +896,17 @@ find experiments/results/maintenance -maxdepth 4 -type f | sort
   - top bottleneck phase durations
   - stable workload-shape counters from `commands.log`
 - Counter drift is treated more strictly than timing drift; reduced-confidence runs are reported as non-comparable rather than clean passes.
-- Capture a v2 candidate:
+- Inspect the v2 workload as a non-promotional diagnostic:
 ```bash
 PYTHONPATH=. .venv/bin/python scripts/profile_pipeline.py \
   --mode baseline \
-  --manifest profiling/manifests/baseline_representative_v2.txt
+  --manifest profiling/manifests/baseline_representative_v2.txt \
+  --diagnostic
 ```
 
-Do not compare v1 with v2. City Coverage Expansion remains blocked until a
-valid, reproduced v2 expected-baseline PR merges.
+Promotion-grade baseline capture is quarantined. Do not compare v1 with v2.
+City Coverage Expansion remains blocked until a valid, reproduced v2
+expected-baseline PR merges.
 
 ### Maintenance salvage helper for flaky Laserfiche agenda PDFs
 - `scripts/repair_san_mateo_laserfiche_backlog.py` now distinguishes generated-PDF transport failures from permanent failures.
@@ -1516,8 +1518,8 @@ Modes:
   - diagnostic only
 - `baseline`
   - pinned manifest under `profiling/manifests/`
-  - intended for apples-to-apples comparison across runs
-  - only baseline mode should be treated as profiling evidence suitable for direct comparison
+  - baseline-valid captures are intended for apples-to-apples comparison across runs
+  - diagnostic baseline captures remain non-comparable
 
 Commands:
 ```bash
@@ -1526,9 +1528,11 @@ python scripts/profile_pipeline.py --mode triage
 python scripts/build_profile_manifest.py --name <name>
 python scripts/build_profile_manifest.py --name <name> --write
 python scripts/profile_pipeline.py --mode baseline --manifest profiling/manifests/<name>.txt --dry-run-prepare
-python scripts/profile_pipeline.py --mode baseline --manifest profiling/manifests/<name>.txt
+python scripts/profile_pipeline.py --mode baseline --manifest profiling/manifests/<name>.txt --diagnostic
 python scripts/analyze_pipeline_profile.py --run-id <run_id>
 ```
+
+Promotion-grade baseline capture is quarantined until evidence-integrity activation. Diagnostic captures are useful for investigation but are not comparable evidence.
 
 Runtime note:
 - `triage` manifest selection is resolved inside the running Docker stack so it uses the same database/runtime context as the live pipeline.
@@ -1573,7 +1577,7 @@ Manifest package guidance:
 - keep baseline manifests checked in under `profiling/manifests/`
 - use the `.txt` file as the pinned catalog list and the optional `.json` sidecar as the controlled preconditioning contract
 - run `python scripts/build_profile_manifest.py --name <name>` first to inspect candidate counts before writing a package
-- run `python scripts/profile_pipeline.py --mode baseline --manifest profiling/manifests/<name>.txt --dry-run-prepare` before a baseline profile when a sidecar is present
+- run `python scripts/profile_pipeline.py --mode baseline --manifest profiling/manifests/<name>.txt --dry-run-prepare` before a manifest-driven diagnostic when a sidecar is present
 - sidecar preconditioning is intentionally scoped to derived or rebuildable fields on the selected workload only; if a candidate is not safe to reset, the builder should reject it instead of broadening the mutation scope
 
 Manifest guidance:
@@ -2110,43 +2114,9 @@ The scorer now preserves arm identity from `run_config.json`:
 - `experiments/results/ab_score_<control>_<treatment>.json`
 - `experiments/results/ab_report_v1.md`
 
-4) Run paired pipeline profiles with the same representative manifest.
+4) Paired promotion-grade pipeline profiles are temporarily unavailable.
 
-Control:
-```bash
-LOCAL_AI_BACKEND=http LOCAL_AI_HTTP_MODEL=gemma-3-270m-custom \
-  LOCAL_AI_HTTP_PROFILE=conservative WORKER_CONCURRENCY=3 WORKER_POOL=prefork \
-  docker compose -f docker-compose.yml -f docker-compose.dev.yml \
-  up -d --build inference worker api pipeline enrichment-worker
-sleep 1 && PYTHONPATH=. .venv/bin/python scripts/profile_pipeline.py --mode baseline --manifest profiling/manifests/baseline_representative_v2.txt
-```
-
-Treatment:
-```bash
-LOCAL_AI_BACKEND=http LOCAL_AI_HTTP_MODEL=gemma4:e2b \
-  LOCAL_AI_HTTP_PROFILE=conservative WORKER_CONCURRENCY=3 WORKER_POOL=prefork \
-  docker compose -f docker-compose.yml -f docker-compose.dev.yml \
-  up -d --build inference worker api pipeline enrichment-worker
-sleep 1 && PYTHONPATH=. .venv/bin/python scripts/profile_pipeline.py --mode baseline --manifest profiling/manifests/baseline_representative_v2.txt
-```
-
-5) Compare the treatment profile directly against the control run instead of the
-checked-in baseline guardrail:
-```bash
-PYTHONPATH=. .venv/bin/python scripts/analyze_pipeline_profile.py \
-  --run-id <TREATMENT_RUN_ID> \
-  --output-dir experiments/results/profiling \
-  --compare-run <CONTROL_RUN_ID>
-```
-
-The treatment run writes:
-- `experiments/results/profiling/<TREATMENT_RUN_ID>/pairwise_compare.json`
-- `experiments/results/profiling/<TREATMENT_RUN_ID>/pairwise_compare.md`
-
-Interpretation:
-- `pass`: promising enough for a future opt-in profile follow-up
-- `fail`: treatment breached the paired latency/runtime guardrails
-- `non_comparable`: one arm was not baseline-valid or had reduced-confidence data
+Do not substitute diagnostic captures for the former pass/fail procedure: pairwise comparison rejects non-baseline-valid arms. Resume this step only after evidence-integrity activation restores baseline capture.
 
 Default is `false` for staged rollout.
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1,6 +1,6 @@
 # Performance
 
-Last updated: 2026-08-07
+Last updated: 2026-08-09
 
 This page describes how to interpret and reproduce performance evidence for local Docker runs.
 For operational troubleshooting and sorting diagnostics, use `docs/OPERATIONS.md`.
@@ -75,11 +75,11 @@ PYTHONPATH=. .venv/bin/python scripts/build_profile_manifest.py --name <name>
 PYTHONPATH=. .venv/bin/python scripts/build_profile_manifest.py --name <name> --write
 PYTHONPATH=. .venv/bin/python scripts/profile_pipeline.py --mode baseline --manifest profiling/manifests/<name>.txt --dry-run-prepare
 PYTHONPATH=. .venv/bin/python scripts/profile_pipeline.py --mode baseline --manifest profiling/manifests/<name>.txt --diagnostic
-PYTHONPATH=. .venv/bin/python scripts/profile_pipeline.py --mode baseline --manifest profiling/manifests/<name>.txt
-PYTHONPATH=. .venv/bin/python scripts/profile_pipeline.py --mode baseline --manifest profiling/manifests/<name>.txt --compare-to profiling/baselines/<name>.json
 PYTHONPATH=. .venv/bin/python scripts/analyze_pipeline_profile.py --run-id <run_id>
 PYTHONPATH=. .venv/bin/python scripts/analyze_pipeline_profile.py --run-id <run_id> --compare-to profiling/baselines/<name>.json
 ```
+
+Promotion-grade baseline capture is quarantined until workload completion and comparison evidence are bound to the run. Diagnostic captures remain non-comparable.
 
 Artifacts:
 - `experiments/results/profiling/<run_id>/run_manifest.json`
@@ -121,13 +121,13 @@ Ranking model:
 
 Interpretation rule:
 - do not compare `triage` runs to baseline runs as if they were equivalent evidence
-- use `baseline` runs for longitudinal comparison and `triage` runs for local diagnosis
+- use historical baseline-valid runs for longitudinal comparison; new promotion-grade captures remain quarantined
 - if the analyzer reports `reduced-confidence`, inspect `result.json` and run-quality notes before using the ranking to prioritize work
 - selected-manifest profiling runs are workload-only by default, so unrelated global prelude work such as staged promotion and downloader retries should not appear in the ranked bottlenecks
 - if a baseline manifest has a `.json` sidecar, the harness applies controlled preconditioning to only the selected workload before the run so the baseline still contains real pending work
 - use `--dry-run-prepare` to inspect that preconditioning plan before mutating the selected workload
 - use `--diagnostic` when a pinned baseline manifest is needed for investigation but the resulting evidence must remain non-comparable and `baseline_valid=false`
-- use `--compare-to` to guard steady-state baselines against regressions in elapsed time, top bottleneck phases, and stable workload-shape counters
+- use `--compare-to` to analyze existing baseline-valid evidence; diagnostic captures remain non-comparable
 - `baseline_representative_v1` and its checked-in expectation are immutable
   historical evidence for the retired document-derived person pipeline; they
   are non-comparable with roster-gated runs
@@ -144,7 +144,7 @@ Baseline compare report:
 - `status=fail` means the report's `Failed Checks` section is the priority list; inspect the first failed reason, then compare expected, actual, delta, and tolerance values before changing code.
 - `status=non_comparable` means the run is diagnostic only. Fix the listed confidence or baseline-validity reason before using the run for regression or promotion decisions.
 - `Failed Checks` lists timing regressions, missing artifacts, and workload-shape drift separately enough for an engineer to reproduce the failing condition without reading the JSON payload.
-- The `Reproduce` command at the end of the report is the canonical rerun command for that manifest/baseline pair.
+- Reports do not emit a recapture command while promotion-grade baseline execution is quarantined.
 
 ### Latest runtime optimization note
 

--- a/docs/plans/T_GOV_2A_ROSTER_GATED_LINKING_PLAN.md
+++ b/docs/plans/T_GOV_2A_ROSTER_GATED_LINKING_PLAN.md
@@ -318,18 +318,18 @@ docker compose start \
   semantic-worker nlp tables topics
 ```
 
-Post-change baseline capture:
+Post-change baseline capture remains quarantined pending evidence-integrity activation. A diagnostic may be used for investigation only:
 
 ```bash
 PYTHONPATH=. .venv/bin/python scripts/profile_pipeline.py \
   --mode baseline \
-  --manifest profiling/manifests/baseline_representative_v2.txt
+  --manifest profiling/manifests/baseline_representative_v2.txt \
+  --diagnostic
 ```
 
-The first valid v2 run becomes the candidate expectation in a separate
-evidence PR. No v1-to-v2 comparison is allowed. City Coverage Expansion stays
-blocked until the v2 baseline-valid capture is reproduced and its expected
-baseline PR merges.
+No v1-to-v2 comparison is allowed. City Coverage Expansion stays blocked until
+promotion-grade capture is restored, a v2 baseline-valid run is reproduced,
+and its expected-baseline PR merges.
 
 **v) Rollback.** This governance transition is roll-forward in production.
 Keep a roster-gated build running with people publication disabled until

--- a/scripts/operator_profile_reports.py
+++ b/scripts/operator_profile_reports.py
@@ -19,8 +19,9 @@ AGENDA_SUMMARY_SUBPHASE_KEYS = (
     AGENDA_SUMMARY_REINDEX_MS,
     AGENDA_SUMMARY_EMBED_DISPATCH_MS,
 )
-BASELINE_MANIFEST_DIR = "profiling/manifests"
-BASELINE_PROFILE_COMMAND = "PYTHONPATH=. .venv/bin/python scripts/profile_pipeline.py"
+BASELINE_QUARANTINE_NOTE = (
+    "Promotion-grade baseline recapture is quarantined pending evidence-integrity activation."
+)
 NON_COMPARABLE_REASON_TEXT = {
     "baseline_invalid": "Run is not baseline-valid, so timing and counter checks are diagnostic only.",
     "confidence_reduced": "Run has reduced-confidence evidence, so timing and counter checks are diagnostic only.",
@@ -148,10 +149,8 @@ def render_compare_report(summary: dict[str, Any], comparison: dict[str, Any]) -
             "## Checks",
             *_render_check_lines(checks),
             "",
-            "## Reproduce",
-            "```bash",
-            _baseline_compare_command(comparison),
-            "```",
+            "## Baseline Capture",
+            BASELINE_QUARANTINE_NOTE,
         ]
     )
     return "\n".join(lines) + "\n"
@@ -205,24 +204,6 @@ def _render_tolerance(check: dict[str, Any]) -> str:
     if tolerance_pct is None and tolerance_abs is None:
         return ""
     return f"tolerance=`{tolerance_pct}% / {tolerance_abs}` "
-
-
-def _baseline_compare_command(comparison: dict[str, Any]) -> str:
-    return " ".join(
-        [
-            BASELINE_PROFILE_COMMAND,
-            "--mode baseline",
-            f"--manifest {_manifest_path_for_comparison(comparison)}",
-            f"--compare-to {comparison.get('expected_baseline') or '<baseline.json>'}",
-        ]
-    )
-
-
-def _manifest_path_for_comparison(comparison: dict[str, Any]) -> str:
-    manifest_name = str(comparison.get("manifest_name") or "").strip()
-    if not manifest_name:
-        return "<manifest.txt>"
-    return f"{BASELINE_MANIFEST_DIR}/{manifest_name}.txt"
 
 
 def render_pairwise_compare_report(comparison: dict[str, Any]) -> str:

--- a/scripts/profile_pipeline.py
+++ b/scripts/profile_pipeline.py
@@ -19,6 +19,7 @@ from scripts.operator_profile_artifacts import write_json as _write_json
 from scripts.operator_prometheus import parse_metrics as _parse_metrics
 from scripts.operator_prometheus import sum_metric as _sum_metric
 from scripts.profile_pipeline_runner import ProfilePipelineDeps
+from scripts.profile_pipeline_runner import require_non_promotional_baseline
 from scripts.profile_pipeline_runner import run_profile
 from scripts.profile_pipeline_selection import select_triage_catalog_ids as _select_triage_catalog_ids  # noqa: F401
 
@@ -206,7 +207,9 @@ def _deps() -> ProfilePipelineDeps:
 
 
 def main(argv: list[str] | None = None) -> int:
-    return run_profile(parse_args(argv), _deps())
+    args = parse_args(argv)
+    require_non_promotional_baseline(args)
+    return run_profile(args, _deps())
 
 
 if __name__ == "__main__":

--- a/scripts/profile_pipeline_runner.py
+++ b/scripts/profile_pipeline_runner.py
@@ -15,6 +15,12 @@ from scripts.profile_pipeline_commands import build_profile_commands, profile_en
 from scripts.profile_pipeline_results import write_result_manifest, write_run_manifest
 
 
+BASELINE_QUARANTINE_MESSAGE = (
+    "promotion-grade baseline execution is quarantined pending evidence-integrity activation; "
+    "use --diagnostic or --dry-run-prepare"
+)
+
+
 @dataclass(frozen=True)
 class ProfilePipelineDeps:
     repo_root: Path
@@ -34,6 +40,11 @@ class ProfilePipelineDeps:
     utc_now_iso: Callable[[], str]
     write_catalog_manifest: Callable[[Path, list[int]], None]
     write_json: Callable[[Path, dict], None]
+
+
+def require_non_promotional_baseline(args: Any) -> None:
+    if args.mode == "baseline" and not args.diagnostic and not args.dry_run_prepare:
+        raise SystemExit(BASELINE_QUARANTINE_MESSAGE)
 
 
 def _catalog_ids_for_args(args: Any, deps: ProfilePipelineDeps) -> tuple[list[int], dict | None, Path | None]:
@@ -90,6 +101,7 @@ def _run_post_processors(args: Any, deps: ProfilePipelineDeps, run_id: str, outp
 
 
 def run_profile(args: Any, deps: ProfilePipelineDeps) -> int:
+    require_non_promotional_baseline(args)
     if args.mode == "baseline" and not args.manifest:
         raise SystemExit("--manifest is required for baseline mode")
     if args.diagnostic and args.mode != "baseline":

--- a/tests/test_pipeline_profile_report.py
+++ b/tests/test_pipeline_profile_report.py
@@ -351,8 +351,10 @@ def test_render_compare_report_explains_failed_elapsed_phase_and_counter_checks(
     assert "tolerance=`25.0% / 0.9`" in report
     assert "`summary_hydration_backfill.selected`" in report
     assert "reason=`workload_shape_drift`" in report
-    assert "PYTHONPATH=. .venv/bin/python scripts/profile_pipeline.py --mode baseline" in report
-    assert "--compare-to profiling/baselines/baseline_representative_v1.json" in report
+    assert "Promotion-grade baseline recapture is quarantined" in report
+    assert "## Reproduce" not in report
+    assert "scripts/profile_pipeline.py" not in report
+    assert "scripts/analyze_pipeline_profile.py" not in report
 
 
 def test_render_compare_report_explains_non_comparable_confidence_reason():
@@ -392,7 +394,8 @@ def test_render_compare_report_handles_empty_checks_without_crashing():
 
     assert "- status: `pass`" in report
     assert "No checks were evaluated." in report
-    assert "## Reproduce" in report
+    assert "Promotion-grade baseline recapture is quarantined" in report
+    assert "## Reproduce" not in report
 
 
 def test_render_compare_report_handles_malformed_checks_without_crashing():

--- a/tests/test_profile_pipeline_cli.py
+++ b/tests/test_profile_pipeline_cli.py
@@ -1,6 +1,8 @@
 import importlib.util
 import json
 from pathlib import Path
+import subprocess
+import sys
 
 import pytest
 
@@ -10,9 +12,22 @@ mod = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(mod)
 
 
+PROFILE_PIPELINE_SCRIPT = Path("scripts/profile_pipeline.py")
+BASELINE_QUARANTINE_PHRASE = "promotion-grade baseline execution is quarantined"
+
+
+def _run_profile_cli(*arguments: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(PROFILE_PIPELINE_SCRIPT), *arguments],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
 def test_profile_pipeline_requires_manifest_for_baseline(tmp_path: Path):
     try:
-        mod.main(["--mode", "baseline", "--output-dir", str(tmp_path)])
+        mod.main(["--mode", "baseline", "--output-dir", str(tmp_path), "--diagnostic"])
     except SystemExit as exc:
         assert "--manifest is required for baseline mode" in str(exc)
     else:
@@ -53,100 +68,47 @@ def test_profile_pipeline_writes_manifest_and_result(monkeypatch, tmp_path: Path
     assert any("collect_soak_metrics.py" in " ".join(cmd) for cmd, _ in commands)
 
 
-def test_profile_pipeline_baseline_loads_manifest_package_and_preconditions(monkeypatch, tmp_path: Path):
-    manifest_path = tmp_path / "baseline_demo.txt"
-    manifest_path.write_text("21\n22\n", encoding="utf-8")
-    manifest_path.with_suffix(".json").write_text(
-        json.dumps(
-            {
-                "schema_version": 3,
-                "manifest_name": "baseline_demo",
-                "catalog_ids": [21, 22],
-                "strata": {"extract": [21], "segment": [22], "summary": [], "entity": [], "org": []},
-                "extract_source_sha256": {"21": "a" * 64},
-                "expected_phase_coverage": {"extract": 1, "segment": 1, "summary": 0, "entity": 0, "org": 0},
-            }
-        ),
-        encoding="utf-8",
-    )
-    monkeypatch.setattr(mod, "_provider_counters_before_run", lambda: None)
-    prepare_calls = []
-
-    def _fake_prepare(manifest_rel, dry_run):
-        prepare_calls.append(dry_run)
-        return {"dry_run": dry_run, "report": {"catalog_count": 2}, "applied": {"cleared_summary_catalogs": 0}}
-
-    monkeypatch.setattr(mod, "_prepare_manifest_package_via_docker", _fake_prepare)
-    commands = []
-
-    def _fake_run(command, **kwargs):
-        commands.append((command, kwargs))
-        return type("Completed", (), {"returncode": 0})()
-
-    monkeypatch.setattr(mod.subprocess, "run", _fake_run)
-    exit_code = mod.main(["--mode", "baseline", "--manifest", str(manifest_path), "--output-dir", str(tmp_path), "--skip-batch"])
-
-    run_dirs = [path for path in tmp_path.iterdir() if path.is_dir()]
-    assert exit_code == 0
-    assert len(run_dirs) == 1
-    run_manifest = json.loads((run_dirs[0] / "run_manifest.json").read_text(encoding="utf-8"))
-    assert run_manifest["baseline_valid"] is True
-    assert run_manifest["manifest_package"]["manifest_name"] == "baseline_demo"
-    assert run_manifest["preconditioning"]["dry_run"] is False
-    assert prepare_calls == [True, False]
-    assert (run_dirs[0] / "catalog_manifest.json").exists()
-    assert any("collect_soak_metrics.py" in " ".join(cmd) for cmd, _ in commands)
-
-
-def test_profile_pipeline_verifies_sources_before_mutating_commands(monkeypatch, tmp_path: Path):
-    manifest_path = tmp_path / "baseline_demo.txt"
-    manifest_path.write_text("21\n", encoding="utf-8")
-    manifest_path.with_suffix(".json").write_text(
-        json.dumps(
-            {
-                "schema_version": 3,
-                "manifest_name": "baseline_demo",
-                "catalog_ids": [21],
-                "strata": {"extract": [21], "segment": [], "summary": [], "entity": [], "org": []},
-                "extract_source_sha256": {"21": "a" * 64},
-                "expected_phase_coverage": {"extract": 1, "segment": 0, "summary": 0, "entity": 0, "org": 0},
-            }
-        ),
-        encoding="utf-8",
-    )
-    mutating_commands: list[str] = []
-
-    def _reject_source(manifest_rel, dry_run):
-        raise ValueError("extract replay source digest mismatch")
-
-    monkeypatch.setattr(mod, "_prepare_manifest_package_via_docker", _reject_source)
-    monkeypatch.setattr(
-        mod,
-        "_run_db_migrate_via_docker",
-        lambda **kwargs: mutating_commands.append("migrate"),
-    )
-    monkeypatch.setattr(
-        mod,
-        "_run_backfill_catalog_hashes_via_docker",
-        lambda **kwargs: mutating_commands.append("backfill"),
+@pytest.mark.parametrize("extra_arguments", [(), ("--compare-to", "expected.json")])
+def test_profile_pipeline_quarantines_bare_baseline_before_artifact_creation(
+    tmp_path: Path,
+    extra_arguments: tuple[str, ...],
+):
+    output_dir = tmp_path / "profiles"
+    completed = _run_profile_cli(
+        "--mode",
+        "baseline",
+        "--manifest",
+        str(tmp_path / "missing.txt"),
+        "--output-dir",
+        str(output_dir),
+        *extra_arguments,
     )
 
-    with pytest.raises(ValueError, match="digest mismatch"):
-        mod.main(
-            [
-                "--mode",
-                "baseline",
-                "--manifest",
-                str(manifest_path),
-                "--output-dir",
-                str(tmp_path),
-                "--run-id",
-                "digest-mismatch",
-            ]
-        )
+    assert completed.returncode != 0
+    assert BASELINE_QUARANTINE_PHRASE in completed.stderr
+    assert not output_dir.exists()
 
-    assert mutating_commands == []
-    assert not (tmp_path / "digest-mismatch").exists()
+
+@pytest.mark.parametrize("allowed_argument", ["--diagnostic", "--dry-run-prepare"])
+def test_profile_pipeline_quarantine_allows_non_promotional_baseline_paths(
+    tmp_path: Path,
+    allowed_argument: str,
+):
+    output_dir = tmp_path / "profiles"
+    completed = _run_profile_cli(
+        "--mode",
+        "baseline",
+        "--manifest",
+        str(tmp_path / "missing.txt"),
+        "--output-dir",
+        str(output_dir),
+        allowed_argument,
+    )
+
+    assert completed.returncode != 0
+    assert BASELINE_QUARANTINE_PHRASE not in completed.stderr
+    assert "No such file or directory" in completed.stderr
+    assert not output_dir.exists()
 
 
 def test_profile_pipeline_diagnostic_baseline_is_non_promotional(monkeypatch, tmp_path: Path):
@@ -266,53 +228,8 @@ def test_profile_pipeline_rejects_invalid_manifest_package_without_run_directory
                 "--run-id",
                 "invalid-package",
                 "--skip-batch",
+                "--diagnostic",
             ]
         )
 
     assert not (tmp_path / "invalid-package").exists()
-
-
-def test_profile_pipeline_compare_mode_runs_analyzer_with_expected_baseline(monkeypatch, tmp_path: Path):
-    manifest_path = tmp_path / "baseline_demo.txt"
-    manifest_path.write_text("21\n22\n", encoding="utf-8")
-    expected_baseline_path = tmp_path / "expected_baseline.json"
-    expected_baseline_path.write_text("{}\n", encoding="utf-8")
-    manifest_path.with_suffix(".json").write_text(
-        json.dumps(
-            {
-                "schema_version": 3,
-                "manifest_name": "baseline_demo",
-                "catalog_ids": [21, 22],
-                "strata": {"extract": [21], "segment": [22], "summary": [], "entity": [], "org": []},
-                "extract_source_sha256": {"21": "a" * 64},
-                "expected_phase_coverage": {"extract": 1, "segment": 1, "summary": 0, "entity": 0, "org": 0},
-            }
-        ),
-        encoding="utf-8",
-    )
-    monkeypatch.setattr(mod, "_provider_counters_before_run", lambda: None)
-    monkeypatch.setattr(mod, "_prepare_manifest_package_via_docker", lambda manifest_rel, dry_run: {"dry_run": dry_run, "report": {"catalog_count": 2}, "applied": {"cleared_summary_catalogs": 0}})
-    commands = []
-
-    def _fake_run(command, **kwargs):
-        commands.append((command, kwargs))
-        return type("Completed", (), {"returncode": 0})()
-
-    monkeypatch.setattr(mod.subprocess, "run", _fake_run)
-    exit_code = mod.main(
-        [
-            "--mode",
-            "baseline",
-            "--manifest",
-            str(manifest_path),
-            "--output-dir",
-            str(tmp_path),
-            "--skip-batch",
-            "--compare-to",
-            str(expected_baseline_path),
-        ]
-    )
-
-    assert exit_code == 0
-    assert any("--compare-to" in command for command, _ in commands)
-    assert any(str(expected_baseline_path) in " ".join(command) for command, _ in commands)


### PR DESCRIPTION
## Summary

- Reject bare `--mode baseline` execution before dependencies, artifacts, or workload mutation can begin.
- Keep `--diagnostic` and `--dry-run-prepare` available for non-promotional investigation.
- Remove promotion-grade recapture commands from generated reports and operator documentation.

This prevents incomplete profiling evidence from being labeled or reused as a valid baseline while the evidence-integrity contract is rebuilt.

## Risk and compatibility

- Intentional behavior change: promotion-grade baseline capture now exits with a clear quarantine message.
- Diagnostic baseline runs and dry-run preparation remain available.
- No API, schema, migration, runtime-model, or database-state change.
- Remaining deficit: evidence-integrity activation must prove workload completion and comparison evidence before promotion-grade capture can return. City Coverage Expansion remains blocked on a valid `baseline_representative_v2` expected-baseline PR.

## Validation

- [x] Tests added or updated for changed behavior
- [x] Local validation commands and results included
- PASS: `./.venv/bin/ruff check .`
- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py` (2 passed)
- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_profile_pipeline_cli.py tests/test_pipeline_profile_report.py` (27 passed)
- PASS: `PYTHONPATH=. .venv/bin/pytest -q` (1,842 passed, 21 skipped)
- PASS: `PYTHONPATH=. .venv/bin/python -m pytest -q --cov --cov-config=.coveragerc --cov-report=term-missing:skip-covered tests/` (83.64% coverage; 1,842 passed, 21 skipped)
- PASS: `git diff --check`
- PASS: independent pre-commit review after one documentation clarification; no unresolved P1, P2, or P3 findings

## Security Checklist

- [x] No secrets or partial secrets are logged
- [x] New endpoints/mutations enforce existing auth requirements (not applicable; no endpoint or mutation added)