### PR TITLE
Record synchronous phase eligibility evidence

### DIFF
--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -901,7 +901,8 @@ find experiments/results/maintenance -maxdepth 4 -type f | sort
   phases record paired `before` and `after` rows, including paired empty rows
   for zero-work phases. A missing `after` row is incomplete evidence, not a
   zero remainder. These rows do not change timing rankings or baseline-validity
-  status.
+  status. Post-phase eligibility selection runs after the measured phase closes
+  so evidence collection does not inflate that phase's duration.
 - Inspect freshly downloaded pending work as a non-promotional diagnostic:
 ```bash
 MANIFEST=experiments/results/baseline_v2_fresh_pending.txt

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -896,6 +896,12 @@ find experiments/results/maintenance -maxdepth 4 -type f | sort
   - top bottleneck phase durations
   - stable workload-shape counters from `commands.log`
 - Counter drift is treated more strictly than timing drift; reduced-confidence runs are reported as non-comparable rather than clean passes.
+- Inspect `phase_eligibility` rows in `spans.jsonl` when checking whether a
+  synchronous backlog phase reduced its eligible catalog set. Successful
+  phases record paired `before` and `after` rows, including paired empty rows
+  for zero-work phases. A missing `after` row is incomplete evidence, not a
+  zero remainder. These rows do not change timing rankings or baseline-validity
+  status.
 - Inspect freshly downloaded pending work as a non-promotional diagnostic:
 ```bash
 MANIFEST=experiments/results/baseline_v2_fresh_pending.txt

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -118,7 +118,8 @@ phases. Each successful phase has a `before` and `after` row with the sorted
 catalog IDs selected by that phase's existing eligibility query. Successful
 zero-work phases record two empty rows. A missing `after` row means the phase
 or its post-phase eligibility query did not complete. These rows are evidence
-about workload state; the bottleneck analyzer excludes them from occurrence
+about workload state. Post-phase selection runs after the measured callable
+closes, and the bottleneck analyzer excludes eligibility rows from occurrence
 counts, components, and duration totals.
 
 Confidence model:

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1,6 +1,6 @@
 # Performance
 
-Last updated: 2026-08-09
+Last updated: 2026-08-11
 
 This page describes how to interpret and reproduce performance evidence for local Docker runs.
 For operational troubleshooting and sorting diagnostics, use `docs/OPERATIONS.md`.
@@ -112,6 +112,14 @@ What the profiler attributes:
 - task execution time (`tc_celery_task_duration_seconds`)
 - phase timing (`tc_pipeline_phase_duration_seconds`)
 - provider evidence correlation via existing `tc_provider_*` metrics
+
+`spans.jsonl` also records `phase_eligibility` rows for synchronous backlog
+phases. Each successful phase has a `before` and `after` row with the sorted
+catalog IDs selected by that phase's existing eligibility query. Successful
+zero-work phases record two empty rows. A missing `after` row means the phase
+or its post-phase eligibility query did not complete. These rows are evidence
+about workload state; the bottleneck analyzer excludes them from occurrence
+counts, components, and duration totals.
 
 Confidence model:
 - `baseline-valid`

--- a/pipeline/agenda_worker.py
+++ b/pipeline/agenda_worker.py
@@ -17,7 +17,7 @@ from pipeline.llm import LocalAI
 from pipeline.agenda_service import persist_agenda_items
 from pipeline.agenda_resolver import has_viable_structured_agenda_source, resolve_agenda_items
 from pipeline.indexer import reindex_catalog
-from pipeline.profiling import apply_catalog_id_scope
+from pipeline.profiling import append_phase_eligibility, apply_catalog_id_scope, profiling_enabled
 
 
 logger = logging.getLogger("agenda-worker")
@@ -208,6 +208,15 @@ def run_agenda_segmentation_backfill(
     with db_session() as session:
         catalog_ids = select_catalog_ids_for_agenda_segmentation(session, limit=limit)
 
+    capture_eligibility = profiling_enabled()
+    if capture_eligibility:
+        append_phase_eligibility(
+            phase="segment_agenda",
+            boundary="before",
+            subject="catalog",
+            eligible_ids=catalog_ids,
+        )
+
     counts = {
         "selected": len(catalog_ids),
         "complete": 0,
@@ -222,6 +231,13 @@ def run_agenda_segmentation_backfill(
         "llm_timeout_then_fallback": 0,
     }
     if not catalog_ids:
+        if capture_eligibility:
+            append_phase_eligibility(
+                phase="segment_agenda",
+                boundary="after",
+                subject="catalog",
+                eligible_ids=[],
+            )
         logger.info("agenda_segmentation_backfill selected=0")
         return counts
 
@@ -246,6 +262,16 @@ def run_agenda_segmentation_backfill(
         counts["timeout_fallbacks"] = int(fallback_counts.get("timeout", 0))
         counts["empty_response_fallbacks"] = int(fallback_counts.get("empty_response", 0))
         counts["llm_timeout_then_fallback"] = int(fallback_counts.get("timeout", 0))
+
+    if capture_eligibility:
+        with db_session() as session:
+            remaining_catalog_ids = select_catalog_ids_for_agenda_segmentation(session, limit=limit)
+        append_phase_eligibility(
+            phase="segment_agenda",
+            boundary="after",
+            subject="catalog",
+            eligible_ids=remaining_catalog_ids,
+        )
 
     logger.info(
         "agenda_segmentation_backfill selected=%s complete=%s empty=%s failed=%s other=%s timeout_fallbacks=%s empty_response_fallbacks=%s llm_attempted=%s llm_skipped_heuristic_first=%s heuristic_complete=%s llm_timeout_then_fallback=%s",

--- a/pipeline/agenda_worker.py
+++ b/pipeline/agenda_worker.py
@@ -193,7 +193,7 @@ def segment_agendas():
         segment_document_agenda(cid)
 
 
-def run_agenda_segmentation_backfill(
+def run_agenda_segmentation_workload(
     limit: int | None = None,
     *,
     segment_mode: str = "normal",
@@ -231,13 +231,6 @@ def run_agenda_segmentation_backfill(
         "llm_timeout_then_fallback": 0,
     }
     if not catalog_ids:
-        if capture_eligibility:
-            append_phase_eligibility(
-                phase="segment_agenda",
-                boundary="after",
-                subject="catalog",
-                eligible_ids=[],
-            )
         logger.info("agenda_segmentation_backfill selected=0")
         return counts
 
@@ -263,16 +256,6 @@ def run_agenda_segmentation_backfill(
         counts["empty_response_fallbacks"] = int(fallback_counts.get("empty_response", 0))
         counts["llm_timeout_then_fallback"] = int(fallback_counts.get("timeout", 0))
 
-    if capture_eligibility:
-        with db_session() as session:
-            remaining_catalog_ids = select_catalog_ids_for_agenda_segmentation(session, limit=limit)
-        append_phase_eligibility(
-            phase="segment_agenda",
-            boundary="after",
-            subject="catalog",
-            eligible_ids=remaining_catalog_ids,
-        )
-
     logger.info(
         "agenda_segmentation_backfill selected=%s complete=%s empty=%s failed=%s other=%s timeout_fallbacks=%s empty_response_fallbacks=%s llm_attempted=%s llm_skipped_heuristic_first=%s heuristic_complete=%s llm_timeout_then_fallback=%s",
         counts["selected"],
@@ -287,6 +270,43 @@ def run_agenda_segmentation_backfill(
         counts["heuristic_complete"],
         counts["llm_timeout_then_fallback"],
     )
+    return counts
+
+
+def capture_agenda_segmentation_after_eligibility(
+    counts: dict[str, int],
+    *,
+    limit: int | None = None,
+) -> None:
+    if not profiling_enabled():
+        return
+    remaining_catalog_ids: list[int] = []
+    if counts["selected"]:
+        with db_session() as session:
+            remaining_catalog_ids = select_catalog_ids_for_agenda_segmentation(
+                session,
+                limit=limit,
+            )
+    append_phase_eligibility(
+        phase="segment_agenda",
+        boundary="after",
+        subject="catalog",
+        eligible_ids=remaining_catalog_ids,
+    )
+
+
+def run_agenda_segmentation_backfill(
+    limit: int | None = None,
+    *,
+    segment_mode: str = "normal",
+    agenda_timeout_seconds: int | None = None,
+) -> dict[str, int]:
+    counts = run_agenda_segmentation_workload(
+        limit=limit,
+        segment_mode=segment_mode,
+        agenda_timeout_seconds=agenda_timeout_seconds,
+    )
+    capture_agenda_segmentation_after_eligibility(counts, limit=limit)
     return counts
 
 

--- a/pipeline/agenda_worker.py
+++ b/pipeline/agenda_worker.py
@@ -17,7 +17,7 @@ from pipeline.llm import LocalAI
 from pipeline.agenda_service import persist_agenda_items
 from pipeline.agenda_resolver import has_viable_structured_agenda_source, resolve_agenda_items
 from pipeline.indexer import reindex_catalog
-from pipeline.profiling import append_phase_eligibility, apply_catalog_id_scope, profiling_enabled
+from pipeline.profiling import append_phase_eligibility, apply_catalog_id_scope, profile_observer, profiling_enabled
 
 
 logger = logging.getLogger("agenda-worker")
@@ -280,19 +280,20 @@ def capture_agenda_segmentation_after_eligibility(
 ) -> None:
     if not profiling_enabled():
         return
-    remaining_catalog_ids: list[int] = []
-    if counts["selected"]:
-        with db_session() as session:
-            remaining_catalog_ids = select_catalog_ids_for_agenda_segmentation(
-                session,
-                limit=limit,
-            )
-    append_phase_eligibility(
-        phase="segment_agenda",
-        boundary="after",
-        subject="catalog",
-        eligible_ids=remaining_catalog_ids,
-    )
+    with profile_observer():
+        remaining_catalog_ids: list[int] = []
+        if counts["selected"]:
+            with db_session() as session:
+                remaining_catalog_ids = select_catalog_ids_for_agenda_segmentation(
+                    session,
+                    limit=limit,
+                )
+        append_phase_eligibility(
+            phase="segment_agenda",
+            boundary="after",
+            subject="catalog",
+            eligible_ids=remaining_catalog_ids,
+        )
 
 
 def run_agenda_segmentation_backfill(

--- a/pipeline/backfill_entities.py
+++ b/pipeline/backfill_entities.py
@@ -6,6 +6,7 @@ from pipeline.cli_logging import configure_cli_logging
 from pipeline.config import ENTITY_BACKFILL_IN_PROCESS_THRESHOLD, MAX_WORKERS, PIPELINE_CPU_FRACTION
 from pipeline.content_hash import compute_content_hash
 from pipeline.db_session import db_session
+from pipeline.profiling import append_phase_eligibility, profiling_enabled
 from pipeline.run_pipeline import (
     PIPELINE_ONBOARDING_CITY,
     _resolve_parallel_processing_settings,
@@ -105,10 +106,26 @@ def run_entity_backfill():
     with db_session() as db:
         catalog_ids = select_catalog_ids_for_entity_backfill(db)
 
+    capture_eligibility = profiling_enabled()
+    if capture_eligibility:
+        append_phase_eligibility(
+            phase="entity_backfill",
+            boundary="before",
+            subject="catalog",
+            eligible_ids=catalog_ids,
+        )
+
     counts = _empty_counts()
     counts["selected"] = len(catalog_ids)
 
     if not catalog_ids:
+        if capture_eligibility:
+            append_phase_eligibility(
+                phase="entity_backfill",
+                boundary="after",
+                subject="catalog",
+                eligible_ids=[],
+            )
         logger.info("No documents need entity enrichment.")
         return counts
 
@@ -185,6 +202,15 @@ def run_entity_backfill():
         counts["freshness_advanced"],
         counts["candidate_slice_fallback_prefix"],
     )
+    if capture_eligibility:
+        with db_session() as db:
+            remaining_catalog_ids = select_catalog_ids_for_entity_backfill(db)
+        append_phase_eligibility(
+            phase="entity_backfill",
+            boundary="after",
+            subject="catalog",
+            eligible_ids=remaining_catalog_ids,
+        )
     return counts
 
 

--- a/pipeline/backfill_entities.py
+++ b/pipeline/backfill_entities.py
@@ -102,7 +102,7 @@ def process_entity_chunk(catalog_ids):
     }
 
 
-def run_entity_backfill():
+def run_entity_backfill_workload() -> dict[str, object]:
     with db_session() as db:
         catalog_ids = select_catalog_ids_for_entity_backfill(db)
 
@@ -119,13 +119,6 @@ def run_entity_backfill():
     counts["selected"] = len(catalog_ids)
 
     if not catalog_ids:
-        if capture_eligibility:
-            append_phase_eligibility(
-                phase="entity_backfill",
-                boundary="after",
-                subject="catalog",
-                eligible_ids=[],
-            )
         logger.info("No documents need entity enrichment.")
         return counts
 
@@ -202,15 +195,27 @@ def run_entity_backfill():
         counts["freshness_advanced"],
         counts["candidate_slice_fallback_prefix"],
     )
-    if capture_eligibility:
+    return counts
+
+
+def capture_entity_backfill_after_eligibility(counts: dict[str, object]) -> None:
+    if not profiling_enabled():
+        return
+    remaining_catalog_ids: list[int] = []
+    if counts["selected"]:
         with db_session() as db:
             remaining_catalog_ids = select_catalog_ids_for_entity_backfill(db)
-        append_phase_eligibility(
-            phase="entity_backfill",
-            boundary="after",
-            subject="catalog",
-            eligible_ids=remaining_catalog_ids,
-        )
+    append_phase_eligibility(
+        phase="entity_backfill",
+        boundary="after",
+        subject="catalog",
+        eligible_ids=remaining_catalog_ids,
+    )
+
+
+def run_entity_backfill() -> dict[str, object]:
+    counts = run_entity_backfill_workload()
+    capture_entity_backfill_after_eligibility(counts)
     return counts
 
 

--- a/pipeline/backfill_entities.py
+++ b/pipeline/backfill_entities.py
@@ -6,7 +6,7 @@ from pipeline.cli_logging import configure_cli_logging
 from pipeline.config import ENTITY_BACKFILL_IN_PROCESS_THRESHOLD, MAX_WORKERS, PIPELINE_CPU_FRACTION
 from pipeline.content_hash import compute_content_hash
 from pipeline.db_session import db_session
-from pipeline.profiling import append_phase_eligibility, profiling_enabled
+from pipeline.profiling import append_phase_eligibility, profile_observer, profiling_enabled
 from pipeline.run_pipeline import (
     PIPELINE_ONBOARDING_CITY,
     _resolve_parallel_processing_settings,
@@ -201,16 +201,17 @@ def run_entity_backfill_workload() -> dict[str, object]:
 def capture_entity_backfill_after_eligibility(counts: dict[str, object]) -> None:
     if not profiling_enabled():
         return
-    remaining_catalog_ids: list[int] = []
-    if counts["selected"]:
-        with db_session() as db:
-            remaining_catalog_ids = select_catalog_ids_for_entity_backfill(db)
-    append_phase_eligibility(
-        phase="entity_backfill",
-        boundary="after",
-        subject="catalog",
-        eligible_ids=remaining_catalog_ids,
-    )
+    with profile_observer():
+        remaining_catalog_ids: list[int] = []
+        if counts["selected"]:
+            with db_session() as db:
+                remaining_catalog_ids = select_catalog_ids_for_entity_backfill(db)
+        append_phase_eligibility(
+            phase="entity_backfill",
+            boundary="after",
+            subject="catalog",
+            eligible_ids=remaining_catalog_ids,
+        )
 
 
 def run_entity_backfill() -> dict[str, object]:

--- a/pipeline/metrics_task_recorders.py
+++ b/pipeline/metrics_task_recorders.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pipeline import metrics_definitions
+from pipeline.profiling import profile_observer
 
 
 def record_task_duration(task_name: str, status: str, duration_s: float) -> None:
@@ -29,12 +30,13 @@ def record_task_queue_wait(task_name: str, queue: str, duration_s: float) -> Non
 
 
 def record_pipeline_phase_duration(phase: str, component: str, mode: str, status: str, duration_s: float) -> None:
-    metrics_definitions.PIPELINE_PHASE_DURATION_SECONDS.labels(
-        phase=phase,
-        component=component,
-        mode=mode,
-        status=status,
-    ).observe(max(0.0, duration_s))
+    with profile_observer():
+        metrics_definitions.PIPELINE_PHASE_DURATION_SECONDS.labels(
+            phase=phase,
+            component=component,
+            mode=mode,
+            status=status,
+        ).observe(max(0.0, duration_s))
 
 
 def record_lineage_recompute(updated_count: int, merge_count: int) -> None:

--- a/pipeline/profiling.py
+++ b/pipeline/profiling.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
 from datetime import datetime, timezone
 import json
 import os
@@ -18,9 +20,21 @@ PROFILE_WORKLOAD_ONLY_ENV = "TC_PROFILE_WORKLOAD_ONLY"
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _SELECTED_IDS_CACHE: tuple[str | None, set[int] | None] = (None, None)
+_OBSERVER_DEPTH: ContextVar[int] = ContextVar("profile_observer_depth", default=0)
+_OBSERVER_SECONDS: ContextVar[float] = ContextVar("profile_observer_seconds", default=0.0)
 QueryT = TypeVar("QueryT", bound="CatalogScopedQuery")
 EligibilityBoundary = Literal["before", "after"]
 EligibilitySubject = Literal["catalog"]
+
+
+@dataclass(frozen=True, slots=True)
+class ProfileSpanContext:
+    phase: str
+    component: str
+    catalog_id: int | None
+    started_at: str
+    started_perf: float
+    observer_at_start: float
 
 
 class CatalogIdPredicate(Protocol):
@@ -148,17 +162,70 @@ def append_phase_eligibility(
     subject: EligibilitySubject,
     eligible_ids: Sequence[int],
 ) -> None:
-    normalized_ids = sorted({int(eligible_id) for eligible_id in eligible_ids})
-    append_profile_event(
-        {
-            "event_type": "phase_eligibility",
-            "phase": phase,
-            "boundary": boundary,
-            "subject": subject,
-            "eligible_ids": normalized_ids,
-            "eligible_count": len(normalized_ids),
-        }
-    )
+    with profile_observer():
+        normalized_ids = sorted({int(eligible_id) for eligible_id in eligible_ids})
+        append_profile_event(
+            {
+                "event_type": "phase_eligibility",
+                "phase": phase,
+                "boundary": boundary,
+                "subject": subject,
+                "eligible_ids": normalized_ids,
+                "eligible_count": len(normalized_ids),
+            }
+        )
+
+
+def observer_seconds() -> float:
+    return _OBSERVER_SECONDS.get()
+
+
+@contextmanager
+def profile_observer() -> Iterator[None]:
+    depth = _OBSERVER_DEPTH.get()
+    depth_token = _OBSERVER_DEPTH.set(depth + 1)
+    started_perf = time.perf_counter() if depth == 0 else None
+    try:
+        yield
+    finally:
+        _OBSERVER_DEPTH.reset(depth_token)
+        if started_perf is not None:
+            _OBSERVER_SECONDS.set(observer_seconds() + time.perf_counter() - started_perf)
+
+
+def workload_duration_seconds(started_perf: float, observer_at_start: float) -> float:
+    elapsed_seconds = time.perf_counter() - started_perf
+    observer_overhead_seconds = observer_seconds() - observer_at_start
+    return max(0.0, elapsed_seconds - observer_overhead_seconds)
+
+
+def _append_span_event(
+    *,
+    span_context: ProfileSpanContext,
+    outcome: str,
+    span_metadata: dict[str, Any],
+) -> None:
+    observer_overhead_seconds = observer_seconds() - span_context.observer_at_start
+    span_metadata["observer_overhead_s"] = round(observer_overhead_seconds, 6)
+    span_event = {
+        "event_type": "span",
+        "phase": span_context.phase,
+        "component": span_context.component,
+        "catalog_id": span_context.catalog_id,
+        "started_at": span_context.started_at,
+        "finished_at": utc_now_iso(),
+        "duration_s": round(
+            workload_duration_seconds(
+                span_context.started_perf,
+                span_context.observer_at_start,
+            ),
+            6,
+        ),
+        "outcome": outcome,
+        "metadata": span_metadata or None,
+    }
+    with profile_observer():
+        append_profile_event(span_event)
 
 
 @contextmanager
@@ -170,38 +237,28 @@ def profile_span(
     metadata: dict[str, Any] | None = None,
     catalog_id: int | None = None,
 ) -> Iterator[dict[str, Any]]:
-    started_at = utc_now_iso()
-    started_perf = time.perf_counter()
+    span_context = ProfileSpanContext(
+        phase=phase,
+        component=component,
+        catalog_id=catalog_id,
+        started_at=utc_now_iso(),
+        started_perf=time.perf_counter(),
+        observer_at_start=observer_seconds(),
+    )
     span_meta: dict[str, Any] = dict(metadata or {})
     try:
         yield span_meta
     except Exception:
-        append_profile_event(
-            {
-                "event_type": "span",
-                "phase": phase,
-                "component": component,
-                "catalog_id": catalog_id,
-                "started_at": started_at,
-                "finished_at": utc_now_iso(),
-                "duration_s": round(time.perf_counter() - started_perf, 6),
-                "outcome": "failure",
-                "metadata": span_meta or None,
-            }
+        _append_span_event(
+            span_context=span_context,
+            outcome="failure",
+            span_metadata=span_meta,
         )
         raise
-    append_profile_event(
-        {
-            "event_type": "span",
-            "phase": phase,
-            "component": component,
-            "catalog_id": catalog_id,
-            "started_at": started_at,
-            "finished_at": utc_now_iso(),
-            "duration_s": round(time.perf_counter() - started_perf, 6),
-            "outcome": outcome,
-            "metadata": span_meta or None,
-        }
+    _append_span_event(
+        span_context=span_context,
+        outcome=outcome,
+        span_metadata=span_meta,
     )
 
 

--- a/pipeline/profiling.py
+++ b/pipeline/profiling.py
@@ -6,7 +6,7 @@ import json
 import os
 from pathlib import Path
 import time
-from typing import Any, Iterator, Protocol, Sequence, TypeVar
+from typing import Any, Iterator, Literal, Protocol, Sequence, TypeVar
 
 
 PROFILE_RUN_ID_ENV = "TC_PROFILE_RUN_ID"
@@ -19,6 +19,8 @@ PROFILE_WORKLOAD_ONLY_ENV = "TC_PROFILE_WORKLOAD_ONLY"
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _SELECTED_IDS_CACHE: tuple[str | None, set[int] | None] = (None, None)
 QueryT = TypeVar("QueryT", bound="CatalogScopedQuery")
+EligibilityBoundary = Literal["before", "after"]
+EligibilitySubject = Literal["catalog"]
 
 
 class CatalogIdPredicate(Protocol):
@@ -137,6 +139,26 @@ def append_profile_event(payload: dict[str, Any]) -> None:
         **payload,
     }
     append_jsonl(artifact_dir / "spans.jsonl", body)
+
+
+def append_phase_eligibility(
+    *,
+    phase: str,
+    boundary: EligibilityBoundary,
+    subject: EligibilitySubject,
+    eligible_ids: Sequence[int],
+) -> None:
+    normalized_ids = sorted({int(eligible_id) for eligible_id in eligible_ids})
+    append_profile_event(
+        {
+            "event_type": "phase_eligibility",
+            "phase": phase,
+            "boundary": boundary,
+            "subject": subject,
+            "eligible_ids": normalized_ids,
+            "eligible_count": len(normalized_ids),
+        }
+    )
 
 
 @contextmanager

--- a/pipeline/run_batch_enrichment.py
+++ b/pipeline/run_batch_enrichment.py
@@ -6,7 +6,7 @@ import time
 from pipeline.cli_logging import configure_cli_logging
 from pipeline.db_session import db_session
 from pipeline.metrics import record_pipeline_phase_duration
-from pipeline.profiling import current_mode, profile_span
+from pipeline.profiling import append_phase_eligibility, current_mode, profile_span, profiling_enabled
 from pipeline.run_pipeline import run_callable_step, run_step
 from pipeline.backfill_entities import run_entity_backfill
 from pipeline.backfill_orgs import run_organization_backfill
@@ -65,15 +65,39 @@ def main(argv=None):
     parse_args([] if argv is None else argv)
     logger.info(">>> Starting Batch Enrichment Pipeline")
     started = time.perf_counter()
+    capture_eligibility = profiling_enabled()
     with profile_span(phase="batch_enrichment_total", component="pipeline-batch"):
         run_callable_step("Entity Backfill", run_entity_backfill, component="pipeline-batch")
         with db_session() as session:
             table_catalog_ids = select_catalog_ids_for_table_extraction(session)
+        if capture_eligibility:
+            append_phase_eligibility(
+                phase="table_extraction",
+                boundary="before",
+                subject="catalog",
+                eligible_ids=table_catalog_ids,
+            )
         logger.info("table_extraction_preflight selected=%s", len(table_catalog_ids))
         if table_catalog_ids:
             run_step("Table Extraction", ["python", "table_worker.py"])
+            if capture_eligibility:
+                with db_session() as session:
+                    remaining_table_catalog_ids = select_catalog_ids_for_table_extraction(session)
+                append_phase_eligibility(
+                    phase="table_extraction",
+                    boundary="after",
+                    subject="catalog",
+                    eligible_ids=remaining_table_catalog_ids,
+                )
         else:
             logger.info("Step: Table Extraction skipped=1 reason=no_eligible_catalogs")
+            if capture_eligibility:
+                append_phase_eligibility(
+                    phase="table_extraction",
+                    boundary="after",
+                    subject="catalog",
+                    eligible_ids=[],
+                )
         run_callable_step(
             "Backfill Organizations",
             run_organization_backfill,
@@ -81,6 +105,13 @@ def main(argv=None):
         )
         with db_session() as session:
             topic_catalog_ids = select_catalog_ids_for_topic_hydration(session)
+        if capture_eligibility:
+            append_phase_eligibility(
+                phase="topic_modeling",
+                boundary="before",
+                subject="catalog",
+                eligible_ids=topic_catalog_ids,
+            )
         logger.info("topic_modeling_preflight selected=%s", len(topic_catalog_ids))
         if topic_catalog_ids:
             run_batch_callable_step(
@@ -88,8 +119,24 @@ def main(argv=None):
                 "topic_modeling",
                 lambda: run_topic_hydration_backfill(catalog_ids=topic_catalog_ids),
             )
+            if capture_eligibility:
+                with db_session() as session:
+                    remaining_topic_catalog_ids = select_catalog_ids_for_topic_hydration(session)
+                append_phase_eligibility(
+                    phase="topic_modeling",
+                    boundary="after",
+                    subject="catalog",
+                    eligible_ids=remaining_topic_catalog_ids,
+                )
         else:
             logger.info("Step: Topic Modeling skipped=1 reason=no_eligible_catalogs")
+            if capture_eligibility:
+                append_phase_eligibility(
+                    phase="topic_modeling",
+                    boundary="after",
+                    subject="catalog",
+                    eligible_ids=[],
+                )
     record_pipeline_phase_duration(
         "batch_enrichment_total",
         "pipeline-batch",

--- a/pipeline/run_batch_enrichment.py
+++ b/pipeline/run_batch_enrichment.py
@@ -6,7 +6,15 @@ import time
 from pipeline.cli_logging import configure_cli_logging
 from pipeline.db_session import db_session
 from pipeline.metrics import record_pipeline_phase_duration
-from pipeline.profiling import append_phase_eligibility, current_mode, profile_span, profiling_enabled
+from pipeline.profiling import (
+    append_phase_eligibility,
+    current_mode,
+    observer_seconds,
+    profile_observer,
+    profile_span,
+    profiling_enabled,
+    workload_duration_seconds,
+)
 from pipeline.run_pipeline import run_callable_step, run_step
 from pipeline.backfill_entities import (
     capture_entity_backfill_after_eligibility,
@@ -40,19 +48,21 @@ def run_batch_callable_step(name, phase, func):
     logger.info("Step: %s", name)
     with profile_span(phase=phase, component="pipeline-batch"):
         start_perf = time.perf_counter()
+        observer_at_start = observer_seconds()
         try:
             result = func()
         except Exception as exc:
             logger.exception("Step %s failed.", name)
+            phase_duration_s = workload_duration_seconds(start_perf, observer_at_start)
             record_pipeline_phase_duration(
                 phase,
                 "pipeline-batch",
                 current_mode(),
                 "failure",
-                time.perf_counter() - start_perf,
+                phase_duration_s,
             )
             raise SystemExit(STEP_FAILURE_EXIT_CODE) from exc
-        duration_s = time.perf_counter() - start_perf
+        duration_s = workload_duration_seconds(start_perf, observer_at_start)
         record_pipeline_phase_duration(
             phase,
             "pipeline-batch",
@@ -68,6 +78,7 @@ def main(argv=None):
     parse_args([] if argv is None else argv)
     logger.info(">>> Starting Batch Enrichment Pipeline")
     started = time.perf_counter()
+    observer_at_start = observer_seconds()
     capture_eligibility = profiling_enabled()
     with profile_span(phase="batch_enrichment_total", component="pipeline-batch"):
         entity_counts = run_callable_step(
@@ -89,14 +100,15 @@ def main(argv=None):
         if table_catalog_ids:
             run_step("Table Extraction", ["python", "table_worker.py"])
             if capture_eligibility:
-                with db_session() as session:
-                    remaining_table_catalog_ids = select_catalog_ids_for_table_extraction(session)
-                append_phase_eligibility(
-                    phase="table_extraction",
-                    boundary="after",
-                    subject="catalog",
-                    eligible_ids=remaining_table_catalog_ids,
-                )
+                with profile_observer():
+                    with db_session() as session:
+                        remaining_table_catalog_ids = select_catalog_ids_for_table_extraction(session)
+                    append_phase_eligibility(
+                        phase="table_extraction",
+                        boundary="after",
+                        subject="catalog",
+                        eligible_ids=remaining_table_catalog_ids,
+                    )
         else:
             logger.info("Step: Table Extraction skipped=1 reason=no_eligible_catalogs")
             if capture_eligibility:
@@ -128,14 +140,15 @@ def main(argv=None):
                 lambda: run_topic_hydration_backfill(catalog_ids=topic_catalog_ids),
             )
             if capture_eligibility:
-                with db_session() as session:
-                    remaining_topic_catalog_ids = select_catalog_ids_for_topic_hydration(session)
-                append_phase_eligibility(
-                    phase="topic_modeling",
-                    boundary="after",
-                    subject="catalog",
-                    eligible_ids=remaining_topic_catalog_ids,
-                )
+                with profile_observer():
+                    with db_session() as session:
+                        remaining_topic_catalog_ids = select_catalog_ids_for_topic_hydration(session)
+                    append_phase_eligibility(
+                        phase="topic_modeling",
+                        boundary="after",
+                        subject="catalog",
+                        eligible_ids=remaining_topic_catalog_ids,
+                    )
         else:
             logger.info("Step: Topic Modeling skipped=1 reason=no_eligible_catalogs")
             if capture_eligibility:
@@ -150,7 +163,7 @@ def main(argv=None):
         "pipeline-batch",
         current_mode(),
         "success",
-        time.perf_counter() - started,
+        workload_duration_seconds(started, observer_at_start),
     )
     logger.info("<<< Batch Enrichment Pipeline Complete")
 

--- a/pipeline/run_batch_enrichment.py
+++ b/pipeline/run_batch_enrichment.py
@@ -8,7 +8,10 @@ from pipeline.db_session import db_session
 from pipeline.metrics import record_pipeline_phase_duration
 from pipeline.profiling import append_phase_eligibility, current_mode, profile_span, profiling_enabled
 from pipeline.run_pipeline import run_callable_step, run_step
-from pipeline.backfill_entities import run_entity_backfill
+from pipeline.backfill_entities import (
+    capture_entity_backfill_after_eligibility,
+    run_entity_backfill_workload,
+)
 from pipeline.backfill_orgs import run_organization_backfill
 from pipeline.table_worker import select_catalog_ids_for_table_extraction
 from pipeline.topic_worker import run_topic_hydration_backfill, select_catalog_ids_for_topic_hydration
@@ -67,7 +70,12 @@ def main(argv=None):
     started = time.perf_counter()
     capture_eligibility = profiling_enabled()
     with profile_span(phase="batch_enrichment_total", component="pipeline-batch"):
-        run_callable_step("Entity Backfill", run_entity_backfill, component="pipeline-batch")
+        entity_counts = run_callable_step(
+            "Entity Backfill",
+            run_entity_backfill_workload,
+            component="pipeline-batch",
+        )
+        capture_entity_backfill_after_eligibility(entity_counts)
         with db_session() as session:
             table_catalog_ids = select_catalog_ids_for_table_extraction(session)
         if capture_eligibility:

--- a/pipeline/run_pipeline.py
+++ b/pipeline/run_pipeline.py
@@ -212,28 +212,33 @@ def _run_generation_backfill_steps() -> None:
     from functools import partial
 
     from pipeline import summary_backfill_runner
-    from pipeline.agenda_worker import run_agenda_segmentation_backfill
+    from pipeline.agenda_worker import (
+        capture_agenda_segmentation_after_eligibility,
+        run_agenda_segmentation_workload,
+    )
 
     # Agenda summaries depend on structured agenda items, so segmentation must
     # run before summary hydration in the canonical batch pipeline.
-    run_callable_step(
+    agenda_counts = run_callable_step(
         "Agenda Segmentation",
         partial(
-            run_agenda_segmentation_backfill,
+            run_agenda_segmentation_workload,
             segment_mode="maintenance",
             agenda_timeout_seconds=AGENDA_SEGMENT_MAINTENANCE_TIMEOUT_SECONDS,
         ),
     )
+    capture_agenda_segmentation_after_eligibility(agenda_counts)
     # Reuse the same summary-task rules as the interactive path instead of
     # duplicating prompt, grounding, or caching behavior in the pipeline.
-    run_callable_step(
+    summary_counts = run_callable_step(
         "Summary Hydration",
         partial(
-            summary_backfill_runner.run_summary_hydration_backfill,
+            summary_backfill_runner.run_summary_hydration_workload,
             summary_timeout_seconds=SUMMARY_HYDRATION_MAINTENANCE_TIMEOUT_SECONDS,
             summary_fallback_mode="deterministic",
         ),
     )
+    summary_backfill_runner.capture_summary_hydration_after_eligibility(summary_counts)
 
 
 def _should_skip_generation_backfill_steps() -> bool:

--- a/pipeline/run_pipeline_parallel.py
+++ b/pipeline/run_pipeline_parallel.py
@@ -4,7 +4,7 @@ from concurrent.futures import Future
 from dataclasses import dataclass
 from typing import Protocol, TypeAlias
 
-from pipeline.profiling import profile_span
+from pipeline.profiling import append_phase_eligibility, profile_span, profiling_enabled
 
 
 GLOBAL_PROCESSING_MODE = "global"
@@ -174,7 +174,22 @@ def run_parallel_processing(
     dependencies: ParallelProcessingDependencies,
 ) -> None:
     catalog_ids = _select_catalog_ids(dependencies)
+    capture_eligibility = profiling_enabled()
+    if capture_eligibility:
+        append_phase_eligibility(
+            phase=EXTRACT_PARALLEL_PHASE,
+            boundary="before",
+            subject="catalog",
+            eligible_ids=catalog_ids,
+        )
     if not catalog_ids:
+        if capture_eligibility:
+            append_phase_eligibility(
+                phase=EXTRACT_PARALLEL_PHASE,
+                boundary="after",
+                subject="catalog",
+                eligible_ids=[],
+            )
         dependencies.logger.info("No documents need processing.")
         return
 
@@ -205,4 +220,11 @@ def run_parallel_processing(
             dependencies=dependencies,
             workers=workers,
             catalog_count=len(catalog_ids),
+        )
+    if capture_eligibility:
+        append_phase_eligibility(
+            phase=EXTRACT_PARALLEL_PHASE,
+            boundary="after",
+            subject="catalog",
+            eligible_ids=_select_catalog_ids(dependencies),
         )

--- a/pipeline/run_pipeline_parallel.py
+++ b/pipeline/run_pipeline_parallel.py
@@ -4,7 +4,7 @@ from concurrent.futures import Future
 from dataclasses import dataclass
 from typing import Protocol, TypeAlias
 
-from pipeline.profiling import append_phase_eligibility, profile_span, profiling_enabled
+from pipeline.profiling import append_phase_eligibility, profile_observer, profile_span, profiling_enabled
 
 
 GLOBAL_PROCESSING_MODE = "global"
@@ -222,9 +222,10 @@ def run_parallel_processing(
             catalog_count=len(catalog_ids),
         )
     if capture_eligibility:
-        append_phase_eligibility(
-            phase=EXTRACT_PARALLEL_PHASE,
-            boundary="after",
-            subject="catalog",
-            eligible_ids=_select_catalog_ids(dependencies),
-        )
+        with profile_observer():
+            append_phase_eligibility(
+                phase=EXTRACT_PARALLEL_PHASE,
+                boundary="after",
+                subject="catalog",
+                eligible_ids=_select_catalog_ids(dependencies),
+            )

--- a/pipeline/run_pipeline_steps.py
+++ b/pipeline/run_pipeline_steps.py
@@ -7,7 +7,11 @@ from collections.abc import Callable, Sequence
 from typing import TypeVar
 
 from pipeline.metrics import record_pipeline_phase_duration
-from pipeline.profiling import profile_span
+from pipeline.profiling import (
+    observer_seconds,
+    profile_span,
+    workload_duration_seconds,
+)
 
 
 PIPELINE_PROFILE_MODE_ENV = "TC_PROFILE_MODE"
@@ -57,24 +61,27 @@ def run_step(
         metadata={"command": list(command)},
     ):
         start_perf = time.perf_counter()
+        observer_at_start = observer_seconds()
         try:
             subprocess_module.run(command, check=True)  # type: ignore[attr-defined]
         except subprocess.CalledProcessError:
             logger.error("Step %s failed.", name)
+            phase_duration_s = workload_duration_seconds(start_perf, observer_at_start)
             record_pipeline_phase_duration(
                 phase,
                 SUBPROCESS_COMPONENT,
                 current_profile_mode(),
                 STEP_FAILURE_OUTCOME,
-                time.perf_counter() - start_perf,
+                phase_duration_s,
             )
             sys.exit(1)
+        phase_duration_s = workload_duration_seconds(start_perf, observer_at_start)
         record_pipeline_phase_duration(
             phase,
             SUBPROCESS_COMPONENT,
             current_profile_mode(),
             STEP_SUCCESS_OUTCOME,
-            time.perf_counter() - start_perf,
+            phase_duration_s,
         )
 
 
@@ -89,23 +96,26 @@ def run_callable_step(
     phase = phase_name_for_step(name)
     with profile_span(phase=phase, component=component):
         start_perf = time.perf_counter()
+        observer_at_start = observer_seconds()
         try:
             step_result = func()
         except Exception:
             logger.error("Step %s failed.", name)
+            phase_duration_s = workload_duration_seconds(start_perf, observer_at_start)
             record_pipeline_phase_duration(
                 phase,
                 component,
                 current_profile_mode(),
                 STEP_FAILURE_OUTCOME,
-                time.perf_counter() - start_perf,
+                phase_duration_s,
             )
             sys.exit(1)
+        phase_duration_s = workload_duration_seconds(start_perf, observer_at_start)
         record_pipeline_phase_duration(
             phase,
             component,
             current_profile_mode(),
             STEP_SUCCESS_OUTCOME,
-            time.perf_counter() - start_perf,
+            phase_duration_s,
         )
         return step_result

--- a/pipeline/summary_backfill_runner.py
+++ b/pipeline/summary_backfill_runner.py
@@ -20,7 +20,7 @@ from pipeline.summary_backfill_progress import (
     initial_summary_backfill_counts,
     record_summary_result_counts,
 )
-from pipeline.profiling import append_phase_eligibility, profiling_enabled
+from pipeline.profiling import append_phase_eligibility, profile_observer, profiling_enabled
 
 
 @dataclass(frozen=True)
@@ -100,13 +100,14 @@ def capture_summary_hydration_after_eligibility(
 ) -> None:
     if not profiling_enabled():
         return
-    eligible_ids = [] if counts["selected"] == 0 else _select_catalog_ids(limit=limit, city=city)
-    append_phase_eligibility(
-        phase="summarize",
-        boundary="after",
-        subject="catalog",
-        eligible_ids=eligible_ids,
-    )
+    with profile_observer():
+        eligible_ids = [] if counts["selected"] == 0 else _select_catalog_ids(limit=limit, city=city)
+        append_phase_eligibility(
+            phase="summarize",
+            boundary="after",
+            subject="catalog",
+            eligible_ids=eligible_ids,
+        )
 
 
 def run_summary_hydration_backfill(

--- a/pipeline/summary_backfill_runner.py
+++ b/pipeline/summary_backfill_runner.py
@@ -20,6 +20,7 @@ from pipeline.summary_backfill_progress import (
     initial_summary_backfill_counts,
     record_summary_result_counts,
 )
+from pipeline.profiling import append_phase_eligibility, profiling_enabled
 
 
 @dataclass(frozen=True)
@@ -51,8 +52,23 @@ def run_summary_hydration_backfill(
         limit=limit,
         city=city,
     )
+    capture_eligibility = profiling_enabled()
+    if capture_eligibility:
+        append_phase_eligibility(
+            phase="summarize",
+            boundary="before",
+            subject="catalog",
+            eligible_ids=catalog_ids,
+        )
     counts = initial_summary_backfill_counts(selected=len(catalog_ids))
     if not catalog_ids:
+        if capture_eligibility:
+            append_phase_eligibility(
+                phase="summarize",
+                boundary="after",
+                subject="catalog",
+                eligible_ids=[],
+            )
         finish_empty_summary_backfill(counts, progress_callback)
         return counts
 
@@ -80,6 +96,13 @@ def run_summary_hydration_backfill(
     log_backfill_counts(counts)
     if progress_callback:
         progress_callback({"event_type": "stage_finish", "stage": "summary", "counts": counts.copy()})
+    if capture_eligibility:
+        append_phase_eligibility(
+            phase="summarize",
+            boundary="after",
+            subject="catalog",
+            eligible_ids=_select_catalog_ids(limit=limit, city=city),
+        )
     return counts
 
 

--- a/pipeline/summary_backfill_runner.py
+++ b/pipeline/summary_backfill_runner.py
@@ -35,7 +35,7 @@ class SummaryBackfillLoopContext:
     progress_every: int
 
 
-def run_summary_hydration_backfill(
+def run_summary_hydration_workload(
     force: bool = False,
     limit: int | None = None,
     city: str | None = None,
@@ -62,13 +62,6 @@ def run_summary_hydration_backfill(
         )
     counts = initial_summary_backfill_counts(selected=len(catalog_ids))
     if not catalog_ids:
-        if capture_eligibility:
-            append_phase_eligibility(
-                phase="summarize",
-                boundary="after",
-                subject="catalog",
-                eligible_ids=[],
-            )
         finish_empty_summary_backfill(counts, progress_callback)
         return counts
 
@@ -96,13 +89,46 @@ def run_summary_hydration_backfill(
     log_backfill_counts(counts)
     if progress_callback:
         progress_callback({"event_type": "stage_finish", "stage": "summary", "counts": counts.copy()})
-    if capture_eligibility:
-        append_phase_eligibility(
-            phase="summarize",
-            boundary="after",
-            subject="catalog",
-            eligible_ids=_select_catalog_ids(limit=limit, city=city),
-        )
+    return counts
+
+
+def capture_summary_hydration_after_eligibility(
+    counts: dict[str, int],
+    *,
+    limit: int | None = None,
+    city: str | None = None,
+) -> None:
+    if not profiling_enabled():
+        return
+    eligible_ids = [] if counts["selected"] == 0 else _select_catalog_ids(limit=limit, city=city)
+    append_phase_eligibility(
+        phase="summarize",
+        boundary="after",
+        subject="catalog",
+        eligible_ids=eligible_ids,
+    )
+
+
+def run_summary_hydration_backfill(
+    force: bool = False,
+    limit: int | None = None,
+    city: str | None = None,
+    *,
+    summary_timeout_seconds: int | None = None,
+    summary_fallback_mode: str = "none",
+    progress_callback: Callable[[dict[str, Any]], None] | None = None,
+    progress_every: int = 25,
+) -> dict[str, int]:
+    counts = run_summary_hydration_workload(
+        force=force,
+        limit=limit,
+        city=city,
+        summary_timeout_seconds=summary_timeout_seconds,
+        summary_fallback_mode=summary_fallback_mode,
+        progress_callback=progress_callback,
+        progress_every=progress_every,
+    )
+    capture_summary_hydration_after_eligibility(counts, limit=limit, city=city)
     return counts
 
 

--- a/scripts/pipeline_profile_analysis.py
+++ b/scripts/pipeline_profile_analysis.py
@@ -153,6 +153,8 @@ def _extract_summary_subphase_timings(summary_counts: Mapping[str, CounterValue]
 def _aggregate_phase_rows(spans: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
     totals: dict[str, PhaseStats] = {}
     for row in spans:
+        if row.get("event_type") not in {"span", "task_span"}:
+            continue
         phase = str(row.get("phase") or "")
         if phase not in LEAF_PHASES:
             continue

--- a/scripts/pipeline_profile_analysis.py
+++ b/scripts/pipeline_profile_analysis.py
@@ -174,34 +174,67 @@ def _aggregate_phase_rows(spans: list[dict[str, Any]]) -> dict[str, dict[str, An
     return totals
 
 
-def _derived_total_from_spans(spans: list[dict[str, Any]]) -> tuple[float, list[str]]:
-    pipeline_total = next((float(row.get("duration_s") or 0.0) for row in spans if row.get("phase") == "pipeline_total"), 0.0)
-    batch_total = next((float(row.get("duration_s") or 0.0) for row in spans if row.get("phase") == "batch_enrichment_total"), 0.0)
-    notes = []
-    combined = 0.0
-    if pipeline_total > 0:
-        combined += pipeline_total
-        notes.append("pipeline_total")
-    if batch_total > 0:
-        combined += batch_total
-        notes.append("batch_enrichment_total")
-    return combined, notes
+def _total_span_duration(spans: list[dict[str, Any]], phase: str) -> float:
+    return next(
+        (
+            float(row.get("duration_s") or 0.0)
+            for row in spans
+            if row.get("event_type") == "span"
+            and row.get("phase") == phase
+            and row.get("outcome") == "success"
+            and isinstance(row.get("metadata"), dict)
+            and "observer_overhead_s" in row["metadata"]
+        ),
+        0.0,
+    )
 
 
-def _select_total_elapsed_seconds(result: dict[str, Any], spans: list[dict[str, Any]]) -> tuple[float, str | None]:
+def _resolve_include_batch(
+    manifest: dict[str, Any],
+    run_result: dict[str, Any],
+) -> tuple[bool, list[str]]:
+    manifest_include_batch = manifest.get("include_batch")
+    if not isinstance(manifest_include_batch, bool):
+        return False, ["include_batch_manifest_invalid"]
+    include_batch = manifest_include_batch
+    if "include_batch" not in run_result:
+        return include_batch, []
+    run_result_include_batch = run_result.get("include_batch")
+    if isinstance(run_result_include_batch, bool) and run_result_include_batch == include_batch:
+        return include_batch, []
+    return include_batch, ["include_batch_mismatch"]
+
+
+def _select_total_elapsed_seconds(
+    result: dict[str, Any],
+    spans: list[dict[str, Any]],
+    *,
+    include_batch: bool,
+) -> tuple[float, str, list[str]]:
+    required_phases = ["pipeline_total"]
+    if include_batch:
+        required_phases.append("batch_enrichment_total")
+    corrected_totals = {phase: _total_span_duration(spans, phase) for phase in required_phases}
+    missing_total_reasons = [
+        f"missing_corrected_total:{phase}"
+        for phase, duration in corrected_totals.items()
+        if duration <= 0
+    ]
+    if not missing_total_reasons:
+        confidence_reasons = [] if result else ["result_missing"]
+        return sum(corrected_totals.values()), "corrected_total_spans", confidence_reasons
+
     raw_totals = result.get("totals")
     totals: dict[str, Any] = raw_totals if isinstance(raw_totals, dict) else {}
     combined_total = float(totals.get("combined_elapsed_seconds") or 0.0)
     if combined_total > 0:
-        return combined_total, None
-    derived_total, notes = _derived_total_from_spans(spans)
-    if derived_total > 0:
-        note = "result_missing" if not result else f"derived_total_from_{'+'.join(notes)}"
-        return derived_total, note
+        return combined_total, "raw_result_totals", missing_total_reasons
     fallback = float(result.get("elapsed_seconds") or 0.0)
     if fallback > 0:
-        return fallback, "fallback_elapsed_seconds_only"
-    return 0.0, "no_total_elapsed_time"
+        return fallback, "raw_elapsed_seconds", missing_total_reasons
+    if not result:
+        return 0.0, "no_total_elapsed_time", ["result_missing", *missing_total_reasons]
+    return 0.0, "no_total_elapsed_time", missing_total_reasons
 
 
 def rank_bottlenecks(run_dir: Path) -> dict[str, Any]:
@@ -214,7 +247,15 @@ def rank_bottlenecks(run_dir: Path) -> dict[str, Any]:
     summary_hydration_counts = _load_summary_hydration_counts(run_dir)
     provider_metrics_present = bool(day_summary.get("provider_metrics_present")) if isinstance(day_summary, dict) else False
     provider_metrics_reason = str(day_summary.get("provider_metrics_reason") or "provider_metrics_missing") if isinstance(day_summary, dict) else "provider_metrics_missing"
-    total_elapsed_s, total_note = _select_total_elapsed_seconds(result, spans)
+    include_batch, include_batch_confidence_reasons = _resolve_include_batch(
+        manifest,
+        result,
+    )
+    total_elapsed_s, elapsed_source, total_confidence_reasons = _select_total_elapsed_seconds(
+        result,
+        spans,
+        include_batch=include_batch,
+    )
     ranked = []
     for phase, stats in sorted(_aggregate_phase_rows(spans).items(), key=lambda item: item[1]["duration_s"], reverse=True):
         duration_s = float(stats["duration_s"])
@@ -245,15 +286,16 @@ def rank_bottlenecks(run_dir: Path) -> dict[str, Any]:
                 "durations": list(stats["durations"]),
             }
         )
-    confidence = "ok"
+    confidence_reasons: list[str] = []
     if not spans:
-        confidence = "reduced-confidence:no_spans"
-    elif not provider_metrics_present:
-        confidence = f"reduced-confidence:{provider_metrics_reason}"
-    elif total_note is not None:
-        confidence = f"reduced-confidence:{total_note}"
-    elif total_elapsed_s > 0 and ranked and float(cast(Any, ranked[0].get("contribution_pct")) or 0.0) > 100.0:
-        confidence = "reduced-confidence:inconsistent_totals"
+        confidence_reasons.append("no_spans")
+    if not provider_metrics_present:
+        confidence_reasons.append(provider_metrics_reason)
+    confidence_reasons.extend(include_batch_confidence_reasons)
+    confidence_reasons.extend(total_confidence_reasons)
+    if total_elapsed_s > 0 and ranked and float(cast(Any, ranked[0].get("contribution_pct")) or 0.0) > 100.0:
+        confidence_reasons.append("inconsistent_totals")
+    confidence = "ok" if not confidence_reasons else f"reduced-confidence:{'+'.join(confidence_reasons)}"
     return {
         "run_id": manifest.get("run_id"),
         "mode": manifest.get("mode"),
@@ -261,7 +303,8 @@ def rank_bottlenecks(run_dir: Path) -> dict[str, Any]:
         "baseline_valid": manifest.get("baseline_valid") is True,
         "elapsed_seconds": round(float(total_elapsed_s), 3),
         "confidence": confidence,
-        "elapsed_source": total_note or "result_totals",
+        "confidence_reasons": confidence_reasons,
+        "elapsed_source": elapsed_source,
         "top_bottlenecks": ranked[:3],
         "all_phases": ranked,
         "summary_hydration_backfill": summary_hydration_counts,

--- a/tests/test_agenda_worker.py
+++ b/tests/test_agenda_worker.py
@@ -65,9 +65,9 @@ def test_agenda_segmentation_logic(db_session, mocker):
 
 
 def test_run_agenda_segmentation_backfill_uses_maintenance_metrics(mocker):
-    selector = mocker.patch(
+    mocker.patch(
         "pipeline.agenda_worker.select_catalog_ids_for_agenda_segmentation",
-        return_value=[101, 102, 103],
+        side_effect=[[101, 102, 103]],
     )
 
     @contextmanager
@@ -107,13 +107,12 @@ def test_run_agenda_segmentation_backfill_uses_maintenance_metrics(mocker):
     assert counts["heuristic_complete"] == 1
     assert counts["llm_timeout_then_fallback"] == 2
     assert segment_spy.call_count == 3
-    selector.assert_called_once()
 
 
 def test_agenda_backfill_records_before_and_after_eligibility(monkeypatch, mocker, tmp_path: Path):
     monkeypatch.setenv(profiling.PROFILE_RUN_ID_ENV, "profile_run")
     monkeypatch.setenv(profiling.PROFILE_ARTIFACT_DIR_ENV, str(tmp_path))
-    selector = mocker.patch(
+    mocker.patch(
         "pipeline.agenda_worker.select_catalog_ids_for_agenda_segmentation",
         side_effect=[[31, 32], [32]],
     )
@@ -147,15 +146,14 @@ def test_agenda_backfill_records_before_and_after_eligibility(monkeypatch, mocke
         ("after", [32]),
     ]
     assert counts["selected"] == 2
-    assert selector.call_count == 2
 
 
 def test_agenda_backfill_records_paired_empty_eligibility(monkeypatch, mocker, tmp_path: Path):
     monkeypatch.setenv(profiling.PROFILE_RUN_ID_ENV, "profile_run")
     monkeypatch.setenv(profiling.PROFILE_ARTIFACT_DIR_ENV, str(tmp_path))
-    selector = mocker.patch(
+    mocker.patch(
         "pipeline.agenda_worker.select_catalog_ids_for_agenda_segmentation",
-        return_value=[],
+        side_effect=[[]],
     )
 
     @contextmanager
@@ -172,15 +170,14 @@ def test_agenda_backfill_records_paired_empty_eligibility(monkeypatch, mocker, t
         ("after", []),
     ]
     assert counts["selected"] == 0
-    selector.assert_called_once()
 
 
 def test_agenda_backfill_omits_after_eligibility_when_work_fails(monkeypatch, mocker, tmp_path: Path):
     monkeypatch.setenv(profiling.PROFILE_RUN_ID_ENV, "profile_run")
     monkeypatch.setenv(profiling.PROFILE_ARTIFACT_DIR_ENV, str(tmp_path))
-    selector = mocker.patch(
+    mocker.patch(
         "pipeline.agenda_worker.select_catalog_ids_for_agenda_segmentation",
-        return_value=[31],
+        side_effect=[[31]],
     )
 
     @contextmanager
@@ -208,13 +205,12 @@ def test_agenda_backfill_omits_after_eligibility_when_work_fails(monkeypatch, mo
 
     rows = [json.loads(line) for line in (tmp_path / "spans.jsonl").read_text(encoding="utf-8").splitlines()]
     assert [row["boundary"] for row in rows] == ["before"]
-    selector.assert_called_once()
 
 
 def test_agenda_backfill_propagates_after_selector_failure(monkeypatch, mocker, tmp_path: Path):
     monkeypatch.setenv(profiling.PROFILE_RUN_ID_ENV, "profile_run")
     monkeypatch.setenv(profiling.PROFILE_ARTIFACT_DIR_ENV, str(tmp_path))
-    selector = mocker.patch(
+    mocker.patch(
         "pipeline.agenda_worker.select_catalog_ids_for_agenda_segmentation",
         side_effect=[[31], RuntimeError("selector failed")],
     )
@@ -244,4 +240,3 @@ def test_agenda_backfill_propagates_after_selector_failure(monkeypatch, mocker, 
 
     rows = [json.loads(line) for line in (tmp_path / "spans.jsonl").read_text(encoding="utf-8").splitlines()]
     assert [row["boundary"] for row in rows] == ["before"]
-    assert selector.call_count == 2

--- a/tests/test_agenda_worker.py
+++ b/tests/test_agenda_worker.py
@@ -1,10 +1,13 @@
 from contextlib import contextmanager
+import json
+from pathlib import Path
 import pytest
 from unittest.mock import MagicMock
 import sys
 
 sys.modules["llama_cpp"] = MagicMock()
 from pipeline.agenda_worker import run_agenda_segmentation_backfill, segment_document_agenda
+from pipeline import profiling
 from pipeline.models import Place, Event, Document, Catalog, AgendaItem
 
 def test_agenda_segmentation_logic(db_session, mocker):
@@ -62,7 +65,10 @@ def test_agenda_segmentation_logic(db_session, mocker):
 
 
 def test_run_agenda_segmentation_backfill_uses_maintenance_metrics(mocker):
-    mocker.patch("pipeline.agenda_worker.select_catalog_ids_for_agenda_segmentation", return_value=[101, 102, 103])
+    selector = mocker.patch(
+        "pipeline.agenda_worker.select_catalog_ids_for_agenda_segmentation",
+        return_value=[101, 102, 103],
+    )
 
     @contextmanager
     def _fake_db_session():
@@ -101,3 +107,141 @@ def test_run_agenda_segmentation_backfill_uses_maintenance_metrics(mocker):
     assert counts["heuristic_complete"] == 1
     assert counts["llm_timeout_then_fallback"] == 2
     assert segment_spy.call_count == 3
+    selector.assert_called_once()
+
+
+def test_agenda_backfill_records_before_and_after_eligibility(monkeypatch, mocker, tmp_path: Path):
+    monkeypatch.setenv(profiling.PROFILE_RUN_ID_ENV, "profile_run")
+    monkeypatch.setenv(profiling.PROFILE_ARTIFACT_DIR_ENV, str(tmp_path))
+    selector = mocker.patch(
+        "pipeline.agenda_worker.select_catalog_ids_for_agenda_segmentation",
+        side_effect=[[31, 32], [32]],
+    )
+
+    @contextmanager
+    def _fake_db_session():
+        yield MagicMock()
+
+    @contextmanager
+    def _fake_timeout(_timeout_seconds):
+        yield
+
+    @contextmanager
+    def _fake_capture():
+        yield {"timeout": 0, "empty_response": 0}
+
+    mocker.patch("pipeline.agenda_worker.db_session", _fake_db_session)
+    mocker.patch("pipeline.agenda_worker.segment_timeout_override", _fake_timeout)
+    mocker.patch("pipeline.agenda_worker.capture_agenda_fallback_events", _fake_capture)
+    mocker.patch(
+        "pipeline.agenda_worker.segment_catalog_with_mode",
+        return_value={"status": "complete"},
+    )
+
+    counts = run_agenda_segmentation_backfill(segment_mode="maintenance")
+
+    rows = [json.loads(line) for line in (tmp_path / "spans.jsonl").read_text(encoding="utf-8").splitlines()]
+    eligibility_rows = [row for row in rows if row["event_type"] == "phase_eligibility"]
+    assert [(row["boundary"], row["eligible_ids"]) for row in eligibility_rows] == [
+        ("before", [31, 32]),
+        ("after", [32]),
+    ]
+    assert counts["selected"] == 2
+    assert selector.call_count == 2
+
+
+def test_agenda_backfill_records_paired_empty_eligibility(monkeypatch, mocker, tmp_path: Path):
+    monkeypatch.setenv(profiling.PROFILE_RUN_ID_ENV, "profile_run")
+    monkeypatch.setenv(profiling.PROFILE_ARTIFACT_DIR_ENV, str(tmp_path))
+    selector = mocker.patch(
+        "pipeline.agenda_worker.select_catalog_ids_for_agenda_segmentation",
+        return_value=[],
+    )
+
+    @contextmanager
+    def _fake_db_session():
+        yield MagicMock()
+
+    mocker.patch("pipeline.agenda_worker.db_session", _fake_db_session)
+
+    counts = run_agenda_segmentation_backfill()
+
+    rows = [json.loads(line) for line in (tmp_path / "spans.jsonl").read_text(encoding="utf-8").splitlines()]
+    assert [(row["boundary"], row["eligible_ids"]) for row in rows] == [
+        ("before", []),
+        ("after", []),
+    ]
+    assert counts["selected"] == 0
+    selector.assert_called_once()
+
+
+def test_agenda_backfill_omits_after_eligibility_when_work_fails(monkeypatch, mocker, tmp_path: Path):
+    monkeypatch.setenv(profiling.PROFILE_RUN_ID_ENV, "profile_run")
+    monkeypatch.setenv(profiling.PROFILE_ARTIFACT_DIR_ENV, str(tmp_path))
+    selector = mocker.patch(
+        "pipeline.agenda_worker.select_catalog_ids_for_agenda_segmentation",
+        return_value=[31],
+    )
+
+    @contextmanager
+    def _fake_db_session():
+        yield MagicMock()
+
+    @contextmanager
+    def _fake_timeout(_timeout_seconds):
+        yield
+
+    @contextmanager
+    def _fake_capture():
+        yield {"timeout": 0, "empty_response": 0}
+
+    mocker.patch("pipeline.agenda_worker.db_session", _fake_db_session)
+    mocker.patch("pipeline.agenda_worker.segment_timeout_override", _fake_timeout)
+    mocker.patch("pipeline.agenda_worker.capture_agenda_fallback_events", _fake_capture)
+    mocker.patch(
+        "pipeline.agenda_worker.segment_catalog_with_mode",
+        side_effect=RuntimeError("agenda failed"),
+    )
+
+    with pytest.raises(RuntimeError, match="agenda failed"):
+        run_agenda_segmentation_backfill(segment_mode="maintenance")
+
+    rows = [json.loads(line) for line in (tmp_path / "spans.jsonl").read_text(encoding="utf-8").splitlines()]
+    assert [row["boundary"] for row in rows] == ["before"]
+    selector.assert_called_once()
+
+
+def test_agenda_backfill_propagates_after_selector_failure(monkeypatch, mocker, tmp_path: Path):
+    monkeypatch.setenv(profiling.PROFILE_RUN_ID_ENV, "profile_run")
+    monkeypatch.setenv(profiling.PROFILE_ARTIFACT_DIR_ENV, str(tmp_path))
+    selector = mocker.patch(
+        "pipeline.agenda_worker.select_catalog_ids_for_agenda_segmentation",
+        side_effect=[[31], RuntimeError("selector failed")],
+    )
+
+    @contextmanager
+    def _fake_db_session():
+        yield MagicMock()
+
+    @contextmanager
+    def _fake_timeout(_timeout_seconds):
+        yield
+
+    @contextmanager
+    def _fake_capture():
+        yield {"timeout": 0, "empty_response": 0}
+
+    mocker.patch("pipeline.agenda_worker.db_session", _fake_db_session)
+    mocker.patch("pipeline.agenda_worker.segment_timeout_override", _fake_timeout)
+    mocker.patch("pipeline.agenda_worker.capture_agenda_fallback_events", _fake_capture)
+    mocker.patch(
+        "pipeline.agenda_worker.segment_catalog_with_mode",
+        return_value={"status": "complete"},
+    )
+
+    with pytest.raises(RuntimeError, match="selector failed"):
+        run_agenda_segmentation_backfill(segment_mode="maintenance")
+
+    rows = [json.loads(line) for line in (tmp_path / "spans.jsonl").read_text(encoding="utf-8").splitlines()]
+    assert [row["boundary"] for row in rows] == ["before"]
+    assert selector.call_count == 2

--- a/tests/test_pipeline_batching.py
+++ b/tests/test_pipeline_batching.py
@@ -108,9 +108,9 @@ def test_run_entity_backfill_returns_zero_counts_when_nothing_is_selected(mocker
     mock_session.__enter__.return_value = mock_session
     mock_session.__exit__.return_value = False
     mocker.patch("pipeline.backfill_entities.db_session", return_value=mock_session)
-    selector = mocker.patch(
+    mocker.patch(
         "pipeline.backfill_entities.select_catalog_ids_for_entity_backfill",
-        return_value=[],
+        side_effect=[[]],
     )
 
     from pipeline.backfill_entities import run_entity_backfill
@@ -127,7 +127,6 @@ def test_run_entity_backfill_returns_zero_counts_when_nothing_is_selected(mocker
         "freshness_advanced": 0,
         "candidate_slice_fallback_prefix": 0,
     }
-    selector.assert_called_once()
 
 
 def test_run_entity_backfill_uses_in_process_fast_path_for_small_snapshots(mocker):
@@ -135,9 +134,9 @@ def test_run_entity_backfill_uses_in_process_fast_path_for_small_snapshots(mocke
     mock_session.__enter__.return_value = mock_session
     mock_session.__exit__.return_value = False
     mocker.patch("pipeline.backfill_entities.db_session", return_value=mock_session)
-    selector = mocker.patch(
+    mocker.patch(
         "pipeline.backfill_entities.select_catalog_ids_for_entity_backfill",
-        return_value=[1, 2, 3],
+        side_effect=[[1, 2, 3]],
     )
     mocker.patch(
         "pipeline.backfill_entities._resolve_parallel_processing_settings",
@@ -162,15 +161,14 @@ def test_run_entity_backfill_uses_in_process_fast_path_for_small_snapshots(mocke
     assert counts["ner_skipped_low_signal"] == 0
     process_chunk_spy.assert_called_once_with([1, 2, 3])
     executor_spy.assert_not_called()
-    selector.assert_called_once()
 
 
-def _patch_entity_in_process(mocker, *, selector_side_effect):
+def _patch_entity_in_process(mocker, *, selector_side_effect) -> None:
     mock_session = MagicMock()
     mock_session.__enter__.return_value = mock_session
     mock_session.__exit__.return_value = False
     mocker.patch("pipeline.backfill_entities.db_session", return_value=mock_session)
-    selector = mocker.patch(
+    mocker.patch(
         "pipeline.backfill_entities.select_catalog_ids_for_entity_backfill",
         side_effect=selector_side_effect,
     )
@@ -179,13 +177,12 @@ def _patch_entity_in_process(mocker, *, selector_side_effect):
         return_value={"mode": "global", "chunk_size": 10, "workers_override": None},
     )
     mocker.patch("pipeline.backfill_entities.ENTITY_BACKFILL_IN_PROCESS_THRESHOLD", 10)
-    return selector
 
 
 def test_entity_backfill_records_before_and_after_eligibility(monkeypatch, mocker, tmp_path: Path):
     monkeypatch.setenv(profiling.PROFILE_RUN_ID_ENV, "profile_run")
     monkeypatch.setenv(profiling.PROFILE_ARTIFACT_DIR_ENV, str(tmp_path))
-    selector = _patch_entity_in_process(mocker, selector_side_effect=[[1, 2], [2]])
+    _patch_entity_in_process(mocker, selector_side_effect=[[1, 2], [2]])
     mocker.patch(
         "pipeline.backfill_entities.process_entity_chunk",
         return_value={"complete": 2, "updated_catalog_ids": [1, 2]},
@@ -200,13 +197,12 @@ def test_entity_backfill_records_before_and_after_eligibility(monkeypatch, mocke
         ("before", [1, 2]),
         ("after", [2]),
     ]
-    assert selector.call_count == 2
 
 
 def test_entity_backfill_records_paired_empty_eligibility(monkeypatch, mocker, tmp_path: Path):
     monkeypatch.setenv(profiling.PROFILE_RUN_ID_ENV, "profile_run")
     monkeypatch.setenv(profiling.PROFILE_ARTIFACT_DIR_ENV, str(tmp_path))
-    selector = _patch_entity_in_process(mocker, selector_side_effect=[[]])
+    _patch_entity_in_process(mocker, selector_side_effect=[[]])
 
     from pipeline.backfill_entities import run_entity_backfill
 
@@ -217,13 +213,12 @@ def test_entity_backfill_records_paired_empty_eligibility(monkeypatch, mocker, t
         ("before", []),
         ("after", []),
     ]
-    selector.assert_called_once()
 
 
 def test_entity_backfill_omits_after_eligibility_when_work_fails(monkeypatch, mocker, tmp_path: Path):
     monkeypatch.setenv(profiling.PROFILE_RUN_ID_ENV, "profile_run")
     monkeypatch.setenv(profiling.PROFILE_ARTIFACT_DIR_ENV, str(tmp_path))
-    selector = _patch_entity_in_process(mocker, selector_side_effect=[[1]])
+    _patch_entity_in_process(mocker, selector_side_effect=[[1]])
     mocker.patch(
         "pipeline.backfill_entities.process_entity_chunk",
         side_effect=RuntimeError("entity failed"),
@@ -236,13 +231,12 @@ def test_entity_backfill_omits_after_eligibility_when_work_fails(monkeypatch, mo
 
     rows = _profile_eligibility_rows(tmp_path)
     assert [row["boundary"] for row in rows] == ["before"]
-    selector.assert_called_once()
 
 
 def test_entity_backfill_propagates_after_selector_failure(monkeypatch, mocker, tmp_path: Path):
     monkeypatch.setenv(profiling.PROFILE_RUN_ID_ENV, "profile_run")
     monkeypatch.setenv(profiling.PROFILE_ARTIFACT_DIR_ENV, str(tmp_path))
-    selector = _patch_entity_in_process(
+    _patch_entity_in_process(
         mocker,
         selector_side_effect=[[1], RuntimeError("entity selector failed")],
     )
@@ -258,34 +252,31 @@ def test_entity_backfill_propagates_after_selector_failure(monkeypatch, mocker, 
 
     rows = _profile_eligibility_rows(tmp_path)
     assert [row["boundary"] for row in rows] == ["before"]
-    assert selector.call_count == 2
 
 
-def _patch_summary_backfill_work(mocker, *, selector_side_effect):
-    selector = mocker.patch(
+def _patch_summary_backfill_work(mocker, *, selector_side_effect) -> None:
+    mocker.patch(
         "pipeline.summary_backfill_runner._select_catalog_ids",
         side_effect=selector_side_effect,
     )
     mocker.patch("pipeline.summary_backfill_runner._load_doc_kind_map", return_value={})
     mocker.patch("pipeline.summary_backfill_runner._run_agenda_batch", return_value={})
     mocker.patch("pipeline.summary_backfill_runner.log_backfill_counts")
-    return selector
 
 
 def test_summary_backfill_does_not_reselect_when_profiling_is_disabled(mocker):
-    selector = _patch_summary_backfill_work(mocker, selector_side_effect=[[1]])
+    _patch_summary_backfill_work(mocker, selector_side_effect=[[1]])
     mocker.patch("pipeline.summary_backfill_runner._run_backfill_loop")
 
     counts = run_summary_hydration_backfill()
 
     assert counts["selected"] == 1
-    selector.assert_called_once()
 
 
 def test_summary_backfill_records_before_and_after_eligibility(monkeypatch, mocker, tmp_path: Path):
     monkeypatch.setenv(profiling.PROFILE_RUN_ID_ENV, "profile_run")
     monkeypatch.setenv(profiling.PROFILE_ARTIFACT_DIR_ENV, str(tmp_path))
-    selector = _patch_summary_backfill_work(mocker, selector_side_effect=[[1, 2], [2]])
+    _patch_summary_backfill_work(mocker, selector_side_effect=[[1, 2], [2]])
     mocker.patch("pipeline.summary_backfill_runner._run_backfill_loop")
 
     counts = run_summary_hydration_backfill()
@@ -296,13 +287,12 @@ def test_summary_backfill_records_before_and_after_eligibility(monkeypatch, mock
         ("after", [2]),
     ]
     assert counts["selected"] == 2
-    assert selector.call_count == 2
 
 
 def test_summary_backfill_records_paired_empty_eligibility(monkeypatch, mocker, tmp_path: Path):
     monkeypatch.setenv(profiling.PROFILE_RUN_ID_ENV, "profile_run")
     monkeypatch.setenv(profiling.PROFILE_ARTIFACT_DIR_ENV, str(tmp_path))
-    selector = _patch_summary_backfill_work(mocker, selector_side_effect=[[]])
+    _patch_summary_backfill_work(mocker, selector_side_effect=[[]])
 
     counts = run_summary_hydration_backfill()
 
@@ -312,13 +302,12 @@ def test_summary_backfill_records_paired_empty_eligibility(monkeypatch, mocker, 
         ("after", []),
     ]
     assert counts["selected"] == 0
-    selector.assert_called_once()
 
 
 def test_summary_backfill_omits_after_eligibility_when_work_fails(monkeypatch, mocker, tmp_path: Path):
     monkeypatch.setenv(profiling.PROFILE_RUN_ID_ENV, "profile_run")
     monkeypatch.setenv(profiling.PROFILE_ARTIFACT_DIR_ENV, str(tmp_path))
-    selector = _patch_summary_backfill_work(mocker, selector_side_effect=[[1]])
+    _patch_summary_backfill_work(mocker, selector_side_effect=[[1]])
     mocker.patch(
         "pipeline.summary_backfill_runner._run_backfill_loop",
         side_effect=RuntimeError("summary failed"),
@@ -329,13 +318,12 @@ def test_summary_backfill_omits_after_eligibility_when_work_fails(monkeypatch, m
 
     rows = _profile_eligibility_rows(tmp_path)
     assert [row["boundary"] for row in rows] == ["before"]
-    selector.assert_called_once()
 
 
 def test_summary_backfill_propagates_after_selector_failure(monkeypatch, mocker, tmp_path: Path):
     monkeypatch.setenv(profiling.PROFILE_RUN_ID_ENV, "profile_run")
     monkeypatch.setenv(profiling.PROFILE_ARTIFACT_DIR_ENV, str(tmp_path))
-    selector = _patch_summary_backfill_work(
+    _patch_summary_backfill_work(
         mocker,
         selector_side_effect=[[1], RuntimeError("summary selector failed")],
     )
@@ -346,7 +334,6 @@ def test_summary_backfill_propagates_after_selector_failure(monkeypatch, mocker,
 
     rows = _profile_eligibility_rows(tmp_path)
     assert [row["boundary"] for row in rows] == ["before"]
-    assert selector.call_count == 2
 
 
 def test_process_entity_chunk_marks_low_signal_docs_fresh_without_spacy(db_session, mocker):

--- a/tests/test_pipeline_batching.py
+++ b/tests/test_pipeline_batching.py
@@ -1,3 +1,5 @@
+import json
+from pathlib import Path
 import sys
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -39,6 +41,18 @@ from pipeline.models import Base, Catalog, Document, AgendaItem, Event, Place
 from pipeline.city_scope import ordered_hydration_cities, source_aliases_for_city
 from pipeline.content_hash import compute_content_hash
 from pipeline.summary_freshness import compute_agenda_items_hash
+from pipeline import profiling
+
+
+def _profile_eligibility_rows(artifact_dir: Path) -> list[dict[str, object]]:
+    return [
+        row
+        for row in (
+            json.loads(line)
+            for line in (artifact_dir / "spans.jsonl").read_text(encoding="utf-8").splitlines()
+        )
+        if row["event_type"] == "phase_eligibility"
+    ]
 
 
 def _successful_meilisearch_client() -> MagicMock:
@@ -94,7 +108,10 @@ def test_run_entity_backfill_returns_zero_counts_when_nothing_is_selected(mocker
     mock_session.__enter__.return_value = mock_session
     mock_session.__exit__.return_value = False
     mocker.patch("pipeline.backfill_entities.db_session", return_value=mock_session)
-    mocker.patch("pipeline.backfill_entities.select_catalog_ids_for_entity_backfill", return_value=[])
+    selector = mocker.patch(
+        "pipeline.backfill_entities.select_catalog_ids_for_entity_backfill",
+        return_value=[],
+    )
 
     from pipeline.backfill_entities import run_entity_backfill
 
@@ -110,6 +127,7 @@ def test_run_entity_backfill_returns_zero_counts_when_nothing_is_selected(mocker
         "freshness_advanced": 0,
         "candidate_slice_fallback_prefix": 0,
     }
+    selector.assert_called_once()
 
 
 def test_run_entity_backfill_uses_in_process_fast_path_for_small_snapshots(mocker):
@@ -117,7 +135,10 @@ def test_run_entity_backfill_uses_in_process_fast_path_for_small_snapshots(mocke
     mock_session.__enter__.return_value = mock_session
     mock_session.__exit__.return_value = False
     mocker.patch("pipeline.backfill_entities.db_session", return_value=mock_session)
-    mocker.patch("pipeline.backfill_entities.select_catalog_ids_for_entity_backfill", return_value=[1, 2, 3])
+    selector = mocker.patch(
+        "pipeline.backfill_entities.select_catalog_ids_for_entity_backfill",
+        return_value=[1, 2, 3],
+    )
     mocker.patch(
         "pipeline.backfill_entities._resolve_parallel_processing_settings",
         return_value={"mode": "global", "chunk_size": 10, "workers_override": None},
@@ -141,6 +162,191 @@ def test_run_entity_backfill_uses_in_process_fast_path_for_small_snapshots(mocke
     assert counts["ner_skipped_low_signal"] == 0
     process_chunk_spy.assert_called_once_with([1, 2, 3])
     executor_spy.assert_not_called()
+    selector.assert_called_once()
+
+
+def _patch_entity_in_process(mocker, *, selector_side_effect):
+    mock_session = MagicMock()
+    mock_session.__enter__.return_value = mock_session
+    mock_session.__exit__.return_value = False
+    mocker.patch("pipeline.backfill_entities.db_session", return_value=mock_session)
+    selector = mocker.patch(
+        "pipeline.backfill_entities.select_catalog_ids_for_entity_backfill",
+        side_effect=selector_side_effect,
+    )
+    mocker.patch(
+        "pipeline.backfill_entities._resolve_parallel_processing_settings",
+        return_value={"mode": "global", "chunk_size": 10, "workers_override": None},
+    )
+    mocker.patch("pipeline.backfill_entities.ENTITY_BACKFILL_IN_PROCESS_THRESHOLD", 10)
+    return selector
+
+
+def test_entity_backfill_records_before_and_after_eligibility(monkeypatch, mocker, tmp_path: Path):
+    monkeypatch.setenv(profiling.PROFILE_RUN_ID_ENV, "profile_run")
+    monkeypatch.setenv(profiling.PROFILE_ARTIFACT_DIR_ENV, str(tmp_path))
+    selector = _patch_entity_in_process(mocker, selector_side_effect=[[1, 2], [2]])
+    mocker.patch(
+        "pipeline.backfill_entities.process_entity_chunk",
+        return_value={"complete": 2, "updated_catalog_ids": [1, 2]},
+    )
+
+    from pipeline.backfill_entities import run_entity_backfill
+
+    run_entity_backfill()
+
+    rows = _profile_eligibility_rows(tmp_path)
+    assert [(row["boundary"], row["eligible_ids"]) for row in rows] == [
+        ("before", [1, 2]),
+        ("after", [2]),
+    ]
+    assert selector.call_count == 2
+
+
+def test_entity_backfill_records_paired_empty_eligibility(monkeypatch, mocker, tmp_path: Path):
+    monkeypatch.setenv(profiling.PROFILE_RUN_ID_ENV, "profile_run")
+    monkeypatch.setenv(profiling.PROFILE_ARTIFACT_DIR_ENV, str(tmp_path))
+    selector = _patch_entity_in_process(mocker, selector_side_effect=[[]])
+
+    from pipeline.backfill_entities import run_entity_backfill
+
+    run_entity_backfill()
+
+    rows = _profile_eligibility_rows(tmp_path)
+    assert [(row["boundary"], row["eligible_ids"]) for row in rows] == [
+        ("before", []),
+        ("after", []),
+    ]
+    selector.assert_called_once()
+
+
+def test_entity_backfill_omits_after_eligibility_when_work_fails(monkeypatch, mocker, tmp_path: Path):
+    monkeypatch.setenv(profiling.PROFILE_RUN_ID_ENV, "profile_run")
+    monkeypatch.setenv(profiling.PROFILE_ARTIFACT_DIR_ENV, str(tmp_path))
+    selector = _patch_entity_in_process(mocker, selector_side_effect=[[1]])
+    mocker.patch(
+        "pipeline.backfill_entities.process_entity_chunk",
+        side_effect=RuntimeError("entity failed"),
+    )
+
+    from pipeline.backfill_entities import run_entity_backfill
+
+    with pytest.raises(RuntimeError, match="entity failed"):
+        run_entity_backfill()
+
+    rows = _profile_eligibility_rows(tmp_path)
+    assert [row["boundary"] for row in rows] == ["before"]
+    selector.assert_called_once()
+
+
+def test_entity_backfill_propagates_after_selector_failure(monkeypatch, mocker, tmp_path: Path):
+    monkeypatch.setenv(profiling.PROFILE_RUN_ID_ENV, "profile_run")
+    monkeypatch.setenv(profiling.PROFILE_ARTIFACT_DIR_ENV, str(tmp_path))
+    selector = _patch_entity_in_process(
+        mocker,
+        selector_side_effect=[[1], RuntimeError("entity selector failed")],
+    )
+    mocker.patch(
+        "pipeline.backfill_entities.process_entity_chunk",
+        return_value={"complete": 1, "updated_catalog_ids": [1]},
+    )
+
+    from pipeline.backfill_entities import run_entity_backfill
+
+    with pytest.raises(RuntimeError, match="entity selector failed"):
+        run_entity_backfill()
+
+    rows = _profile_eligibility_rows(tmp_path)
+    assert [row["boundary"] for row in rows] == ["before"]
+    assert selector.call_count == 2
+
+
+def _patch_summary_backfill_work(mocker, *, selector_side_effect):
+    selector = mocker.patch(
+        "pipeline.summary_backfill_runner._select_catalog_ids",
+        side_effect=selector_side_effect,
+    )
+    mocker.patch("pipeline.summary_backfill_runner._load_doc_kind_map", return_value={})
+    mocker.patch("pipeline.summary_backfill_runner._run_agenda_batch", return_value={})
+    mocker.patch("pipeline.summary_backfill_runner.log_backfill_counts")
+    return selector
+
+
+def test_summary_backfill_does_not_reselect_when_profiling_is_disabled(mocker):
+    selector = _patch_summary_backfill_work(mocker, selector_side_effect=[[1]])
+    mocker.patch("pipeline.summary_backfill_runner._run_backfill_loop")
+
+    counts = run_summary_hydration_backfill()
+
+    assert counts["selected"] == 1
+    selector.assert_called_once()
+
+
+def test_summary_backfill_records_before_and_after_eligibility(monkeypatch, mocker, tmp_path: Path):
+    monkeypatch.setenv(profiling.PROFILE_RUN_ID_ENV, "profile_run")
+    monkeypatch.setenv(profiling.PROFILE_ARTIFACT_DIR_ENV, str(tmp_path))
+    selector = _patch_summary_backfill_work(mocker, selector_side_effect=[[1, 2], [2]])
+    mocker.patch("pipeline.summary_backfill_runner._run_backfill_loop")
+
+    counts = run_summary_hydration_backfill()
+
+    rows = _profile_eligibility_rows(tmp_path)
+    assert [(row["boundary"], row["eligible_ids"]) for row in rows] == [
+        ("before", [1, 2]),
+        ("after", [2]),
+    ]
+    assert counts["selected"] == 2
+    assert selector.call_count == 2
+
+
+def test_summary_backfill_records_paired_empty_eligibility(monkeypatch, mocker, tmp_path: Path):
+    monkeypatch.setenv(profiling.PROFILE_RUN_ID_ENV, "profile_run")
+    monkeypatch.setenv(profiling.PROFILE_ARTIFACT_DIR_ENV, str(tmp_path))
+    selector = _patch_summary_backfill_work(mocker, selector_side_effect=[[]])
+
+    counts = run_summary_hydration_backfill()
+
+    rows = _profile_eligibility_rows(tmp_path)
+    assert [(row["boundary"], row["eligible_ids"]) for row in rows] == [
+        ("before", []),
+        ("after", []),
+    ]
+    assert counts["selected"] == 0
+    selector.assert_called_once()
+
+
+def test_summary_backfill_omits_after_eligibility_when_work_fails(monkeypatch, mocker, tmp_path: Path):
+    monkeypatch.setenv(profiling.PROFILE_RUN_ID_ENV, "profile_run")
+    monkeypatch.setenv(profiling.PROFILE_ARTIFACT_DIR_ENV, str(tmp_path))
+    selector = _patch_summary_backfill_work(mocker, selector_side_effect=[[1]])
+    mocker.patch(
+        "pipeline.summary_backfill_runner._run_backfill_loop",
+        side_effect=RuntimeError("summary failed"),
+    )
+
+    with pytest.raises(RuntimeError, match="summary failed"):
+        run_summary_hydration_backfill()
+
+    rows = _profile_eligibility_rows(tmp_path)
+    assert [row["boundary"] for row in rows] == ["before"]
+    selector.assert_called_once()
+
+
+def test_summary_backfill_propagates_after_selector_failure(monkeypatch, mocker, tmp_path: Path):
+    monkeypatch.setenv(profiling.PROFILE_RUN_ID_ENV, "profile_run")
+    monkeypatch.setenv(profiling.PROFILE_ARTIFACT_DIR_ENV, str(tmp_path))
+    selector = _patch_summary_backfill_work(
+        mocker,
+        selector_side_effect=[[1], RuntimeError("summary selector failed")],
+    )
+    mocker.patch("pipeline.summary_backfill_runner._run_backfill_loop")
+
+    with pytest.raises(RuntimeError, match="summary selector failed"):
+        run_summary_hydration_backfill()
+
+    rows = _profile_eligibility_rows(tmp_path)
+    assert [row["boundary"] for row in rows] == ["before"]
+    assert selector.call_count == 2
 
 
 def test_process_entity_chunk_marks_low_signal_docs_fresh_without_spacy(db_session, mocker):

--- a/tests/test_pipeline_profile_report.py
+++ b/tests/test_pipeline_profile_report.py
@@ -41,6 +41,63 @@ def test_rank_bottlenecks_prefers_longest_leaf_phase(tmp_path: Path):
     assert summary["top_bottlenecks"][0]["classification"] in {"queueing", "inference/provider"}
 
 
+def test_rank_bottlenecks_ignores_phase_eligibility_events(tmp_path: Path):
+    run_dir = tmp_path / "profile_run"
+    run_dir.mkdir()
+    (run_dir / "run_manifest.json").write_text(
+        json.dumps({"run_id": "profile_run", "mode": "triage", "catalog_count": 2, "baseline_valid": False}),
+        encoding="utf-8",
+    )
+    (run_dir / "result.json").write_text(
+        json.dumps({"totals": {"combined_elapsed_seconds": 10.0}}),
+        encoding="utf-8",
+    )
+    (run_dir / "day_summary.json").write_text("{}", encoding="utf-8")
+    (run_dir / "worker_metrics.prom").write_text("", encoding="utf-8")
+    (run_dir / "spans.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "event_type": "phase_eligibility",
+                        "phase": "summarize",
+                        "boundary": "before",
+                        "eligible_count": 2,
+                        "eligible_ids": [1, 2],
+                    }
+                ),
+                json.dumps(
+                    {
+                        "event_type": "span",
+                        "phase": "summarize",
+                        "component": "pipeline",
+                        "duration_s": 4.0,
+                    }
+                ),
+                json.dumps(
+                    {
+                        "event_type": "phase_eligibility",
+                        "phase": "summarize",
+                        "boundary": "after",
+                        "eligible_count": 0,
+                        "eligible_ids": [],
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    summary = mod.rank_bottlenecks(run_dir)
+
+    summarize = summary["top_bottlenecks"][0]
+    assert summarize["phase"] == "summarize"
+    assert summarize["duration_s"] == 4.0
+    assert summarize["occurrence_count"] == 1
+    assert summarize["components"] == ["pipeline"]
+
+
 def test_rank_bottlenecks_classifies_deterministic_summary_runs_without_provider_bias(tmp_path: Path):
     run_dir = tmp_path / "profile_run_deterministic"
     run_dir.mkdir()

--- a/tests/test_pipeline_profile_report.py
+++ b/tests/test_pipeline_profile_report.py
@@ -222,8 +222,8 @@ def test_rank_bottlenecks_uses_combined_total_for_repeated_phases(tmp_path: Path
     (run_dir / "spans.jsonl").write_text(
         "\n".join(
             [
-                json.dumps({"event_type": "span", "phase": "pipeline_total", "duration_s": 23.0}),
-                json.dumps({"event_type": "span", "phase": "batch_enrichment_total", "duration_s": 24.2}),
+                json.dumps({"event_type": "span", "phase": "pipeline_total", "duration_s": 23.0, "outcome": "success", "metadata": {"observer_overhead_s": 0.1}}),
+                json.dumps({"event_type": "span", "phase": "batch_enrichment_total", "duration_s": 24.2, "outcome": "success", "metadata": {"observer_overhead_s": 0.1}}),
                 json.dumps({"event_type": "span", "phase": "index_search", "component": "subprocess", "duration_s": 18.8}),
                 json.dumps({"event_type": "span", "phase": "index_search", "component": "subprocess", "duration_s": 19.3}),
                 json.dumps({"event_type": "span", "phase": "entity_backfill", "component": "subprocess", "duration_s": 2.1}),
@@ -237,7 +237,8 @@ def test_rank_bottlenecks_uses_combined_total_for_repeated_phases(tmp_path: Path
 
     top = summary["top_bottlenecks"][0]
     assert summary["confidence"] == "ok"
-    assert summary["elapsed_source"] == "result_totals"
+    assert summary["elapsed_source"] == "corrected_total_spans"
+    assert summary["elapsed_seconds"] == 47.2
     assert top["phase"] == "index_search"
     assert top["occurrence_count"] == 2
     assert top["contribution_pct"] < 100.0
@@ -247,15 +248,15 @@ def test_rank_bottlenecks_marks_missing_result_as_reduced_confidence(tmp_path: P
     run_dir = tmp_path / "profile_run_missing_result"
     run_dir.mkdir()
     (run_dir / "run_manifest.json").write_text(
-        json.dumps({"run_id": "profile_run_missing_result", "mode": "triage", "catalog_count": 25, "baseline_valid": False}),
+        json.dumps({"run_id": "profile_run_missing_result", "mode": "triage", "catalog_count": 25, "baseline_valid": False, "include_batch": True}),
         encoding="utf-8",
     )
     (run_dir / "day_summary.json").write_text(json.dumps({"provider_metrics_present": True}), encoding="utf-8")
     (run_dir / "spans.jsonl").write_text(
         "\n".join(
             [
-                json.dumps({"event_type": "span", "phase": "pipeline_total", "duration_s": 20.0}),
-                json.dumps({"event_type": "span", "phase": "batch_enrichment_total", "duration_s": 10.0}),
+                json.dumps({"event_type": "span", "phase": "pipeline_total", "duration_s": 20.0, "outcome": "success", "metadata": {"observer_overhead_s": 0.1}}),
+                json.dumps({"event_type": "span", "phase": "batch_enrichment_total", "duration_s": 10.0, "outcome": "success", "metadata": {"observer_overhead_s": 0.1}}),
                 json.dumps({"event_type": "span", "phase": "index_search", "component": "subprocess", "duration_s": 12.0}),
             ]
         )
@@ -269,9 +270,317 @@ def test_rank_bottlenecks_marks_missing_result_as_reduced_confidence(tmp_path: P
     assert summary["confidence"] == "reduced-confidence:result_missing"
 
 
+def test_rank_bottlenecks_rejects_partial_corrected_total_without_result(tmp_path: Path):
+    run_dir = tmp_path / "profile_run_partial_missing_result"
+    run_dir.mkdir()
+    (run_dir / "run_manifest.json").write_text(
+        json.dumps({"run_id": "profile_run_partial_missing_result", "include_batch": True}),
+        encoding="utf-8",
+    )
+    (run_dir / "day_summary.json").write_text(
+        json.dumps({"provider_metrics_present": True}),
+        encoding="utf-8",
+    )
+    (run_dir / "spans.jsonl").write_text(
+        json.dumps({"event_type": "span", "phase": "pipeline_total", "duration_s": 20.0, "outcome": "success", "metadata": {"observer_overhead_s": 0.1}})
+        + "\n",
+        encoding="utf-8",
+    )
+
+    summary = mod.rank_bottlenecks(run_dir)
+
+    assert summary["elapsed_seconds"] == 0.0
+    assert summary["elapsed_source"] == "no_total_elapsed_time"
+    assert summary["confidence_reasons"] == [
+        "result_missing",
+        "missing_corrected_total:batch_enrichment_total",
+    ]
+
+
+def test_rank_bottlenecks_reports_every_missing_corrected_total_phase(tmp_path: Path):
+    run_dir = tmp_path / "profile_run_missing_totals"
+    run_dir.mkdir()
+    (run_dir / "run_manifest.json").write_text(
+        json.dumps({"run_id": "profile_run_missing_totals", "include_batch": True}),
+        encoding="utf-8",
+    )
+    (run_dir / "result.json").write_text(
+        json.dumps({"include_batch": True, "totals": {"combined_elapsed_seconds": 42.0}}),
+        encoding="utf-8",
+    )
+    (run_dir / "day_summary.json").write_text(
+        json.dumps({"provider_metrics_present": True}),
+        encoding="utf-8",
+    )
+
+    summary = mod.rank_bottlenecks(run_dir)
+
+    assert summary["confidence_reasons"] == [
+        "no_spans",
+        "missing_corrected_total:pipeline_total",
+        "missing_corrected_total:batch_enrichment_total",
+    ]
+
+
+def test_rank_bottlenecks_rejects_failed_corrected_total_span(tmp_path: Path):
+    run_dir = tmp_path / "profile_run_failed_total"
+    run_dir.mkdir()
+    (run_dir / "run_manifest.json").write_text(
+        json.dumps({"run_id": "profile_run_failed_total", "include_batch": True}),
+        encoding="utf-8",
+    )
+    (run_dir / "result.json").write_text(
+        json.dumps({"include_batch": True, "totals": {"combined_elapsed_seconds": 42.0}}),
+        encoding="utf-8",
+    )
+    (run_dir / "day_summary.json").write_text(
+        json.dumps({"provider_metrics_present": True}),
+        encoding="utf-8",
+    )
+    (run_dir / "spans.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "event_type": "span",
+                        "phase": "pipeline_total",
+                        "duration_s": 20.0,
+                        "outcome": "success",
+                        "metadata": {"observer_overhead_s": 0.1},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "event_type": "span",
+                        "phase": "batch_enrichment_total",
+                        "duration_s": 10.0,
+                        "outcome": "failure",
+                        "metadata": {"observer_overhead_s": 0.1},
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    summary = mod.rank_bottlenecks(run_dir)
+
+    assert summary["elapsed_source"] == "raw_result_totals"
+    assert summary["confidence_reasons"] == [
+        "missing_corrected_total:batch_enrichment_total"
+    ]
+
+
+def test_rank_bottlenecks_rejects_corrected_total_without_success_outcome(tmp_path: Path):
+    run_dir = tmp_path / "profile_run_missing_outcome"
+    run_dir.mkdir()
+    (run_dir / "run_manifest.json").write_text(
+        json.dumps({"run_id": "profile_run_missing_outcome", "include_batch": False}),
+        encoding="utf-8",
+    )
+    (run_dir / "result.json").write_text(
+        json.dumps({"include_batch": False, "totals": {"combined_elapsed_seconds": 42.0}}),
+        encoding="utf-8",
+    )
+    (run_dir / "day_summary.json").write_text(
+        json.dumps({"provider_metrics_present": True}),
+        encoding="utf-8",
+    )
+    (run_dir / "spans.jsonl").write_text(
+        json.dumps({"event_type": "span", "phase": "pipeline_total", "duration_s": 20.0})
+        + "\n",
+        encoding="utf-8",
+    )
+
+    summary = mod.rank_bottlenecks(run_dir)
+
+    assert summary["elapsed_source"] == "raw_result_totals"
+    assert summary["confidence_reasons"] == ["missing_corrected_total:pipeline_total"]
+
+
+def test_rank_bottlenecks_rejects_legacy_total_without_observer_marker(tmp_path: Path):
+    run_dir = tmp_path / "profile_run_legacy_total"
+    run_dir.mkdir()
+    (run_dir / "run_manifest.json").write_text(
+        json.dumps({"run_id": "profile_run_legacy_total", "include_batch": False}),
+        encoding="utf-8",
+    )
+    (run_dir / "result.json").write_text(
+        json.dumps({"include_batch": False, "totals": {"combined_elapsed_seconds": 42.0}}),
+        encoding="utf-8",
+    )
+    (run_dir / "day_summary.json").write_text(
+        json.dumps({"provider_metrics_present": True}),
+        encoding="utf-8",
+    )
+    (run_dir / "spans.jsonl").write_text(
+        json.dumps(
+            {
+                "event_type": "span",
+                "phase": "pipeline_total",
+                "duration_s": 20.0,
+                "outcome": "success",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    summary = mod.rank_bottlenecks(run_dir)
+
+    assert summary["elapsed_source"] == "raw_result_totals"
+    assert summary["confidence_reasons"] == ["missing_corrected_total:pipeline_total"]
+
+
+def test_rank_bottlenecks_reduces_confidence_without_manifest_batch_authority(tmp_path: Path):
+    run_dir = tmp_path / "profile_run_missing_batch_authority"
+    run_dir.mkdir()
+    (run_dir / "run_manifest.json").write_text(
+        json.dumps({"run_id": "profile_run_missing_batch_authority"}),
+        encoding="utf-8",
+    )
+    (run_dir / "result.json").write_text(
+        json.dumps({"totals": {"combined_elapsed_seconds": 42.0}}),
+        encoding="utf-8",
+    )
+    (run_dir / "day_summary.json").write_text(
+        json.dumps({"provider_metrics_present": True}),
+        encoding="utf-8",
+    )
+    (run_dir / "spans.jsonl").write_text(
+        json.dumps(
+            {
+                "event_type": "span",
+                "phase": "pipeline_total",
+                "duration_s": 20.0,
+                "outcome": "success",
+                "metadata": {"observer_overhead_s": 0.1},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    summary = mod.rank_bottlenecks(run_dir)
+
+    assert summary["elapsed_source"] == "corrected_total_spans"
+    assert summary["confidence_reasons"] == ["include_batch_manifest_invalid"]
+
+
+def test_rank_bottlenecks_uses_manifest_batch_requirement_on_result_conflict(tmp_path: Path):
+    run_dir = tmp_path / "profile_run_batch_conflict"
+    run_dir.mkdir()
+    (run_dir / "run_manifest.json").write_text(
+        json.dumps({"run_id": "profile_run_batch_conflict", "include_batch": True}),
+        encoding="utf-8",
+    )
+    (run_dir / "result.json").write_text(
+        json.dumps({"include_batch": False, "totals": {"combined_elapsed_seconds": 42.0}}),
+        encoding="utf-8",
+    )
+    (run_dir / "day_summary.json").write_text(
+        json.dumps({"provider_metrics_present": True}),
+        encoding="utf-8",
+    )
+    (run_dir / "spans.jsonl").write_text(
+        json.dumps(
+            {
+                "event_type": "span",
+                "phase": "pipeline_total",
+                "duration_s": 20.0,
+                "outcome": "success",
+                "metadata": {"observer_overhead_s": 0.1},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    summary = mod.rank_bottlenecks(run_dir)
+
+    assert summary["elapsed_source"] == "raw_result_totals"
+    assert summary["confidence_reasons"] == [
+        "include_batch_mismatch",
+        "missing_corrected_total:batch_enrichment_total",
+    ]
+
+
+def test_rank_bottlenecks_prefers_complete_corrected_spans_over_raw_result_totals(tmp_path: Path):
+    run_dir = tmp_path / "profile_run_corrected"
+    run_dir.mkdir()
+    (run_dir / "run_manifest.json").write_text(
+        json.dumps({"run_id": "profile_run_corrected", "include_batch": True}),
+        encoding="utf-8",
+    )
+    (run_dir / "result.json").write_text(
+        json.dumps({"include_batch": True, "totals": {"combined_elapsed_seconds": 100.0}}),
+        encoding="utf-8",
+    )
+    (run_dir / "day_summary.json").write_text(
+        json.dumps({"provider_metrics_present": True}), encoding="utf-8"
+    )
+    (run_dir / "spans.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps({"event_type": "span", "phase": "pipeline_total", "duration_s": 20.0, "outcome": "success", "metadata": {"observer_overhead_s": 0.1}}),
+                json.dumps(
+                    {"event_type": "span", "phase": "batch_enrichment_total", "duration_s": 10.0, "outcome": "success", "metadata": {"observer_overhead_s": 0.1}}
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    summary = mod.rank_bottlenecks(run_dir)
+
+    assert summary["elapsed_seconds"] == 30.0
+    assert summary["elapsed_source"] == "corrected_total_spans"
+    assert summary["confidence"] == "ok"
+
+
+def test_rank_bottlenecks_preserves_provider_and_partial_total_confidence_reasons(tmp_path: Path):
+    run_dir = tmp_path / "profile_run_partial"
+    run_dir.mkdir()
+    (run_dir / "run_manifest.json").write_text(
+        json.dumps({"run_id": "profile_run_partial", "include_batch": True}),
+        encoding="utf-8",
+    )
+    (run_dir / "result.json").write_text(
+        json.dumps({"include_batch": True, "totals": {"combined_elapsed_seconds": 42.0}}),
+        encoding="utf-8",
+    )
+    (run_dir / "day_summary.json").write_text(
+        json.dumps(
+            {
+                "provider_metrics_present": False,
+                "provider_metrics_reason": "worker_metrics_missing",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (run_dir / "spans.jsonl").write_text(
+        json.dumps({"event_type": "span", "phase": "pipeline_total", "duration_s": 20.0, "outcome": "success", "metadata": {"observer_overhead_s": 0.1}}) + "\n",
+        encoding="utf-8",
+    )
+
+    summary = mod.rank_bottlenecks(run_dir)
+
+    assert summary["elapsed_seconds"] == 42.0
+    assert summary["elapsed_source"] == "raw_result_totals"
+    assert summary["confidence_reasons"] == [
+        "worker_metrics_missing",
+        "missing_corrected_total:batch_enrichment_total",
+    ]
+    assert summary["confidence"] == (
+        "reduced-confidence:worker_metrics_missing+missing_corrected_total:batch_enrichment_total"
+    )
+
+
 def _write_compare_fixture(run_dir: Path, *, elapsed_seconds: float = 9.473, summarize_duration: float = 3.601, selected: int = 12, confidence_provider: bool = True):
     (run_dir / "run_manifest.json").write_text(
-        json.dumps({"run_id": run_dir.name, "mode": "baseline", "catalog_count": 30, "baseline_valid": True}),
+        json.dumps({"run_id": run_dir.name, "mode": "baseline", "catalog_count": 30, "baseline_valid": True, "include_batch": False}),
         encoding="utf-8",
     )
     (run_dir / "result.json").write_text(
@@ -297,6 +606,15 @@ def _write_compare_fixture(run_dir: Path, *, elapsed_seconds: float = 9.473, sum
     (run_dir / "spans.jsonl").write_text(
         "\n".join(
             [
+                json.dumps(
+                    {
+                        "event_type": "span",
+                        "phase": "pipeline_total",
+                        "duration_s": elapsed_seconds,
+                        "outcome": "success",
+                        "metadata": {"observer_overhead_s": 0.1},
+                    }
+                ),
                 json.dumps({"event_type": "span", "phase": "summarize", "duration_s": summarize_duration, "component": "pipeline"}),
                 json.dumps({"event_type": "span", "phase": "entity_backfill", "duration_s": 1.576, "component": "pipeline-batch"}),
                 json.dumps({"event_type": "span", "phase": "people_linking", "duration_s": 0.987, "component": "pipeline-batch"}),

--- a/tests/test_pipeline_profile_spans.py
+++ b/tests/test_pipeline_profile_spans.py
@@ -23,6 +23,36 @@ def test_profile_span_writes_jsonl_event(monkeypatch, tmp_path: Path):
     assert rows[0]["event_type"] == "span"
 
 
+def test_phase_eligibility_writes_normalized_catalog_ids(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv(profiling.PROFILE_RUN_ID_ENV, "profile_run")
+    monkeypatch.setenv(profiling.PROFILE_MODE_ENV, "baseline")
+    monkeypatch.setenv(profiling.PROFILE_ARTIFACT_DIR_ENV, str(tmp_path))
+    monkeypatch.setenv(profiling.PROFILE_BASELINE_VALID_ENV, "0")
+
+    profiling.append_phase_eligibility(
+        phase="summarize",
+        boundary="before",
+        subject="catalog",
+        eligible_ids=[13, 11, 13, 12],
+    )
+
+    rows = [json.loads(line) for line in (tmp_path / "spans.jsonl").read_text(encoding="utf-8").splitlines()]
+    assert rows == [
+        {
+            "baseline_valid": False,
+            "boundary": "before",
+            "eligible_count": 3,
+            "eligible_ids": [11, 12, 13],
+            "event_type": "phase_eligibility",
+            "mode": "baseline",
+            "phase": "summarize",
+            "run_id": "profile_run",
+            "subject": "catalog",
+            "timestamp": rows[0]["timestamp"],
+        }
+    ]
+
+
 def test_selected_catalog_ids_accept_comments_and_duplicates(monkeypatch, tmp_path: Path):
     manifest_path = tmp_path / "selected_catalogs.txt"
     manifest_path.write_text("11\n12 # retained\n11\n", encoding="utf-8")

--- a/tests/test_pipeline_profile_spans.py
+++ b/tests/test_pipeline_profile_spans.py
@@ -23,6 +23,56 @@ def test_profile_span_writes_jsonl_event(monkeypatch, tmp_path: Path):
     assert rows[0]["event_type"] == "span"
 
 
+def test_profile_span_excludes_nested_observer_work(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv(profiling.PROFILE_RUN_ID_ENV, "profile_run")
+    monkeypatch.setenv(profiling.PROFILE_ARTIFACT_DIR_ENV, str(tmp_path))
+    clock = [0.0]
+    monkeypatch.setattr(profiling.time, "perf_counter", lambda: clock[0])
+
+    with profiling.profile_span(phase="pipeline_total", component="pipeline"):
+        clock[0] += 2.0
+        with profiling.profile_observer():
+            clock[0] += 3.0
+        clock[0] += 5.0
+
+    row = json.loads((tmp_path / "spans.jsonl").read_text(encoding="utf-8"))
+    assert row["duration_s"] == 7.0
+    assert row["metadata"]["observer_overhead_s"] == 3.0
+
+
+def test_workload_duration_excludes_observer_work(monkeypatch):
+    clock = [0.0]
+    monkeypatch.setattr(profiling.time, "perf_counter", lambda: clock[0])
+    started_perf = profiling.time.perf_counter()
+    observer_at_start = profiling.observer_seconds()
+
+    clock[0] += 2.0
+    with profiling.profile_observer():
+        clock[0] += 3.0
+    clock[0] += 5.0
+
+    assert profiling.workload_duration_seconds(started_perf, observer_at_start) == 7.0
+
+
+def test_failed_span_excludes_observer_work(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv(profiling.PROFILE_RUN_ID_ENV, "profile_run")
+    monkeypatch.setenv(profiling.PROFILE_ARTIFACT_DIR_ENV, str(tmp_path))
+    clock = [0.0]
+    monkeypatch.setattr(profiling.time, "perf_counter", lambda: clock[0])
+
+    with pytest.raises(RuntimeError, match="profiled work failed"):
+        with profiling.profile_span(phase="pipeline_total", component="pipeline"):
+            clock[0] += 4.0
+            with profiling.profile_observer():
+                clock[0] += 3.0
+            raise RuntimeError("profiled work failed")
+
+    recorded_span = json.loads((tmp_path / "spans.jsonl").read_text(encoding="utf-8"))
+    assert recorded_span["outcome"] == "failure"
+    assert recorded_span["duration_s"] == 4.0
+    assert recorded_span["metadata"]["observer_overhead_s"] == 3.0
+
+
 def test_phase_eligibility_writes_normalized_catalog_ids(monkeypatch, tmp_path: Path):
     monkeypatch.setenv(profiling.PROFILE_RUN_ID_ENV, "profile_run")
     monkeypatch.setenv(profiling.PROFILE_MODE_ENV, "baseline")

--- a/tests/test_run_pipeline_orchestration.py
+++ b/tests/test_run_pipeline_orchestration.py
@@ -1,3 +1,5 @@
+import json
+from pathlib import Path
 import sys
 from unittest.mock import MagicMock
 
@@ -9,7 +11,45 @@ from sqlalchemy.exc import SQLAlchemyError
 
 from pipeline import run_pipeline
 from pipeline import run_batch_enrichment
+from pipeline import profiling
 from pipeline.models import Base, Catalog, Document, Event, Place, UrlStage, UrlStageHist
+
+
+class _ImmediateFuture:
+    def __init__(self, *, failure: RuntimeError | None = None) -> None:
+        self.failure = failure
+
+    def result(self) -> int:
+        if self.failure is not None:
+            raise self.failure
+        return 1
+
+
+class _ImmediateExecutor:
+    failure: RuntimeError | None = None
+
+    def __init__(self, *, max_workers: int) -> None:
+        self.max_workers = max_workers
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, _exc_type, _exc, _traceback) -> bool:
+        return False
+
+    def submit(self, _func, _chunk, _ocr_fallback_enabled):
+        return _ImmediateFuture(failure=self.failure)
+
+
+def _eligibility_rows(artifact_dir: Path) -> list[dict[str, object]]:
+    return [
+        row
+        for row in (
+            json.loads(line)
+            for line in (artifact_dir / "spans.jsonl").read_text(encoding="utf-8").splitlines()
+        )
+        if row["event_type"] == "phase_eligibility"
+    ]
 
 
 def test_run_pipeline_facade_exports_patch_sensitive_public_names():
@@ -102,6 +142,97 @@ def test_run_parallel_processing_uses_facade_patched_executor_and_worker(mocker)
         ("workers", 2),
         ("submit", worker, [1, 2], run_pipeline.TIKA_OCR_FALLBACK_ENABLED),
     ]
+
+
+def test_parallel_processing_records_before_and_after_eligibility(monkeypatch, mocker, tmp_path: Path):
+    monkeypatch.setenv(profiling.PROFILE_RUN_ID_ENV, "profile_run")
+    monkeypatch.setenv(profiling.PROFILE_ARTIFACT_DIR_ENV, str(tmp_path))
+    mock_session = MagicMock()
+    mock_session.__enter__.return_value = mock_session
+    mock_session.__exit__.return_value = False
+    mocker.patch("pipeline.db_session.db_session", return_value=mock_session)
+    selector = mocker.patch(
+        "pipeline.run_pipeline.select_catalog_ids_for_processing",
+        side_effect=[[1, 2], [2]],
+    )
+    mocker.patch("pipeline.run_pipeline.ProcessPoolExecutor", _ImmediateExecutor)
+    mocker.patch("pipeline.run_pipeline.as_completed", side_effect=lambda futures: list(futures))
+    mocker.patch("pipeline.run_pipeline.cpu_count", return_value=1)
+
+    run_pipeline.run_parallel_processing()
+
+    rows = _eligibility_rows(tmp_path)
+    assert [(row["boundary"], row["eligible_ids"]) for row in rows] == [
+        ("before", [1, 2]),
+        ("after", [2]),
+    ]
+    assert selector.call_count == 2
+
+
+def test_parallel_processing_records_paired_empty_eligibility(monkeypatch, mocker, tmp_path: Path):
+    monkeypatch.setenv(profiling.PROFILE_RUN_ID_ENV, "profile_run")
+    monkeypatch.setenv(profiling.PROFILE_ARTIFACT_DIR_ENV, str(tmp_path))
+    mock_session = MagicMock()
+    mock_session.__enter__.return_value = mock_session
+    mock_session.__exit__.return_value = False
+    mocker.patch("pipeline.db_session.db_session", return_value=mock_session)
+    selector = mocker.patch("pipeline.run_pipeline.select_catalog_ids_for_processing", return_value=[])
+
+    run_pipeline.run_parallel_processing()
+
+    rows = _eligibility_rows(tmp_path)
+    assert [(row["boundary"], row["eligible_ids"]) for row in rows] == [
+        ("before", []),
+        ("after", []),
+    ]
+    selector.assert_called_once()
+
+
+def test_parallel_processing_omits_after_eligibility_when_work_fails(monkeypatch, mocker, tmp_path: Path):
+    monkeypatch.setenv(profiling.PROFILE_RUN_ID_ENV, "profile_run")
+    monkeypatch.setenv(profiling.PROFILE_ARTIFACT_DIR_ENV, str(tmp_path))
+    mock_session = MagicMock()
+    mock_session.__enter__.return_value = mock_session
+    mock_session.__exit__.return_value = False
+    mocker.patch("pipeline.db_session.db_session", return_value=mock_session)
+    selector = mocker.patch("pipeline.run_pipeline.select_catalog_ids_for_processing", return_value=[1])
+    _ImmediateExecutor.failure = RuntimeError("extraction failed")
+    mocker.patch("pipeline.run_pipeline.ProcessPoolExecutor", _ImmediateExecutor)
+    mocker.patch("pipeline.run_pipeline.as_completed", side_effect=lambda futures: list(futures))
+    mocker.patch("pipeline.run_pipeline.cpu_count", return_value=1)
+
+    try:
+        with pytest.raises(RuntimeError, match="extraction failed"):
+            run_pipeline.run_parallel_processing()
+    finally:
+        _ImmediateExecutor.failure = None
+
+    rows = _eligibility_rows(tmp_path)
+    assert [row["boundary"] for row in rows if row["event_type"] == "phase_eligibility"] == ["before"]
+    selector.assert_called_once()
+
+
+def test_parallel_processing_propagates_after_selector_failure(monkeypatch, mocker, tmp_path: Path):
+    monkeypatch.setenv(profiling.PROFILE_RUN_ID_ENV, "profile_run")
+    monkeypatch.setenv(profiling.PROFILE_ARTIFACT_DIR_ENV, str(tmp_path))
+    mock_session = MagicMock()
+    mock_session.__enter__.return_value = mock_session
+    mock_session.__exit__.return_value = False
+    mocker.patch("pipeline.db_session.db_session", return_value=mock_session)
+    selector = mocker.patch(
+        "pipeline.run_pipeline.select_catalog_ids_for_processing",
+        side_effect=[[1], RuntimeError("selector failed")],
+    )
+    mocker.patch("pipeline.run_pipeline.ProcessPoolExecutor", _ImmediateExecutor)
+    mocker.patch("pipeline.run_pipeline.as_completed", side_effect=lambda futures: list(futures))
+    mocker.patch("pipeline.run_pipeline.cpu_count", return_value=1)
+
+    with pytest.raises(RuntimeError, match="selector failed"):
+        run_pipeline.run_parallel_processing()
+
+    rows = _eligibility_rows(tmp_path)
+    assert [row["boundary"] for row in rows if row["event_type"] == "phase_eligibility"] == ["before"]
+    assert selector.call_count == 2
 
 
 def test_main_runs_steps_in_expected_order(mocker):
@@ -225,8 +356,14 @@ def test_run_batch_enrichment_runs_heavy_steps_in_expected_order(mocker):
         "pipeline.run_batch_enrichment.run_entity_backfill",
         return_value={"selected": 1, "complete": 1, "updated_catalog_ids": [10]},
     )
-    mocker.patch("pipeline.run_batch_enrichment.select_catalog_ids_for_table_extraction", return_value=[1])
-    mocker.patch("pipeline.run_batch_enrichment.select_catalog_ids_for_topic_hydration", return_value=[2, 3])
+    table_selector = mocker.patch(
+        "pipeline.run_batch_enrichment.select_catalog_ids_for_table_extraction",
+        return_value=[1],
+    )
+    topic_selector = mocker.patch(
+        "pipeline.run_batch_enrichment.select_catalog_ids_for_topic_hydration",
+        return_value=[2, 3],
+    )
     org_spy = mocker.patch(
         "pipeline.run_batch_enrichment.run_organization_backfill",
         return_value={"selected": 1, "linked": 1, "reindexed": 1, "failed_reindex": 0},
@@ -246,6 +383,8 @@ def test_run_batch_enrichment_runs_heavy_steps_in_expected_order(mocker):
     entity_spy.assert_called_once_with()
     org_spy.assert_called_once_with()
     topic_backfill_spy.assert_called_once_with(catalog_ids=[2, 3])
+    table_selector.assert_called_once()
+    topic_selector.assert_called_once()
 
 
 def test_run_batch_callable_step_records_failure_context_before_exit(
@@ -286,8 +425,14 @@ def test_run_batch_enrichment_skips_noop_topic_and_table_steps(mocker):
         "pipeline.run_batch_enrichment.run_entity_backfill",
         return_value={"selected": 0, "complete": 0, "updated_catalog_ids": []},
     )
-    mocker.patch("pipeline.run_batch_enrichment.select_catalog_ids_for_table_extraction", return_value=[])
-    mocker.patch("pipeline.run_batch_enrichment.select_catalog_ids_for_topic_hydration", return_value=[])
+    table_selector = mocker.patch(
+        "pipeline.run_batch_enrichment.select_catalog_ids_for_table_extraction",
+        return_value=[],
+    )
+    topic_selector = mocker.patch(
+        "pipeline.run_batch_enrichment.select_catalog_ids_for_topic_hydration",
+        return_value=[],
+    )
     org_spy = mocker.patch(
         "pipeline.run_batch_enrichment.run_organization_backfill",
         return_value={"selected": 0, "linked": 0, "reindexed": 0, "failed_reindex": 0},
@@ -304,6 +449,183 @@ def test_run_batch_enrichment_skips_noop_topic_and_table_steps(mocker):
     entity_spy.assert_called_once_with()
     org_spy.assert_called_once_with()
     topic_backfill_spy.assert_not_called()
+    table_selector.assert_called_once()
+    topic_selector.assert_called_once()
+
+
+def _patch_batch_non_target_steps(mocker) -> None:
+    mocker.patch(
+        "pipeline.run_batch_enrichment.run_callable_step",
+        side_effect=lambda _name, func, component="pipeline-batch": func(),
+    )
+    mocker.patch(
+        "pipeline.run_batch_enrichment.run_entity_backfill",
+        return_value={"selected": 0, "complete": 0, "updated_catalog_ids": []},
+    )
+    mocker.patch(
+        "pipeline.run_batch_enrichment.run_organization_backfill",
+        return_value={"selected": 0, "linked": 0, "reindexed": 0, "failed_reindex": 0},
+    )
+    mocker.patch("pipeline.run_batch_enrichment.db_session")
+
+
+def test_batch_enrichment_records_table_and_topic_eligibility(monkeypatch, mocker, tmp_path: Path):
+    monkeypatch.setenv(profiling.PROFILE_RUN_ID_ENV, "profile_run")
+    monkeypatch.setenv(profiling.PROFILE_ARTIFACT_DIR_ENV, str(tmp_path))
+    _patch_batch_non_target_steps(mocker)
+    mocker.patch("pipeline.run_batch_enrichment.run_step")
+    mocker.patch(
+        "pipeline.run_batch_enrichment.run_batch_callable_step",
+        side_effect=lambda _name, _phase, func: func(),
+    )
+    table_selector = mocker.patch(
+        "pipeline.run_batch_enrichment.select_catalog_ids_for_table_extraction",
+        side_effect=[[41], []],
+    )
+    topic_selector = mocker.patch(
+        "pipeline.run_batch_enrichment.select_catalog_ids_for_topic_hydration",
+        side_effect=[[51, 52], [52]],
+    )
+    mocker.patch(
+        "pipeline.run_batch_enrichment.run_topic_hydration_backfill",
+        return_value={"selected": 2, "complete": 2},
+    )
+
+    run_batch_enrichment.main()
+
+    rows = _eligibility_rows(tmp_path)
+    assert [(row["phase"], row["boundary"], row["eligible_ids"]) for row in rows] == [
+        ("table_extraction", "before", [41]),
+        ("table_extraction", "after", []),
+        ("topic_modeling", "before", [51, 52]),
+        ("topic_modeling", "after", [52]),
+    ]
+    assert table_selector.call_count == 2
+    assert topic_selector.call_count == 2
+
+
+def test_batch_enrichment_records_paired_empty_eligibility(monkeypatch, mocker, tmp_path: Path):
+    monkeypatch.setenv(profiling.PROFILE_RUN_ID_ENV, "profile_run")
+    monkeypatch.setenv(profiling.PROFILE_ARTIFACT_DIR_ENV, str(tmp_path))
+    _patch_batch_non_target_steps(mocker)
+    table_selector = mocker.patch(
+        "pipeline.run_batch_enrichment.select_catalog_ids_for_table_extraction",
+        return_value=[],
+    )
+    topic_selector = mocker.patch(
+        "pipeline.run_batch_enrichment.select_catalog_ids_for_topic_hydration",
+        return_value=[],
+    )
+
+    run_batch_enrichment.main()
+
+    rows = _eligibility_rows(tmp_path)
+    assert [(row["phase"], row["boundary"], row["eligible_ids"]) for row in rows] == [
+        ("table_extraction", "before", []),
+        ("table_extraction", "after", []),
+        ("topic_modeling", "before", []),
+        ("topic_modeling", "after", []),
+    ]
+    table_selector.assert_called_once()
+    topic_selector.assert_called_once()
+
+
+def test_table_eligibility_omits_after_when_work_fails(monkeypatch, mocker, tmp_path: Path):
+    monkeypatch.setenv(profiling.PROFILE_RUN_ID_ENV, "profile_run")
+    monkeypatch.setenv(profiling.PROFILE_ARTIFACT_DIR_ENV, str(tmp_path))
+    _patch_batch_non_target_steps(mocker)
+    table_selector = mocker.patch(
+        "pipeline.run_batch_enrichment.select_catalog_ids_for_table_extraction",
+        return_value=[41],
+    )
+    mocker.patch("pipeline.run_batch_enrichment.run_step", side_effect=RuntimeError("table failed"))
+
+    with pytest.raises(RuntimeError, match="table failed"):
+        run_batch_enrichment.main()
+
+    rows = _eligibility_rows(tmp_path)
+    assert [(row["phase"], row["boundary"]) for row in rows] == [("table_extraction", "before")]
+    table_selector.assert_called_once()
+
+
+def test_table_eligibility_propagates_after_selector_failure(monkeypatch, mocker, tmp_path: Path):
+    monkeypatch.setenv(profiling.PROFILE_RUN_ID_ENV, "profile_run")
+    monkeypatch.setenv(profiling.PROFILE_ARTIFACT_DIR_ENV, str(tmp_path))
+    _patch_batch_non_target_steps(mocker)
+    table_selector = mocker.patch(
+        "pipeline.run_batch_enrichment.select_catalog_ids_for_table_extraction",
+        side_effect=[[41], RuntimeError("table selector failed")],
+    )
+    mocker.patch("pipeline.run_batch_enrichment.run_step")
+
+    with pytest.raises(RuntimeError, match="table selector failed"):
+        run_batch_enrichment.main()
+
+    rows = _eligibility_rows(tmp_path)
+    assert [(row["phase"], row["boundary"]) for row in rows] == [("table_extraction", "before")]
+    assert table_selector.call_count == 2
+
+
+def test_topic_eligibility_omits_after_when_work_fails(monkeypatch, mocker, tmp_path: Path):
+    monkeypatch.setenv(profiling.PROFILE_RUN_ID_ENV, "profile_run")
+    monkeypatch.setenv(profiling.PROFILE_ARTIFACT_DIR_ENV, str(tmp_path))
+    _patch_batch_non_target_steps(mocker)
+    mocker.patch(
+        "pipeline.run_batch_enrichment.select_catalog_ids_for_table_extraction",
+        return_value=[],
+    )
+    topic_selector = mocker.patch(
+        "pipeline.run_batch_enrichment.select_catalog_ids_for_topic_hydration",
+        return_value=[51],
+    )
+    mocker.patch(
+        "pipeline.run_batch_enrichment.run_batch_callable_step",
+        side_effect=RuntimeError("topic failed"),
+    )
+
+    with pytest.raises(RuntimeError, match="topic failed"):
+        run_batch_enrichment.main()
+
+    rows = _eligibility_rows(tmp_path)
+    assert [
+        (row["phase"], row["boundary"])
+        for row in rows
+        if row["phase"] == "topic_modeling"
+    ] == [("topic_modeling", "before")]
+    topic_selector.assert_called_once()
+
+
+def test_topic_eligibility_propagates_after_selector_failure(monkeypatch, mocker, tmp_path: Path):
+    monkeypatch.setenv(profiling.PROFILE_RUN_ID_ENV, "profile_run")
+    monkeypatch.setenv(profiling.PROFILE_ARTIFACT_DIR_ENV, str(tmp_path))
+    _patch_batch_non_target_steps(mocker)
+    mocker.patch(
+        "pipeline.run_batch_enrichment.select_catalog_ids_for_table_extraction",
+        return_value=[],
+    )
+    topic_selector = mocker.patch(
+        "pipeline.run_batch_enrichment.select_catalog_ids_for_topic_hydration",
+        side_effect=[[51], RuntimeError("topic selector failed")],
+    )
+    mocker.patch(
+        "pipeline.run_batch_enrichment.run_batch_callable_step",
+        side_effect=lambda _name, _phase, func: func(),
+    )
+    mocker.patch(
+        "pipeline.run_batch_enrichment.run_topic_hydration_backfill",
+        return_value={"selected": 1, "complete": 1},
+    )
+
+    with pytest.raises(RuntimeError, match="topic selector failed"):
+        run_batch_enrichment.main()
+
+    rows = _eligibility_rows(tmp_path)
+    assert [
+        (row["phase"], row["boundary"])
+        for row in rows
+        if row["phase"] == "topic_modeling"
+    ] == [("topic_modeling", "before")]
+    assert topic_selector.call_count == 2
 
 
 def test_run_batch_enrichment_help_exits_before_work(mocker):

--- a/tests/test_run_pipeline_orchestration.py
+++ b/tests/test_run_pipeline_orchestration.py
@@ -13,6 +13,7 @@ from pipeline import run_pipeline
 from pipeline import run_batch_enrichment
 from pipeline import profiling
 from pipeline.models import Base, Catalog, Document, Event, Place, UrlStage, UrlStageHist
+from pipeline import run_pipeline_steps
 
 
 class _ImmediateFuture:
@@ -85,6 +86,27 @@ def test_run_step_exits_on_subprocess_failure(mocker):
     mocker.patch("subprocess.run", side_effect=run_pipeline.subprocess.CalledProcessError(1, ["cmd"]))
     with pytest.raises(SystemExit):
         run_pipeline.run_step("bad", ["cmd"])
+
+
+def test_callable_step_excludes_metric_emission_from_profile_span(
+    monkeypatch,
+    tmp_path: Path,
+):
+    monkeypatch.setenv(profiling.PROFILE_RUN_ID_ENV, "profile_run")
+    monkeypatch.setenv(profiling.PROFILE_ARTIFACT_DIR_ENV, str(tmp_path))
+
+    step_status = run_pipeline_steps.run_callable_step(
+        "Summary Hydration",
+        lambda: "complete",
+        logger=run_pipeline.logger,
+    )
+
+    recorded_span = next(
+        row for row in _profile_rows(tmp_path) if row["event_type"] == "span"
+    )
+    assert step_status == "complete"
+    assert recorded_span["outcome"] == "success"
+    assert recorded_span["metadata"]["observer_overhead_s"] > 0.0
 
 
 def test_process_document_chunk_returns_zero_when_db_unavailable(mocker):

--- a/tests/test_run_pipeline_orchestration.py
+++ b/tests/test_run_pipeline_orchestration.py
@@ -52,6 +52,13 @@ def _eligibility_rows(artifact_dir: Path) -> list[dict[str, object]]:
     ]
 
 
+def _profile_rows(artifact_dir: Path) -> list[dict[str, object]]:
+    return [
+        json.loads(line)
+        for line in (artifact_dir / "spans.jsonl").read_text(encoding="utf-8").splitlines()
+    ]
+
+
 def test_run_pipeline_facade_exports_patch_sensitive_public_names():
     expected_names = (
         "main",
@@ -241,12 +248,20 @@ def test_main_runs_steps_in_expected_order(mocker):
     calls = []
     mocker.patch("pipeline.run_pipeline.run_parallel_processing", side_effect=lambda: calls.append("parallel"))
     agenda_spy = mocker.patch(
-        "pipeline.agenda_worker.run_agenda_segmentation_backfill",
+        "pipeline.agenda_worker.run_agenda_segmentation_workload",
         side_effect=lambda **kwargs: calls.append("agenda"),
     )
+    mocker.patch(
+        "pipeline.agenda_worker.capture_agenda_segmentation_after_eligibility",
+        side_effect=lambda _counts, **kwargs: calls.append("agenda-after"),
+    )
     summary_spy = mocker.patch(
-        "pipeline.summary_backfill_runner.run_summary_hydration_backfill",
+        "pipeline.summary_backfill_runner.run_summary_hydration_workload",
         side_effect=lambda **kwargs: calls.append("summary"),
+    )
+    mocker.patch(
+        "pipeline.summary_backfill_runner.capture_summary_hydration_after_eligibility",
+        side_effect=lambda _counts, **kwargs: calls.append("summary-after"),
     )
 
     def fake_run_step(name, command):
@@ -267,8 +282,10 @@ def test_main_runs_steps_in_expected_order(mocker):
     assert calls[4] == "parallel"
     assert calls[5] == ("Agenda Segmentation", "pipeline")
     assert calls[6] == "agenda"
-    assert calls[7] == ("Summary Hydration", "pipeline")
-    assert calls[8] == "summary"
+    assert calls[7] == "agenda-after"
+    assert calls[8] == ("Summary Hydration", "pipeline")
+    assert calls[9] == "summary"
+    assert calls[10] == "summary-after"
     agenda_spy.assert_called_once_with(
         segment_mode="maintenance",
         agenda_timeout_seconds=run_pipeline.AGENDA_SEGMENT_MAINTENANCE_TIMEOUT_SECONDS,
@@ -282,17 +299,95 @@ def test_main_runs_steps_in_expected_order(mocker):
     assert ("Topic Modeling", ("python", "topic_worker.py")) not in calls
 
 
+def test_generation_backfill_records_after_eligibility_outside_phase_spans(
+    monkeypatch,
+    mocker,
+    tmp_path: Path,
+):
+    monkeypatch.setenv(profiling.PROFILE_RUN_ID_ENV, "profile_run")
+    monkeypatch.setenv(profiling.PROFILE_ARTIFACT_DIR_ENV, str(tmp_path))
+
+    def _empty_workload(phase: str) -> dict[str, int]:
+        profiling.append_phase_eligibility(
+            phase=phase,
+            boundary="before",
+            subject="catalog",
+            eligible_ids=[],
+        )
+        return {"selected": 0}
+
+    mocker.patch(
+        "pipeline.agenda_worker.run_agenda_segmentation_workload",
+        side_effect=lambda **_kwargs: _empty_workload("segment_agenda"),
+    )
+    mocker.patch(
+        "pipeline.summary_backfill_runner.run_summary_hydration_workload",
+        side_effect=lambda **_kwargs: _empty_workload("summarize"),
+    )
+
+    run_pipeline._run_generation_backfill_steps()
+
+    rows = _profile_rows(tmp_path)
+    for phase in ("segment_agenda", "summarize"):
+        assert [
+            (row["event_type"], row.get("boundary"))
+            for row in rows
+            if row.get("phase") == phase
+        ] == [
+            ("phase_eligibility", "before"),
+            ("span", None),
+            ("phase_eligibility", "after"),
+        ]
+
+
+def test_generation_backfill_failure_omits_after_eligibility(
+    monkeypatch,
+    mocker,
+    tmp_path: Path,
+):
+    monkeypatch.setenv(profiling.PROFILE_RUN_ID_ENV, "profile_run")
+    monkeypatch.setenv(profiling.PROFILE_ARTIFACT_DIR_ENV, str(tmp_path))
+
+    def _fail_agenda_workload(**_kwargs) -> dict[str, int]:
+        profiling.append_phase_eligibility(
+            phase="segment_agenda",
+            boundary="before",
+            subject="catalog",
+            eligible_ids=[1],
+        )
+        raise RuntimeError("agenda failed")
+
+    mocker.patch(
+        "pipeline.agenda_worker.run_agenda_segmentation_workload",
+        side_effect=_fail_agenda_workload,
+    )
+
+    with pytest.raises(SystemExit):
+        run_pipeline._run_generation_backfill_steps()
+
+    rows = _profile_rows(tmp_path)
+    assert [
+        (row["event_type"], row.get("boundary"))
+        for row in rows
+        if row.get("phase") == "segment_agenda"
+    ] == [
+        ("phase_eligibility", "before"),
+    ]
+
+
 def test_main_skips_non_gating_steps_in_onboarding_fast_profile(mocker):
     calls = []
     mocker.patch("pipeline.run_pipeline.run_parallel_processing", side_effect=lambda: calls.append("parallel"))
     agenda_spy = mocker.patch(
-        "pipeline.agenda_worker.run_agenda_segmentation_backfill",
+        "pipeline.agenda_worker.run_agenda_segmentation_workload",
         side_effect=lambda **kwargs: calls.append("agenda"),
     )
+    agenda_after_spy = mocker.patch("pipeline.agenda_worker.capture_agenda_segmentation_after_eligibility")
     summary_spy = mocker.patch(
-        "pipeline.summary_backfill_runner.run_summary_hydration_backfill",
+        "pipeline.summary_backfill_runner.run_summary_hydration_workload",
         side_effect=lambda **kwargs: calls.append("summary"),
     )
+    summary_after_spy = mocker.patch("pipeline.summary_backfill_runner.capture_summary_hydration_after_eligibility")
 
     def fake_run_step(name, command):
         calls.append((name, tuple(command)))
@@ -310,7 +405,9 @@ def test_main_skips_non_gating_steps_in_onboarding_fast_profile(mocker):
     assert ("Agenda Segmentation", "pipeline") not in calls
     assert ("Summary Hydration", "pipeline") not in calls
     agenda_spy.assert_not_called()
+    agenda_after_spy.assert_not_called()
     summary_spy.assert_not_called()
+    summary_after_spy.assert_not_called()
     assert ("Search Indexing", ("python", "indexer.py")) not in calls
     assert ("Table Extraction", ("python", "table_worker.py")) not in calls
     assert ("Backfill Organizations", ("python", "backfill_orgs.py")) not in calls
@@ -355,8 +452,12 @@ def test_run_batch_enrichment_runs_heavy_steps_in_expected_order(mocker):
     )
     mocker.patch("pipeline.run_batch_enrichment.db_session")
     entity_spy = mocker.patch(
-        "pipeline.run_batch_enrichment.run_entity_backfill",
+        "pipeline.run_batch_enrichment.run_entity_backfill_workload",
         return_value={"selected": 1, "complete": 1, "updated_catalog_ids": [10]},
+    )
+    mocker.patch(
+        "pipeline.run_batch_enrichment.capture_entity_backfill_after_eligibility",
+        side_effect=lambda _counts: calls.append("entity-after"),
     )
     mocker.patch(
         "pipeline.run_batch_enrichment.select_catalog_ids_for_table_extraction",
@@ -372,12 +473,21 @@ def test_run_batch_enrichment_runs_heavy_steps_in_expected_order(mocker):
     )
     topic_backfill_spy = mocker.patch(
         "pipeline.run_batch_enrichment.run_topic_hydration_backfill",
-        return_value={"selected": 2, "complete": 2, "cached": 0, "stale": 0, "blocked_low_signal": 0, "error": 0, "other": 0},
+        return_value={
+            "selected": 2,
+            "complete": 2,
+            "cached": 0,
+            "stale": 0,
+            "blocked_low_signal": 0,
+            "error": 0,
+            "other": 0,
+        },
     )
     run_batch_enrichment.main()
 
     assert calls == [
         ("Entity Backfill", "pipeline-batch"),
+        "entity-after",
         ("Table Extraction", ("python", "table_worker.py")),
         ("Backfill Organizations", "pipeline-batch"),
         ("Topic Modeling", "topic_modeling"),
@@ -385,6 +495,55 @@ def test_run_batch_enrichment_runs_heavy_steps_in_expected_order(mocker):
     entity_spy.assert_called_once_with()
     org_spy.assert_called_once_with()
     topic_backfill_spy.assert_called_once_with(catalog_ids=[2, 3])
+
+
+def test_batch_entity_after_eligibility_is_outside_phase_span(
+    monkeypatch,
+    mocker,
+    tmp_path: Path,
+):
+    monkeypatch.setenv(profiling.PROFILE_RUN_ID_ENV, "profile_run")
+    monkeypatch.setenv(profiling.PROFILE_ARTIFACT_DIR_ENV, str(tmp_path))
+
+    def _empty_entity_workload() -> dict[str, int]:
+        profiling.append_phase_eligibility(
+            phase="entity_backfill",
+            boundary="before",
+            subject="catalog",
+            eligible_ids=[],
+        )
+        return {"selected": 0}
+
+    mocker.patch(
+        "pipeline.run_batch_enrichment.run_entity_backfill_workload",
+        side_effect=_empty_entity_workload,
+    )
+    mocker.patch(
+        "pipeline.run_batch_enrichment.run_organization_backfill",
+        return_value={"selected": 0, "linked": 0, "reindexed": 0, "failed_reindex": 0},
+    )
+    mocker.patch("pipeline.run_batch_enrichment.db_session")
+    mocker.patch(
+        "pipeline.run_batch_enrichment.select_catalog_ids_for_table_extraction",
+        return_value=[],
+    )
+    mocker.patch(
+        "pipeline.run_batch_enrichment.select_catalog_ids_for_topic_hydration",
+        return_value=[],
+    )
+
+    run_batch_enrichment.main([])
+
+    rows = _profile_rows(tmp_path)
+    assert [
+        (row["event_type"], row.get("boundary"))
+        for row in rows
+        if row.get("phase") == "entity_backfill"
+    ] == [
+        ("phase_eligibility", "before"),
+        ("span", None),
+        ("phase_eligibility", "after"),
+    ]
 
 
 def test_run_batch_callable_step_records_failure_context_before_exit(
@@ -422,9 +581,10 @@ def test_run_batch_enrichment_skips_noop_topic_and_table_steps(mocker):
     )
     mocker.patch("pipeline.run_batch_enrichment.db_session")
     entity_spy = mocker.patch(
-        "pipeline.run_batch_enrichment.run_entity_backfill",
+        "pipeline.run_batch_enrichment.run_entity_backfill_workload",
         return_value={"selected": 0, "complete": 0, "updated_catalog_ids": []},
     )
+    mocker.patch("pipeline.run_batch_enrichment.capture_entity_backfill_after_eligibility")
     mocker.patch(
         "pipeline.run_batch_enrichment.select_catalog_ids_for_table_extraction",
         side_effect=[[]],
@@ -457,9 +617,10 @@ def _patch_batch_non_target_steps(mocker) -> None:
         side_effect=lambda _name, func, component="pipeline-batch": func(),
     )
     mocker.patch(
-        "pipeline.run_batch_enrichment.run_entity_backfill",
+        "pipeline.run_batch_enrichment.run_entity_backfill_workload",
         return_value={"selected": 0, "complete": 0, "updated_catalog_ids": []},
     )
+    mocker.patch("pipeline.run_batch_enrichment.capture_entity_backfill_after_eligibility")
     mocker.patch(
         "pipeline.run_batch_enrichment.run_organization_backfill",
         return_value={"selected": 0, "linked": 0, "reindexed": 0, "failed_reindex": 0},

--- a/tests/test_run_pipeline_orchestration.py
+++ b/tests/test_run_pipeline_orchestration.py
@@ -151,7 +151,7 @@ def test_parallel_processing_records_before_and_after_eligibility(monkeypatch, m
     mock_session.__enter__.return_value = mock_session
     mock_session.__exit__.return_value = False
     mocker.patch("pipeline.db_session.db_session", return_value=mock_session)
-    selector = mocker.patch(
+    mocker.patch(
         "pipeline.run_pipeline.select_catalog_ids_for_processing",
         side_effect=[[1, 2], [2]],
     )
@@ -166,7 +166,6 @@ def test_parallel_processing_records_before_and_after_eligibility(monkeypatch, m
         ("before", [1, 2]),
         ("after", [2]),
     ]
-    assert selector.call_count == 2
 
 
 def test_parallel_processing_records_paired_empty_eligibility(monkeypatch, mocker, tmp_path: Path):
@@ -176,7 +175,10 @@ def test_parallel_processing_records_paired_empty_eligibility(monkeypatch, mocke
     mock_session.__enter__.return_value = mock_session
     mock_session.__exit__.return_value = False
     mocker.patch("pipeline.db_session.db_session", return_value=mock_session)
-    selector = mocker.patch("pipeline.run_pipeline.select_catalog_ids_for_processing", return_value=[])
+    mocker.patch(
+        "pipeline.run_pipeline.select_catalog_ids_for_processing",
+        side_effect=[[]],
+    )
 
     run_pipeline.run_parallel_processing()
 
@@ -185,7 +187,6 @@ def test_parallel_processing_records_paired_empty_eligibility(monkeypatch, mocke
         ("before", []),
         ("after", []),
     ]
-    selector.assert_called_once()
 
 
 def test_parallel_processing_omits_after_eligibility_when_work_fails(monkeypatch, mocker, tmp_path: Path):
@@ -195,7 +196,10 @@ def test_parallel_processing_omits_after_eligibility_when_work_fails(monkeypatch
     mock_session.__enter__.return_value = mock_session
     mock_session.__exit__.return_value = False
     mocker.patch("pipeline.db_session.db_session", return_value=mock_session)
-    selector = mocker.patch("pipeline.run_pipeline.select_catalog_ids_for_processing", return_value=[1])
+    mocker.patch(
+        "pipeline.run_pipeline.select_catalog_ids_for_processing",
+        side_effect=[[1]],
+    )
     _ImmediateExecutor.failure = RuntimeError("extraction failed")
     mocker.patch("pipeline.run_pipeline.ProcessPoolExecutor", _ImmediateExecutor)
     mocker.patch("pipeline.run_pipeline.as_completed", side_effect=lambda futures: list(futures))
@@ -209,7 +213,6 @@ def test_parallel_processing_omits_after_eligibility_when_work_fails(monkeypatch
 
     rows = _eligibility_rows(tmp_path)
     assert [row["boundary"] for row in rows if row["event_type"] == "phase_eligibility"] == ["before"]
-    selector.assert_called_once()
 
 
 def test_parallel_processing_propagates_after_selector_failure(monkeypatch, mocker, tmp_path: Path):
@@ -219,7 +222,7 @@ def test_parallel_processing_propagates_after_selector_failure(monkeypatch, mock
     mock_session.__enter__.return_value = mock_session
     mock_session.__exit__.return_value = False
     mocker.patch("pipeline.db_session.db_session", return_value=mock_session)
-    selector = mocker.patch(
+    mocker.patch(
         "pipeline.run_pipeline.select_catalog_ids_for_processing",
         side_effect=[[1], RuntimeError("selector failed")],
     )
@@ -232,7 +235,6 @@ def test_parallel_processing_propagates_after_selector_failure(monkeypatch, mock
 
     rows = _eligibility_rows(tmp_path)
     assert [row["boundary"] for row in rows if row["event_type"] == "phase_eligibility"] == ["before"]
-    assert selector.call_count == 2
 
 
 def test_main_runs_steps_in_expected_order(mocker):
@@ -356,13 +358,13 @@ def test_run_batch_enrichment_runs_heavy_steps_in_expected_order(mocker):
         "pipeline.run_batch_enrichment.run_entity_backfill",
         return_value={"selected": 1, "complete": 1, "updated_catalog_ids": [10]},
     )
-    table_selector = mocker.patch(
+    mocker.patch(
         "pipeline.run_batch_enrichment.select_catalog_ids_for_table_extraction",
-        return_value=[1],
+        side_effect=[[1]],
     )
-    topic_selector = mocker.patch(
+    mocker.patch(
         "pipeline.run_batch_enrichment.select_catalog_ids_for_topic_hydration",
-        return_value=[2, 3],
+        side_effect=[[2, 3]],
     )
     org_spy = mocker.patch(
         "pipeline.run_batch_enrichment.run_organization_backfill",
@@ -383,8 +385,6 @@ def test_run_batch_enrichment_runs_heavy_steps_in_expected_order(mocker):
     entity_spy.assert_called_once_with()
     org_spy.assert_called_once_with()
     topic_backfill_spy.assert_called_once_with(catalog_ids=[2, 3])
-    table_selector.assert_called_once()
-    topic_selector.assert_called_once()
 
 
 def test_run_batch_callable_step_records_failure_context_before_exit(
@@ -425,13 +425,13 @@ def test_run_batch_enrichment_skips_noop_topic_and_table_steps(mocker):
         "pipeline.run_batch_enrichment.run_entity_backfill",
         return_value={"selected": 0, "complete": 0, "updated_catalog_ids": []},
     )
-    table_selector = mocker.patch(
+    mocker.patch(
         "pipeline.run_batch_enrichment.select_catalog_ids_for_table_extraction",
-        return_value=[],
+        side_effect=[[]],
     )
-    topic_selector = mocker.patch(
+    mocker.patch(
         "pipeline.run_batch_enrichment.select_catalog_ids_for_topic_hydration",
-        return_value=[],
+        side_effect=[[]],
     )
     org_spy = mocker.patch(
         "pipeline.run_batch_enrichment.run_organization_backfill",
@@ -449,8 +449,6 @@ def test_run_batch_enrichment_skips_noop_topic_and_table_steps(mocker):
     entity_spy.assert_called_once_with()
     org_spy.assert_called_once_with()
     topic_backfill_spy.assert_not_called()
-    table_selector.assert_called_once()
-    topic_selector.assert_called_once()
 
 
 def _patch_batch_non_target_steps(mocker) -> None:
@@ -478,11 +476,11 @@ def test_batch_enrichment_records_table_and_topic_eligibility(monkeypatch, mocke
         "pipeline.run_batch_enrichment.run_batch_callable_step",
         side_effect=lambda _name, _phase, func: func(),
     )
-    table_selector = mocker.patch(
+    mocker.patch(
         "pipeline.run_batch_enrichment.select_catalog_ids_for_table_extraction",
         side_effect=[[41], []],
     )
-    topic_selector = mocker.patch(
+    mocker.patch(
         "pipeline.run_batch_enrichment.select_catalog_ids_for_topic_hydration",
         side_effect=[[51, 52], [52]],
     )
@@ -500,21 +498,19 @@ def test_batch_enrichment_records_table_and_topic_eligibility(monkeypatch, mocke
         ("topic_modeling", "before", [51, 52]),
         ("topic_modeling", "after", [52]),
     ]
-    assert table_selector.call_count == 2
-    assert topic_selector.call_count == 2
 
 
 def test_batch_enrichment_records_paired_empty_eligibility(monkeypatch, mocker, tmp_path: Path):
     monkeypatch.setenv(profiling.PROFILE_RUN_ID_ENV, "profile_run")
     monkeypatch.setenv(profiling.PROFILE_ARTIFACT_DIR_ENV, str(tmp_path))
     _patch_batch_non_target_steps(mocker)
-    table_selector = mocker.patch(
+    mocker.patch(
         "pipeline.run_batch_enrichment.select_catalog_ids_for_table_extraction",
-        return_value=[],
+        side_effect=[[]],
     )
-    topic_selector = mocker.patch(
+    mocker.patch(
         "pipeline.run_batch_enrichment.select_catalog_ids_for_topic_hydration",
-        return_value=[],
+        side_effect=[[]],
     )
 
     run_batch_enrichment.main()
@@ -526,17 +522,15 @@ def test_batch_enrichment_records_paired_empty_eligibility(monkeypatch, mocker, 
         ("topic_modeling", "before", []),
         ("topic_modeling", "after", []),
     ]
-    table_selector.assert_called_once()
-    topic_selector.assert_called_once()
 
 
 def test_table_eligibility_omits_after_when_work_fails(monkeypatch, mocker, tmp_path: Path):
     monkeypatch.setenv(profiling.PROFILE_RUN_ID_ENV, "profile_run")
     monkeypatch.setenv(profiling.PROFILE_ARTIFACT_DIR_ENV, str(tmp_path))
     _patch_batch_non_target_steps(mocker)
-    table_selector = mocker.patch(
+    mocker.patch(
         "pipeline.run_batch_enrichment.select_catalog_ids_for_table_extraction",
-        return_value=[41],
+        side_effect=[[41]],
     )
     mocker.patch("pipeline.run_batch_enrichment.run_step", side_effect=RuntimeError("table failed"))
 
@@ -545,14 +539,13 @@ def test_table_eligibility_omits_after_when_work_fails(monkeypatch, mocker, tmp_
 
     rows = _eligibility_rows(tmp_path)
     assert [(row["phase"], row["boundary"]) for row in rows] == [("table_extraction", "before")]
-    table_selector.assert_called_once()
 
 
 def test_table_eligibility_propagates_after_selector_failure(monkeypatch, mocker, tmp_path: Path):
     monkeypatch.setenv(profiling.PROFILE_RUN_ID_ENV, "profile_run")
     monkeypatch.setenv(profiling.PROFILE_ARTIFACT_DIR_ENV, str(tmp_path))
     _patch_batch_non_target_steps(mocker)
-    table_selector = mocker.patch(
+    mocker.patch(
         "pipeline.run_batch_enrichment.select_catalog_ids_for_table_extraction",
         side_effect=[[41], RuntimeError("table selector failed")],
     )
@@ -563,7 +556,6 @@ def test_table_eligibility_propagates_after_selector_failure(monkeypatch, mocker
 
     rows = _eligibility_rows(tmp_path)
     assert [(row["phase"], row["boundary"]) for row in rows] == [("table_extraction", "before")]
-    assert table_selector.call_count == 2
 
 
 def test_topic_eligibility_omits_after_when_work_fails(monkeypatch, mocker, tmp_path: Path):
@@ -574,9 +566,9 @@ def test_topic_eligibility_omits_after_when_work_fails(monkeypatch, mocker, tmp_
         "pipeline.run_batch_enrichment.select_catalog_ids_for_table_extraction",
         return_value=[],
     )
-    topic_selector = mocker.patch(
+    mocker.patch(
         "pipeline.run_batch_enrichment.select_catalog_ids_for_topic_hydration",
-        return_value=[51],
+        side_effect=[[51]],
     )
     mocker.patch(
         "pipeline.run_batch_enrichment.run_batch_callable_step",
@@ -592,7 +584,6 @@ def test_topic_eligibility_omits_after_when_work_fails(monkeypatch, mocker, tmp_
         for row in rows
         if row["phase"] == "topic_modeling"
     ] == [("topic_modeling", "before")]
-    topic_selector.assert_called_once()
 
 
 def test_topic_eligibility_propagates_after_selector_failure(monkeypatch, mocker, tmp_path: Path):
@@ -603,7 +594,7 @@ def test_topic_eligibility_propagates_after_selector_failure(monkeypatch, mocker
         "pipeline.run_batch_enrichment.select_catalog_ids_for_table_extraction",
         return_value=[],
     )
-    topic_selector = mocker.patch(
+    mocker.patch(
         "pipeline.run_batch_enrichment.select_catalog_ids_for_topic_hydration",
         side_effect=[[51], RuntimeError("topic selector failed")],
     )
@@ -625,7 +616,6 @@ def test_topic_eligibility_propagates_after_selector_failure(monkeypatch, mocker
         for row in rows
         if row["phase"] == "topic_modeling"
     ] == [("topic_modeling", "before")]
-    assert topic_selector.call_count == 2
 
 
 def test_run_batch_enrichment_help_exits_before_work(mocker):


### PR DESCRIPTION
## What changed

- record before-and-after eligible catalog IDs for extraction, agenda segmentation, summary hydration, entity backfill, table extraction, and topic modeling
- emit paired empty evidence for successful zero-work phases
- exclude eligibility events from bottleneck occurrence counts, components, and durations
- document how operators should interpret missing and paired evidence

## Why

The baseline-v2 diagnostic needs durable evidence showing whether each synchronous backlog phase reduced its eligible workload. Existing timing spans could show how long a phase ran, but not the eligible catalog set before and after it.

## Risk and compatibility

- normal non-profiled runs do not perform the post-phase eligibility query
- phase or post-selector failures propagate and do not emit an `after` row
- no runtime defaults, baseline-validity rules, schemas, task signatures, or APIs change

## Verification

- PASS: `.venv/bin/ruff check .`
- PASS: `.venv/bin/ruff format --config ruff-format.toml --check .`
- PASS: `.venv/bin/mypy`
- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_pipeline_profile_spans.py tests/test_pipeline_profile_report.py tests/test_agenda_worker.py tests/test_run_pipeline_orchestration.py tests/test_pipeline_batching.py` (`98 passed`)
- PASS: `PYTHONPATH=. .venv/bin/pytest -q tests/test_docs_links.py` (`2 passed`)
- PASS: `PYTHONPATH=. .venv/bin/pytest -q` (`1866 passed, 21 skipped`)
- PASS: `git diff --check`
- APPROVE: independent pre-commit review after two P2 test gaps were fixed

## Remaining deficits

- organization eligibility evidence is intentionally separate
- task execution and dispatch evidence require separate Celery-aligned changes
- this PR collects evidence only and does not restore `baseline_valid=true`
