### PR TITLE
Isolate fresh-work profile diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,10 +115,18 @@ Notes:
 - `triage` and manifest-driven `baseline` runs are workload-only by default: they measure the selected catalog set and intentionally skip unrelated global prelude steps like staged download/promotion.
 - if the report marks a run as `reduced-confidence`, inspect `summary.json` and `result.json` before comparing it to other runs.
 
-Pinned-manifest diagnostic run:
+Fresh-work diagnostic run:
 ```bash
-python scripts/profile_pipeline.py --mode baseline --manifest profiling/manifests/<name>.txt --diagnostic
+MANIFEST=experiments/results/baseline_v2_fresh_pending.txt
+test -s "$MANIFEST"
+test ! -e "${MANIFEST%.txt}.json"
+python scripts/profile_pipeline.py --mode baseline --manifest "$MANIFEST" --diagnostic
 ```
+
+Use this only after a fresh crawl, promotion, and scoped download have created
+new pending catalogs, and stop before `run_pipeline.py`. The profiler disables
+startup purge and clears onboarding filters inside its Docker commands. Do not
+pass `--skip-batch`; the resulting evidence remains non-comparable.
 
 Promotion-grade baseline capture is temporarily quarantined while evidence-integrity checks are completed.
 
@@ -129,6 +137,9 @@ python scripts/build_profile_manifest.py --name <name> --write
 python scripts/profile_pipeline.py --mode baseline --manifest profiling/manifests/<name>.txt --dry-run-prepare
 python scripts/profile_pipeline.py --mode baseline --manifest profiling/manifests/<name>.txt --diagnostic
 ```
+
+This package workflow reconditions selected completed records. It is not the
+fresh-work trace path above.
 
 Analyze an existing profiling run:
 ```bash
@@ -144,7 +155,7 @@ Artifacts land under `experiments/results/profiling/<run_id>/` and include:
 Interpretation:
 - `triage` runs are diagnostic and optimized for speed.
 - Baseline-valid runs use a pinned manifest and are the only profiling runs that should be compared directly over time; diagnostic baseline runs remain non-comparable.
-- baseline manifests can include a checked-in `.json` sidecar that recreates a representative pending-work workload for just the selected catalog IDs before the run starts.
+- baseline manifests can include a checked-in `.json` sidecar that applies the separate preconditioning workflow to selected catalog IDs before the run starts.
 - `--dry-run-prepare` shows the exact preconditioning plan without mutating the workload.
 - queue wait is tracked separately from task execution so the report can distinguish worker backlog from slow execution.
 - default core and batch pipeline runs now keep search fresh with targeted per-catalog reindex hooks; use the manual reindex command below only when you changed indexing logic or need a repair rebuild.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,6 +1,6 @@
 # Operations Runbook
 
-Last updated: 2026-08-09
+Last updated: 2026-08-11
 
 ## Core workflow
 
@@ -896,13 +896,22 @@ find experiments/results/maintenance -maxdepth 4 -type f | sort
   - top bottleneck phase durations
   - stable workload-shape counters from `commands.log`
 - Counter drift is treated more strictly than timing drift; reduced-confidence runs are reported as non-comparable rather than clean passes.
-- Inspect the v2 workload as a non-promotional diagnostic:
+- Inspect freshly downloaded pending work as a non-promotional diagnostic:
 ```bash
+MANIFEST=experiments/results/baseline_v2_fresh_pending.txt
+test -s "$MANIFEST"
+test ! -e "${MANIFEST%.txt}.json"
 PYTHONPATH=. .venv/bin/python scripts/profile_pipeline.py \
   --mode baseline \
-  --manifest profiling/manifests/baseline_representative_v2.txt \
+  --manifest "$MANIFEST" \
   --diagnostic
 ```
+
+Create this temporary text manifest after the fresh crawl, promotion, and
+scoped downloader finish, then stop before `run_pipeline.py`. Do not add a
+sibling JSON sidecar and do not pass `--skip-batch`. The profiler disables
+startup purge and clears onboarding filters in the container commands. The
+result remains exploratory and non-comparable.
 
 Promotion-grade baseline capture is quarantined. Do not compare v1 with v2.
 City Coverage Expansion remains blocked until a valid, reproduced v2
@@ -1533,6 +1542,11 @@ python scripts/analyze_pipeline_profile.py --run-id <run_id>
 ```
 
 Promotion-grade baseline capture is quarantined until evidence-integrity activation. Diagnostic captures are useful for investigation but are not comparable evidence.
+
+The fresh-work trace uses a temporary plain-text manifest under
+`experiments/results/`, verifies that no sibling `.json` sidecar exists, and
+runs both core and batch processing. Checked-in sidecars use the separate
+preconditioning workflow and must not be used for that trace.
 
 Runtime note:
 - `triage` manifest selection is resolved inside the running Docker stack so it uses the same database/runtime context as the live pipeline.

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -81,6 +81,22 @@ PYTHONPATH=. .venv/bin/python scripts/analyze_pipeline_profile.py --run-id <run_
 
 Promotion-grade baseline capture is quarantined until workload completion and comparison evidence are bound to the run. Diagnostic captures remain non-comparable.
 
+For the fresh-work trace, use a temporary manifest with no sidecar after the
+crawl, promotion, and scoped downloader have finished, but before
+`run_pipeline.py` starts:
+```bash
+MANIFEST=experiments/results/baseline_v2_fresh_pending.txt
+test -s "$MANIFEST"
+test ! -e "${MANIFEST%.txt}.json"
+PYTHONPATH=. .venv/bin/python scripts/profile_pipeline.py \
+  --mode baseline \
+  --manifest "$MANIFEST" \
+  --diagnostic
+```
+Do not use `--skip-batch`. The profiler disables startup purge and clears
+onboarding filters for its Docker commands. This trace is exploratory and
+remains non-comparable.
+
 Artifacts:
 - `experiments/results/profiling/<run_id>/run_manifest.json`
 - `experiments/results/profiling/<run_id>/spans.jsonl`
@@ -127,6 +143,7 @@ Interpretation rule:
 - if a baseline manifest has a `.json` sidecar, the harness applies controlled preconditioning to only the selected workload before the run so the baseline still contains real pending work
 - use `--dry-run-prepare` to inspect that preconditioning plan before mutating the selected workload
 - use `--diagnostic` when a pinned baseline manifest is needed for investigation but the resulting evidence must remain non-comparable and `baseline_valid=false`
+- do not attach a sidecar to the fresh-work trace manifest; sidecars invoke the separate preconditioning workflow
 - use `--compare-to` to analyze existing baseline-valid evidence; diagnostic captures remain non-comparable
 - `baseline_representative_v1` and its checked-in expectation are immutable
   historical evidence for the retired document-derived person pipeline; they

--- a/profiling/manifests/README.md
+++ b/profiling/manifests/README.md
@@ -25,6 +25,18 @@ Rules:
 - run `python scripts/build_profile_manifest.py --name <name>` first if you want to inspect candidate coverage before writing a manifest package
 - use `python scripts/profile_pipeline.py --mode baseline --manifest profiling/manifests/<name>.txt --dry-run-prepare` to inspect sidecar resets without mutating the workload
 
+Fresh-work trace:
+- write the temporary catalog list under `experiments/results/` after the
+  fresh crawl, promotion, and scoped downloader finish
+- stop before `run_pipeline.py`
+- require a nonempty `.txt` file and verify that its sibling `.json` does not
+  exist
+- run the profiler with `--diagnostic` and without `--skip-batch`
+- treat the resulting artifacts as exploratory and non-comparable
+
+The fresh-work trace does not use this directory's sidecar preconditioning
+workflow.
+
 Baseline lifecycle:
 - `baseline_representative_v1` is immutable historical evidence. Its schema includes the retired document-derived people phase, so active preparation rejects it as non-comparable.
 - `baseline_representative_v2` is the active capture candidate. It uses a distinct 30-catalog workload regenerated from a fresh local corpus, excludes the retired phase, and assigns eight catalogs to entity enrichment.

--- a/scripts/profile_pipeline_commands.py
+++ b/scripts/profile_pipeline_commands.py
@@ -4,6 +4,18 @@ import os
 from typing import Any
 
 
+PROFILE_EXECUTION_ISOLATION_ARGS = (
+    "-e",
+    "STARTUP_PURGE_DERIVED=false",
+    "-e",
+    "PIPELINE_ONBOARDING_CITY=",
+    "-e",
+    "PIPELINE_ONBOARDING_STARTED_AT_UTC=",
+    "-e",
+    "PIPELINE_RUNTIME_PROFILE=",
+)
+
+
 def profile_env(
     *, run_id: str, mode: str, artifact_dir: str, baseline_valid: bool, manifest_path: str
 ) -> dict[str, str]:
@@ -32,6 +44,7 @@ def profile_command(
         "compose",
         "exec",
         "-T",
+        *PROFILE_EXECUTION_ISOLATION_ARGS,
         "-e",
         f"TC_PROFILE_RUN_ID={run_id}",
         "-e",

--- a/tests/test_operator_profile_helpers.py
+++ b/tests/test_operator_profile_helpers.py
@@ -164,6 +164,18 @@ def test_profile_command_helpers_preserve_env_and_docker_command(monkeypatch):
     assert [command[-1] for command in commands] == ["run_pipeline.py", "run_batch_enrichment.py"]
     assert commands[0][:4] == ["docker", "compose", "exec", "-T"]
     assert "TC_PROFILE_BASELINE_VALID=1" in commands[0]
+    expected_isolation_env = (
+        "STARTUP_PURGE_DERIVED=false",
+        "PIPELINE_ONBOARDING_CITY=",
+        "PIPELINE_ONBOARDING_STARTED_AT_UTC=",
+        "PIPELINE_RUNTIME_PROFILE=",
+    )
+    for command, service in zip(commands, ("api", "worker"), strict=True):
+        service_index = command.index(service)
+        for assignment in expected_isolation_env:
+            assignment_index = command.index(assignment)
+            assert command[assignment_index - 1] == "-e"
+            assert assignment_index < service_index
     assert commands[1][commands[1].index("-w") + 1] == "/app/pipeline"
 
 


### PR DESCRIPTION
## Summary

- Disable startup purge for profiled Docker Compose commands.
- Clear ambient onboarding city, timestamp, and runtime-profile filters for both core and batch commands.
- Document the temporary plain-text, no-sidecar workflow for fresh-work diagnostic evidence.
- Keep diagnostic evidence non-comparable; no validity, replay, schema, database, migration, or shared-default behavior changes.

## Why

A fresh-crawl diagnostic must measure the selected pending catalogs without deleting unrelated derived state or inheriting onboarding-only filters from the running containers.

## Risk and compatibility

Low. The change is limited to the existing profiling command builder and operator documentation. Normal pipeline startup defaults and baseline promotion policy are unchanged.

## Validation

- [x] Tests added or updated for changed behavior
- [x] Local validation commands and results included

PASS: `./.venv/bin/ruff check .`

PASS: `./.venv/bin/ruff format --check . --config ruff-format.toml`

PASS: `./.venv/bin/mypy`

PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_operator_profile_helpers.py` (15 passed)

PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_profile_pipeline_cli.py` (11 passed)

PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py tests/test_env_example_profile_alignment.py` (6 passed)

PASS: `PYTHONPATH=. .venv/bin/pytest -q` (1,842 passed, 21 skipped)

PASS: `git diff --check`

Independent pre-commit review: APPROVE with no P1, P2, or P3 findings.

## Security Checklist

- [x] No secrets or partial secrets are logged
- [x] New endpoints/mutations enforce existing auth requirements (not applicable; no endpoint or mutation changes)

## Remaining work

After merge, run the fresh crawl and scoped download, create a temporary plain-text pending-catalog manifest without a sibling JSON sidecar, execute the core-plus-batch diagnostic, and review signal completeness before proposing promotion-grade baseline-v2 evidence.