### PR TITLE
Record each profiled task execution

### DIFF
--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1566,8 +1566,10 @@ Artifacts:
   - workload identity, profile env, baseline-valid flag, and pre-run provider counters
 - `experiments/results/profiling/<run_id>/spans.jsonl`
   - append-only orchestrator and task timing spans
+  - `task_start` rows mark worker-attempt starts; an unmatched start lowers
+    confidence because the attempt did not produce a terminal timing row
   - task spans include the Celery `task_id`, a per-attempt `execution_id`, the
-    `retry_ordinal`, and optional broker `redelivered` metadata
+    optional `retry_ordinal`, and optional broker `redelivered` metadata
 - `experiments/results/profiling/<run_id>/summary.json`
   - ranked bottleneck summary
 - `experiments/results/profiling/<run_id>/top_bottlenecks.md`
@@ -1587,6 +1589,9 @@ Interpretation rules:
 - queue wait and execution time are intentionally separated so backlog is not mistaken for slow model/runtime execution
 - interpret retry ordinal and broker redelivery independently: one task
   attempt may be retried, redelivered, both, or neither
+- treat an unknown retry ordinal as reduced-confidence task evidence
+- queue wait is recorded only for a known initial, non-redelivered attempt;
+  inherited timestamps on retries and redeliveries are not treated as queue time
 - `baseline-valid` requires a pinned manifest and stable workload conditions; `triage` is diagnostic only
 - profiling artifacts are observational and should not be used as a source of business truth
 - `result.json` is the primary contract for elapsed-time totals; if totals are incomplete or derived from fallback spans, the analyzer should mark the run `reduced-confidence`

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,6 +1,6 @@
 # Operations Runbook
 
-Last updated: 2026-08-11
+Last updated: 2026-08-12
 
 ## Core workflow
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1566,6 +1566,8 @@ Artifacts:
   - workload identity, profile env, baseline-valid flag, and pre-run provider counters
 - `experiments/results/profiling/<run_id>/spans.jsonl`
   - append-only orchestrator and task timing spans
+  - task spans include the Celery `task_id`, a per-attempt `execution_id`, the
+    `retry_ordinal`, and optional broker `redelivered` metadata
 - `experiments/results/profiling/<run_id>/summary.json`
   - ranked bottleneck summary
 - `experiments/results/profiling/<run_id>/top_bottlenecks.md`
@@ -1583,6 +1585,8 @@ What is measured:
 Interpretation rules:
 - treat missing queue timestamps or missing provider telemetry as reduced confidence, not as zero cost
 - queue wait and execution time are intentionally separated so backlog is not mistaken for slow model/runtime execution
+- interpret retry ordinal and broker redelivery independently: one task
+  attempt may be retried, redelivered, both, or neither
 - `baseline-valid` requires a pinned manifest and stable workload conditions; `triage` is diagnostic only
 - profiling artifacts are observational and should not be used as a source of business truth
 - `result.json` is the primary contract for elapsed-time totals; if totals are incomplete or derived from fallback spans, the analyzer should mark the run `reduced-confidence`

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -122,15 +122,20 @@ about workload state. Post-phase selection runs after the measured callable
 closes, and the bottleneck analyzer excludes eligibility rows from occurrence
 counts, components, and duration totals.
 
-Celery `task_span` rows identify both the logical task and the worker attempt:
+Celery `task_start` and `task_span` rows identify both the logical task and the
+worker attempt:
 
 - `task_id` correlates attempts for the same Celery task;
 - `execution_id` is unique to each worker attempt;
-- `retry_ordinal` records Celery's retry count for that attempt;
+- `retry_ordinal` records Celery's retry count when valid metadata is available;
 - `redelivered` records broker redelivery when that metadata is available.
 
 Retry and redelivery are independent observations. Neither field changes the
-task outcome, run validity, or promotion status.
+task outcome, run validity, or promotion status. Queue wait is omitted for
+retries and redeliveries when their message only carries an inherited publish
+timestamp. An unmatched `task_start` row marks an unfinished attempt and
+reduces report confidence. An unknown retry ordinal also reduces confidence
+rather than being reported as an initial attempt.
 
 Confidence model:
 - `baseline-valid`

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1,6 +1,6 @@
 # Performance
 
-Last updated: 2026-08-11
+Last updated: 2026-08-12
 
 This page describes how to interpret and reproduce performance evidence for local Docker runs.
 For operational troubleshooting and sorting diagnostics, use `docs/OPERATIONS.md`.

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -122,6 +122,16 @@ about workload state. Post-phase selection runs after the measured callable
 closes, and the bottleneck analyzer excludes eligibility rows from occurrence
 counts, components, and duration totals.
 
+Celery `task_span` rows identify both the logical task and the worker attempt:
+
+- `task_id` correlates attempts for the same Celery task;
+- `execution_id` is unique to each worker attempt;
+- `retry_ordinal` records Celery's retry count for that attempt;
+- `redelivered` records broker redelivery when that metadata is available.
+
+Retry and redelivery are independent observations. Neither field changes the
+task outcome, run validity, or promotion status.
+
 Confidence model:
 - `baseline-valid`
   - pinned manifest

--- a/pipeline/metrics.py
+++ b/pipeline/metrics.py
@@ -10,7 +10,12 @@ from prometheus_client import REGISTRY, start_http_server
 
 from pipeline import metrics_celery_signals, metrics_provider_recorders, profiling
 from pipeline.metrics_definitions import *  # noqa: F403 - compatibility facade for metric objects
-from pipeline.metrics_profile_events import TaskProfileContext, component_for_queue, write_task_profile_event
+from pipeline.metrics_profile_events import (
+    TaskProfileContext,
+    component_for_queue,
+    write_task_profile_event,
+    write_task_start_profile_event,
+)
 from pipeline.metrics_provider_keys import provider_base_labels_key, provider_labels_key
 from pipeline.metrics_redis_backend import RedisProviderMetricsCollector
 from pipeline.metrics_task_recorders import (
@@ -131,7 +136,7 @@ def _before_task_publish(headers: dict[str, object] | None = None, **_kwargs: ob
 
 @signals.task_prerun.connect
 def _task_prerun(task_id: object = None, task: object = None, **_kwargs: object) -> None:
-    metrics_celery_signals.task_prerun(
+    context = metrics_celery_signals.task_prerun(
         task_id=task_id,
         task=task,
         task_start=_TASK_START,
@@ -139,6 +144,8 @@ def _task_prerun(task_id: object = None, task: object = None, **_kwargs: object)
         time_module=time,
         record_queue_wait=record_task_queue_wait,
     )
+    if context is not None:
+        write_task_start_profile_event(context, profiling_module=profiling)
 
 
 @signals.task_postrun.connect

--- a/pipeline/metrics_celery_signals.py
+++ b/pipeline/metrics_celery_signals.py
@@ -43,9 +43,9 @@ def task_prerun(
     task_context: MutableMapping[str, TaskProfileContext],
     time_module: ModuleType,
     record_queue_wait: RecordQueueWait,
-) -> None:
+) -> TaskProfileContext | None:
     if not task_id or task is None:
-        return
+        return None
     task_id_value = str(task_id)
     task_start[task_id_value] = time_module.perf_counter()
     request = getattr(task, "request", None)
@@ -53,13 +53,23 @@ def task_prerun(
     delivery = _delivery_info(request)
     task_name = str(getattr(task, "name", "unknown"))
     queue = str(delivery.get("routing_key") or delivery.get("queue") or "celery")
-    queue_wait_s = _record_queue_wait_from_headers(headers, task_name, queue, time_module, record_queue_wait)
-    task_context[task_id_value] = TaskProfileContext(
+    retry_ordinal = _retry_ordinal(request)
+    redelivered = _redelivered(delivery)
+    queue_wait_s = _queue_wait_for_attempt(
+        headers,
+        task_name,
+        queue,
+        retry_ordinal=retry_ordinal,
+        redelivered=redelivered,
+        time_module=time_module,
+        record_queue_wait=record_queue_wait,
+    )
+    context = TaskProfileContext(
         task_name=task_name,
         task_id=task_id_value,
         execution_id=str(uuid4()),
-        retry_ordinal=_retry_ordinal(request),
-        redelivered=_redelivered(delivery),
+        retry_ordinal=retry_ordinal,
+        redelivered=redelivered,
         queue=queue,
         queue_wait_s=queue_wait_s,
         queued_at=headers.get("tc_queued_at"),
@@ -69,6 +79,8 @@ def task_prerun(
         baseline_valid=_optional_str(headers.get("tc_profile_baseline_valid")),
         catalog_id=catalog_id_from_request(request),
     )
+    task_context[task_id_value] = context
+    return context
 
 
 def task_postrun(
@@ -171,16 +183,31 @@ def _delivery_info(request: object) -> Mapping[str, object]:
     return {}
 
 
-def _retry_ordinal(request: object) -> int:
-    retries = getattr(request, "retries", 0)
+def _retry_ordinal(request: object) -> int | None:
+    retries = getattr(request, "retries", None)
     if isinstance(retries, int) and not isinstance(retries, bool) and retries >= 0:
         return retries
-    return 0
+    return None
 
 
 def _redelivered(delivery_info: Mapping[str, object]) -> bool | None:
     redelivered = delivery_info.get("redelivered")
     return redelivered if isinstance(redelivered, bool) else None
+
+
+def _queue_wait_for_attempt(
+    headers: object,
+    task_name: str,
+    queue: str,
+    *,
+    retry_ordinal: int | None,
+    redelivered: bool | None,
+    time_module: ModuleType,
+    record_queue_wait: RecordQueueWait,
+) -> float | None:
+    if retry_ordinal != 0 or redelivered is not False:
+        return None
+    return _record_queue_wait_from_headers(headers, task_name, queue, time_module, record_queue_wait)
 
 
 def _record_task_span(

--- a/pipeline/metrics_celery_signals.py
+++ b/pipeline/metrics_celery_signals.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from collections.abc import Callable, MutableMapping
+from collections.abc import Callable, Mapping, MutableMapping
 from types import ModuleType
+from uuid import uuid4
 
 from pipeline.metrics_profile_events import TaskProfileContext, catalog_id_from_request, component_for_queue
 
@@ -49,12 +50,16 @@ def task_prerun(
     task_start[task_id_value] = time_module.perf_counter()
     request = getattr(task, "request", None)
     headers = getattr(request, "headers", None) or {}
-    delivery = getattr(request, "delivery_info", None) or {}
+    delivery = _delivery_info(request)
     task_name = str(getattr(task, "name", "unknown"))
     queue = str(delivery.get("routing_key") or delivery.get("queue") or "celery")
     queue_wait_s = _record_queue_wait_from_headers(headers, task_name, queue, time_module, record_queue_wait)
     task_context[task_id_value] = TaskProfileContext(
         task_name=task_name,
+        task_id=task_id_value,
+        execution_id=str(uuid4()),
+        retry_ordinal=_retry_ordinal(request),
+        redelivered=_redelivered(delivery),
         queue=queue,
         queue_wait_s=queue_wait_s,
         queued_at=headers.get("tc_queued_at"),
@@ -157,6 +162,25 @@ def _record_queue_wait_from_headers(
     queue_wait_s = max(0.0, time_module.time() - queued_at)
     record_queue_wait(task_name, queue, queue_wait_s)
     return queue_wait_s
+
+
+def _delivery_info(request: object) -> Mapping[str, object]:
+    delivery_info = getattr(request, "delivery_info", None)
+    if isinstance(delivery_info, Mapping):
+        return delivery_info
+    return {}
+
+
+def _retry_ordinal(request: object) -> int:
+    retries = getattr(request, "retries", 0)
+    if isinstance(retries, int) and not isinstance(retries, bool) and retries >= 0:
+        return retries
+    return 0
+
+
+def _redelivered(delivery_info: Mapping[str, object]) -> bool | None:
+    redelivered = delivery_info.get("redelivered")
+    return redelivered if isinstance(redelivered, bool) else None
 
 
 def _record_task_span(

--- a/pipeline/metrics_profile_events.py
+++ b/pipeline/metrics_profile_events.py
@@ -8,6 +8,10 @@ from types import ModuleType
 @dataclass(slots=True)
 class TaskProfileContext:
     task_name: str
+    task_id: str
+    execution_id: str
+    retry_ordinal: int
+    redelivered: bool | None
     queue: str
     queue_wait_s: float | None
     queued_at: object
@@ -68,6 +72,10 @@ def write_task_profile_event(
                 "component": component_for_queue(context.queue),
                 "catalog_id": context.catalog_id,
                 "task_name": task_name,
+                "task_id": context.task_id,
+                "execution_id": context.execution_id,
+                "retry_ordinal": context.retry_ordinal,
+                "redelivered": context.redelivered,
                 "queue": context.queue,
                 "queued_at": context.queued_at,
                 "queue_wait_s": context.queue_wait_s,

--- a/pipeline/metrics_profile_events.py
+++ b/pipeline/metrics_profile_events.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass
+from pathlib import Path
 from types import ModuleType
 
 
@@ -10,7 +10,7 @@ class TaskProfileContext:
     task_name: str
     task_id: str
     execution_id: str
-    retry_ordinal: int
+    retry_ordinal: int | None
     redelivered: bool | None
     queue: str
     queue_wait_s: float | None
@@ -50,43 +50,67 @@ def write_task_profile_event(
     profiling_module: ModuleType,
     exception_type: str | None = None,
 ) -> None:
-    run_id = str(context.run_id or "").strip()
-    artifact_dir = str(context.artifact_dir or "").strip()
-    if not run_id or not artifact_dir:
+    profile_event = _task_profile_event(context, task_name, profiling_module)
+    if profile_event is None:
         return
-    previous = {
-        profiling_module.PROFILE_RUN_ID_ENV: os.getenv(profiling_module.PROFILE_RUN_ID_ENV),
-        profiling_module.PROFILE_MODE_ENV: os.getenv(profiling_module.PROFILE_MODE_ENV),
-        profiling_module.PROFILE_ARTIFACT_DIR_ENV: os.getenv(profiling_module.PROFILE_ARTIFACT_DIR_ENV),
-        profiling_module.PROFILE_BASELINE_VALID_ENV: os.getenv(profiling_module.PROFILE_BASELINE_VALID_ENV),
+    profile_event.update(
+        {
+            "event_type": "task_span",
+            "duration_s": round(float(duration_s), 6),
+            "outcome": status,
+            "metadata": {"exception_type": exception_type} if exception_type else None,
+        }
+    )
+    _append_task_profile_event(context, profile_event, profiling_module)
+
+
+def write_task_start_profile_event(
+    context: TaskProfileContext,
+    *,
+    profiling_module: ModuleType,
+) -> None:
+    profile_event = _task_profile_event(context, context.task_name, profiling_module)
+    if profile_event is None:
+        return
+    profile_event["event_type"] = "task_start"
+    _append_task_profile_event(context, profile_event, profiling_module)
+
+
+def _task_profile_event(
+    context: TaskProfileContext,
+    task_name: str,
+    profiling_module: ModuleType,
+) -> dict[str, object] | None:
+    if not str(context.run_id or "").strip() or not str(context.artifact_dir or "").strip():
+        return None
+    return {
+        "phase": profiling_module.phase_from_task_name(task_name),
+        "component": component_for_queue(context.queue),
+        "catalog_id": context.catalog_id,
+        "task_name": task_name,
+        "task_id": context.task_id,
+        "execution_id": context.execution_id,
+        "retry_ordinal": context.retry_ordinal,
+        "redelivered": context.redelivered,
+        "queue": context.queue,
+        "queued_at": context.queued_at,
+        "queue_wait_s": context.queue_wait_s,
     }
-    try:
-        os.environ[profiling_module.PROFILE_RUN_ID_ENV] = run_id
-        os.environ[profiling_module.PROFILE_MODE_ENV] = str(context.mode or "triage")
-        os.environ[profiling_module.PROFILE_ARTIFACT_DIR_ENV] = artifact_dir
-        os.environ[profiling_module.PROFILE_BASELINE_VALID_ENV] = str(context.baseline_valid or "0")
-        profiling_module.append_profile_event(
-            {
-                "event_type": "task_span",
-                "phase": profiling_module.phase_from_task_name(task_name),
-                "component": component_for_queue(context.queue),
-                "catalog_id": context.catalog_id,
-                "task_name": task_name,
-                "task_id": context.task_id,
-                "execution_id": context.execution_id,
-                "retry_ordinal": context.retry_ordinal,
-                "redelivered": context.redelivered,
-                "queue": context.queue,
-                "queued_at": context.queued_at,
-                "queue_wait_s": context.queue_wait_s,
-                "duration_s": round(float(duration_s), 6),
-                "outcome": status,
-                "metadata": {"exception_type": exception_type} if exception_type else None,
-            }
-        )
-    finally:
-        for key, value in previous.items():
-            if value is None:
-                os.environ.pop(key, None)
-            else:
-                os.environ[key] = value
+
+
+def _append_task_profile_event(
+    context: TaskProfileContext,
+    profile_event: dict[str, object],
+    profiling_module: ModuleType,
+) -> None:
+    artifact_dir = Path(str(context.artifact_dir))
+    profiling_module.append_jsonl(
+        artifact_dir / "spans.jsonl",
+        {
+            "run_id": str(context.run_id),
+            "mode": str(context.mode or "triage"),
+            "baseline_valid": str(context.baseline_valid or "0").lower() in {"1", "true", "yes"},
+            "timestamp": profiling_module.utc_now_iso(),
+            **profile_event,
+        },
+    )

--- a/scripts/pipeline_profile_analysis.py
+++ b/scripts/pipeline_profile_analysis.py
@@ -174,6 +174,34 @@ def _aggregate_phase_rows(spans: list[dict[str, Any]]) -> dict[str, dict[str, An
     return totals
 
 
+def _unfinished_task_attempts(spans: list[dict[str, Any]]) -> set[str]:
+    started_attempts = {
+        str(row.get("execution_id"))
+        for row in spans
+        if row.get("event_type") == "task_start" and row.get("execution_id")
+    }
+    finished_attempts = {
+        str(row.get("execution_id"))
+        for row in spans
+        if row.get("event_type") == "task_span" and row.get("execution_id")
+    }
+    return started_attempts - finished_attempts
+
+
+def _task_evidence_confidence_reasons(spans: list[dict[str, Any]]) -> list[str]:
+    confidence_reasons: list[str] = []
+    if _unfinished_task_attempts(spans):
+        confidence_reasons.append("unfinished_task_attempt")
+    if any(
+        row.get("event_type") in {"task_start", "task_span"}
+        and "retry_ordinal" in row
+        and row.get("retry_ordinal") is None
+        for row in spans
+    ):
+        confidence_reasons.append("unknown_task_retry_ordinal")
+    return confidence_reasons
+
+
 def _total_span_duration(spans: list[dict[str, Any]], phase: str) -> float:
     return next(
         (
@@ -291,6 +319,7 @@ def rank_bottlenecks(run_dir: Path) -> dict[str, Any]:
         confidence_reasons.append("no_spans")
     if not provider_metrics_present:
         confidence_reasons.append(provider_metrics_reason)
+    confidence_reasons.extend(_task_evidence_confidence_reasons(spans))
     confidence_reasons.extend(include_batch_confidence_reasons)
     confidence_reasons.extend(total_confidence_reasons)
     if total_elapsed_s > 0 and ranked and float(cast(Any, ranked[0].get("contribution_pct")) or 0.0) > 100.0:

--- a/tests/test_pipeline_profile_report.py
+++ b/tests/test_pipeline_profile_report.py
@@ -41,6 +41,107 @@ def test_rank_bottlenecks_prefers_longest_leaf_phase(tmp_path: Path):
     assert summary["top_bottlenecks"][0]["classification"] in {"queueing", "inference/provider"}
 
 
+def test_rank_bottlenecks_reduces_confidence_for_unfinished_task_attempt(tmp_path: Path):
+    run_dir = tmp_path / "profile_run"
+    run_dir.mkdir()
+    (run_dir / "run_manifest.json").write_text(
+        json.dumps({"run_id": "profile_run", "mode": "baseline", "include_batch": False}),
+        encoding="utf-8",
+    )
+    (run_dir / "result.json").write_text(
+        json.dumps({"include_batch": False, "totals": {"combined_elapsed_seconds": 4.0}}),
+        encoding="utf-8",
+    )
+    (run_dir / "day_summary.json").write_text(
+        json.dumps({"provider_metrics_present": True}),
+        encoding="utf-8",
+    )
+    (run_dir / "spans.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "event_type": "span",
+                        "phase": "pipeline_total",
+                        "duration_s": 4.0,
+                        "outcome": "success",
+                        "metadata": {"observer_overhead_s": 0.1},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "event_type": "task_start",
+                        "phase": "summarize",
+                        "execution_id": "unfinished-attempt",
+                        "retry_ordinal": 0,
+                    }
+                ),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    summary = mod.rank_bottlenecks(run_dir)
+
+    assert summary["confidence_reasons"] == ["unfinished_task_attempt"]
+    assert summary["confidence"] == "reduced-confidence:unfinished_task_attempt"
+
+
+def test_rank_bottlenecks_reduces_confidence_for_unknown_retry_ordinal(tmp_path: Path):
+    run_dir = tmp_path / "profile_run"
+    run_dir.mkdir()
+    (run_dir / "run_manifest.json").write_text(
+        json.dumps({"run_id": "profile_run", "mode": "baseline", "include_batch": False}),
+        encoding="utf-8",
+    )
+    (run_dir / "result.json").write_text(
+        json.dumps({"include_batch": False, "totals": {"combined_elapsed_seconds": 4.0}}),
+        encoding="utf-8",
+    )
+    (run_dir / "day_summary.json").write_text(
+        json.dumps({"provider_metrics_present": True}),
+        encoding="utf-8",
+    )
+    (run_dir / "spans.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "event_type": "span",
+                        "phase": "pipeline_total",
+                        "duration_s": 4.0,
+                        "outcome": "success",
+                        "metadata": {"observer_overhead_s": 0.1},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "event_type": "task_start",
+                        "phase": "summarize",
+                        "execution_id": "completed-attempt",
+                        "retry_ordinal": None,
+                    }
+                ),
+                json.dumps(
+                    {
+                        "event_type": "task_span",
+                        "phase": "summarize",
+                        "execution_id": "completed-attempt",
+                        "retry_ordinal": None,
+                        "duration_s": 1.0,
+                    }
+                ),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    summary = mod.rank_bottlenecks(run_dir)
+
+    assert summary["confidence_reasons"] == ["unknown_task_retry_ordinal"]
+    assert summary["confidence"] == "reduced-confidence:unknown_task_retry_ordinal"
+
+
 def test_rank_bottlenecks_ignores_phase_eligibility_events(tmp_path: Path):
     run_dir = tmp_path / "profile_run"
     run_dir.mkdir()

--- a/tests/test_task_metrics.py
+++ b/tests/test_task_metrics.py
@@ -60,6 +60,10 @@ def test_task_failure_clears_timing_context(monkeypatch):
     metrics._TASK_START[task_id] = 5.0
     metrics._TASK_CONTEXT[task_id] = metrics.TaskProfileContext(
         task_name="pipeline.tasks.generate_summary_task",
+        task_id=task_id,
+        execution_id="00000000-0000-0000-0000-000000000001",
+        retry_ordinal=0,
+        redelivered=None,
         queue="celery",
         queue_wait_s=None,
         queued_at=None,

--- a/tests/test_task_queue_wait_metrics.py
+++ b/tests/test_task_queue_wait_metrics.py
@@ -1,4 +1,5 @@
 import json
+from uuid import UUID
 
 from prometheus_client import generate_latest
 
@@ -13,6 +14,13 @@ class _FakeTask:
         headers = {}
         delivery_info = {"routing_key": "celery"}
         args = (123,)
+
+
+def _task_spans(artifact_dir):
+    profile_events = [
+        json.loads(line) for line in (artifact_dir / "spans.jsonl").read_text(encoding="utf-8").splitlines()
+    ]
+    return [profile_event for profile_event in profile_events if profile_event["event_type"] == "task_span"]
 
 
 def test_queue_wait_metric_and_task_context_are_recorded(monkeypatch, tmp_path):
@@ -71,3 +79,87 @@ def test_diagnostic_validity_propagates_from_publish_header_to_task_span(monkeyp
     assert headers["tc_profile_baseline_valid"] == "0"
     assert task_spans[-1]["event_type"] == "task_span"
     assert task_spans[-1]["baseline_valid"] is False
+
+
+def test_task_spans_distinguish_retry_and_redelivery_attempts(monkeypatch, tmp_path):
+    artifact_dir = tmp_path / "profile"
+    monkeypatch.setenv(profiling.PROFILE_RUN_ID_ENV, "task_attempt_run")
+    monkeypatch.setenv(profiling.PROFILE_MODE_ENV, "baseline")
+    monkeypatch.setenv(profiling.PROFILE_ARTIFACT_DIR_ENV, str(artifact_dir))
+    monkeypatch.setenv(profiling.PROFILE_BASELINE_VALID_ENV, "0")
+    monkeypatch.setattr(metrics.time, "time", lambda: 1.0)
+
+    headers: dict[str, object] = {}
+    metrics._before_task_publish(headers=headers)
+    _FakeTask.request.headers = headers
+
+    attempt_contexts = [(0, False), (0, True), (1, False), (1, True)]
+    for attempt_index, (retry_ordinal, redelivered) in enumerate(attempt_contexts):
+        _FakeTask.request.retries = retry_ordinal
+        _FakeTask.request.delivery_info = {"routing_key": "celery", "redelivered": redelivered}
+        attempt_started = float(attempt_index * 2 + 2)
+        monkeypatch.setattr(metrics.time, "perf_counter", lambda value=attempt_started: value)
+        metrics._task_prerun(task_id="shared-task-id", task=_FakeTask())
+        monkeypatch.setattr(metrics.time, "perf_counter", lambda value=attempt_started + 1.0: value)
+        metrics._task_postrun(task_id="shared-task-id", task=_FakeTask(), state="SUCCESS")
+
+    task_spans = _task_spans(artifact_dir)
+    assert [task_span["task_id"] for task_span in task_spans] == ["shared-task-id"] * len(attempt_contexts)
+    assert [
+        (task_span["retry_ordinal"], task_span["redelivered"]) for task_span in task_spans
+    ] == attempt_contexts
+    execution_ids = [task_span["execution_id"] for task_span in task_spans]
+    assert all(str(UUID(execution_id)) == execution_id for execution_id in execution_ids)
+    assert len(set(execution_ids)) == len(attempt_contexts)
+
+
+def test_task_span_uses_safe_defaults_for_invalid_optional_delivery_metadata(monkeypatch, tmp_path):
+    artifact_dir = tmp_path / "profile"
+    _FakeTask.request.headers = {
+        "tc_profile_run_id": "invalid_metadata_run",
+        "tc_profile_mode": "triage",
+        "tc_profile_artifact_dir": str(artifact_dir),
+        "tc_profile_baseline_valid": "0",
+    }
+    _FakeTask.request.retries = -1
+    _FakeTask.request.delivery_info = {"routing_key": "celery"}
+    monkeypatch.setattr(metrics.time, "perf_counter", lambda: 10.0)
+
+    metrics._task_prerun(task_id="invalid-metadata-task", task=_FakeTask())
+    monkeypatch.setattr(metrics.time, "perf_counter", lambda: 11.0)
+    metrics._task_postrun(task_id="invalid-metadata-task", task=_FakeTask(), state="SUCCESS")
+
+    task_span = _task_spans(artifact_dir)[0]
+    assert task_span["retry_ordinal"] == 0
+    assert task_span["redelivered"] is None
+
+
+def test_failed_task_span_keeps_attempt_identity_without_postrun_duplicate(monkeypatch, tmp_path):
+    artifact_dir = tmp_path / "profile"
+    _FakeTask.request.headers = {
+        "tc_profile_run_id": "failed_task_run",
+        "tc_profile_mode": "triage",
+        "tc_profile_artifact_dir": str(artifact_dir),
+        "tc_profile_baseline_valid": "0",
+    }
+    _FakeTask.request.retries = 2
+    _FakeTask.request.delivery_info = {"routing_key": "celery", "redelivered": False}
+    monkeypatch.setattr(metrics.time, "perf_counter", lambda: 20.0)
+
+    metrics._task_prerun(task_id="failed-task-id", task=_FakeTask())
+    monkeypatch.setattr(metrics.time, "perf_counter", lambda: 21.0)
+    metrics._task_failure(
+        task_id="failed-task-id",
+        exception=RuntimeError("boom"),
+        sender=_FakeTask(),
+    )
+    metrics._task_postrun(task_id="failed-task-id", task=_FakeTask(), state="FAILURE")
+
+    task_spans = _task_spans(artifact_dir)
+    assert len(task_spans) == 1
+    assert task_spans[0]["task_id"] == "failed-task-id"
+    assert str(UUID(task_spans[0]["execution_id"])) == task_spans[0]["execution_id"]
+    assert task_spans[0]["retry_ordinal"] == 2
+    assert task_spans[0]["redelivered"] is False
+    assert task_spans[0]["outcome"] == "failure"
+    assert task_spans[0]["metadata"] == {"exception_type": "RuntimeError"}

--- a/tests/test_task_queue_wait_metrics.py
+++ b/tests/test_task_queue_wait_metrics.py
@@ -14,6 +14,7 @@ class _FakeTask:
         headers = {}
         delivery_info = {"routing_key": "celery"}
         args = (123,)
+        retries = 0
 
 
 def _task_spans(artifact_dir):
@@ -67,6 +68,7 @@ def test_diagnostic_validity_propagates_from_publish_header_to_task_span(monkeyp
 
     headers: dict[str, object] = {}
     metrics._before_task_publish(headers=headers)
+    monkeypatch.setattr(metrics.time, "time", lambda: 2.0)
     _FakeTask.request.headers = headers
     metrics._task_prerun(task_id="diagnostic-task", task=_FakeTask())
     monkeypatch.setattr(metrics.time, "perf_counter", lambda: 3.0)
@@ -91,6 +93,7 @@ def test_task_spans_distinguish_retry_and_redelivery_attempts(monkeypatch, tmp_p
 
     headers: dict[str, object] = {}
     metrics._before_task_publish(headers=headers)
+    monkeypatch.setattr(metrics.time, "time", lambda: 2.0)
     _FakeTask.request.headers = headers
 
     attempt_contexts = [(0, False), (0, True), (1, False), (1, True)]
@@ -111,9 +114,10 @@ def test_task_spans_distinguish_retry_and_redelivery_attempts(monkeypatch, tmp_p
     execution_ids = [task_span["execution_id"] for task_span in task_spans]
     assert all(str(UUID(execution_id)) == execution_id for execution_id in execution_ids)
     assert len(set(execution_ids)) == len(attempt_contexts)
+    assert [task_span["queue_wait_s"] for task_span in task_spans] == [1.0, None, None, None]
 
 
-def test_task_span_uses_safe_defaults_for_invalid_optional_delivery_metadata(monkeypatch, tmp_path):
+def test_task_span_preserves_unknown_optional_delivery_metadata(monkeypatch, tmp_path):
     artifact_dir = tmp_path / "profile"
     _FakeTask.request.headers = {
         "tc_profile_run_id": "invalid_metadata_run",
@@ -130,8 +134,63 @@ def test_task_span_uses_safe_defaults_for_invalid_optional_delivery_metadata(mon
     metrics._task_postrun(task_id="invalid-metadata-task", task=_FakeTask(), state="SUCCESS")
 
     task_span = _task_spans(artifact_dir)[0]
+    assert task_span["retry_ordinal"] is None
+    assert task_span["redelivered"] is None
+    assert task_span["queue_wait_s"] is None
+
+
+def test_task_span_omits_queue_wait_when_redelivery_metadata_is_unknown(monkeypatch, tmp_path):
+    artifact_dir = tmp_path / "profile"
+    _FakeTask.request.headers = {
+        "tc_profile_run_id": "unknown_redelivery_run",
+        "tc_profile_mode": "triage",
+        "tc_profile_artifact_dir": str(artifact_dir),
+        "tc_profile_baseline_valid": "0",
+        "tc_queued_at": "1.0",
+    }
+    _FakeTask.request.retries = 0
+    _FakeTask.request.delivery_info = {"routing_key": "celery"}
+    monkeypatch.setattr(metrics.time, "time", lambda: 2.0)
+    monkeypatch.setattr(metrics.time, "perf_counter", lambda: 10.0)
+
+    metrics._task_prerun(task_id="unknown-redelivery-task", task=_FakeTask())
+    monkeypatch.setattr(metrics.time, "perf_counter", lambda: 11.0)
+    metrics._task_postrun(task_id="unknown-redelivery-task", task=_FakeTask(), state="SUCCESS")
+
+    task_span = _task_spans(artifact_dir)[0]
     assert task_span["retry_ordinal"] == 0
     assert task_span["redelivered"] is None
+    assert task_span["queue_wait_s"] is None
+
+
+def test_task_attempt_emits_start_before_matching_finish(monkeypatch, tmp_path):
+    artifact_dir = tmp_path / "profile"
+    _FakeTask.request.headers = {
+        "tc_profile_run_id": "task_lifecycle_run",
+        "tc_profile_mode": "baseline",
+        "tc_profile_artifact_dir": str(artifact_dir),
+        "tc_profile_baseline_valid": "0",
+        "tc_queued_at": "1.0",
+    }
+    _FakeTask.request.retries = 0
+    _FakeTask.request.delivery_info = {"routing_key": "celery", "redelivered": False}
+    monkeypatch.setattr(metrics.time, "time", lambda: 2.0)
+    monkeypatch.setattr(metrics.time, "perf_counter", lambda: 10.0)
+
+    metrics._task_prerun(task_id="lifecycle-task", task=_FakeTask())
+    monkeypatch.setattr(metrics.time, "perf_counter", lambda: 11.0)
+    metrics._task_postrun(task_id="lifecycle-task", task=_FakeTask(), state="SUCCESS")
+
+    profile_events = [
+        json.loads(line)
+        for line in (artifact_dir / "spans.jsonl").read_text(encoding="utf-8").splitlines()
+    ]
+    assert [profile_event["event_type"] for profile_event in profile_events] == [
+        "task_start",
+        "task_span",
+    ]
+    assert profile_events[0]["execution_id"] == profile_events[1]["execution_id"]
+    assert profile_events[0]["task_id"] == profile_events[1]["task_id"] == "lifecycle-task"
 
 
 def test_failed_task_span_keeps_attempt_identity_without_postrun_duplicate(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

- Record a stable task identifier and a unique execution identifier for every profiled Celery attempt.
- Preserve retry ordinal and broker redelivery as independent evidence.
- Document how operators should interpret repeated task attempts.

## Why

A task can be retried without broker redelivery, redelivered without a Celery retry, both, or neither. Profiling artifacts need all four states without collapsing them into one lifecycle label.

## Risk and compatibility

- No Celery task signature, dispatch behavior, runtime default, database schema, or gate policy changes.
- Existing task span fields remain unchanged; four additive fields are included in profiling artifacts.
- This PR is stacked on `codex/profile-phase-eligibility-evidence` and should merge after PR #238.

## Validation

- [x] Tests added or updated for changed behavior
- [x] Local validation commands and results included

PASS: `PYTHONPATH=. <shared-venv>/bin/pytest -q tests/test_task_queue_wait_metrics.py tests/test_task_metrics.py` (9 passed)
PASS: `<shared-venv>/bin/ruff check pipeline/metrics_celery_signals.py pipeline/metrics_profile_events.py tests/test_task_metrics.py tests/test_task_queue_wait_metrics.py`
PASS: `<shared-venv>/bin/ruff check .`
PASS: `<shared-venv>/bin/mypy`
PASS: `PYTHONPATH=. .venv/bin/pytest -q --benchmark-disable` with a temporary worktree-local symlink to the shared virtual environment (1,873 passed, 21 skipped)
PASS: independent pre-commit diff review

## Security Checklist

- [x] No secrets or partial secrets are logged
- [x] New endpoints/mutations enforce existing auth requirements (not applicable; no endpoint or mutation changes)

## Remaining deficits

- PR #238 must merge first because this branch builds on its profiling event contract.

