### PR TITLE
Record Celery dispatch attempts in profiling evidence

### DIFF
--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1598,6 +1598,8 @@ Interpretation rules:
   inherited timestamps on retries and redeliveries are not treated as queue time
 - interpret `task_dispatch` and `task_span` separately: dispatch rows describe
   producer-side broker publication, while task spans describe worker execution
+- unmatched dispatch rows or retry attempts without dispatch evidence reduce
+  report confidence
 - `baseline-valid` requires a pinned manifest and stable workload conditions; `triage` is diagnostic only
 - profiling artifacts are observational and should not be used as a source of business truth
 - `result.json` is the primary contract for elapsed-time totals; if totals are incomplete or derived from fallback spans, the analyzer should mark the run `reduced-confidence`

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1571,6 +1571,7 @@ Artifacts:
   - task dispatch rows pair `before` publish attempts with `after` rows only
     when Celery's broker publish call returns; a missing `after` row is
     incomplete dispatch evidence, not a task outcome
+  - each dispatch attempt records its own publish timestamp, including retries
   - task spans include the Celery `task_id`, a per-attempt `execution_id`, the
     optional `retry_ordinal`, and optional broker `redelivered` metadata
 - `experiments/results/profiling/<run_id>/summary.json`

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1565,9 +1565,12 @@ Artifacts:
 - `experiments/results/profiling/<run_id>/run_manifest.json`
   - workload identity, profile env, baseline-valid flag, and pre-run provider counters
 - `experiments/results/profiling/<run_id>/spans.jsonl`
-  - append-only orchestrator and task timing spans
+  - append-only orchestrator, dispatch, and task timing evidence
   - `task_start` rows mark worker-attempt starts; an unmatched start lowers
     confidence because the attempt did not produce a terminal timing row
+  - task dispatch rows pair `before` publish attempts with `after` rows only
+    when Celery's broker publish call returns; a missing `after` row is
+    incomplete dispatch evidence, not a task outcome
   - task spans include the Celery `task_id`, a per-attempt `execution_id`, the
     optional `retry_ordinal`, and optional broker `redelivered` metadata
 - `experiments/results/profiling/<run_id>/summary.json`
@@ -1592,6 +1595,8 @@ Interpretation rules:
 - treat an unknown retry ordinal as reduced-confidence task evidence
 - queue wait is recorded only for a known initial, non-redelivered attempt;
   inherited timestamps on retries and redeliveries are not treated as queue time
+- interpret `task_dispatch` and `task_span` separately: dispatch rows describe
+  producer-side broker publication, while task spans describe worker execution
 - `baseline-valid` requires a pinned manifest and stable workload conditions; `triage` is diagnostic only
 - profiling artifacts are observational and should not be used as a source of business truth
 - `result.json` is the primary contract for elapsed-time totals; if totals are incomplete or derived from fallback spans, the analyzer should mark the run `reduced-confidence`

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -147,6 +147,9 @@ also record the current publication timestamp. Each publish refreshes that
 timestamp, including retries. Dispatch rows never represent task execution or
 completion. Use `task_span` rows for worker-attempt outcomes.
 
+The analyzer reduces confidence when dispatch boundaries are unpaired or a
+retry attempt has no matching dispatch evidence.
+
 Confidence model:
 - `baseline-valid`
   - pinned manifest

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -143,8 +143,9 @@ Celery `task_dispatch` rows record producer-side publish boundaries. A
 call returned. When that pair repeats, match rows in event order. A missing
 `after` row is incomplete dispatch evidence, not task failure. Dispatch rows
 include the task name, queue, retry ordinal, and catalog ID when available; they
-never represent task execution or completion. Use `task_span` rows for
-worker-attempt outcomes.
+also record the current publication timestamp. Each publish refreshes that
+timestamp, including retries. Dispatch rows never represent task execution or
+completion. Use `task_span` rows for worker-attempt outcomes.
 
 Confidence model:
 - `baseline-valid`

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -137,6 +137,15 @@ timestamp. An unmatched `task_start` row marks an unfinished attempt and
 reduces report confidence. An unknown retry ordinal also reduces confidence
 rather than being reported as an initial attempt.
 
+Celery `task_dispatch` rows record producer-side publish boundaries. A
+`before` row means the producer attempted the broker publish. A matching
+`after` row with the same `task_id` and `retry_ordinal` means Celery's publish
+call returned. When that pair repeats, match rows in event order. A missing
+`after` row is incomplete dispatch evidence, not task failure. Dispatch rows
+include the task name, queue, retry ordinal, and catalog ID when available; they
+never represent task execution or completion. Use `task_span` rows for
+worker-attempt outcomes.
+
 Confidence model:
 - `baseline-valid`
   - pinned manifest

--- a/pipeline/celery_app.py
+++ b/pipeline/celery_app.py
@@ -3,6 +3,8 @@ import os
 from celery import Celery
 from kombu import Queue
 
+from pipeline import metrics as _worker_metrics  # noqa: F401 - importing registers shared Celery signals
+
 
 app = Celery("tasks")
 app.conf.broker_url = os.getenv("CELERY_BROKER_URL", "redis://redis:6379/0")

--- a/pipeline/metrics.py
+++ b/pipeline/metrics.py
@@ -173,6 +173,7 @@ def _task_prerun(task_id: object = None, task: object = None, **_kwargs: object)
         task_context=_TASK_CONTEXT,
         time_module=time,
         record_queue_wait=record_task_queue_wait,
+        profiling_module=profiling,
     )
     if context is not None:
         write_task_start_profile_event(context, profiling_module=profiling)

--- a/pipeline/metrics.py
+++ b/pipeline/metrics.py
@@ -130,8 +130,38 @@ def _start_metrics_server(**_kwargs: object) -> None:
 
 
 @signals.before_task_publish.connect
-def _before_task_publish(headers: dict[str, object] | None = None, **_kwargs: object) -> None:
-    metrics_celery_signals.before_task_publish(headers, profiling_module=profiling, time_module=time)
+def _before_task_publish(
+    sender: object = None,
+    body: object = None,
+    headers: dict[str, object] | None = None,
+    routing_key: object = None,
+    **_kwargs: object,
+) -> None:
+    metrics_celery_signals.before_task_publish(
+        headers,
+        sender=sender,
+        body=body,
+        routing_key=routing_key,
+        profiling_module=profiling,
+        time_module=time,
+    )
+
+
+@signals.after_task_publish.connect
+def _after_task_publish(
+    sender: object = None,
+    body: object = None,
+    headers: dict[str, object] | None = None,
+    routing_key: object = None,
+    **_kwargs: object,
+) -> None:
+    metrics_celery_signals.after_task_publish(
+        headers,
+        sender=sender,
+        body=body,
+        routing_key=routing_key,
+        profiling_module=profiling,
+    )
 
 
 @signals.task_prerun.connect

--- a/pipeline/metrics_celery_signals.py
+++ b/pipeline/metrics_celery_signals.py
@@ -4,7 +4,12 @@ from collections.abc import Callable, Mapping, MutableMapping
 from types import ModuleType
 from uuid import uuid4
 
-from pipeline.metrics_profile_events import TaskProfileContext, catalog_id_from_request, component_for_queue
+from pipeline.metrics_profile_events import (
+    TaskProfileContext,
+    append_task_dispatch_event,
+    catalog_id_from_request,
+    component_for_queue,
+)
 
 RecordQueueWait = Callable[[str, str, float], None]
 RecordTaskDuration = Callable[[str, str, float], None]
@@ -17,6 +22,9 @@ WriteProfileEvent = Callable[[TaskProfileContext, str, str, float, str | None], 
 def before_task_publish(
     headers: MutableMapping[str, object] | None,
     *,
+    sender: object = None,
+    body: object = None,
+    routing_key: object = None,
     profiling_module: ModuleType,
     time_module: ModuleType,
 ) -> None:
@@ -25,14 +33,39 @@ def before_task_publish(
     if headers.get("tc_queued_at") is None:
         headers["tc_queued_at"] = time_module.time()
     run_id = profiling_module.current_run_id()
-    if not run_id:
-        return
-    headers.setdefault("tc_profile_run_id", run_id)
-    headers.setdefault("tc_profile_mode", profiling_module.current_mode())
-    artifact_dir = profiling_module.os.getenv(profiling_module.PROFILE_ARTIFACT_DIR_ENV, "")
-    if artifact_dir:
-        headers.setdefault("tc_profile_artifact_dir", artifact_dir)
-    headers.setdefault("tc_profile_baseline_valid", "1" if profiling_module.baseline_valid() else "0")
+    if run_id:
+        headers.setdefault("tc_profile_run_id", run_id)
+        headers.setdefault("tc_profile_mode", profiling_module.current_mode())
+        artifact_dir = profiling_module.current_artifact_dir()
+        if artifact_dir is not None:
+            headers.setdefault("tc_profile_artifact_dir", str(artifact_dir))
+        headers.setdefault("tc_profile_baseline_valid", "1" if profiling_module.baseline_valid() else "0")
+    append_task_dispatch_event(
+        boundary="before",
+        sender=sender,
+        body=body,
+        headers=headers,
+        routing_key=routing_key,
+        profiling_module=profiling_module,
+    )
+
+
+def after_task_publish(
+    headers: Mapping[str, object] | None,
+    *,
+    sender: object = None,
+    body: object = None,
+    routing_key: object = None,
+    profiling_module: ModuleType,
+) -> None:
+    append_task_dispatch_event(
+        boundary="after",
+        sender=sender,
+        body=body,
+        headers=headers,
+        routing_key=routing_key,
+        profiling_module=profiling_module,
+    )
 
 
 def task_prerun(

--- a/pipeline/metrics_celery_signals.py
+++ b/pipeline/metrics_celery_signals.py
@@ -74,6 +74,7 @@ def task_prerun(
     task_start: MutableMapping[str, float],
     task_context: MutableMapping[str, TaskProfileContext],
     time_module: ModuleType,
+    profiling_module: ModuleType,
     record_queue_wait: RecordQueueWait,
 ) -> TaskProfileContext | None:
     if not task_id or task is None:
@@ -110,6 +111,7 @@ def task_prerun(
         artifact_dir=_optional_str(headers.get("tc_profile_artifact_dir")),
         baseline_valid=_optional_str(headers.get("tc_profile_baseline_valid")),
         catalog_id=catalog_id_from_request(request),
+        observer_at_start=profiling_module.observer_seconds(),
     )
     task_context[task_id_value] = context
     return context
@@ -137,7 +139,12 @@ def task_postrun(
         return
     status = "success" if str(state or "").lower() in ("success", "succeeded") else "unknown"
     task_name = str(getattr(task, "name", "unknown"))
-    duration_s = time_module.perf_counter() - start
+    duration_s = _task_duration_seconds(
+        start,
+        context,
+        time_module=time_module,
+        profiling_module=profiling_module,
+    )
     _record_task_span(
         context,
         task_name=task_name,
@@ -178,7 +185,12 @@ def task_failure(
         context,
         task_name=task_name,
         status="failure",
-        duration_s=time_module.perf_counter() - start,
+        duration_s=_task_duration_seconds(
+            start,
+            context,
+            time_module=time_module,
+            profiling_module=profiling_module,
+        ),
         profiling_module=profiling_module,
         record_task_duration=record_task_duration,
         record_phase_duration=record_phase_duration,
@@ -190,6 +202,21 @@ def task_failure(
 def task_retry(request: object, *, record_task_retry: RecordTaskRetry) -> None:
     task_name = getattr(getattr(request, "task", None), "name", None) or getattr(request, "task_name", None) or "unknown"
     record_task_retry(str(task_name))
+
+
+def _task_duration_seconds(
+    started_perf: float,
+    context: TaskProfileContext | None,
+    *,
+    time_module: ModuleType,
+    profiling_module: ModuleType,
+) -> float:
+    if context is None:
+        return max(0.0, time_module.perf_counter() - started_perf)
+    return profiling_module.workload_duration_seconds(
+        started_perf,
+        context.observer_at_start,
+    )
 
 
 def _record_queue_wait_from_headers(

--- a/pipeline/metrics_celery_signals.py
+++ b/pipeline/metrics_celery_signals.py
@@ -30,8 +30,7 @@ def before_task_publish(
 ) -> None:
     if headers is None:
         return
-    if headers.get("tc_queued_at") is None:
-        headers["tc_queued_at"] = time_module.time()
+    headers["tc_queued_at"] = time_module.time()
     run_id = profiling_module.current_run_id()
     if run_id:
         headers.setdefault("tc_profile_run_id", run_id)

--- a/pipeline/metrics_profile_events.py
+++ b/pipeline/metrics_profile_events.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from types import ModuleType
+from typing import Literal
+
+
+DispatchBoundary = Literal["before", "after"]
 
 
 @dataclass(slots=True)
@@ -22,6 +27,14 @@ class TaskProfileContext:
     catalog_id: int | None
 
 
+@dataclass(frozen=True, slots=True)
+class DispatchProfileContext:
+    run_id: str
+    mode: str
+    artifact_dir: Path
+    baseline_valid: bool
+
+
 def catalog_id_from_request(request: object) -> int | None:
     args = getattr(request, "args", None) or ()
     if not args:
@@ -30,6 +43,90 @@ def catalog_id_from_request(request: object) -> int | None:
         return int(args[0])
     except (TypeError, ValueError):
         return None
+
+
+def catalog_id_from_publish_body(body: object) -> int | None:
+    task_args: object = None
+    if isinstance(body, Mapping):
+        task_args = body.get("args")
+    elif isinstance(body, Sequence) and not isinstance(body, str | bytes) and body:
+        task_args = body[0]
+    if not isinstance(task_args, Sequence) or isinstance(task_args, str | bytes) or not task_args:
+        return None
+    catalog_id = task_args[0]
+    if not isinstance(catalog_id, int) or isinstance(catalog_id, bool):
+        return None
+    return catalog_id
+
+
+def _publish_field(
+    headers: Mapping[str, object] | None,
+    body: object,
+    field_name: str,
+) -> object:
+    if headers is not None and headers.get(field_name) is not None:
+        return headers[field_name]
+    if isinstance(body, Mapping):
+        return body.get(field_name)
+    return None
+
+
+def append_task_dispatch_event(
+    *,
+    boundary: DispatchBoundary,
+    sender: object,
+    body: object,
+    headers: Mapping[str, object] | None,
+    routing_key: object,
+    profiling_module: ModuleType,
+) -> None:
+    profile_context = _dispatch_profile_context(headers, body)
+    if profile_context is None:
+        return
+    task_id = str(_publish_field(headers, body, "id") or "").strip()
+    if not task_id:
+        return
+    task_name = str(sender or _publish_field(headers, body, "task") or "unknown")
+    retries = _publish_field(headers, body, "retries")
+    retry_ordinal = retries if isinstance(retries, int) and not isinstance(retries, bool) and retries >= 0 else None
+    profiling_module.append_jsonl(
+        profile_context.artifact_dir / "spans.jsonl",
+        {
+            "run_id": profile_context.run_id,
+            "mode": profile_context.mode,
+            "baseline_valid": profile_context.baseline_valid,
+            "timestamp": profiling_module.utc_now_iso(),
+            "event_type": "task_dispatch",
+            "boundary": boundary,
+            "task_id": task_id,
+            "task_name": task_name,
+            "queue": str(routing_key or "celery"),
+            "retry_ordinal": retry_ordinal,
+            "catalog_id": catalog_id_from_publish_body(body),
+        }
+    )
+
+
+def _dispatch_profile_context(
+    headers: Mapping[str, object] | None,
+    body: object,
+) -> DispatchProfileContext | None:
+    run_id = str(_publish_field(headers, body, "tc_profile_run_id") or "").strip()
+    artifact_dir = str(
+        _publish_field(headers, body, "tc_profile_artifact_dir") or ""
+    ).strip()
+    if not run_id or not artifact_dir:
+        return None
+    mode = str(_publish_field(headers, body, "tc_profile_mode") or "triage")
+    baseline_value = str(
+        _publish_field(headers, body, "tc_profile_baseline_valid") or "0"
+    ).lower()
+    return DispatchProfileContext(
+        run_id=run_id,
+        mode=mode,
+        artifact_dir=Path(artifact_dir),
+        baseline_valid=baseline_value in {"1", "true", "yes"},
+    )
 
 
 def component_for_queue(queue: object) -> str:

--- a/pipeline/metrics_profile_events.py
+++ b/pipeline/metrics_profile_events.py
@@ -101,6 +101,7 @@ def append_task_dispatch_event(
             "task_id": task_id,
             "task_name": task_name,
             "queue": str(routing_key or "celery"),
+            "queued_at": _publish_field(headers, body, "tc_queued_at"),
             "retry_ordinal": retry_ordinal,
             "catalog_id": catalog_id_from_publish_body(body),
         }

--- a/pipeline/metrics_profile_events.py
+++ b/pipeline/metrics_profile_events.py
@@ -25,6 +25,7 @@ class TaskProfileContext:
     artifact_dir: str | None
     baseline_valid: str | None
     catalog_id: int | None
+    observer_at_start: float
 
 
 @dataclass(frozen=True, slots=True)
@@ -168,11 +169,12 @@ def write_task_start_profile_event(
     *,
     profiling_module: ModuleType,
 ) -> None:
-    profile_event = _task_profile_event(context, context.task_name, profiling_module)
-    if profile_event is None:
-        return
-    profile_event["event_type"] = "task_start"
-    _append_task_profile_event(context, profile_event, profiling_module)
+    with profiling_module.profile_observer():
+        profile_event = _task_profile_event(context, context.task_name, profiling_module)
+        if profile_event is None:
+            return
+        profile_event["event_type"] = "task_start"
+        _append_task_profile_event(context, profile_event, profiling_module)
 
 
 def _task_profile_event(

--- a/pipeline/metrics_profile_events.py
+++ b/pipeline/metrics_profile_events.py
@@ -89,23 +89,24 @@ def append_task_dispatch_event(
     task_name = str(sender or _publish_field(headers, body, "task") or "unknown")
     retries = _publish_field(headers, body, "retries")
     retry_ordinal = retries if isinstance(retries, int) and not isinstance(retries, bool) and retries >= 0 else None
-    profiling_module.append_jsonl(
-        profile_context.artifact_dir / "spans.jsonl",
-        {
-            "run_id": profile_context.run_id,
-            "mode": profile_context.mode,
-            "baseline_valid": profile_context.baseline_valid,
-            "timestamp": profiling_module.utc_now_iso(),
-            "event_type": "task_dispatch",
-            "boundary": boundary,
-            "task_id": task_id,
-            "task_name": task_name,
-            "queue": str(routing_key or "celery"),
-            "queued_at": _publish_field(headers, body, "tc_queued_at"),
-            "retry_ordinal": retry_ordinal,
-            "catalog_id": catalog_id_from_publish_body(body),
-        }
-    )
+    with profiling_module.profile_observer():
+        profiling_module.append_jsonl(
+            profile_context.artifact_dir / "spans.jsonl",
+            {
+                "run_id": profile_context.run_id,
+                "mode": profile_context.mode,
+                "baseline_valid": profile_context.baseline_valid,
+                "timestamp": profiling_module.utc_now_iso(),
+                "event_type": "task_dispatch",
+                "boundary": boundary,
+                "task_id": task_id,
+                "task_name": task_name,
+                "queue": str(routing_key or "celery"),
+                "queued_at": _publish_field(headers, body, "tc_queued_at"),
+                "retry_ordinal": retry_ordinal,
+                "catalog_id": catalog_id_from_publish_body(body),
+            },
+        )
 
 
 def _dispatch_profile_context(

--- a/scripts/pipeline_profile_analysis.py
+++ b/scripts/pipeline_profile_analysis.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 import re
-from collections import Counter
 from pathlib import Path
 from typing import Any, Mapping, cast
 
@@ -189,40 +188,45 @@ def _unfinished_task_attempts(spans: list[dict[str, Any]]) -> set[str]:
     return started_attempts - finished_attempts
 
 
+def _completed_dispatch_attempts(
+    spans: list[dict[str, Any]],
+) -> tuple[set[tuple[str, Any]], bool]:
+    outstanding_before: dict[tuple[str, Any], int] = {}
+    matched_attempts: set[tuple[str, Any]] = set()
+    invalid_attempts: set[tuple[str, Any]] = set()
+    for row in spans:
+        if row.get("event_type") != "task_dispatch" or not row.get("task_id"):
+            continue
+        dispatch_attempt = (str(row.get("task_id")), row.get("retry_ordinal"))
+        if row.get("boundary") == "before":
+            outstanding_before[dispatch_attempt] = outstanding_before.get(dispatch_attempt, 0) + 1
+        elif row.get("boundary") == "after" and outstanding_before.get(dispatch_attempt, 0) > 0:
+            outstanding_before[dispatch_attempt] -= 1
+            matched_attempts.add(dispatch_attempt)
+        else:
+            invalid_attempts.add(dispatch_attempt)
+    invalid_attempts.update(
+        dispatch_attempt
+        for dispatch_attempt, outstanding_count in outstanding_before.items()
+        if outstanding_count > 0
+    )
+    return matched_attempts - invalid_attempts, bool(invalid_attempts)
+
+
 def _task_evidence_confidence_reasons(spans: list[dict[str, Any]]) -> list[str]:
     confidence_reasons: list[str] = []
     if _unfinished_task_attempts(spans):
         confidence_reasons.append("unfinished_task_attempt")
     if any(
-        row.get("event_type") in {"task_start", "task_span"}
+        row.get("event_type") in {"task_dispatch", "task_start", "task_span"}
         and "retry_ordinal" in row
         and row.get("retry_ordinal") is None
         for row in spans
     ):
         confidence_reasons.append("unknown_task_retry_ordinal")
-    dispatch_counts = Counter(
-        (
-            str(row.get("task_id")),
-            row.get("retry_ordinal"),
-            str(row.get("boundary")),
-        )
-        for row in spans
-        if row.get("event_type") == "task_dispatch" and row.get("task_id")
-    )
-    dispatch_attempts = {(task_id, retry_ordinal) for task_id, retry_ordinal, _boundary in dispatch_counts}
-    if any(
-        dispatch_counts[(task_id, retry_ordinal, "before")]
-        != dispatch_counts[(task_id, retry_ordinal, "after")]
-        for task_id, retry_ordinal in dispatch_attempts
-    ):
+    completed_dispatches, has_unmatched_dispatch = _completed_dispatch_attempts(spans)
+    if has_unmatched_dispatch:
         confidence_reasons.append("unmatched_task_dispatch")
-    completed_dispatches = {
-        (task_id, retry_ordinal)
-        for task_id, retry_ordinal in dispatch_attempts
-        if dispatch_counts[(task_id, retry_ordinal, "before")] > 0
-        and dispatch_counts[(task_id, retry_ordinal, "before")]
-        == dispatch_counts[(task_id, retry_ordinal, "after")]
-    }
     if any(
         row.get("event_type") in {"task_start", "task_span"}
         and isinstance(row.get("retry_ordinal"), int)

--- a/scripts/pipeline_profile_analysis.py
+++ b/scripts/pipeline_profile_analysis.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import re
+from collections import Counter
 from pathlib import Path
 from typing import Any, Mapping, cast
 
@@ -199,6 +200,37 @@ def _task_evidence_confidence_reasons(spans: list[dict[str, Any]]) -> list[str]:
         for row in spans
     ):
         confidence_reasons.append("unknown_task_retry_ordinal")
+    dispatch_counts = Counter(
+        (
+            str(row.get("task_id")),
+            row.get("retry_ordinal"),
+            str(row.get("boundary")),
+        )
+        for row in spans
+        if row.get("event_type") == "task_dispatch" and row.get("task_id")
+    )
+    dispatch_attempts = {(task_id, retry_ordinal) for task_id, retry_ordinal, _boundary in dispatch_counts}
+    if any(
+        dispatch_counts[(task_id, retry_ordinal, "before")]
+        != dispatch_counts[(task_id, retry_ordinal, "after")]
+        for task_id, retry_ordinal in dispatch_attempts
+    ):
+        confidence_reasons.append("unmatched_task_dispatch")
+    completed_dispatches = {
+        (task_id, retry_ordinal)
+        for task_id, retry_ordinal in dispatch_attempts
+        if dispatch_counts[(task_id, retry_ordinal, "before")] > 0
+        and dispatch_counts[(task_id, retry_ordinal, "before")]
+        == dispatch_counts[(task_id, retry_ordinal, "after")]
+    }
+    if any(
+        row.get("event_type") in {"task_start", "task_span"}
+        and isinstance(row.get("retry_ordinal"), int)
+        and row.get("retry_ordinal", 0) > 0
+        and (str(row.get("task_id")), row.get("retry_ordinal")) not in completed_dispatches
+        for row in spans
+    ):
+        confidence_reasons.append("missing_retry_dispatch")
     return confidence_reasons
 
 

--- a/tests/test_pipeline_profile_report.py
+++ b/tests/test_pipeline_profile_report.py
@@ -142,6 +142,107 @@ def test_rank_bottlenecks_reduces_confidence_for_unknown_retry_ordinal(tmp_path:
     assert summary["confidence"] == "reduced-confidence:unknown_task_retry_ordinal"
 
 
+def test_rank_bottlenecks_reduces_confidence_for_unmatched_dispatch(tmp_path: Path):
+    run_dir = tmp_path / "profile_run"
+    run_dir.mkdir()
+    (run_dir / "run_manifest.json").write_text(
+        json.dumps({"run_id": "profile_run", "mode": "baseline", "include_batch": False}),
+        encoding="utf-8",
+    )
+    (run_dir / "result.json").write_text(
+        json.dumps({"include_batch": False, "totals": {"combined_elapsed_seconds": 4.0}}),
+        encoding="utf-8",
+    )
+    (run_dir / "day_summary.json").write_text(
+        json.dumps({"provider_metrics_present": True}),
+        encoding="utf-8",
+    )
+    (run_dir / "spans.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "event_type": "span",
+                        "phase": "pipeline_total",
+                        "duration_s": 4.0,
+                        "outcome": "success",
+                        "metadata": {"observer_overhead_s": 0.1},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "event_type": "task_dispatch",
+                        "boundary": "before",
+                        "task_id": "unmatched-dispatch",
+                        "retry_ordinal": 0,
+                    }
+                ),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    summary = mod.rank_bottlenecks(run_dir)
+
+    assert summary["confidence_reasons"] == ["unmatched_task_dispatch"]
+
+
+def test_rank_bottlenecks_reduces_confidence_when_retry_has_no_dispatch(tmp_path: Path):
+    run_dir = tmp_path / "profile_run"
+    run_dir.mkdir()
+    (run_dir / "run_manifest.json").write_text(
+        json.dumps({"run_id": "profile_run", "mode": "baseline", "include_batch": False}),
+        encoding="utf-8",
+    )
+    (run_dir / "result.json").write_text(
+        json.dumps({"include_batch": False, "totals": {"combined_elapsed_seconds": 4.0}}),
+        encoding="utf-8",
+    )
+    (run_dir / "day_summary.json").write_text(
+        json.dumps({"provider_metrics_present": True}),
+        encoding="utf-8",
+    )
+    (run_dir / "spans.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "event_type": "span",
+                        "phase": "pipeline_total",
+                        "duration_s": 4.0,
+                        "outcome": "success",
+                        "metadata": {"observer_overhead_s": 0.1},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "event_type": "task_start",
+                        "phase": "summarize",
+                        "task_id": "retry-without-dispatch",
+                        "execution_id": "retry-attempt",
+                        "retry_ordinal": 1,
+                    }
+                ),
+                json.dumps(
+                    {
+                        "event_type": "task_span",
+                        "phase": "summarize",
+                        "task_id": "retry-without-dispatch",
+                        "execution_id": "retry-attempt",
+                        "retry_ordinal": 1,
+                        "duration_s": 1.0,
+                    }
+                ),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    summary = mod.rank_bottlenecks(run_dir)
+
+    assert summary["confidence_reasons"] == ["missing_retry_dispatch"]
+
+
 def test_rank_bottlenecks_ignores_phase_eligibility_events(tmp_path: Path):
     run_dir = tmp_path / "profile_run"
     run_dir.mkdir()

--- a/tests/test_pipeline_profile_report.py
+++ b/tests/test_pipeline_profile_report.py
@@ -2,6 +2,8 @@ import importlib.util
 import json
 from pathlib import Path
 
+import pytest
+
 
 spec = importlib.util.spec_from_file_location("analyze_pipeline_profile", Path("scripts/analyze_pipeline_profile.py"))
 mod = importlib.util.module_from_spec(spec)
@@ -185,6 +187,62 @@ def test_rank_bottlenecks_reduces_confidence_for_unmatched_dispatch(tmp_path: Pa
     summary = mod.rank_bottlenecks(run_dir)
 
     assert summary["confidence_reasons"] == ["unmatched_task_dispatch"]
+
+
+@pytest.mark.parametrize(
+    ("dispatch_boundaries", "retry_ordinal", "expected_reasons"),
+    [
+        (["before", "after", "after", "before"], 0, ["unmatched_task_dispatch"]),
+        (["before", "after", "before", "after"], 0, []),
+        (["before", "after"], None, ["unknown_task_retry_ordinal"]),
+    ],
+)
+def test_rank_bottlenecks_pairs_repeated_dispatches_in_event_order(
+    tmp_path: Path,
+    dispatch_boundaries: list[str],
+    retry_ordinal: int | None,
+    expected_reasons: list[str],
+):
+    run_dir = tmp_path / "profile_run"
+    run_dir.mkdir()
+    (run_dir / "run_manifest.json").write_text(
+        json.dumps({"run_id": "profile_run", "mode": "baseline", "include_batch": False}),
+        encoding="utf-8",
+    )
+    (run_dir / "result.json").write_text(
+        json.dumps({"include_batch": False, "totals": {"combined_elapsed_seconds": 4.0}}),
+        encoding="utf-8",
+    )
+    (run_dir / "day_summary.json").write_text(
+        json.dumps({"provider_metrics_present": True}),
+        encoding="utf-8",
+    )
+    profile_events = [
+        {
+            "event_type": "span",
+            "phase": "pipeline_total",
+            "duration_s": 4.0,
+            "outcome": "success",
+            "metadata": {"observer_overhead_s": 0.1},
+        },
+        *[
+            {
+                "event_type": "task_dispatch",
+                "boundary": boundary,
+                "task_id": "repeated-dispatch",
+                "retry_ordinal": retry_ordinal,
+            }
+            for boundary in dispatch_boundaries
+        ],
+    ]
+    (run_dir / "spans.jsonl").write_text(
+        "\n".join(json.dumps(profile_event) for profile_event in profile_events),
+        encoding="utf-8",
+    )
+
+    summary = mod.rank_bottlenecks(run_dir)
+
+    assert summary["confidence_reasons"] == expected_reasons
 
 
 def test_rank_bottlenecks_reduces_confidence_when_retry_has_no_dispatch(tmp_path: Path):

--- a/tests/test_task_metrics.py
+++ b/tests/test_task_metrics.py
@@ -72,6 +72,7 @@ def test_task_failure_clears_timing_context(monkeypatch):
         artifact_dir=None,
         baseline_valid=None,
         catalog_id=123,
+        observer_at_start=0.0,
     )
     monkeypatch.setattr(metrics.time, "perf_counter", lambda: 7.0)
 

--- a/tests/test_task_queue_wait_metrics.py
+++ b/tests/test_task_queue_wait_metrics.py
@@ -336,6 +336,7 @@ def test_task_retry_records_dispatch_from_inherited_profile_headers(monkeypatch,
     ):
         monkeypatch.delenv(profile_env, raising=False)
     celery_app = _memory_broker_app("profile-dispatch-retry")
+    monkeypatch.setattr(metrics.time, "time", lambda: 9.0)
 
     @celery_app.task(bind=True, name="pipeline.tasks.profile_retry_probe")
     def profile_retry_probe(task: object, catalog_id: int) -> int:
@@ -368,6 +369,7 @@ def test_task_retry_records_dispatch_from_inherited_profile_headers(monkeypatch,
     assert {dispatch["task_id"] for dispatch in dispatches} == {"retry-dispatch-id"}
     assert {dispatch["retry_ordinal"] for dispatch in dispatches} == {2}
     assert {dispatch["catalog_id"] for dispatch in dispatches} == {321}
+    assert {dispatch["queued_at"] for dispatch in dispatches} == {9.0}
     assert all(dispatch["baseline_valid"] is False for dispatch in dispatches)
 
 
@@ -391,7 +393,7 @@ def test_task_publish_uses_safe_defaults_for_optional_dispatch_metadata(monkeypa
     dispatch = _task_dispatches(artifact_dir)[0]
     assert dispatch["task_name"] == "pipeline.tasks.generate_summary_task"
     assert dispatch["queue"] == "celery"
-    assert dispatch["retry_ordinal"] == 0
+    assert dispatch["retry_ordinal"] is None
     assert dispatch["catalog_id"] is None
 
 
@@ -430,5 +432,6 @@ def test_task_dispatch_and_task_span_remain_distinct_profile_events(monkeypatch,
     assert [profile_event["event_type"] for profile_event in profile_events] == [
         "task_dispatch",
         "task_dispatch",
+        "task_start",
         "task_span",
     ]

--- a/tests/test_task_queue_wait_metrics.py
+++ b/tests/test_task_queue_wait_metrics.py
@@ -1,7 +1,10 @@
 import json
 from uuid import UUID
 
+from celery import Celery
+from kombu.exceptions import SerializerNotInstalled
 from prometheus_client import generate_latest
+import pytest
 
 from pipeline import metrics
 from pipeline import profiling
@@ -22,6 +25,19 @@ def _task_spans(artifact_dir):
         json.loads(line) for line in (artifact_dir / "spans.jsonl").read_text(encoding="utf-8").splitlines()
     ]
     return [profile_event for profile_event in profile_events if profile_event["event_type"] == "task_span"]
+
+
+def _task_dispatches(artifact_dir):
+    profile_events = [
+        json.loads(line) for line in (artifact_dir / "spans.jsonl").read_text(encoding="utf-8").splitlines()
+    ]
+    return [profile_event for profile_event in profile_events if profile_event["event_type"] == "task_dispatch"]
+
+
+def _memory_broker_app(app_name: str, *, task_protocol: int = 2) -> Celery:
+    celery_app = Celery(app_name, broker="memory://")
+    celery_app.conf.task_protocol = task_protocol
+    return celery_app
 
 
 def test_queue_wait_metric_and_task_context_are_recorded(monkeypatch, tmp_path):
@@ -222,3 +238,197 @@ def test_failed_task_span_keeps_attempt_identity_without_postrun_duplicate(monke
     assert task_spans[0]["redelivered"] is False
     assert task_spans[0]["outcome"] == "failure"
     assert task_spans[0]["metadata"] == {"exception_type": "RuntimeError"}
+
+
+def test_task_publish_records_paired_dispatch_boundaries(monkeypatch, tmp_path):
+    artifact_dir = tmp_path / "profile"
+    monkeypatch.setenv(profiling.PROFILE_RUN_ID_ENV, "dispatch_run")
+    monkeypatch.setenv(profiling.PROFILE_MODE_ENV, "baseline")
+    monkeypatch.setenv(profiling.PROFILE_ARTIFACT_DIR_ENV, str(artifact_dir))
+    monkeypatch.setenv(profiling.PROFILE_BASELINE_VALID_ENV, "0")
+    celery_app = _memory_broker_app("profile-dispatch-success")
+
+    dispatch_result = celery_app.send_task(
+        "pipeline.tasks.generate_summary_task",
+        args=(456,),
+        queue="enrichment",
+    )
+
+    dispatches = _task_dispatches(artifact_dir)
+    assert [dispatch["boundary"] for dispatch in dispatches] == ["before", "after"]
+    for dispatch in dispatches:
+        assert dispatch["task_id"] == dispatch_result.id
+        assert dispatch["task_name"] == "pipeline.tasks.generate_summary_task"
+        assert dispatch["queue"] == "enrichment"
+        assert dispatch["retry_ordinal"] == 0
+        assert dispatch["catalog_id"] == 456
+        assert dispatch["baseline_valid"] is False
+        assert "duration_s" not in dispatch
+        assert "outcome" not in dispatch
+
+
+def test_task_publish_before_event_remains_unpaired_when_publish_does_not_complete(monkeypatch, tmp_path):
+    artifact_dir = tmp_path / "profile"
+    monkeypatch.setenv(profiling.PROFILE_RUN_ID_ENV, "failed_dispatch_run")
+    monkeypatch.setenv(profiling.PROFILE_ARTIFACT_DIR_ENV, str(artifact_dir))
+    celery_app = _memory_broker_app("profile-dispatch-failure")
+
+    with pytest.raises(SerializerNotInstalled):
+        celery_app.send_task(
+            "pipeline.tasks.generate_summary_task",
+            args=(789,),
+            serializer="missing-serializer",
+        )
+
+    dispatches = _task_dispatches(artifact_dir)
+    assert [dispatch["boundary"] for dispatch in dispatches] == ["before"]
+
+
+def test_task_publish_omits_dispatch_without_profile_or_task_id(monkeypatch, tmp_path):
+    artifact_dir = tmp_path / "profile"
+    headers: dict[str, object] = {"id": "unprofiled-task-id"}
+
+    metrics._before_task_publish(
+        sender="pipeline.tasks.generate_summary_task",
+        body=((1,), {}, {}),
+        headers=headers,
+        routing_key="celery",
+    )
+    assert not (artifact_dir / "spans.jsonl").exists()
+
+    monkeypatch.setenv(profiling.PROFILE_RUN_ID_ENV, "missing_id_run")
+    monkeypatch.setenv(profiling.PROFILE_ARTIFACT_DIR_ENV, str(artifact_dir))
+    metrics._before_task_publish(
+        sender="pipeline.tasks.generate_summary_task",
+        body={"args": (1,)},
+        headers={},
+        routing_key="celery",
+    )
+    assert not (artifact_dir / "spans.jsonl").exists()
+
+
+def test_task_publish_records_protocol_v1_dispatch_metadata(monkeypatch, tmp_path):
+    artifact_dir = tmp_path / "profile"
+    monkeypatch.setenv(profiling.PROFILE_RUN_ID_ENV, "dispatch_v1_run")
+    monkeypatch.setenv(profiling.PROFILE_ARTIFACT_DIR_ENV, str(artifact_dir))
+    celery_app = _memory_broker_app("profile-dispatch-v1", task_protocol=1)
+
+    dispatch_result = celery_app.send_task(
+        "pipeline.tasks.generate_summary_task",
+        args=(654,),
+        queue="enrichment",
+    )
+
+    dispatches = _task_dispatches(artifact_dir)
+    assert [dispatch["boundary"] for dispatch in dispatches] == ["before", "after"]
+    assert {dispatch["task_id"] for dispatch in dispatches} == {dispatch_result.id}
+    assert {dispatch["retry_ordinal"] for dispatch in dispatches} == {0}
+    assert {dispatch["catalog_id"] for dispatch in dispatches} == {654}
+
+
+def test_task_retry_records_dispatch_from_inherited_profile_headers(monkeypatch, tmp_path):
+    artifact_dir = tmp_path / "profile"
+    for profile_env in (
+        profiling.PROFILE_RUN_ID_ENV,
+        profiling.PROFILE_MODE_ENV,
+        profiling.PROFILE_ARTIFACT_DIR_ENV,
+        profiling.PROFILE_BASELINE_VALID_ENV,
+    ):
+        monkeypatch.delenv(profile_env, raising=False)
+    celery_app = _memory_broker_app("profile-dispatch-retry")
+
+    @celery_app.task(bind=True, name="pipeline.tasks.profile_retry_probe")
+    def profile_retry_probe(task: object, catalog_id: int) -> int:
+        return catalog_id
+
+    inherited_headers = {
+        "tc_profile_run_id": "retry-dispatch-run",
+        "tc_profile_mode": "baseline",
+        "tc_profile_artifact_dir": str(artifact_dir),
+        "tc_profile_baseline_valid": "0",
+        "tc_queued_at": 1.0,
+    }
+    profile_retry_probe.push_request(
+        id="retry-dispatch-id",
+        args=(321,),
+        kwargs={},
+        retries=1,
+        called_directly=False,
+        is_eager=False,
+        headers=inherited_headers,
+        delivery_info={"exchange": "", "routing_key": "celery"},
+    )
+    try:
+        profile_retry_probe.retry(args=(321,), kwargs={}, countdown=0, throw=False)
+    finally:
+        profile_retry_probe.pop_request()
+
+    dispatches = _task_dispatches(artifact_dir)
+    assert [dispatch["boundary"] for dispatch in dispatches] == ["before", "after"]
+    assert {dispatch["task_id"] for dispatch in dispatches} == {"retry-dispatch-id"}
+    assert {dispatch["retry_ordinal"] for dispatch in dispatches} == {2}
+    assert {dispatch["catalog_id"] for dispatch in dispatches} == {321}
+    assert all(dispatch["baseline_valid"] is False for dispatch in dispatches)
+
+
+def test_task_publish_uses_safe_defaults_for_optional_dispatch_metadata(monkeypatch, tmp_path):
+    artifact_dir = tmp_path / "profile"
+    monkeypatch.setenv(profiling.PROFILE_RUN_ID_ENV, "dispatch_defaults_run")
+    monkeypatch.setenv(profiling.PROFILE_ARTIFACT_DIR_ENV, str(artifact_dir))
+    headers: dict[str, object] = {
+        "id": "dispatch-defaults-id",
+        "task": "pipeline.tasks.generate_summary_task",
+        "retries": "invalid",
+    }
+
+    metrics._before_task_publish(
+        sender=None,
+        body=(("not-a-catalog-id",), {}, {}),
+        headers=headers,
+        routing_key=None,
+    )
+
+    dispatch = _task_dispatches(artifact_dir)[0]
+    assert dispatch["task_name"] == "pipeline.tasks.generate_summary_task"
+    assert dispatch["queue"] == "celery"
+    assert dispatch["retry_ordinal"] == 0
+    assert dispatch["catalog_id"] is None
+
+
+def test_task_dispatch_and_task_span_remain_distinct_profile_events(monkeypatch, tmp_path):
+    artifact_dir = tmp_path / "profile"
+    monkeypatch.setenv(profiling.PROFILE_RUN_ID_ENV, "dispatch_execution_run")
+    monkeypatch.setenv(profiling.PROFILE_ARTIFACT_DIR_ENV, str(artifact_dir))
+    monkeypatch.setattr(metrics.time, "time", lambda: 1.0)
+    monkeypatch.setattr(metrics.time, "perf_counter", lambda: 2.0)
+    headers: dict[str, object] = {
+        "id": "dispatch-execution-id",
+        "task": "pipeline.tasks.generate_summary_task",
+    }
+    body = ((123,), {}, {})
+
+    metrics._before_task_publish(
+        sender="pipeline.tasks.generate_summary_task",
+        body=body,
+        headers=headers,
+        routing_key="celery",
+    )
+    metrics._after_task_publish(
+        sender="pipeline.tasks.generate_summary_task",
+        body=body,
+        headers=headers,
+        routing_key="celery",
+    )
+    _FakeTask.request.headers = headers
+    metrics._task_prerun(task_id="dispatch-execution-id", task=_FakeTask())
+    monkeypatch.setattr(metrics.time, "perf_counter", lambda: 3.0)
+    metrics._task_postrun(task_id="dispatch-execution-id", task=_FakeTask(), state="SUCCESS")
+
+    profile_events = [
+        json.loads(line) for line in (artifact_dir / "spans.jsonl").read_text(encoding="utf-8").splitlines()
+    ]
+    assert [profile_event["event_type"] for profile_event in profile_events] == [
+        "task_dispatch",
+        "task_dispatch",
+        "task_span",
+    ]

--- a/tests/test_task_queue_wait_metrics.py
+++ b/tests/test_task_queue_wait_metrics.py
@@ -1,4 +1,6 @@
 import json
+import subprocess
+import sys
 from uuid import UUID
 
 from celery import Celery
@@ -435,3 +437,52 @@ def test_task_dispatch_and_task_span_remain_distinct_profile_events(monkeypatch,
         "task_start",
         "task_span",
     ]
+
+
+@pytest.mark.parametrize("worker_module", ["pipeline.enrichment_tasks", "pipeline.semantic_tasks"])
+def test_worker_entrypoints_register_dispatch_evidence(worker_module, tmp_path):
+    artifact_dir = tmp_path / worker_module.rsplit(".", 1)[-1]
+    worker_script = f"""
+import importlib
+import os
+
+os.environ['TC_PROFILE_RUN_ID'] = 'worker-entrypoint-run'
+os.environ['TC_PROFILE_ARTIFACT_DIR'] = {str(artifact_dir)!r}
+worker = importlib.import_module({worker_module!r})
+worker.app.conf.broker_url = 'memory://'
+worker.app.send_task('pipeline.tasks.generate_summary_task', args=(123,), ignore_result=True)
+"""
+
+    worker_process = subprocess.run(
+        [sys.executable, "-c", worker_script],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert worker_process.returncode == 0, worker_process.stderr
+    assert [dispatch["boundary"] for dispatch in _task_dispatches(artifact_dir)] == [
+        "before",
+        "after",
+    ]
+
+
+def test_dispatch_writes_count_as_profile_observer_overhead(monkeypatch, tmp_path):
+    artifact_dir = tmp_path / "profile"
+    monkeypatch.setenv(profiling.PROFILE_RUN_ID_ENV, "dispatch-observer-run")
+    monkeypatch.setenv(profiling.PROFILE_ARTIFACT_DIR_ENV, str(artifact_dir))
+    headers: dict[str, object] = {
+        "id": "dispatch-observer-task",
+        "task": "pipeline.tasks.generate_summary_task",
+    }
+
+    with profiling.profile_span(phase="summarize", component="pipeline"):
+        metrics._before_task_publish(headers=headers)
+        metrics._after_task_publish(headers=headers)
+
+    profile_events = [
+        json.loads(line)
+        for line in (artifact_dir / "spans.jsonl").read_text(encoding="utf-8").splitlines()
+    ]
+    span = next(profile_event for profile_event in profile_events if profile_event["event_type"] == "span")
+    assert span["metadata"]["observer_overhead_s"] > 0.0

--- a/tests/test_task_queue_wait_metrics.py
+++ b/tests/test_task_queue_wait_metrics.py
@@ -135,6 +135,53 @@ def test_task_spans_distinguish_retry_and_redelivery_attempts(monkeypatch, tmp_p
     assert [task_span["queue_wait_s"] for task_span in task_spans] == [1.0, None, None, None]
 
 
+@pytest.mark.parametrize("attempt_outcome", ["success", "retry", "failure"])
+def test_profile_observer_time_is_excluded_from_task_span(monkeypatch, tmp_path, attempt_outcome):
+    artifact_dir = tmp_path / "profile"
+    monkeypatch.setenv(profiling.PROFILE_RUN_ID_ENV, "retry_observer_run")
+    monkeypatch.setenv(profiling.PROFILE_ARTIFACT_DIR_ENV, str(artifact_dir))
+    _FakeTask.request.headers = {
+        "id": "retry-observer-task",
+        "task": "pipeline.tasks.generate_summary_task",
+        "retries": 1,
+        "tc_profile_run_id": "retry_observer_run",
+        "tc_profile_mode": "triage",
+        "tc_profile_artifact_dir": str(artifact_dir),
+        "tc_profile_baseline_valid": "0",
+    }
+    _FakeTask.request.retries = 1
+    _FakeTask.request.delivery_info = {"routing_key": "celery", "redelivered": False}
+    clock = {"now": 10.0}
+    monkeypatch.setattr(metrics.time, "perf_counter", lambda: clock["now"])
+    append_jsonl = profiling.append_jsonl
+
+    def append_with_profile_delay(path, profile_event):
+        if profile_event.get("event_type") in {"task_dispatch", "task_start"}:
+            clock["now"] += 2.0
+        append_jsonl(path, profile_event)
+
+    monkeypatch.setattr(profiling, "append_jsonl", append_with_profile_delay)
+
+    metrics._task_prerun(task_id="retry-observer-task", task=_FakeTask())
+    if attempt_outcome == "retry":
+        clock["now"] = 13.0
+        metrics._before_task_publish(headers=_FakeTask.request.headers)
+        clock["now"] = 17.0
+        metrics._task_postrun(task_id="retry-observer-task", task=_FakeTask(), state="RETRY")
+    elif attempt_outcome == "failure":
+        clock["now"] = 15.0
+        metrics._task_failure(
+            task_id="retry-observer-task",
+            exception=RuntimeError("boom"),
+            sender=_FakeTask(),
+        )
+    else:
+        clock["now"] = 15.0
+        metrics._task_postrun(task_id="retry-observer-task", task=_FakeTask(), state="SUCCESS")
+
+    assert _task_spans(artifact_dir)[0]["duration_s"] == 3.0
+
+
 def test_task_span_preserves_unknown_optional_delivery_metadata(monkeypatch, tmp_path):
     artifact_dir = tmp_path / "profile"
     _FakeTask.request.headers = {


### PR DESCRIPTION
## Summary

- record producer-side `before` and `after` dispatch evidence for Celery publishes
- refresh publish timestamps for every attempt, including retries
- keep dispatch evidence separate from worker-attempt lifecycle evidence

## Why

The baseline diagnostic needs to distinguish broker publication from worker execution. Without producer-side boundaries, a queued task that never reaches a worker cannot be separated from missing worker evidence.

## Risk and compatibility

- observational profiling change only
- no task signatures, retry policy, runtime defaults, or baseline-valid rules change
- dispatch rows are emitted only when profiling context and a task ID are present

## Verification

- PASS: `/Users/dennisshah/Documents/GitHub/town-council/.venv/bin/ruff check .`
- PASS: `/Users/dennisshah/Documents/GitHub/town-council/.venv/bin/mypy`
- PASS: focused profiling, telemetry, and docs tests, 48 passed
- PASS: `PYTHONPATH=. .venv/bin/pytest -q`, 1897 passed and 21 skipped
- PASS: `git diff --check`
- PASS: independent pre-commit review

## Remaining deficits

- organization-backfill eligibility evidence remains a separate follow-up
- no promotion-grade baseline capture is authorized by this PR
